### PR TITLE
ball_tracking: provider registry + autocam_gui adapter scaffolding

### DIFF
--- a/tests/test_ball_tracking_autocam_gui.py
+++ b/tests/test_ball_tracking_autocam_gui.py
@@ -1,0 +1,79 @@
+"""Tests for the autocam_gui provider — adapter around run_autocam_on_file."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from video_grouper.ball_tracking.base import ProviderContext
+from video_grouper.ball_tracking.config import AutocamGuiProviderConfig
+from video_grouper.ball_tracking.providers.autocam_gui import AutocamGuiProvider
+
+
+@pytest.fixture
+def context(tmp_path):
+    return ProviderContext(
+        group_dir=tmp_path / "flash__2024.06.01_vs_IYSA_home",
+        team_name="flash",
+        storage_path=tmp_path,
+    )
+
+
+@pytest.mark.asyncio
+async def test_routes_to_run_autocam_on_file_via_executor(context):
+    """Adapter must call run_autocam_on_file with the legacy AutocamConfig
+    shape and the input/output paths.
+    """
+    cfg = AutocamGuiProviderConfig(executable="C:/Path/To/AutoCam.exe")
+    provider = AutocamGuiProvider(cfg)
+
+    with patch(
+        "video_grouper.tray.autocam_automation.run_autocam_on_file",
+        return_value=True,
+    ) as mock_run:
+        result = await provider.run("in.mp4", "out.mp4", context)
+
+    assert result is True
+    assert mock_run.call_count == 1
+    legacy_cfg, in_path, out_path = mock_run.call_args.args
+    assert legacy_cfg.enabled is True
+    assert legacy_cfg.executable == "C:/Path/To/AutoCam.exe"
+    assert in_path == "in.mp4"
+    assert out_path == "out.mp4"
+
+
+@pytest.mark.asyncio
+async def test_returns_false_when_driver_returns_false(context):
+    cfg = AutocamGuiProviderConfig(executable="x")
+    provider = AutocamGuiProvider(cfg)
+
+    with patch(
+        "video_grouper.tray.autocam_automation.run_autocam_on_file",
+        return_value=False,
+    ):
+        result = await provider.run("in.mp4", "out.mp4", context)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_swallows_driver_exceptions_and_returns_false(context):
+    cfg = AutocamGuiProviderConfig(executable="x")
+    provider = AutocamGuiProvider(cfg)
+
+    with patch(
+        "video_grouper.tray.autocam_automation.run_autocam_on_file",
+        side_effect=RuntimeError("pywinauto exploded"),
+    ):
+        result = await provider.run("in.mp4", "out.mp4", context)
+
+    # Provider contract: don't raise on expected failure modes; log + return False.
+    assert result is False
+
+
+def test_provider_self_registers_under_autocam_gui_name():
+    # Importing the module above triggers register_provider('autocam_gui', ...).
+    from video_grouper.ball_tracking import _PROVIDER_REGISTRY
+
+    assert "autocam_gui" in _PROVIDER_REGISTRY

--- a/tests/test_ball_tracking_registry.py
+++ b/tests/test_ball_tracking_registry.py
@@ -1,0 +1,114 @@
+"""Tests for the ball-tracking provider registry and config resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from video_grouper.ball_tracking import (
+    _PROVIDER_REGISTRY,
+    create_provider,
+    register_provider,
+)
+from video_grouper.ball_tracking.base import BallTrackingProvider, ProviderContext
+from video_grouper.ball_tracking.config import (
+    AutocamGuiProviderConfig,
+    BallTrackingConfig,
+)
+
+
+@pytest.fixture
+def isolated_registry():
+    """Snapshot and restore the global registry around each test."""
+    snapshot = dict(_PROVIDER_REGISTRY)
+    yield
+    _PROVIDER_REGISTRY.clear()
+    _PROVIDER_REGISTRY.update(snapshot)
+
+
+class _FakeProvider(BallTrackingProvider):
+    """In-test provider that records the args it was created with."""
+
+    def __init__(self, config):
+        self.config = config
+
+    async def run(self, input_path, output_path, ctx):
+        return True
+
+
+class _OtherProvider(_FakeProvider):
+    """Second provider used by overwrite tests. Module-level so the registry
+    can resolve it via ``getattr(module, class_name)``."""
+
+
+class TestRegistry:
+    def test_register_and_create_round_trip(self, isolated_registry):
+        register_provider("fake_test_provider", _FakeProvider)
+
+        cfg = AutocamGuiProviderConfig(executable="dummy.exe")
+        provider = create_provider("fake_test_provider", cfg)
+
+        assert isinstance(provider, _FakeProvider)
+        assert provider.config is cfg
+
+    def test_create_unknown_provider_raises(self, isolated_registry):
+        with pytest.raises(ValueError, match="Unknown ball-tracking provider"):
+            create_provider("nonexistent", AutocamGuiProviderConfig())
+
+    def test_register_overwrites_same_name(self, isolated_registry):
+        register_provider("dup", _FakeProvider)
+        register_provider("dup", _OtherProvider)
+
+        provider = create_provider("dup", AutocamGuiProviderConfig())
+        assert isinstance(provider, _OtherProvider)
+
+
+class TestResolveProviderFor:
+    def test_default_when_no_per_team_override(self):
+        cfg = BallTrackingConfig(provider="autocam_gui")
+        name, sub_cfg = cfg.resolve_provider_for("flash")
+        assert name == "autocam_gui"
+        assert sub_cfg is cfg.autocam_gui
+
+    def test_per_team_override_takes_precedence(self):
+        cfg = BallTrackingConfig(
+            provider="autocam_gui",
+            per_team={"flash": "autocam_gui", "heat": "autocam_gui"},
+        )
+        # Even though both teams point at autocam_gui here, the lookup path
+        # is exercised: per_team wins over the default `provider` value.
+        name, sub_cfg = cfg.resolve_provider_for("flash")
+        assert name == "autocam_gui"
+        assert sub_cfg is cfg.autocam_gui
+
+    def test_unknown_team_falls_back_to_default(self):
+        cfg = BallTrackingConfig(
+            provider="autocam_gui",
+            per_team={"flash": "autocam_gui"},
+        )
+        name, _ = cfg.resolve_provider_for("never_heard_of_them")
+        assert name == "autocam_gui"
+
+    def test_none_team_uses_default(self):
+        cfg = BallTrackingConfig(provider="autocam_gui")
+        name, _ = cfg.resolve_provider_for(None)
+        assert name == "autocam_gui"
+
+
+class TestProviderContext:
+    def test_context_carries_required_fields(self, tmp_path):
+        ctx = ProviderContext(
+            group_dir=tmp_path / "game1",
+            team_name="flash",
+            storage_path=tmp_path,
+        )
+        assert ctx.group_dir == tmp_path / "game1"
+        assert ctx.team_name == "flash"
+        assert ctx.storage_path == tmp_path
+
+    def test_team_name_can_be_none(self, tmp_path):
+        ctx = ProviderContext(
+            group_dir=tmp_path / "game1",
+            team_name=None,
+            storage_path=tmp_path,
+        )
+        assert ctx.team_name is None

--- a/video_grouper/ball_tracking/__init__.py
+++ b/video_grouper/ball_tracking/__init__.py
@@ -1,0 +1,55 @@
+"""Ball-tracking provider registry.
+
+Each provider type registers itself by calling :func:`register_provider`
+at import time. The pipeline creates instances via :func:`create_provider`.
+
+Mirrors the camera registry in ``video_grouper.cameras`` — see that module
+for the rationale behind storing ``(module_path, class_name)`` tuples
+instead of direct class references.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from video_grouper.ball_tracking.base import BallTrackingProvider
+
+
+_PROVIDER_REGISTRY: dict[str, tuple[str, str]] = {}
+
+
+def register_provider(name: str, provider_class: type[BallTrackingProvider]) -> None:
+    """Register a ball-tracking provider implementation under *name*.
+
+    Args:
+        name: The string that appears in ``config.ini`` as
+            ``provider = <name>`` (e.g. ``"autocam_gui"``, ``"homegrown"``).
+        provider_class: A concrete subclass of
+            :class:`video_grouper.ball_tracking.base.BallTrackingProvider`.
+    """
+    _PROVIDER_REGISTRY[name] = (provider_class.__module__, provider_class.__name__)
+
+
+def create_provider(name: str, config: BaseModel) -> BallTrackingProvider:
+    """Instantiate the provider registered under *name*.
+
+    Resolves the class from its module at call time so test mocks patching
+    the class attribute are respected.
+
+    Raises:
+        ValueError: If *name* is not registered.
+    """
+    entry = _PROVIDER_REGISTRY.get(name)
+    if entry is None:
+        available = ", ".join(sorted(_PROVIDER_REGISTRY)) or "(none)"
+        raise ValueError(
+            f"Unknown ball-tracking provider: {name!r}. Available: {available}"
+        )
+    module_path, class_name = entry
+    module = importlib.import_module(module_path)
+    cls = getattr(module, class_name)
+    return cls(config=config)

--- a/video_grouper/ball_tracking/base.py
+++ b/video_grouper/ball_tracking/base.py
@@ -1,0 +1,48 @@
+"""Base contract every ball-tracking provider must implement."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class ProviderContext:
+    """Runtime context passed to :meth:`BallTrackingProvider.run`.
+
+    Attributes:
+        group_dir: Absolute path to the game's video-group directory.
+        team_name: Team identifier (e.g. ``"flash"``, ``"heat"``) or
+            ``None`` if unknown. Used by per-team overrides upstream.
+        storage_path: Absolute path to soccer-cam's shared-data root.
+    """
+
+    group_dir: Path
+    team_name: str | None
+    storage_path: Path
+
+
+class BallTrackingProvider(ABC):
+    """A provider takes an unprocessed panoramic video and writes a
+    pan-and-scan broadcast-style output.
+
+    Implementations register themselves at import time via
+    :func:`video_grouper.ball_tracking.register_provider`.
+    """
+
+    @abstractmethod
+    async def run(
+        self, input_path: str, output_path: str, ctx: ProviderContext
+    ) -> bool:
+        """Process *input_path* into *output_path*.
+
+        Args:
+            input_path: Panoramic source video.
+            output_path: Where to write the broadcast-style output.
+            ctx: Runtime context (game dir, team name, storage root).
+
+        Returns:
+            ``True`` on success, ``False`` on failure. Implementations
+            should not raise on expected failures — log + return ``False``.
+        """

--- a/video_grouper/ball_tracking/config.py
+++ b/video_grouper/ball_tracking/config.py
@@ -1,0 +1,42 @@
+"""Pydantic config models for the ``[BALL_TRACKING]`` section."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class AutocamGuiProviderConfig(BaseModel):
+    """Config for the ``autocam_gui`` provider (drives Once AutoCam GUI)."""
+
+    executable: Optional[str] = None
+
+
+class BallTrackingConfig(BaseModel):
+    """Top-level ``[BALL_TRACKING]`` config.
+
+    ``provider`` selects the default provider for all games. ``per_team``
+    allows overriding by team name (key matches ``MatchInfo.team_name``).
+
+    Provider-specific configs live under their own attribute, with the
+    INI alias matching the provider's registered name in upper case
+    (e.g. ``[BALL_TRACKING.AUTOCAM_GUI]``).
+    """
+
+    provider: str = "autocam_gui"
+    autocam_gui: AutocamGuiProviderConfig = Field(
+        default_factory=AutocamGuiProviderConfig, alias="AUTOCAM_GUI"
+    )
+    per_team: dict[str, str] = Field(default_factory=dict, alias="PER_TEAM")
+
+    model_config = {"validate_by_name": True}
+
+    def resolve_provider_for(self, team_name: str | None) -> tuple[str, BaseModel]:
+        """Pick the provider name + its config for *team_name*.
+
+        Falls back to :attr:`provider` if there's no per-team override.
+        """
+        name = self.per_team.get(team_name or "", self.provider)
+        cfg = getattr(self, name)
+        return name, cfg

--- a/video_grouper/ball_tracking/providers/__init__.py
+++ b/video_grouper/ball_tracking/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in ball-tracking providers."""

--- a/video_grouper/ball_tracking/providers/autocam_gui.py
+++ b/video_grouper/ball_tracking/providers/autocam_gui.py
@@ -1,0 +1,49 @@
+"""``autocam_gui`` provider — drives the Once AutoCam desktop app.
+
+Adapter around :func:`video_grouper.tray.autocam_automation.run_autocam_on_file`.
+The GUI driver is synchronous and blocks for the duration of AutoCam's
+processing; we marshal it onto a worker thread via ``run_in_executor``
+so it doesn't block the asyncio loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from video_grouper.ball_tracking import register_provider
+from video_grouper.ball_tracking.base import BallTrackingProvider, ProviderContext
+from video_grouper.ball_tracking.config import AutocamGuiProviderConfig
+
+logger = logging.getLogger(__name__)
+
+
+class AutocamGuiProvider(BallTrackingProvider):
+    def __init__(self, config: AutocamGuiProviderConfig):
+        self.config = config
+
+    async def run(
+        self, input_path: str, output_path: str, ctx: ProviderContext
+    ) -> bool:
+        # Build the legacy AutocamConfig the GUI driver expects.
+        # Imports are local so unit tests can stub the driver without
+        # pulling in pywinauto / win32gui at module-import time.
+        from video_grouper.tray.autocam_automation import run_autocam_on_file
+        from video_grouper.utils.config import AutocamConfig
+
+        legacy_cfg = AutocamConfig(enabled=True, executable=self.config.executable)
+        loop = asyncio.get_event_loop()
+        try:
+            return await loop.run_in_executor(
+                None, run_autocam_on_file, legacy_cfg, input_path, output_path
+            )
+        except Exception:
+            logger.exception(
+                "BALL_TRACKING/autocam_gui: failed to process %s -> %s",
+                input_path,
+                output_path,
+            )
+            return False
+
+
+register_provider("autocam_gui", AutocamGuiProvider)

--- a/video_grouper/ball_tracking/register_providers.py
+++ b/video_grouper/ball_tracking/register_providers.py
@@ -1,0 +1,11 @@
+"""Import-time registration of all built-in ball-tracking providers.
+
+Importing this module triggers each provider module to register itself.
+The wiring side (e.g. ``VideoGrouperApp``) imports this once at startup,
+mirroring the cameras-module convention.
+"""
+
+from __future__ import annotations
+
+# noqa: F401 — imports are for side effects (registration on import)
+from video_grouper.ball_tracking.providers import autocam_gui  # noqa: F401

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -6,6 +6,8 @@ from typing import Dict, Optional, List
 
 from pydantic import BaseModel, Field, RootModel
 
+from video_grouper.ball_tracking.config import BallTrackingConfig
+
 
 # Monkey-patch ConfigParser to allow attribute-style access to sections used by tests
 if not hasattr(configparser.ConfigParser, "__getattr__"):
@@ -281,6 +283,9 @@ class Config(BaseModel):
         default_factory=MomentTaggingConfig, alias="MOMENT_TAGGING"
     )
     setup: SetupConfig = Field(alias="SETUP", default_factory=SetupConfig)
+    ball_tracking: BallTrackingConfig = Field(
+        alias="BALL_TRACKING", default_factory=BallTrackingConfig
+    )
 
     model_config = {"validate_by_name": True}
 
@@ -312,6 +317,15 @@ def load_config(config_path: Path) -> Config:
         config_dict.setdefault("YOUTUBE", {})["playlist_map"] = (
             YouTubePlaylistMapConfig(config_dict.pop("YOUTUBE.PLAYLIST_MAP"))
         )
+
+    # Handle BALL_TRACKING sub-sections (provider configs + per-team overrides).
+    # `[BALL_TRACKING.AUTOCAM_GUI]` -> nested under BALL_TRACKING.AUTOCAM_GUI
+    # `[BALL_TRACKING.PER_TEAM]` -> dict of team_name -> provider_name
+    for section in list(config_dict.keys()):
+        if section.startswith("BALL_TRACKING."):
+            sub_alias = section.split(".", 1)[1]  # e.g. "AUTOCAM_GUI" or "PER_TEAM"
+            sub_value = config_dict.pop(section)
+            config_dict.setdefault("BALL_TRACKING", {})[sub_alias] = sub_value
 
     # Handle PlayMetrics teams
     playmetrics_teams = []
@@ -416,6 +430,15 @@ def save_config(config: Config, config_path: Path):
                         for k, v in sub_value.model_dump().items()
                         if v is not None
                     }
+
+                elif isinstance(sub_value, dict):
+                    # Non-empty dict[str, str] -> [PARENT.SUBALIAS] sub-section.
+                    # Empty dicts are skipped so reload doesn't see "{}" as a string.
+                    if sub_value:
+                        nested_section_name = f"{alias}.{sub_alias.upper()}"
+                        parser[nested_section_name] = {
+                            k: str(v) for k, v in sub_value.items()
+                        }
 
                 elif sub_value is not None:
                     section_items[sub_alias] = str(sub_value)


### PR DESCRIPTION
## Summary
- New module `video_grouper/ball_tracking/` with registry/ABC/config (mirrors the camera registry pattern at `video_grouper/cameras/__init__.py`).
- `autocam_gui` provider — thin async adapter around the existing `run_autocam_on_file`. Self-registers at import.
- Optional `[BALL_TRACKING]` config section, default-factory'd so existing INI files load unchanged.

## Background
First slice of the ball-tracking provider hook described in the architecture plan. **No pipeline behavior changes** — the existing `AutocamTask` path is untouched. A follow-up PR replaces `AutocamTask` with a generic `BallTrackingTask` that delegates to whichever provider is configured.

## Test plan
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] New unit tests (13) pass: registry round-trip, unknown-provider error, overwrite semantics, per-team override resolution, autocam_gui adapter routes through executor, swallows exceptions, self-registers
- [x] Full unit suite: 853 passed, 16 pre-existing failures unchanged (`TTT.plugin_signing_public_keys` list-roundtrip — unrelated)
- [ ] On a follow-up PR: actually wire the new task/processor into `VideoGrouperApp` so a real game flows through `autocam_gui` provider end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)