### PR TITLE
Add binary cache shard system for training

### DIFF
--- a/training/data_prep/manifest_dataset.py
+++ b/training/data_prep/manifest_dataset.py
@@ -14,6 +14,8 @@ Usage:
         train_games=["flash__2024.05.01_vs_RNYFC_away", ...],
         val_games=["flash__2024.06.02_vs_Flash_2014s_scrimmage"],
         neg_ratio=1.0,
+        phase_filter=True,   # skip warmup/halftime/post-game
+        field_filter=True,    # skip off-field detections
     )
 
     # Train (on laptop after transferring training set)
@@ -23,6 +25,7 @@ Usage:
     model.train(data="training_sets/v3.1/dataset.yaml", trainer=ManifestTrainer, ...)
 """
 
+import io
 import math
 import random
 import re
@@ -97,33 +100,26 @@ TILE_RE = re.compile(r"^(.+)_frame_(\d{6})_r(\d+)_c(\d+)$")
 TILE_SIZE = 640
 EXCLUDE_ROWS = {0}  # row 0 is sky/far-field
 
+DEFAULT_GAMES_DIR = Path("D:/training_data/games")
+
 
 # ---------------------------------------------------------------------------
 # ManifestDataset — reads images from packs, labels from SQLite
 # ---------------------------------------------------------------------------
 
-
 class ManifestDataset(YOLODataset):
     """YOLO dataset that reads from manifest.db + pack files."""
 
-    def __init__(
-        self,
-        *args,
-        db_path=None,
-        game_ids=None,
-        neg_ratio=1.0,
-        hard_neg_ratio=0.5,
-        seed=42,
-        **kwargs,
-    ):
+    def __init__(self, *args, db_path=None, game_ids=None,
+                 neg_ratio=1.0, hard_neg_ratio=0.5, seed=42, **kwargs):
         # Store config BEFORE super().__init__ calls get_img_files/get_labels
         self._db_path = db_path
         self._game_ids = game_ids or []
         self._neg_ratio = neg_ratio
         self._hard_neg_ratio = hard_neg_ratio
         self._seed = seed
-        self._tile_index = []  # (pack_file, offset, size) per image
-        self._label_data = []  # label dict per image
+        self._tile_index = []    # (pack_file, offset, size) per image
+        self._label_data = []    # label dict per image
         self._conn = None
         self._pack_handles = {}  # cache open file handles
 
@@ -183,21 +179,17 @@ class ManifestDataset(YOLODataset):
                 tile_index.append((pf, po, ps))
 
                 cls_arr = np.array([[d[0]] for d in detections], dtype=np.float32)
-                bbox_arr = np.array(
-                    [[d[1], d[2], d[3], d[4]] for d in detections], dtype=np.float32
-                )
-                label_data.append(
-                    {
-                        "im_file": f"pack://{gid}/{stem}.jpg",
-                        "shape": (TILE_SIZE, TILE_SIZE),
-                        "cls": cls_arr,
-                        "bboxes": bbox_arr,
-                        "segments": [],
-                        "keypoints": None,
-                        "normalized": True,
-                        "bbox_format": "xywh",
-                    }
-                )
+                bbox_arr = np.array([[d[1], d[2], d[3], d[4]] for d in detections], dtype=np.float32)
+                label_data.append({
+                    "im_file": f"pack://{gid}/{stem}.jpg",
+                    "shape": (TILE_SIZE, TILE_SIZE),
+                    "cls": cls_arr,
+                    "bboxes": bbox_arr,
+                    "segments": [],
+                    "keypoints": None,
+                    "normalized": True,
+                    "bbox_format": "xywh",
+                })
 
             # Hard negatives: spatial + temporal neighbors
             hard_neg_keys = set()
@@ -219,15 +211,11 @@ class ManifestDataset(YOLODataset):
                 hard_neg_keys = set(random.sample(list(hard_neg_keys), max_hard))
 
             # Random negatives
-            max_random = int(
-                len(positive_keys) * self._neg_ratio * (1 - self._hard_neg_ratio)
-            )
+            max_random = int(len(positive_keys) * self._neg_ratio * (1 - self._hard_neg_ratio))
             all_neg = set(tile_info.keys()) - positive_keys - hard_neg_keys
             random_neg_keys = set()
             if max_random > 0 and all_neg:
-                random_neg_keys = set(
-                    random.sample(list(all_neg), min(max_random, len(all_neg)))
-                )
+                random_neg_keys = set(random.sample(list(all_neg), min(max_random, len(all_neg))))
 
             # Add negatives
             empty_cls = np.zeros((0, 1), dtype=np.float32)
@@ -239,33 +227,27 @@ class ManifestDataset(YOLODataset):
                 vpath = f"pack://{gid}/{stem}.jpg"
                 im_files.append(vpath)
                 tile_index.append((pf, po, ps))
-                label_data.append(
-                    {
-                        "im_file": vpath,
-                        "shape": (TILE_SIZE, TILE_SIZE),
-                        "cls": empty_cls,
-                        "bboxes": empty_bbox,
-                        "segments": [],
-                        "keypoints": None,
-                        "normalized": True,
-                        "bbox_format": "xywh",
-                    }
-                )
+                label_data.append({
+                    "im_file": vpath,
+                    "shape": (TILE_SIZE, TILE_SIZE),
+                    "cls": empty_cls,
+                    "bboxes": empty_bbox,
+                    "segments": [],
+                    "keypoints": None,
+                    "normalized": True,
+                    "bbox_format": "xywh",
+                })
 
             n_pos = len(positive_keys)
             n_neg = len(hard_neg_keys) + len(random_neg_keys)
-            LOGGER.info(
-                f"  {gid}: {n_pos} pos + {n_neg} neg ({len(hard_neg_keys)} hard, {len(random_neg_keys)} random)"
-            )
+            LOGGER.info(f"  {gid}: {n_pos} pos + {n_neg} neg ({len(hard_neg_keys)} hard, {len(random_neg_keys)} random)")
 
         self._tile_index = tile_index
         self._label_data = label_data
 
-        LOGGER.info(
-            f"ManifestDataset: {len(im_files)} total tiles "
-            f"({sum(1 for ld in label_data if len(ld['cls']) > 0)} pos, "
-            f"{sum(1 for ld in label_data if len(ld['cls']) == 0)} neg)"
-        )
+        LOGGER.info(f"ManifestDataset: {len(im_files)} total tiles "
+                     f"({sum(1 for ld in label_data if len(ld['cls']) > 0)} pos, "
+                     f"{sum(1 for ld in label_data if len(ld['cls']) == 0)} neg)")
         return im_files
 
     def get_labels(self):
@@ -316,15 +298,10 @@ class ManifestDataset(YOLODataset):
         if rect_mode:
             r = self.imgsz / max(h0, w0)
             if r != 1:
-                w, h = (
-                    min(math.ceil(w0 * r), self.imgsz),
-                    min(math.ceil(h0 * r), self.imgsz),
-                )
+                w, h = (min(math.ceil(w0 * r), self.imgsz), min(math.ceil(h0 * r), self.imgsz))
                 im = cv2.resize(im, (w, h), interpolation=cv2.INTER_LINEAR)
         elif not (h0 == w0 == self.imgsz):
-            im = cv2.resize(
-                im, (self.imgsz, self.imgsz), interpolation=cv2.INTER_LINEAR
-            )
+            im = cv2.resize(im, (self.imgsz, self.imgsz), interpolation=cv2.INTER_LINEAR)
 
         if im.ndim == 2:
             im = im[..., None]
@@ -350,7 +327,6 @@ class ManifestDataset(YOLODataset):
 # ManifestTrainer — plugs ManifestDataset into YOLO training
 # ---------------------------------------------------------------------------
 
-
 class ManifestTrainer(DetectionTrainer):
     """Detection trainer that uses ManifestDataset."""
 
@@ -364,14 +340,10 @@ class ManifestTrainer(DetectionTrainer):
         neg_ratio = self.data.get("manifest_neg_ratio", 1.0)
 
         if not db_path or not game_ids:
-            LOGGER.warning(
-                f"No manifest config for {mode}, falling back to standard dataset"
-            )
+            LOGGER.warning(f"No manifest config for {mode}, falling back to standard dataset")
             return super().build_dataset(img_path, mode, batch)
 
-        LOGGER.info(
-            f"ManifestDataset ({mode}): {len(game_ids)} games, neg_ratio={neg_ratio}"
-        )
+        LOGGER.info(f"ManifestDataset ({mode}): {len(game_ids)} games, neg_ratio={neg_ratio}")
 
         return ManifestDataset(
             img_path=img_path,
@@ -400,7 +372,6 @@ class ManifestTrainer(DetectionTrainer):
 # build_training_set — curate a versioned training dataset
 # ---------------------------------------------------------------------------
 
-
 def build_training_set(
     master_db,
     master_packs,
@@ -412,6 +383,10 @@ def build_training_set(
     seed=42,
     camera_neg_games=None,
     neg_per_camera_game=2000,
+    phase_filter=True,
+    field_filter=True,
+    exclude_rows=None,
+    games_dir=None,
 ):
     """Build a curated training set from the master manifest.
 
@@ -431,12 +406,20 @@ def build_training_set(
         seed: random seed
         camera_neg_games: optional list of unlabeled games for additional negatives
         neg_per_camera_game: how many random negatives per camera game
+        phase_filter: skip tiles outside active play phases (first_half, second_half)
+        field_filter: skip off-field detections using field boundary polygon
+        exclude_rows: set of row indices to exclude (default: {0})
+        games_dir: path to per-game manifest directories (for phase/field data)
     """
+    import json
 
     random.seed(seed)
     output_dir = Path(output_dir)
     master_db = Path(master_db)
     master_packs = Path(master_packs)
+    games_dir = Path(games_dir) if games_dir else DEFAULT_GAMES_DIR
+    if exclude_rows is None:
+        exclude_rows = EXCLUDE_ROWS
 
     output_dir.mkdir(parents=True, exist_ok=True)
     packs_out = output_dir / "packs"
@@ -450,9 +433,14 @@ def build_training_set(
     if camera_neg_games:
         all_games += list(camera_neg_games)
 
-    print(
-        f"Building training set: {len(train_games)} train, {len(val_games)} val games"
-    )
+    filters_desc = []
+    if phase_filter:
+        filters_desc.append("phase")
+    if field_filter:
+        filters_desc.append("field")
+    filters_str = f" [filters: {', '.join(filters_desc)}]" if filters_desc else ""
+
+    print(f"Building training set: {len(train_games)} train, {len(val_games)} val games{filters_str}")
     print(f"Output: {output_dir}")
 
     # Open master DB
@@ -498,9 +486,48 @@ def build_training_set(
     t0 = time.time()
     total_pos = 0
     total_neg = 0
+    total_skipped_phase = 0
+    total_skipped_field = 0
+    games_with_phases = 0
+    games_with_field = 0
 
     for gid in train_games + val_games:
         print(f"\n  Processing {gid}...")
+        rng = random.Random(seed + hash(gid))
+
+        # --- Load per-game phase + field boundary data ---
+        game_phases = None
+        game_manifest = None
+        polygon = None
+
+        game_manifest_path = games_dir / gid / "manifest.db"
+        if game_manifest_path.exists() and (phase_filter or field_filter):
+            from training.data_prep.game_manifest import GameManifest
+
+            game_manifest = GameManifest(games_dir / gid)
+            game_manifest.open(create=False)
+
+            if phase_filter:
+                game_phases = game_manifest.get_phases()
+                if game_phases:
+                    games_with_phases += 1
+
+            if field_filter:
+                fb_json = game_manifest.get_metadata("field_boundary")
+                if fb_json:
+                    try:
+                        fb_data = json.loads(fb_json)
+                        poly_pts = (
+                            fb_data if isinstance(fb_data, list) else fb_data.get("polygon", [])
+                        )
+                        if poly_pts:
+                            polygon = np.asarray(poly_pts, dtype=np.float32).reshape(-1, 1, 2)
+                            games_with_field += 1
+                    except (json.JSONDecodeError, ValueError):
+                        pass
+
+        skipped_phase = 0
+        skipped_field = 0
 
         # Get labels from master
         label_rows = master.execute(
@@ -519,19 +546,55 @@ def build_training_set(
         ).fetchall()
         tile_info = {}
         for seg, fidx, r, c, pf, po, ps in tile_rows:
-            if r in EXCLUDE_ROWS:
+            if r in exclude_rows:
                 continue
+            # Phase filter: skip tiles outside active play
+            if phase_filter and game_phases and game_manifest:
+                if not game_manifest.is_active_play(seg, fidx):
+                    stem = f"{seg}_frame_{fidx:06d}_r{r}_c{c}"
+                    if stem in labels_by_stem:
+                        skipped_phase += 1
+                    continue
             tile_info[(seg, fidx, r, c)] = (pf, po, ps)
 
-        # Identify positive tiles
+        # Identify positive tiles (with field boundary filtering)
         positive_keys = set()
         for stem in labels_by_stem:
             m = TILE_RE.match(stem)
             if not m:
                 continue
             key = (m.group(1), int(m.group(2)), int(m.group(3)), int(m.group(4)))
-            if key in tile_info:
-                positive_keys.add(key)
+            if key not in tile_info:
+                continue
+            # Field boundary filter on positives
+            if field_filter and polygon is not None:
+                from training.data_prep.field_mask_filter import (
+                    NEAR_OFF_FIELD_KEEP_RATE,
+                    classify_label_position,
+                )
+
+                lbl = labels_by_stem[stem][0]  # first label for this tile
+                position = classify_label_position(
+                    lbl[2], lbl[3],  # cx, cy (tile_stem=0, class_id=1, cx=2, cy=3)
+                    int(m.group(3)), int(m.group(4)),  # row, col
+                    polygon,
+                )
+                if position == "far_off_field":
+                    skipped_field += 1
+                    continue
+                if position == "near_off_field":
+                    if rng.random() > NEAR_OFF_FIELD_KEEP_RATE:
+                        skipped_field += 1
+                        continue
+            positive_keys.add(key)
+
+        if skipped_phase or skipped_field:
+            print(f"    Filtered: {skipped_phase} phase, {skipped_field} field")
+        total_skipped_phase += skipped_phase
+        total_skipped_field += skipped_field
+
+        if game_manifest:
+            game_manifest.close()
 
         # Hard negatives
         hard_neg_keys = set()
@@ -552,14 +615,22 @@ def build_training_set(
         if len(hard_neg_keys) > max_hard:
             hard_neg_keys = set(random.sample(list(hard_neg_keys), max_hard))
 
-        # Random negatives
+        # Random negatives (field filter on negatives: skip far-off-field tiles)
         max_random = int(len(positive_keys) * neg_ratio * (1 - hard_neg_ratio))
         all_neg_pool = set(tile_info.keys()) - positive_keys - hard_neg_keys
+        if field_filter and polygon is not None:
+            from training.data_prep.field_mask_filter import classify_label_position
+
+            filtered_neg_pool = set()
+            for key in all_neg_pool:
+                _, _, r, c = key
+                position = classify_label_position(0.5, 0.5, r, c, polygon)
+                if position != "far_off_field":
+                    filtered_neg_pool.add(key)
+            all_neg_pool = filtered_neg_pool
         random_neg_keys = set()
         if max_random > 0 and all_neg_pool:
-            random_neg_keys = set(
-                random.sample(list(all_neg_pool), min(max_random, len(all_neg_pool)))
-            )
+            random_neg_keys = set(random.sample(list(all_neg_pool), min(max_random, len(all_neg_pool))))
 
         selected_keys = positive_keys | hard_neg_keys | random_neg_keys
 
@@ -576,9 +647,7 @@ def build_training_set(
 
         with open(game_pack_path, "wb") as out_fh:
             for src_pack in sorted(by_pack.keys()):
-                entries = sorted(
-                    by_pack[src_pack]
-                )  # sort by offset for sequential read
+                entries = sorted(by_pack[src_pack])  # sort by offset for sequential read
                 with open(src_pack, "rb") as src_fh:
                     for offset, size, key in entries:
                         src_fh.seek(offset)
@@ -586,18 +655,10 @@ def build_training_set(
                         out_fh.write(data)
 
                         seg, fidx, r, c = key
-                        tile_inserts.append(
-                            (
-                                gid,
-                                seg,
-                                fidx,
-                                r,
-                                c,
-                                str(game_pack_path),
-                                new_offset,
-                                len(data),
-                            )
-                        )
+                        tile_inserts.append((
+                            gid, seg, fidx, r, c,
+                            str(game_pack_path), new_offset, len(data),
+                        ))
                         new_offset += len(data)
 
         # Insert tiles into training manifest
@@ -636,9 +697,7 @@ def build_training_set(
         total_pos += n_pos
         total_neg += n_neg
         pack_mb = new_offset / 1024 / 1024
-        print(
-            f"    {n_pos} pos + {n_neg} neg = {len(selected_keys)} tiles, pack: {pack_mb:.0f}MB"
-        )
+        print(f"    {n_pos} pos + {n_neg} neg = {len(selected_keys)} tiles, pack: {pack_mb:.0f}MB")
 
     # Handle camera game negatives
     if camera_neg_games:
@@ -652,7 +711,7 @@ def build_training_set(
             ).fetchall()
 
             if not tile_rows:
-                print("    No packed tiles found, skipping")
+                print(f"    No packed tiles found, skipping")
                 continue
 
             game_pack_path = packs_out / f"{gid}.pack"
@@ -672,18 +731,10 @@ def build_training_set(
                             data = src_fh.read(size)
                             out_fh.write(data)
                             seg, fidx, r, c = key
-                            tile_inserts.append(
-                                (
-                                    gid,
-                                    seg,
-                                    fidx,
-                                    r,
-                                    c,
-                                    str(game_pack_path),
-                                    new_offset,
-                                    len(data),
-                                )
-                            )
+                            tile_inserts.append((
+                                gid, seg, fidx, r, c,
+                                str(game_pack_path), new_offset, len(data),
+                            ))
                             new_offset += len(data)
 
             train_conn.executemany(
@@ -697,9 +748,7 @@ def build_training_set(
             )
             train_conn.commit()
             total_neg += len(tile_inserts)
-            print(
-                f"    {len(tile_inserts)} negative tiles, pack: {new_offset / 1024 / 1024:.0f}MB"
-            )
+            print(f"    {len(tile_inserts)} negative tiles, pack: {new_offset/1024/1024:.0f}MB")
 
     master.close()
     train_conn.close()
@@ -721,7 +770,7 @@ def build_training_set(
     if camera_neg_games:
         for g in camera_neg_games:
             yaml_content += f"  - {g}\n"
-    yaml_content += "manifest_val_games:\n"
+    yaml_content += f"manifest_val_games:\n"
     for g in val_games:
         yaml_content += f"  - {g}\n"
     yaml_content += f"manifest_neg_ratio: {neg_ratio}\n"
@@ -735,9 +784,15 @@ def build_training_set(
     print(f"  Positives:   {total_pos:,}")
     print(f"  Negatives:   {total_neg:,}")
     print(f"  Total:       {total_pos + total_neg:,}")
-    print(f"  Ratio:       1:{total_neg / max(total_pos, 1):.1f}")
-    print(f"  Packs:       {total_pack_size / 1024 / 1024 / 1024:.1f} GB")
-    print(f"  Manifest DB: {db_size / 1024 / 1024:.0f} MB")
+    print(f"  Ratio:       1:{total_neg/max(total_pos, 1):.1f}")
+    print(f"  Packs:       {total_pack_size/1024/1024/1024:.1f} GB")
+    print(f"  Manifest DB: {db_size/1024/1024:.0f} MB")
+    if phase_filter or field_filter:
+        print("  --- Filters ---")
+        if phase_filter:
+            print(f"  Phase filter: {total_skipped_phase:,} labels skipped ({games_with_phases}/{len(train_games)+len(val_games)} games had phases)")
+        if field_filter:
+            print(f"  Field filter: {total_skipped_field:,} labels skipped ({games_with_field}/{len(train_games)+len(val_games)} games had boundaries)")
     print(f"  YAML:        {yaml_path}")
     print(f"\nTransfer {output_dir} to laptop to train.")
 

--- a/training/data_prep/memmap_dataset.py
+++ b/training/data_prep/memmap_dataset.py
@@ -1,0 +1,67 @@
+"""Memory-mapped YOLO dataset for fast training data loading.
+
+Overrides load_image to read from a pre-built binary cache (.bin) via
+np.memmap instead of individual image files. Workers lazy-init their
+own memmap handles, so this works with multiprocessing (spawn on Windows).
+
+This module is imported by worker processes — no monkey-patching needed.
+"""
+
+import numpy as np
+from ultralytics.data.dataset import YOLODataset
+
+TILE_H, TILE_W, TILE_C = 640, 640, 3
+
+
+class MemmapYOLODataset(YOLODataset):
+    """YOLODataset that loads images from a memory-mapped binary cache."""
+
+    def load_image(self, i, rect_mode=True):
+        """Load image from memmap binary cache with lazy-init per worker."""
+        # Check YOLO's own RAM buffer first
+        im = self.ims[i]
+        if im is not None:
+            return self.ims[i], self.im_hw0[i], self.im_hw[i]
+
+        # Check if this dataset has memmap config
+        memmap_idx = getattr(self, "_memmap_idx", None)
+        if memmap_idx is None:
+            return super().load_image(i, rect_mode)
+
+        f = self.im_files[i]
+        if f not in memmap_idx:
+            return super().load_image(i, rect_mode)
+
+        # Lazy-init memmap handle (each worker process opens its own)
+        mmap_handles = getattr(self, "_mmap_handles", None)
+        if mmap_handles is None:
+            self._mmap_handles = {}
+            mmap_handles = self._mmap_handles
+
+        split = self._memmap_split[f]
+        if split not in mmap_handles:
+            bin_path, n = self._memmap_bin_info[split]
+            mmap_handles[split] = np.memmap(
+                bin_path,
+                dtype=np.uint8,
+                mode="r",
+                shape=(n, TILE_H, TILE_W, TILE_C),
+            )
+
+        idx = memmap_idx[f]
+        im = np.array(mmap_handles[split][idx])  # copy for augmentation safety
+
+        h0, w0 = TILE_H, TILE_W
+
+        # Replicate YOLO's buffer management
+        if self.augment:
+            self.ims[i] = im
+            self.im_hw0[i] = (h0, w0)
+            self.im_hw[i] = (h0, w0)
+            self.buffer.append(i)
+            if 1 < len(self.buffer) >= self.max_buffer_length:
+                j = self.buffer.pop(0)
+                if self.cache != "ram":
+                    self.ims[j], self.im_hw0[j], self.im_hw[j] = None, None, None
+
+        return im, (h0, w0), (h0, w0)

--- a/training/pipeline/orchestrator.py
+++ b/training/pipeline/orchestrator.py
@@ -552,40 +552,104 @@ class Orchestrator:
                 g["coverage"] for g in games_with_coverage
             ) / len(games_with_coverage)
 
-        # Find previous best weights to resume from (incremental training)
-        resume_from = None
-        training_sets = Path(self.cfg.paths.training_sets)
-        if training_sets.exists():
-            versions = sorted(training_sets.iterdir(), reverse=True)
-            for v in versions:
-                best = v / "weights" / "best.pt"
-                if best.exists():
-                    resume_from = str(best)
-                    break
+        # Find previous best weights to resume from (incremental training).
+        # Search multiple locations: training_sets on D:, checkpoints on F:,
+        # and models dir. The model with the most recent mtime wins.
+        resume_from = self._find_best_checkpoint()
 
-        version = f"v3.{int(time.time()) % 10000}"
+        # Find latest pre-built shard
+        shard_version = self._find_latest_shard()
+
+        from datetime import datetime
+
+        shard_tag = shard_version if shard_version else "live"
+        version = f"{shard_tag}_{datetime.now().strftime('%Y%m%d_%H%M')}"
         if self.dry_run:
             logger.info(
-                "[DRY RUN] Would enqueue training %s (resume=%s)", version, resume_from
+                "[DRY RUN] Would enqueue training %s (resume=%s, shard=%s)",
+                version, resume_from, shard_version,
             )
         else:
+            payload = {
+                "train_games": train_games,
+                "val_games": val_games,
+                "version": version,
+                "resume_from": resume_from,
+            }
+            if shard_version:
+                payload["shard_version"] = shard_version
+
             self.api.enqueue(
                 "train",
                 priority=10,
                 target_machine=self._get_target_machine("train"),
-                payload={
-                    "train_games": train_games,
-                    "val_games": val_games,
-                    "version": version,
-                    "resume_from": resume_from,
-                },
+                payload=payload,
             )
             logger.info(
-                "Enqueued training %s: %d games, resume=%s",
+                "Enqueued training %s: %d games, resume=%s, shard=%s",
                 version,
                 len(train_games),
                 Path(resume_from).parent.parent.name if resume_from else "scratch",
+                shard_version or "build-from-games",
             )
+
+    def _find_best_checkpoint(self) -> str | None:
+        """Find the most recent best.pt checkpoint across all storage locations."""
+        candidates: list[tuple[float, str]] = []
+
+        # Check D:/training_data/training_sets/*/weights/best.pt
+        training_sets = Path(self.cfg.paths.training_sets)
+        if training_sets.exists():
+            for v in training_sets.iterdir():
+                best = v / "weights" / "best.pt"
+                if best.exists():
+                    candidates.append((best.stat().st_mtime, str(best)))
+
+        # Check F:/training_checkpoints/*/best.pt
+        checkpoints_dir = Path(self.cfg.paths.archive.checkpoints)
+        if checkpoints_dir.exists():
+            for v in checkpoints_dir.iterdir():
+                best = v / "best.pt"
+                if best.exists():
+                    candidates.append((best.stat().st_mtime, str(best)))
+
+        # Check F:/training_data/runs/*/weights/best.pt (legacy location)
+        legacy_runs = Path(self.cfg.paths.archive.video_sources) / "runs"
+        if legacy_runs.exists():
+            for v in legacy_runs.iterdir():
+                best = v / "weights" / "best.pt"
+                if best.exists():
+                    candidates.append((best.stat().st_mtime, str(best)))
+
+        if not candidates:
+            logger.info("No previous checkpoint found — training from pretrained base")
+            return None
+
+        # Use the most recent checkpoint
+        candidates.sort(reverse=True)
+        best_path = candidates[0][1]
+        logger.info("Resuming from checkpoint: %s", best_path)
+        return best_path
+
+    def _find_latest_shard(self) -> str | None:
+        """Find the latest pre-built training shard."""
+        shard_base = Path(self.cfg.paths.training_sets).parent / "training_shards"
+        if not shard_base.exists():
+            # Check via server share
+            shard_base = Path(self.cfg.server.share_training) / "training_shards"
+        if not shard_base.exists():
+            return None
+
+        shards = []
+        for d in shard_base.iterdir():
+            if d.is_dir() and (d / "dataset.yaml").exists():
+                shards.append(d.name)
+        if not shards:
+            return None
+
+        latest = sorted(shards)[-1]
+        logger.info("Using pre-built shard: %s", latest)
+        return latest
 
     def _can_qa(self) -> bool:
         now = time.time()

--- a/training/tasks/__init__.py
+++ b/training/tasks/__init__.py
@@ -78,6 +78,10 @@ def _load_handlers():
         from training.tasks import phase_detect_task  # noqa: F401
     except ImportError:
         pass
+    try:
+        from training.tasks import build_shard  # noqa: F401
+    except ImportError:
+        pass
 
 
 def list_tasks() -> list[str]:

--- a/training/tasks/build_shard.py
+++ b/training/tasks/build_shard.py
@@ -1,0 +1,603 @@
+"""Build training shard with binary cache for fast YOLO training.
+
+Runs on the SERVER (has local F: and D: access). Reads manifests and packs,
+applies quality filters (game phases, field boundaries, QA verdicts), and
+writes a binary cache (.bin) + labels to D:/training_data/training_shards/{version}/.
+
+The laptop copies a few large files instead of 100k+ individual JPEGs.
+
+Output format:
+    {version}/
+      train_images.bin       # raw BGR uint8, N * 640 * 640 * 3 bytes
+      train_index.json       # {"meta": {...}, "paths": [...]}
+      val_images.bin
+      val_index.json
+      labels/train/{game_id}/*.txt
+      labels/val/{game_id}/*.txt
+      labels.zip             # compressed archive of all labels
+      manifest.json
+      dataset.yaml
+
+Usage (via pipeline):
+    uv run python -m training.pipeline enqueue build_shard --priority 10
+"""
+
+import json
+import logging
+import random
+import re
+import shutil
+import time
+import zipfile
+from collections import defaultdict
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from training.data_prep.field_mask_filter import (
+    NEAR_OFF_FIELD_KEEP_RATE,
+    classify_label_position,
+)
+from training.tasks import register_task
+
+logger = logging.getLogger(__name__)
+
+_TILE_RE = re.compile(r"^(.+?)_frame_(\d{6})_r(\d+)_c(\d+)$")
+
+# Binary cache constants
+TILE_H, TILE_W, TILE_C = 640, 640, 3
+TILE_BYTES = TILE_H * TILE_W * TILE_C  # 1,228,800
+
+
+class BinCacheWriter:
+    """Accumulates decoded tiles into a flat binary file."""
+
+    def __init__(self, bin_path: Path):
+        self.bin_path = bin_path
+        self.fh = open(bin_path, "wb")
+        self.paths: list[str] = []
+        self.count = 0
+
+    def write_tile(self, rel_path: str, jpeg_bytes: bytes) -> bool:
+        """Decode JPEG and append raw BGR pixels. Returns True on success."""
+        img = cv2.imdecode(np.frombuffer(jpeg_bytes, dtype=np.uint8), cv2.IMREAD_COLOR)
+        if img is None:
+            logger.debug("Failed to decode JPEG for %s", rel_path)
+            return False
+        h, w = img.shape[:2]
+        if h != TILE_H or w != TILE_W:
+            img = cv2.resize(img, (TILE_W, TILE_H))
+        self.fh.write(img.tobytes())
+        self.paths.append(rel_path)
+        self.count += 1
+        return True
+
+    def flush(self):
+        self.fh.flush()
+
+    def finish(self) -> dict:
+        """Close file and return index metadata."""
+        self.fh.close()
+        return {
+            "meta": {
+                "n": self.count,
+                "h": TILE_H,
+                "w": TILE_W,
+                "c": TILE_C,
+                "dtype": "uint8",
+            },
+            "paths": self.paths,
+        }
+
+
+def _parse_stem(stem: str) -> tuple[str, int, int, int] | None:
+    """Parse tile stem into (segment, frame_idx, row, col)."""
+    m = _TILE_RE.match(stem)
+    if not m:
+        return None
+    return m.group(1), int(m.group(2)), int(m.group(3)), int(m.group(4))
+
+
+def _select_val_games(game_ids: list[str], val_count: int = 2) -> list[str]:
+    """Select diverse val games: one per team, mix home/away."""
+    flash = [g for g in game_ids if g.startswith("flash__")]
+    heat = [g for g in game_ids if g.startswith("heat__")]
+
+    val = []
+    flash_away = [g for g in flash if "away" in g]
+    if flash_away:
+        val.append(flash_away[len(flash_away) // 2])
+    elif flash:
+        val.append(flash[len(flash) // 2])
+
+    heat_home = [g for g in heat if "home" in g]
+    if heat_home:
+        val.append(heat_home[len(heat_home) // 2])
+    elif heat:
+        val.append(heat[len(heat) // 2])
+
+    return val[:val_count]
+
+
+def _create_labels_zip(output_dir: Path):
+    """Create a zip archive of all label files for efficient transfer."""
+    zip_path = output_dir / "labels.zip"
+    labels_dir = output_dir / "labels"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for txt_file in labels_dir.rglob("*.txt"):
+            arcname = txt_file.relative_to(output_dir)
+            zf.write(txt_file, arcname)
+    logger.info("Created %s (%.1f MB)", zip_path.name, zip_path.stat().st_size / 1e6)
+
+
+@register_task("build_shard")
+def run_build_shard(
+    *,
+    item: dict,
+    local_work_dir: Path,
+    server_share: str = "",
+    local_models_dir: Path | None = None,
+) -> dict:
+    """Build a curated training shard from TRAINABLE games."""
+    from training.pipeline.config import load_config
+
+    cfg = load_config()
+    payload = item.get("payload") or {}
+
+    # Parse payload
+    all_games = payload.get("games", [])
+    val_games = payload.get("val_games", [])
+    version = payload.get("version", f"shard_v{int(time.time()) % 10000}")
+    neg_ratio = payload.get("neg_ratio", 1.0)
+    max_tiles_per_game = payload.get("max_tiles_per_game", 4000)
+    phase_filter = payload.get("phase_filter", True)
+    field_filter = payload.get("field_filter", True)
+    qa_filter = payload.get("qa_filter", True)
+
+    if not all_games and not val_games:
+        raise ValueError("No games specified in payload")
+
+    # Auto-select val games if not specified
+    if not val_games:
+        val_games = _select_val_games(all_games)
+    train_games = [g for g in all_games if g not in val_games]
+
+    # Output directory
+    output_dir = Path(cfg.paths.training_sets).parent / "training_shards" / version
+    if output_dir.exists():
+        shutil.rmtree(str(output_dir))
+
+    for split in ("train", "val"):
+        (output_dir / "labels" / split).mkdir(parents=True)
+
+    # Create binary cache writers
+    bin_writers = {}
+    for split in ("train", "val"):
+        bin_writers[split] = BinCacheWriter(output_dir / f"{split}_images.bin")
+
+    # Local work dir on G: SSD for staging packs
+    work_dir = Path(cfg.paths.server_work_dir) / f"shard_{version}"
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info(
+        "Building shard %s: %d train games, %d val games "
+        "(phase=%s, field=%s, qa=%s, neg_ratio=%.1f, max_per_game=%d)",
+        version,
+        len(train_games),
+        len(val_games),
+        phase_filter,
+        field_filter,
+        qa_filter,
+        neg_ratio,
+        max_tiles_per_game,
+    )
+
+    t0 = time.time()
+    stats = {
+        "train_positive": 0,
+        "train_negative": 0,
+        "val_positive": 0,
+        "val_negative": 0,
+        "skipped_phase": 0,
+        "skipped_field": 0,
+        "skipped_qa": 0,
+        "skipped_no_pack": 0,
+        "games_with_phases": 0,
+        "games_with_field_boundary": 0,
+    }
+
+    # Build each split
+    for split, game_ids in [("train", train_games), ("val", val_games)]:
+        for game_id in game_ids:
+            game_stats = _build_game(
+                game_id=game_id,
+                split=split,
+                output_dir=output_dir,
+                work_dir=work_dir,
+                bin_writer=bin_writers[split],
+                games_dir=Path(cfg.paths.games_dir),
+                archive_packs=Path(cfg.paths.archive.tile_packs),
+                neg_ratio=neg_ratio,
+                max_tiles_per_game=max_tiles_per_game,
+                phase_filter=phase_filter,
+                field_filter=field_filter,
+                qa_filter=qa_filter,
+            )
+            stats[f"{split}_positive"] += game_stats["positive"]
+            stats[f"{split}_negative"] += game_stats["negative"]
+            stats["skipped_phase"] += game_stats["skipped_phase"]
+            stats["skipped_field"] += game_stats["skipped_field"]
+            stats["skipped_qa"] += game_stats["skipped_qa"]
+            stats["skipped_no_pack"] += game_stats["skipped_no_pack"]
+            if game_stats["has_phases"]:
+                stats["games_with_phases"] += 1
+            if game_stats["has_field_boundary"]:
+                stats["games_with_field_boundary"] += 1
+
+    build_time = time.time() - t0
+
+    # Finalize binary caches and write index files
+    for split in ("train", "val"):
+        index_data = bin_writers[split].finish()
+        index_path = output_dir / f"{split}_index.json"
+        index_path.write_text(json.dumps(index_data))
+        logger.info(
+            "  %s cache: %d tiles, %.1f GB",
+            split,
+            index_data["meta"]["n"],
+            (output_dir / f"{split}_images.bin").stat().st_size / 1e9,
+        )
+
+    # Create labels.zip for efficient transfer
+    _create_labels_zip(output_dir)
+
+    # Write dataset.yaml
+    dataset_yaml = output_dir / "dataset.yaml"
+    dataset_yaml.write_text(
+        f"path: {output_dir}\n"
+        f"train: images/train\n"
+        f"val: images/val\n"
+        f"nc: 1\n"
+        f"names: ['ball']\n"
+    )
+
+    # Write manifest.json
+    manifest = {
+        "version": version,
+        "format": "bin_cache",
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "train_games": train_games,
+        "val_games": val_games,
+        "filters": {
+            "phase": phase_filter,
+            "field": field_filter,
+            "qa": qa_filter,
+        },
+        "neg_ratio": neg_ratio,
+        "max_tiles_per_game": max_tiles_per_game,
+        "counts": stats,
+        "build_time_seconds": round(build_time),
+    }
+    (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+
+    # Archive shard to F: for safekeeping
+    archive_dir = Path(cfg.paths.archive.root) / "training_shards" / version
+    try:
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        for fname in [
+            "train_images.bin",
+            "train_index.json",
+            "val_images.bin",
+            "val_index.json",
+            "labels.zip",
+            "manifest.json",
+            "dataset.yaml",
+        ]:
+            src = output_dir / fname
+            if src.exists():
+                logger.info("Archiving %s to F: (%.1f GB)...", fname, src.stat().st_size / 1e9)
+                shutil.copy2(str(src), str(archive_dir / fname))
+        logger.info("Shard archived to %s", archive_dir)
+    except Exception as e:
+        logger.warning("Failed to archive shard to F: %s", e)
+
+    # Clean up work dir
+    shutil.rmtree(str(work_dir), ignore_errors=True)
+
+    total_tiles = (
+        stats["train_positive"]
+        + stats["train_negative"]
+        + stats["val_positive"]
+        + stats["val_negative"]
+    )
+    logger.info(
+        "Shard %s built: %d tiles (%d train, %d val) in %.0fs. "
+        "Skipped: %d phase, %d field, %d qa, %d no_pack",
+        version,
+        total_tiles,
+        stats["train_positive"] + stats["train_negative"],
+        stats["val_positive"] + stats["val_negative"],
+        build_time,
+        stats["skipped_phase"],
+        stats["skipped_field"],
+        stats["skipped_qa"],
+        stats["skipped_no_pack"],
+    )
+
+    return {"version": version, "total_tiles": total_tiles, **stats}
+
+
+def _build_game(
+    *,
+    game_id: str,
+    split: str,
+    output_dir: Path,
+    work_dir: Path,
+    bin_writer: BinCacheWriter,
+    games_dir: Path,
+    archive_packs: Path,
+    neg_ratio: float,
+    max_tiles_per_game: int,
+    phase_filter: bool,
+    field_filter: bool,
+    qa_filter: bool,
+) -> dict:
+    """Build one game's contribution to the shard."""
+    from training.data_prep.game_manifest import GameManifest
+
+    stats = {
+        "positive": 0,
+        "negative": 0,
+        "skipped_phase": 0,
+        "skipped_field": 0,
+        "skipped_qa": 0,
+        "skipped_no_pack": 0,
+        "has_phases": False,
+        "has_field_boundary": False,
+    }
+
+    # Copy manifest to work dir
+    game_dir = games_dir / game_id
+    manifest_src = game_dir / "manifest.db"
+    if not manifest_src.exists():
+        logger.warning("  Skipping %s (no manifest.db)", game_id)
+        return stats
+
+    local_game = work_dir / game_id
+    local_game.mkdir(parents=True, exist_ok=True)
+    local_manifest = local_game / "manifest.db"
+    shutil.copy2(str(manifest_src), str(local_manifest))
+
+    manifest = GameManifest(local_game)
+    manifest.open(create=False)
+
+    try:
+        # Get labeled stems and labels
+        labeled_stems = manifest.get_labeled_stems()
+        if not labeled_stems:
+            logger.info("  %s: no labels, skipping", game_id)
+            return stats
+
+        # Load QA-rejected stems
+        qa_rejected: set[str] = set()
+        if qa_filter:
+            rows = manifest.conn.execute(
+                "SELECT DISTINCT tile_stem FROM labels "
+                "WHERE qa_verdict = 'false_positive'"
+            ).fetchall()
+            qa_rejected = {r[0] for r in rows}
+            if qa_rejected:
+                stats["skipped_qa"] = len(qa_rejected & labeled_stems)
+                labeled_stems -= qa_rejected
+
+        # Load phase data
+        phases = manifest.get_phases()
+        stats["has_phases"] = bool(phases)
+
+        # Load field boundary polygon
+        polygon = None
+        fb_json = manifest.get_metadata("field_boundary")
+        if fb_json:
+            try:
+                fb_data = json.loads(fb_json)
+                poly_pts = (
+                    fb_data if isinstance(fb_data, list) else fb_data.get("polygon", [])
+                )
+                if poly_pts:
+                    polygon = np.asarray(poly_pts, dtype=np.float32).reshape(-1, 1, 2)
+                    stats["has_field_boundary"] = True
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        # Collect all candidate tiles with their metadata
+        segments = manifest.get_segments()
+        rng = random.Random(42 + hash(game_id))
+
+        # Phase 1: Collect positives and candidate negatives separately
+        positives: list[tuple[str, dict]] = []
+        candidate_negatives: list[tuple[str, dict]] = []
+
+        for segment in segments:
+            tiles = manifest.get_tiles_for_segment(segment)
+            for tile_info in tiles:
+                frame_idx = tile_info["frame_idx"]
+                row = tile_info["row"]
+                col = tile_info["col"]
+                stem = f"{segment}_frame_{frame_idx:06d}_r{row}_c{col}"
+
+                # Phase filter
+                if phase_filter and phases:
+                    if not manifest.is_active_play(segment, frame_idx):
+                        if stem in labeled_stems:
+                            stats["skipped_phase"] += 1
+                        continue
+
+                has_label = stem in labeled_stems
+
+                # Field boundary filter (for positives)
+                if field_filter and polygon is not None and has_label:
+                    label_rows = manifest.get_labels_for_tile(stem)
+                    if label_rows:
+                        lbl = label_rows[0]
+                        position = classify_label_position(
+                            lbl["cx"], lbl["cy"], row, col, polygon
+                        )
+                        if position == "far_off_field":
+                            stats["skipped_field"] += 1
+                            continue
+                        if position == "near_off_field":
+                            if rng.random() > NEAR_OFF_FIELD_KEEP_RATE:
+                                stats["skipped_field"] += 1
+                                continue
+
+                if has_label:
+                    positives.append((stem, tile_info))
+                else:
+                    # Field filter for negatives too
+                    if field_filter and polygon is not None:
+                        position = classify_label_position(0.5, 0.5, row, col, polygon)
+                        if position == "far_off_field":
+                            continue
+                    candidate_negatives.append((stem, tile_info))
+
+        if not positives:
+            logger.info("  %s: no positive tiles passed filters", game_id)
+            return stats
+
+        # Phase 1b: Apply per-game tile cap, then neg_ratio
+        if len(positives) > max_tiles_per_game:
+            rng.shuffle(positives)
+            pos_count = int(max_tiles_per_game / (1 + neg_ratio))
+            positives = positives[:pos_count]
+        else:
+            pos_count = len(positives)
+
+        max_negatives = min(
+            int(neg_ratio * pos_count),
+            max_tiles_per_game - pos_count,
+        )
+        if len(candidate_negatives) > max_negatives:
+            rng.shuffle(candidate_negatives)
+            candidate_negatives = candidate_negatives[:max_negatives]
+
+        selected: list[tuple[str, dict, bool]] = [
+            (stem, ti, True) for stem, ti in positives
+        ] + [(stem, ti, False) for stem, ti in candidate_negatives]
+
+        logger.info(
+            "  %s: %d positive + %d negative = %d tiles (cap=%d)",
+            game_id,
+            len(positives),
+            len(candidate_negatives),
+            len(selected),
+            max_tiles_per_game,
+        )
+
+        if not selected:
+            logger.info("  %s: no tiles passed filters", game_id)
+            return stats
+
+        # Phase 2: Group by pack and extract
+        pack_tiles: dict[str, list[tuple[str, dict, bool]]] = defaultdict(list)
+        for stem, tile_info, has_label in selected:
+            pack_file = tile_info.get("pack_file")
+            if not pack_file:
+                stats["skipped_no_pack"] += 1
+                continue
+            pack_name = Path(pack_file).name
+            pack_tiles[pack_name].append((stem, tile_info, has_label))
+
+        labels_dir = output_dir / "labels" / split / game_id
+        labels_dir.mkdir(parents=True, exist_ok=True)
+
+        staging_dir = work_dir / "staged_packs"
+        staging_dir.mkdir(parents=True, exist_ok=True)
+
+        for pack_name, tiles_in_pack in pack_tiles.items():
+            # Sort by offset for sequential reads
+            tiles_in_pack.sort(key=lambda t: t[1]["pack_offset"])
+
+            # Find pack source
+            src_path = game_dir / "tile_packs" / pack_name
+            if not src_path.exists():
+                src_path = archive_packs / game_id / pack_name
+            if not src_path.exists():
+                logger.debug("    Pack not found: %s/%s", game_id, pack_name)
+                stats["skipped_no_pack"] += len(tiles_in_pack)
+                continue
+
+            # Stage pack to G: SSD for fast random reads
+            staged_path = staging_dir / pack_name
+            pack_size_gb = src_path.stat().st_size / 1e9
+            logger.info(
+                "    Staging %s (%.1f GB, %d tiles) to SSD",
+                pack_name,
+                pack_size_gb,
+                len(tiles_in_pack),
+            )
+            shutil.copy2(str(src_path), str(staged_path))
+
+            try:
+                with open(staged_path, "rb") as f:
+                    for stem, tile_info, has_label in tiles_in_pack:
+                        try:
+                            f.seek(tile_info["pack_offset"])
+                            jpeg_bytes = f.read(tile_info["pack_size"])
+
+                            # Write to binary cache
+                            rel_path = f"{game_id}/{stem}"
+                            if not bin_writer.write_tile(rel_path, jpeg_bytes):
+                                continue
+
+                            # Write label file
+                            if has_label:
+                                label_rows = manifest.get_labels_for_tile(stem)
+                                lines = []
+                                for lbl in label_rows:
+                                    if lbl.get("qa_verdict") == "false_positive":
+                                        continue
+                                    lines.append(
+                                        f"{lbl['class_id']} "
+                                        f"{lbl['cx']:.6f} {lbl['cy']:.6f} "
+                                        f"{lbl['w']:.6f} {lbl['h']:.6f}"
+                                    )
+                                if lines:
+                                    (labels_dir / f"{stem}.txt").write_text(
+                                        "\n".join(lines) + "\n"
+                                    )
+                                    stats["positive"] += 1
+                                else:
+                                    (labels_dir / f"{stem}.txt").write_text("")
+                                    stats["negative"] += 1
+                            else:
+                                (labels_dir / f"{stem}.txt").write_text("")
+                                stats["negative"] += 1
+                        except Exception as e:
+                            logger.debug("Failed tile %s: %s", stem, e)
+            except Exception as e:
+                logger.warning("Failed pack %s: %s", pack_name, e)
+            finally:
+                try:
+                    staged_path.unlink()
+                except Exception:
+                    pass
+
+        # Flush after each game to ensure data is on disk
+        bin_writer.flush()
+
+        # Clean up staging dir
+        shutil.rmtree(str(staging_dir), ignore_errors=True)
+
+        logger.info(
+            "  %s: %d positive, %d negative tiles",
+            game_id,
+            stats["positive"],
+            stats["negative"],
+        )
+
+    finally:
+        manifest.close()
+        shutil.rmtree(str(local_game), ignore_errors=True)
+
+    return stats

--- a/training/tasks/train.py
+++ b/training/tasks/train.py
@@ -1,22 +1,311 @@
 """Train task — build training set and run YOLO training.
 
+Supports two shard formats:
+  - bin_cache (new): .bin memmap files for fast loading, no individual image files
+  - legacy: individual JPEG files, copied via copytree
+
 Pull-local-process-push pattern:
-  - Pull: copy pack files + manifests for all training games to local SSD
-  - Process: build training set, run YOLO training
+  - Pull: copy shard files from server share to local SSD
+  - Process: run YOLO training with memmap loader
   - Push: copy trained weights back to server
   - Cleanup: remove local training data (keep weights)
 """
 
 import json
 import logging
-import os
 import shutil
 import time
+import zipfile
 from pathlib import Path
+
+import numpy as np
 
 from training.tasks import register_task
 
 logger = logging.getLogger(__name__)
+
+# Binary cache constants (must match build_shard.py)
+TILE_H, TILE_W, TILE_C = 640, 640, 3
+TILE_BYTES = TILE_H * TILE_W * TILE_C
+
+
+def _is_bin_cache_shard(shard_dir: Path) -> bool:
+    """Check if a shard uses the binary cache format."""
+    return (shard_dir / "train_images.bin").exists()
+
+
+def _check_bin_cache_local(local_dataset: Path) -> bool:
+    """Check if binary cache shard is already present locally and valid."""
+    for name in ("train_images.bin", "train_index.json"):
+        if not (local_dataset / name).exists():
+            return False
+    try:
+        index = json.loads((local_dataset / "train_index.json").read_text())
+        expected = index["meta"]["n"] * TILE_BYTES
+        actual = (local_dataset / "train_images.bin").stat().st_size
+        if actual != expected:
+            return False
+    except Exception:
+        return False
+    if not (local_dataset / "labels" / "train").exists():
+        return False
+    return True
+
+
+def _copy_bin_shard(shard_dir: Path, local_dataset: Path) -> tuple[int, int]:
+    """Copy binary cache shard from server to local. Returns (train_count, val_count)."""
+    local_dataset.mkdir(parents=True, exist_ok=True)
+
+    # Copy key files — large sequential reads are fast over SMB
+    files = [
+        "train_images.bin",
+        "train_index.json",
+        "val_images.bin",
+        "val_index.json",
+        "labels.zip",
+        "manifest.json",
+        "dataset.yaml",
+    ]
+    for fname in files:
+        src = shard_dir / fname
+        if not src.exists():
+            continue
+        dst = local_dataset / fname
+        src_size = src.stat().st_size
+        # Skip if local file already exists and matches source size
+        if dst.exists() and dst.stat().st_size == src_size:
+            logger.info("  %s already local (%.2f GB), skipping", fname, src_size / 1e9)
+            continue
+        logger.info("  Copying %s (%.2f GB)...", fname, src_size / 1e9)
+        t0 = time.time()
+        shutil.copy2(str(src), str(dst))
+        logger.info("  %s copied in %.0fs", fname, time.time() - t0)
+
+    # Extract labels
+    zip_path = local_dataset / "labels.zip"
+    if zip_path.exists():
+        logger.info("  Extracting labels.zip...")
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(local_dataset)
+        zip_path.unlink()
+
+    # Create empty image dirs (YOLO needs these to exist for get_img_files)
+    for split in ("train", "val"):
+        (local_dataset / "images" / split).mkdir(parents=True, exist_ok=True)
+
+    # Read counts from indices
+    train_count = 0
+    val_count = 0
+    for split in ("train", "val"):
+        index_path = local_dataset / f"{split}_index.json"
+        if index_path.exists():
+            index = json.loads(index_path.read_text())
+            n = index["meta"]["n"]
+            if split == "train":
+                train_count = n
+            else:
+                val_count = n
+
+    return train_count, val_count
+
+
+def _install_memmap_loader(local_dataset: Path, max_train_tiles: int = 0) -> None:
+    """Monkey-patch YOLO to load images from binary cache via memmap.
+
+    Patches three things:
+    1. get_img_files — returns virtual paths from the index (no physical files needed)
+    2. cache_labels — skips image verification, builds labels from .txt files directly
+    3. load_image — reads from memmap via lazy-init (survives worker process spawn)
+
+    The load_image patch stores serializable config (paths, sizes, index dicts) on
+    each dataset instance. Each worker process lazy-inits its own memmap handle on
+    first access, avoiding the unpicklable-memmap problem with multiprocessing.
+    """
+    from ultralytics.data.base import BaseDataset
+    from ultralytics.data.dataset import YOLODataset
+
+    # Load indices — build lookup tables (all serializable: str, int, dict)
+    split_paths: dict[str, list[str]] = {}  # split -> list of rel_paths
+    split_bin_info: dict[str, tuple[str, int]] = {}  # split -> (bin_path_str, n)
+    path_to_memmap: dict[str, int] = {}  # abs_img_path -> index in bin
+
+    # Track which split each image belongs to
+    path_to_split: dict[str, str] = {}  # abs_img_path -> split name
+
+    for split in ("train", "val"):
+        index_path = local_dataset / f"{split}_index.json"
+        if not index_path.exists():
+            continue
+        index = json.loads(index_path.read_text())
+        n = index["meta"]["n"]
+        bin_path = str(local_dataset / f"{split}_images.bin")
+        paths = index["paths"]
+        if max_train_tiles > 0 and split == "train" and len(paths) > max_train_tiles:
+            logger.info(
+                "  Truncating %s from %d to %d tiles",
+                split,
+                len(paths),
+                max_train_tiles,
+            )
+            paths = paths[:max_train_tiles]
+        split_paths[split] = paths
+        split_bin_info[split] = (bin_path, n)
+
+        images_base = local_dataset / "images" / split
+        for i, rel_path in enumerate(paths):
+            abs_path = str(Path(images_base / f"{rel_path}.jpg"))
+            path_to_memmap[abs_path] = i
+            path_to_split[abs_path] = split
+
+    logger.info(
+        "Memmap loader: %d train + %d val images",
+        split_bin_info.get("train", (None, 0))[1],
+        split_bin_info.get("val", (None, 0))[1],
+    )
+
+    # --- Patch 1: get_img_files ---
+    _original_get_img_files = BaseDataset.get_img_files
+
+    def _patched_get_img_files(self, img_path):
+        """Return image paths from memmap index if available."""
+        img_path_str = (
+            str(img_path) if not isinstance(img_path, list) else str(img_path[0])
+        )
+        img_path_norm = img_path_str.replace("\\", "/").lower()
+        logger.info("  get_img_files called with: %s", img_path_str)
+        for split, paths in split_paths.items():
+            split_dir = str(local_dataset / "images" / split).replace("\\", "/").lower()
+            if split_dir in img_path_norm:
+                images_base = local_dataset / "images" / split
+                result = [
+                    str(Path(images_base / f"{rel_path}.jpg")) for rel_path in paths
+                ]
+                logger.info("  %s: %d images from memmap index", split, len(result))
+                return result
+        logger.warning(
+            "  get_img_files: no memmap match for %s, falling back", img_path_str
+        )
+        return _original_get_img_files(self, img_path)
+
+    BaseDataset.get_img_files = _patched_get_img_files
+
+    # --- Patch 2: cache_labels ---
+    _original_cache_labels = YOLODataset.cache_labels
+
+    def _patched_cache_labels(self, path=Path("./labels.cache")):
+        """Build label cache without image verification."""
+        logger.info(
+            "  cache_labels called, %d im_files",
+            len(self.im_files) if self.im_files else 0,
+        )
+        if self.im_files:
+            logger.info("  first im_file: %s", self.im_files[0])
+            logger.info("  in path_to_memmap: %s", self.im_files[0] in path_to_memmap)
+        if not self.im_files or self.im_files[0] not in path_to_memmap:
+            return _original_cache_labels(self, path)
+
+        # Store memmap config on the dataset instance for worker processes
+        # These are all picklable (str, int, dict)
+        self._memmap_idx = {}  # im_file -> index in bin
+        self._memmap_split = {}  # im_file -> split name
+        self._memmap_bin_info = split_bin_info  # split -> (path, n)
+        for im_file in self.im_files:
+            if im_file in path_to_memmap:
+                self._memmap_idx[im_file] = path_to_memmap[im_file]
+                self._memmap_split[im_file] = path_to_split[im_file]
+
+        x = {"labels": []}
+        nf, nm, ne = 0, 0, 0
+        total = len(self.im_files)
+        for idx, (im_file, lb_file) in enumerate(zip(self.im_files, self.label_files)):
+            if (idx + 1) % 10000 == 0:
+                logger.info("  cache_labels progress: %d/%d", idx + 1, total)
+            lb_path = Path(lb_file)
+            if lb_path.exists():
+                content = lb_path.read_text().strip()
+                if content:
+                    lb = np.array(
+                        [
+                            list(map(float, line.split()))
+                            for line in content.splitlines()
+                        ],
+                        dtype=np.float32,
+                    )
+                    nf += 1
+                else:
+                    lb = np.zeros((0, 5), dtype=np.float32)
+                    ne += 1
+            else:
+                lb = np.zeros((0, 5), dtype=np.float32)
+                nm += 1
+
+            x["labels"].append(
+                {
+                    "im_file": im_file,
+                    "shape": (TILE_H, TILE_W),
+                    "cls": lb[:, 0:1]
+                    if len(lb)
+                    else np.zeros((0, 1), dtype=np.float32),
+                    "bboxes": lb[:, 1:]
+                    if len(lb)
+                    else np.zeros((0, 4), dtype=np.float32),
+                    "segments": [],
+                    "keypoints": None,
+                    "normalized": True,
+                    "bbox_format": "xywh",
+                }
+            )
+
+        x["hash"] = ""
+        x["version"] = ""
+        x["results"] = nf, nm, ne, 0, len(self.im_files)
+        x["msgs"] = []
+        logger.info(
+            "  Label cache: %d found, %d missing, %d empty, %d total",
+            nf,
+            nm,
+            ne,
+            len(self.im_files),
+        )
+        return x
+
+    YOLODataset.cache_labels = _patched_cache_labels
+
+    # --- Patch 3: swap dataset class to MemmapYOLODataset after creation ---
+    # Instead of monkey-patching load_image (which doesn't survive worker spawn),
+    # we swap the dataset's __class__ to MemmapYOLODataset which has a proper
+    # load_image override. Workers import the class from the module file.
+    from ultralytics.data.build import build_yolo_dataset as _orig_build
+
+    def _patched_build(
+        cfg,
+        img_path,
+        batch,
+        data,
+        mode="train",
+        rect=False,
+        stride=32,
+        multi_modal=False,
+    ):
+        """Build dataset then swap class to MemmapYOLODataset."""
+        dataset = _orig_build(
+            cfg, img_path, batch, data, mode, rect, stride, multi_modal
+        )
+        # Only swap if the dataset has memmap config (set by our patched cache_labels)
+        if hasattr(dataset, "_memmap_idx"):
+            from training.data_prep.memmap_dataset import MemmapYOLODataset
+
+            dataset.__class__ = MemmapYOLODataset
+            logger.info("  Swapped dataset class to MemmapYOLODataset (%s)", mode)
+        return dataset
+
+    import ultralytics.data.build
+
+    ultralytics.data.build.build_yolo_dataset = _patched_build
+    # Also patch the import in the detect trainer
+    import ultralytics.models.yolo.detect.train
+
+    ultralytics.models.yolo.detect.train.build_yolo_dataset = _patched_build
 
 
 @register_task("train")
@@ -40,72 +329,173 @@ def run_train(
     version = payload.get("version", f"v{int(time.time())}")
     resume_from = payload.get("resume_from")
 
-    if not train_games:
-        raise ValueError("No train_games specified in payload")
-
     # Local directories
     local_dataset = local_work_dir / "training" / version
-    local_images_train = local_dataset / "images" / "train"
-    local_images_val = local_dataset / "images" / "val"
-    local_labels_train = local_dataset / "labels" / "train"
-    local_labels_val = local_dataset / "labels" / "val"
     local_weights = local_work_dir / "training" / "weights"
+    local_weights.mkdir(parents=True, exist_ok=True)
 
-    for d in [
-        local_images_train,
-        local_images_val,
-        local_labels_train,
-        local_labels_val,
-        local_weights,
-    ]:
-        d.mkdir(parents=True, exist_ok=True)
+    # Check for pre-built shard (from build_shard task)
+    shard_version = payload.get("shard_version")
+    use_memmap = False
 
-    # Step 1: Pull and build training set
-    logger.info(
-        "Building training set %s (%d train, %d val games)...",
-        version,
-        len(train_games),
-        len(val_games),
-    )
+    if shard_version:
+        shard_dir = (
+            Path(cfg.paths.training_sets).parent / "training_shards" / shard_version
+        )
+        if server_share:
+            shard_dir = Path(server_share) / "training_shards" / shard_version
 
-    server_games_dir = Path(cfg.paths.games_dir)
-    if server_share and not server_games_dir.exists():
-        server_games_dir = Path(server_share) / "games"
+        if shard_dir.exists() and (shard_dir / "dataset.yaml").exists():
+            is_bin = _is_bin_cache_shard(shard_dir)
 
-    t0 = time.time()
-    train_tile_count = _build_split(
-        game_ids=train_games,
-        server_games_dir=server_games_dir,
-        images_dir=local_images_train,
-        labels_dir=local_labels_train,
-        local_work_dir=local_work_dir,
-        neg_ratio=cfg.training.neg_ratio,
-    )
-    val_tile_count = _build_split(
-        game_ids=val_games,
-        server_games_dir=server_games_dir,
-        images_dir=local_images_val,
-        labels_dir=local_labels_val,
-        local_work_dir=local_work_dir,
-        neg_ratio=cfg.training.neg_ratio,
-    )
-    build_time = time.time() - t0
-    logger.info(
-        "Training set built: %d train, %d val tiles (%.0fs)",
-        train_tile_count,
-        val_tile_count,
-        build_time,
-    )
+            if is_bin:
+                if _check_bin_cache_local(local_dataset):
+                    logger.info("Binary cache shard already local, skipping copy")
+                    index = json.loads((local_dataset / "train_index.json").read_text())
+                    train_tile_count = index["meta"]["n"]
+                    val_index_path = local_dataset / "val_index.json"
+                    val_tile_count = (
+                        json.loads(val_index_path.read_text())["meta"]["n"]
+                        if val_index_path.exists()
+                        else 0
+                    )
+                else:
+                    logger.info(
+                        "Copying binary cache shard %s from %s",
+                        shard_version,
+                        shard_dir,
+                    )
+                    t0 = time.time()
+                    train_tile_count, val_tile_count = _copy_bin_shard(
+                        shard_dir, local_dataset
+                    )
+                    logger.info(
+                        "Shard copied: %d train, %d val tiles (%.0fs)",
+                        train_tile_count,
+                        val_tile_count,
+                        time.time() - t0,
+                    )
+                use_memmap = True
+            else:
+                # Legacy JPEG shard format
+                local_train_dir = local_dataset / "images" / "train"
+                already_cached = False
+                if local_train_dir.exists():
+                    local_count = sum(1 for _ in local_train_dir.rglob("*.jpg"))
+                    if local_count > 0:
+                        logger.info(
+                            "Legacy shard already local: %d train tiles",
+                            local_count,
+                        )
+                        already_cached = True
+                        train_tile_count = local_count
+                        val_tile_count = sum(
+                            1 for _ in (local_dataset / "images" / "val").rglob("*.jpg")
+                        )
 
-    # Write dataset.yaml
-    dataset_yaml = local_dataset / "dataset.yaml"
-    dataset_yaml.write_text(
-        f"path: {local_dataset}\n"
-        f"train: images/train\n"
-        f"val: images/val\n"
-        f"nc: 1\n"
-        f"names: ['ball']\n"
-    )
+                if not already_cached:
+                    logger.info(
+                        "Using legacy shard %s from %s", shard_version, shard_dir
+                    )
+                    t0 = time.time()
+                    shutil.copytree(
+                        str(shard_dir), str(local_dataset), dirs_exist_ok=True
+                    )
+                    train_tile_count = sum(
+                        1 for _ in (local_dataset / "images" / "train").rglob("*.jpg")
+                    )
+                    val_tile_count = sum(
+                        1 for _ in (local_dataset / "images" / "val").rglob("*.jpg")
+                    )
+                    logger.info(
+                        "Shard copied: %d train, %d val tiles (%.0fs)",
+                        train_tile_count,
+                        val_tile_count,
+                        time.time() - t0,
+                    )
+
+            # Rewrite dataset.yaml to point to local path
+            dataset_yaml = local_dataset / "dataset.yaml"
+            dataset_yaml.write_text(
+                f"path: {local_dataset}\n"
+                f"train: images/train\n"
+                f"val: images/val\n"
+                f"nc: 1\n"
+                f"names: ['ball']\n"
+            )
+        else:
+            logger.warning(
+                "Shard %s not found at %s, falling back to _build_split",
+                shard_version,
+                shard_dir,
+            )
+            shard_version = None
+
+    if not shard_version:
+        if not train_games:
+            raise ValueError("No train_games specified in payload")
+
+        local_images_train = local_dataset / "images" / "train"
+        local_images_val = local_dataset / "images" / "val"
+        local_labels_train = local_dataset / "labels" / "train"
+        local_labels_val = local_dataset / "labels" / "val"
+        for d in [
+            local_images_train,
+            local_images_val,
+            local_labels_train,
+            local_labels_val,
+        ]:
+            d.mkdir(parents=True, exist_ok=True)
+
+        logger.info(
+            "Building training set %s (%d train, %d val games)...",
+            version,
+            len(train_games),
+            len(val_games),
+        )
+
+        server_games_dir = Path(cfg.paths.games_dir)
+        if server_share and not server_games_dir.exists():
+            server_games_dir = Path(server_share) / "games"
+
+        t0 = time.time()
+        train_tile_count = _build_split(
+            game_ids=train_games,
+            server_games_dir=server_games_dir,
+            images_dir=local_images_train,
+            labels_dir=local_labels_train,
+            local_work_dir=local_work_dir,
+            neg_ratio=cfg.training.neg_ratio,
+        )
+        val_tile_count = _build_split(
+            game_ids=val_games,
+            server_games_dir=server_games_dir,
+            images_dir=local_images_val,
+            labels_dir=local_labels_val,
+            local_work_dir=local_work_dir,
+            neg_ratio=cfg.training.neg_ratio,
+        )
+        build_time = time.time() - t0
+        logger.info(
+            "Training set built: %d train, %d val tiles (%.0fs)",
+            train_tile_count,
+            val_tile_count,
+            build_time,
+        )
+
+        dataset_yaml = local_dataset / "dataset.yaml"
+        dataset_yaml.write_text(
+            f"path: {local_dataset}\n"
+            f"train: images/train\n"
+            f"val: images/val\n"
+            f"nc: 1\n"
+            f"names: ['ball']\n"
+        )
+
+    # Install memmap loader if using binary cache
+    if use_memmap:
+        max_train_tiles = payload.get("max_train_tiles", 0)
+        _install_memmap_loader(local_dataset, max_train_tiles=max_train_tiles)
 
     # Step 2: Train
     logger.info("Starting YOLO training...")
@@ -113,9 +503,48 @@ def run_train(
 
     model_base = cfg.training.model_base
     if resume_from:
+        logger.info("Resuming from checkpoint: %s", resume_from)
         model = YOLO(resume_from)
     else:
+        logger.info("Starting from pretrained base: %s", model_base)
         model = YOLO(model_base)
+
+    # Set up epoch-end callback to archive best.pt after each improvement.
+    # If training crashes, we still have the latest best weights on F:.
+    archive_weights = Path(cfg.paths.archive.checkpoints) / version
+    _best_pt_path = local_weights / version / "weights" / "best.pt"
+
+    # Also prepare server weights dir for incremental push
+    server_weights = Path(cfg.paths.training_sets) / version / "weights"
+    if server_share and not Path(cfg.paths.training_sets).exists():
+        server_weights = Path(server_share) / "training_sets" / version / "weights"
+
+    def _archive_on_epoch_end(trainer):
+        """Archive best.pt to F: and D: after each epoch if it was updated."""
+        from datetime import datetime
+
+        if not _best_pt_path.exists():
+            return
+        try:
+            # Archive to F: (permanent)
+            archive_weights.mkdir(parents=True, exist_ok=True)
+            dst = archive_weights / "best.pt"
+            if not dst.exists() or _best_pt_path.stat().st_mtime > dst.stat().st_mtime:
+                shutil.copy2(str(_best_pt_path), str(dst))
+                # Also save a timestamped snapshot so we can compare epochs
+                snapshot = archive_weights / f"best_e{trainer.epoch}_{datetime.now().strftime('%Y%m%d_%H%M')}.pt"
+                shutil.copy2(str(_best_pt_path), str(snapshot))
+                logger.info("Archived best.pt to F: (epoch %d → %s)", trainer.epoch, snapshot.name)
+
+            # Push to D: (server share — so orchestrator can find it for next run)
+            server_weights.mkdir(parents=True, exist_ok=True)
+            srv_dst = server_weights / "best.pt"
+            if not srv_dst.exists() or _best_pt_path.stat().st_mtime > srv_dst.stat().st_mtime:
+                shutil.copy2(str(_best_pt_path), str(srv_dst))
+        except Exception as e:
+            logger.debug("Failed to archive checkpoint: %s", e)
+
+    model.add_callback("on_train_epoch_end", _archive_on_epoch_end)
 
     results = model.train(
         data=str(dataset_yaml),
@@ -124,7 +553,8 @@ def run_train(
         imgsz=cfg.training.imgsz,
         device=0,
         patience=cfg.training.patience,
-        workers=0,
+        workers=4,  # memmap uses lazy-init per worker, safe with multiprocessing
+        cache=False if use_memmap else "disk",
         deterministic=True,
         project=str(local_weights),
         name=version,
@@ -137,22 +567,19 @@ def run_train(
     if not best_pt.exists():
         raise RuntimeError(f"Training did not produce best.pt at {best_pt}")
 
-    # Step 3: Push weights to server
-    server_weights = Path(cfg.paths.training_sets) / version / "weights"
-    if server_share and not Path(cfg.paths.training_sets).exists():
-        server_weights = Path(server_share) / "training_sets" / version / "weights"
-
+    # Step 3: Final push of weights to server + archive
+    # (epoch callback already does incremental pushes, this ensures last.pt too)
     server_weights.mkdir(parents=True, exist_ok=True)
     shutil.copy2(str(best_pt), str(server_weights / "best.pt"))
     if last_pt.exists():
         shutil.copy2(str(last_pt), str(server_weights / "last.pt"))
 
-    # Also archive to F: if available
-    archive_weights = Path(cfg.paths.archive.checkpoints) / version
     try:
         archive_weights.mkdir(parents=True, exist_ok=True)
         shutil.copy2(str(best_pt), str(archive_weights / "best.pt"))
-        logger.info("Archived weights to %s", archive_weights)
+        if last_pt.exists():
+            shutil.copy2(str(last_pt), str(archive_weights / "last.pt"))
+        logger.info("Final archive to %s", archive_weights)
     except Exception as e:
         logger.warning("Failed to archive weights: %s", e)
 
@@ -186,26 +613,18 @@ def run_train(
 
 
 def _get_priority_stems(manifest) -> dict[str, int]:
-    """Get tile stems that should be oversampled for gap-focused training.
-
-    Human-verified gap labels are the highest-value training data (3x).
-    Sonnet-verified tiles near track gaps are also valuable (2x).
-
-    Returns {tile_stem: multiplier}.
-    """
+    """Get tile stems that should be oversampled for gap-focused training."""
     import json as _json
 
     conn = manifest.conn
     priority: dict[str, int] = {}
 
-    # Human-verified gap labels: 3x oversample
     rows = conn.execute(
         "SELECT DISTINCT tile_stem FROM labels WHERE source = 'human_gap_review'"
     ).fetchall()
     for (stem,) in rows:
         priority[stem] = 3
 
-    # Tiles near track gaps: 2x oversample
     try:
         raw = conn.execute(
             "SELECT value FROM metadata WHERE key = 'track_coverage'"
@@ -244,17 +663,12 @@ def _build_split(
     local_work_dir: Path,
     neg_ratio: float = 1.0,
 ) -> int:
-    """Build one split (train or val) by extracting tiles from pack files.
-
-    Returns total tile count.
-    """
+    """Build one split (train or val) by extracting tiles from pack files."""
     from training.data_prep.game_manifest import GameManifest
 
     total = 0
     for game_id in game_ids:
         game_dir = server_games_dir / game_id
-
-        # Pull manifest to local
         local_game = local_work_dir / game_id
         local_game.mkdir(parents=True, exist_ok=True)
 
@@ -271,17 +685,14 @@ def _build_split(
         manifest.open(create=False)
 
         try:
-            # Get all positive tiles (have labels)
             labeled_stems = manifest.get_labeled_stems()
             game_images = images_dir / game_id
             game_labels = labels_dir / game_id
             game_images.mkdir(parents=True, exist_ok=True)
             game_labels.mkdir(parents=True, exist_ok=True)
 
-            # Export labels
             manifest.export_labels_yolo(game_labels)
 
-            # Get priority stems for gap-focused oversampling
             priority_stems = _get_priority_stems(manifest)
             if priority_stems:
                 logger.info(
@@ -290,85 +701,96 @@ def _build_split(
                     len(priority_stems),
                 )
 
-            # Extract tile images from packs for labeled tiles
+            import random
+            from collections import defaultdict
+
             segments = manifest.get_segments()
             extracted = 0
 
+            pack_tiles: dict[str, list[tuple[str, dict, bool]]] = defaultdict(list)
             for segment in segments:
                 tiles = manifest.get_tiles_for_segment(segment)
                 for tile_info in tiles:
                     stem = f"{segment}_frame_{tile_info['frame_idx']:06d}_r{tile_info['row']}_c{tile_info['col']}"
-
-                    # Only extract tiles that have labels (positive) or are sampled negatives
                     has_label = stem in labeled_stems
                     if not has_label:
-                        # Simple negative sampling: skip most negatives
-                        import random
-
                         if random.random() > neg_ratio / max(
                             1, len(tiles) / max(1, len(labeled_stems))
                         ):
                             continue
-
-                    # Read from pack — always stage to local SSD first
                     pack_file = tile_info.get("pack_file")
                     if not pack_file:
                         continue
-
                     pack_name = Path(pack_file).name
-                    local_pack_dir = local_game / "tile_packs"
-                    local_pack_dir.mkdir(parents=True, exist_ok=True)
-                    pack_path = local_pack_dir / pack_name
+                    pack_tiles[pack_name].append((stem, tile_info, has_label))
 
-                    # Stage pack to local SSD if not already there
-                    if not pack_path.exists():
-                        # Try server D: (or SMB share), then F: archive
-                        src = server_games_dir / game_id / "tile_packs" / pack_name
-                        if not src.exists():
-                            from training.data_prep.manifest_dataset import (
-                                _resolve_pack_path,
-                            )
+            local_pack_dir = local_game / "tile_packs"
+            local_pack_dir.mkdir(parents=True, exist_ok=True)
 
-                            try:
-                                src = Path(_resolve_pack_path(pack_file))
-                            except FileNotFoundError:
-                                continue
+            for pack_name, tiles_in_pack in pack_tiles.items():
+                pack_path = local_pack_dir / pack_name
 
-                        logger.info(
-                            "    Staging pack %s to local SSD (%.1f GB)",
-                            pack_name,
-                            src.stat().st_size / 1e9,
+                if not pack_path.exists():
+                    src = server_games_dir / game_id / "tile_packs" / pack_name
+                    if not src.exists():
+                        from training.data_prep.manifest_dataset import (
+                            _resolve_pack_path,
                         )
-                        shutil.copy2(str(src), str(pack_path))
 
-                    try:
-                        with open(pack_path, "rb") as f:
-                            f.seek(tile_info["pack_offset"])
-                            jpeg_bytes = f.read(tile_info["pack_size"])
+                        try:
+                            src = Path(tiles_in_pack[0][1].get("pack_file", ""))
+                            src = Path(_resolve_pack_path(str(src)))
+                        except FileNotFoundError:
+                            continue
 
-                        (game_images / f"{stem}.jpg").write_bytes(jpeg_bytes)
-                        extracted += 1
+                    logger.info(
+                        "    Staging pack %s to local SSD (%.1f GB)",
+                        pack_name,
+                        src.stat().st_size / 1e9,
+                    )
+                    shutil.copy2(str(src), str(pack_path))
 
-                        # Write empty label file for negatives
-                        if not has_label:
-                            (game_labels / f"{stem}.txt").write_text("")
+                try:
+                    with open(pack_path, "rb") as f:
+                        for stem, tile_info, has_label in tiles_in_pack:
+                            try:
+                                f.seek(tile_info["pack_offset"])
+                                jpeg_bytes = f.read(tile_info["pack_size"])
 
-                        # Oversample priority tiles (gap-adjacent / human-verified)
-                        repeat = priority_stems.get(stem, 1)
-                        label_file = game_labels / f"{stem}.txt"
-                        for dup in range(1, repeat):
-                            dup_stem = f"{stem}_dup{dup}"
-                            (game_images / f"{dup_stem}.jpg").write_bytes(jpeg_bytes)
-                            if label_file.exists():
-                                shutil.copy2(
-                                    str(label_file),
-                                    str(game_labels / f"{dup_stem}.txt"),
-                                )
-                            extracted += 1
-                    except Exception as e:
-                        logger.debug("Failed to extract tile %s: %s", stem, e)
+                                (game_images / f"{stem}.jpg").write_bytes(jpeg_bytes)
+                                extracted += 1
+
+                                if not has_label:
+                                    (game_labels / f"{stem}.txt").write_text("")
+
+                                repeat = priority_stems.get(stem, 1)
+                                label_file = game_labels / f"{stem}.txt"
+                                for dup in range(1, repeat):
+                                    dup_stem = f"{stem}_dup{dup}"
+                                    (game_images / f"{dup_stem}.jpg").write_bytes(
+                                        jpeg_bytes
+                                    )
+                                    if label_file.exists():
+                                        shutil.copy2(
+                                            str(label_file),
+                                            str(game_labels / f"{dup_stem}.txt"),
+                                        )
+                                    extracted += 1
+                            except Exception as e:
+                                logger.debug("Failed to extract tile %s: %s", stem, e)
+                except Exception as e:
+                    logger.warning("Failed to read pack %s: %s", pack_name, e)
+
+                try:
+                    pack_path.unlink()
+                except Exception:
+                    pass
         finally:
             manifest.close()
+
+        local_pack_dir = local_game / "tile_packs"
+        if local_pack_dir.exists():
+            shutil.rmtree(str(local_pack_dir), ignore_errors=True)
 
         total += extracted
         logger.info(


### PR DESCRIPTION
## Summary
- Replace 100k+ individual JPEG tiles with large memory-mapped .bin files
- build_shard task: quality-filtered binary cache with phase/field/QA filters
- memmap_dataset: numpy.memmap loader with lazy per-worker initialization
- train.py refactored for binary cache support (monkey-patches YOLO)
- Orchestrator: multi-location checkpoint search, shard-aware training
- manifest_dataset: phase and field boundary filtering for training data quality

## Depends on
- #28 (Tournament Splitting)
- #27 (Phase Detection)
- #26 (Training Pipeline Infrastructure)

## Test plan
- [ ] build_shard task produces valid .bin + labels output
- [ ] Training loads from binary cache without errors
- [ ] Phase and field filters correctly skip out-of-play tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)