### PR TITLE
Group dependabot updates, block Python major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,29 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      python-minor:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/video_grouper"
     schedule:
       interval: "weekly"
+    ignore:
+      # Python major bumps (e.g. 3.13 → 3.14) need manual verification
+      # that all ML deps (torch, onnxruntime, pyav, etc.) support the new
+      # version before merging.
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Summary
- Group pip minor/patch and github-actions updates into rollup PRs (reduces PR noise)
- Block Python major bumps on video_grouper Dockerfile — PR #18 (3.13 → 3.14) is currently failing because ML deps don't yet support 3.14; those need manual verification.

## Test plan
- [ ] Merge and confirm next dependabot weekly run produces grouped PRs
- [ ] Confirm dependabot stops opening Python major-bump PRs for /video_grouper

🤖 Generated with [Claude Code](https://claude.com/claude-code)