### PR TITLE
ball_tracking: homegrown provider + stitch/detect/track/render stages

### DIFF
--- a/.github/workflows/build-windows-service.yml
+++ b/.github/workflows/build-windows-service.yml
@@ -93,13 +93,41 @@ jobs:
           Write-Host "INFO: TTT secrets not configured in GitHub - using production defaults"
         }
 
+    # The homegrown ball-tracking stages (under video_grouper/ball_tracking/
+    # providers/homegrown/stages) reach into training/inference/* at runtime.
+    # PyInstaller's modulegraph follows those into torch + cv2 + ultralytics +
+    # scipy, ballooning each exe past NSIS's 32-bit mmap ceiling (~2 GB) at
+    # install time. Bundled exes are aimed at the autocam_gui happy path; users
+    # who select provider = homegrown should install soccer-cam from source so
+    # they have the full ML stack. The runtime falls back to an ImportError
+    # with a clear message if those modules are missing.
     - name: Build service executable
       run: |
-        uv run pyinstaller --noconfirm --onefile --windowed --icon=video_grouper/icon.ico --name=VideoGrouperService --distpath=video_grouper/dist --workpath=video_grouper/build video_grouper/service/main.py
+        uv run pyinstaller --noconfirm --onefile --windowed `
+          --exclude-module training `
+          --exclude-module torch --exclude-module torchvision `
+          --exclude-module cv2 --exclude-module ultralytics `
+          --exclude-module onnxruntime --exclude-module onnxruntime-directml `
+          --exclude-module scipy --exclude-module filterpy `
+          --icon=video_grouper/icon.ico `
+          --name=VideoGrouperService `
+          --distpath=video_grouper/dist `
+          --workpath=video_grouper/build `
+          video_grouper/service/main.py
 
     - name: Build tray agent executable
       run: |
-        uv run pyinstaller --noconfirm --onefile --windowed --icon=video_grouper/icon.ico --name=VideoGrouperTray --distpath=video_grouper/dist --workpath=video_grouper/build video_grouper/tray/main.py
+        uv run pyinstaller --noconfirm --onefile --windowed `
+          --exclude-module training `
+          --exclude-module torch --exclude-module torchvision `
+          --exclude-module cv2 --exclude-module ultralytics `
+          --exclude-module onnxruntime --exclude-module onnxruntime-directml `
+          --exclude-module scipy --exclude-module filterpy `
+          --icon=video_grouper/icon.ico `
+          --name=VideoGrouperTray `
+          --distpath=video_grouper/dist `
+          --workpath=video_grouper/build `
+          video_grouper/tray/main.py
 
     - name: Install NSIS
       run: choco install nsis -y

--- a/shared_data_simulator/config.ini
+++ b/shared_data_simulator/config.ini
@@ -78,6 +78,9 @@ team_name = 13B Rochester Talone
 enabled = false
 provider = google
 
-[AUTOCAM]
+[BALL_TRACKING]
 enabled = true
+provider = autocam_gui
+
+[BALL_TRACKING.AUTOCAM_GUI]
 executable = C:\Users\markb\AppData\Local\Programs\Autocam\GUI.exe

--- a/tests/e2e/e2e_test_config.ini
+++ b/tests/e2e/e2e_test_config.ini
@@ -72,13 +72,15 @@ privacy_status = private
 # Use mock mode to avoid expired OAuth token issues in e2e testing
 use_mock = true
 
-[AUTOCAM]
-# Enable real autocam processing
+[BALL_TRACKING]
+# Enable ball-tracking processing
 enabled = true
+# Provider: autocam_gui (drives the Once AutoCam desktop app)
+provider = autocam_gui
+
+[BALL_TRACKING.AUTOCAM_GUI]
 # Point to the real Once Autocam executable
 executable = C:\Users\markb\AppData\Local\Programs\Autocam\GUI.exe
-# Disable mock mode to use real autocam
-use_mock = false
 
 # Playlist configuration for processed videos (testing)
 [YOUTUBE.PLAYLIST.PROCESSED]

--- a/tests/test_ball_tracking_homegrown.py
+++ b/tests/test_ball_tracking_homegrown.py
@@ -1,0 +1,293 @@
+"""Tests for the homegrown provider scaffolding + stage registry.
+
+The stage *implementations* themselves call into heavy training-pipeline
+code (PyAV, onnxruntime, filterpy) and need real video / model files
+to verify. Those are exercised by integration tests once footage is
+available. These unit tests cover the registry + orchestrator path:
+config defaults, stage ordering, error propagation, output validation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from video_grouper.ball_tracking import _PROVIDER_REGISTRY, create_provider
+from video_grouper.ball_tracking.base import ProviderContext
+from video_grouper.ball_tracking.config import HomegrownProviderConfig
+from video_grouper.ball_tracking.providers.homegrown import HomegrownProvider
+from video_grouper.ball_tracking.providers.homegrown.stages import (
+    ProcessingStage,
+    list_stages,
+    register_stage,
+)
+
+
+@pytest.fixture
+def context(tmp_path):
+    group = tmp_path / "flash__2024.06.01_vs_IYSA_home"
+    group.mkdir()
+    return ProviderContext(group_dir=group, team_name="flash", storage_path=tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _import_homegrown_for_registration():
+    # Importing the package self-registers the homegrown provider + all stages.
+    import video_grouper.ball_tracking.providers.homegrown  # noqa: F401
+
+
+class TestRegistration:
+    def test_homegrown_is_registered(self):
+        assert "homegrown" in _PROVIDER_REGISTRY
+
+    def test_default_stages_are_registered(self):
+        names = set(list_stages())
+        assert {"stitch_correct", "detect", "track", "render"} <= names
+
+    def test_create_provider_returns_homegrown(self):
+        cfg = HomegrownProviderConfig()
+        provider = create_provider("homegrown", cfg)
+        assert isinstance(provider, HomegrownProvider)
+
+
+class TestConfigDefaults:
+    def test_default_stage_list(self):
+        cfg = HomegrownProviderConfig()
+        assert cfg.enabled_stages == [
+            "stitch_correct",
+            "detect",
+            "track",
+            "render",
+        ]
+
+    def test_csv_string_is_split(self):
+        cfg = HomegrownProviderConfig.model_validate(
+            {"stages": "stitch_correct, detect, track, render"}
+        )
+        assert cfg.enabled_stages == [
+            "stitch_correct",
+            "detect",
+            "track",
+            "render",
+        ]
+
+    def test_render_defaults(self):
+        cfg = HomegrownProviderConfig()
+        assert cfg.render_output_width == 1920
+        assert cfg.render_output_height == 1080
+        assert cfg.render_ema == 0.975
+
+
+class _RecordingStage(ProcessingStage):
+    """Test double: records the order it ran in and writes to output_path."""
+
+    name = "recording"
+    invocations: list[str] = []
+
+    async def run(self, artifacts, ctx):
+        _RecordingStage.invocations.append(artifacts["input_path"])
+        return None
+
+
+class _OutputCreatingStage(ProcessingStage):
+    """Test double: creates a small file at output_path so the provider
+    can validate that the pipeline actually produced something."""
+
+    name = "out_creating"
+
+    async def run(self, artifacts, ctx):
+        Path(artifacts["output_path"]).write_bytes(b"x" * 1024)
+        return None
+
+
+class _RaisingStage(ProcessingStage):
+    name = "raising"
+
+    async def run(self, artifacts, ctx):
+        raise RuntimeError("stage blew up")
+
+
+@pytest.fixture
+def ephemeral_stages():
+    """Register the test-double stages, restore registry afterwards."""
+    from video_grouper.ball_tracking.providers.homegrown.stages import (
+        _STAGE_REGISTRY,
+    )
+
+    snapshot = dict(_STAGE_REGISTRY)
+    _RecordingStage.invocations = []
+    register_stage(_RecordingStage.name, _RecordingStage)
+    register_stage(_OutputCreatingStage.name, _OutputCreatingStage)
+    register_stage(_RaisingStage.name, _RaisingStage)
+    yield
+    _STAGE_REGISTRY.clear()
+    _STAGE_REGISTRY.update(snapshot)
+
+
+class TestProviderRun:
+    @pytest.mark.asyncio
+    async def test_runs_stages_in_order(self, ephemeral_stages, context, tmp_path):
+        cfg = HomegrownProviderConfig(stages=["recording", "out_creating"])
+        provider = HomegrownProvider(cfg)
+        out = tmp_path / "out.mp4"
+
+        ok = await provider.run(str(tmp_path / "in.mp4"), str(out), context)
+
+        assert ok is True
+        assert out.exists() and out.stat().st_size > 0
+        assert _RecordingStage.invocations == [str(tmp_path / "in.mp4")]
+
+    @pytest.mark.asyncio
+    async def test_unknown_stage_returns_false(
+        self, ephemeral_stages, context, tmp_path
+    ):
+        cfg = HomegrownProviderConfig(stages=["nonexistent"])
+        provider = HomegrownProvider(cfg)
+        out = tmp_path / "out.mp4"
+
+        ok = await provider.run(str(tmp_path / "in.mp4"), str(out), context)
+
+        assert ok is False
+        assert not out.exists()
+
+    @pytest.mark.asyncio
+    async def test_stage_exception_is_caught_and_returns_false(
+        self, ephemeral_stages, context, tmp_path
+    ):
+        cfg = HomegrownProviderConfig(stages=["raising", "out_creating"])
+        provider = HomegrownProvider(cfg)
+        out = tmp_path / "out.mp4"
+
+        ok = await provider.run(str(tmp_path / "in.mp4"), str(out), context)
+
+        assert ok is False
+        # Pipeline aborts on first failure — out_creating shouldn't run.
+        assert not out.exists()
+
+    @pytest.mark.asyncio
+    async def test_empty_output_returns_false(
+        self, ephemeral_stages, context, tmp_path
+    ):
+        cfg = HomegrownProviderConfig(stages=["recording"])
+        provider = HomegrownProvider(cfg)
+        out = tmp_path / "out.mp4"
+
+        # No stage writes to out — provider must catch this.
+        ok = await provider.run(str(tmp_path / "in.mp4"), str(out), context)
+
+        assert ok is False
+
+
+class TestStitchCorrectPassThrough:
+    @pytest.mark.asyncio
+    async def test_skips_when_no_profile_path(self, context, tmp_path):
+        from video_grouper.ball_tracking.providers.homegrown.stages.stitch_correct import (
+            StitchCorrectStage,
+        )
+
+        cfg = HomegrownProviderConfig()  # stitch_profile_path is None
+        stage = StitchCorrectStage(cfg)
+        artifacts = {"input_path": str(tmp_path / "in.mp4")}
+        result = await stage.run(artifacts, context)
+
+        # Returning None signals "no changes to artifacts dict"; subsequent
+        # stages keep using the original input_path.
+        assert result is None
+
+
+class TestDetectStageRequiresModel:
+    @pytest.mark.asyncio
+    async def test_raises_when_model_path_missing(self, context, tmp_path):
+        from video_grouper.ball_tracking.providers.homegrown.stages.detect import (
+            DetectStage,
+        )
+
+        cfg = HomegrownProviderConfig()  # model_path is None
+        stage = DetectStage(cfg)
+        artifacts = {"input_path": str(tmp_path / "in.mp4")}
+        with pytest.raises(RuntimeError, match="model_path is not configured"):
+            await stage.run(artifacts, context)
+
+
+class TestTrackStageRequiresDetections:
+    @pytest.mark.asyncio
+    async def test_raises_when_detections_missing(self, context, tmp_path):
+        from video_grouper.ball_tracking.providers.homegrown.stages.track import (
+            TrackStage,
+        )
+
+        cfg = HomegrownProviderConfig()
+        stage = TrackStage(cfg)
+        artifacts = {"input_path": str(tmp_path / "in.mp4")}
+        with pytest.raises(RuntimeError, match="detections_path missing"):
+            await stage.run(artifacts, context)
+
+
+class TestRenderStageRequiresTrajectory:
+    @pytest.mark.asyncio
+    async def test_raises_when_trajectory_missing(self, context, tmp_path):
+        from video_grouper.ball_tracking.providers.homegrown.stages.render import (
+            RenderStage,
+        )
+
+        cfg = HomegrownProviderConfig()
+        stage = RenderStage(cfg)
+        artifacts = {
+            "input_path": str(tmp_path / "in.mp4"),
+            "output_path": str(tmp_path / "out.mp4"),
+        }
+        with pytest.raises(RuntimeError, match="trajectory_path missing"):
+            await stage.run(artifacts, context)
+
+
+class TestProviderResolvesHomegrown:
+    """End-to-end: BallTrackingConfig.resolve_provider_for returns the
+    homegrown provider when configured."""
+
+    def test_homegrown_via_top_level_provider(self):
+        from video_grouper.ball_tracking.config import BallTrackingConfig
+
+        cfg = BallTrackingConfig(provider="homegrown")
+        name, sub = cfg.resolve_provider_for(None)
+        assert name == "homegrown"
+        assert isinstance(sub, HomegrownProviderConfig)
+
+    def test_homegrown_via_per_team_override(self):
+        from video_grouper.ball_tracking.config import BallTrackingConfig
+
+        cfg = BallTrackingConfig(
+            provider="autocam_gui",
+            per_team={"flash": "homegrown"},
+        )
+        name, sub = cfg.resolve_provider_for("flash")
+        assert name == "homegrown"
+        assert isinstance(sub, HomegrownProviderConfig)
+
+
+class TestSmokeProviderRunMockedStages:
+    """Smoke: provider routes through patched stages end-to-end."""
+
+    @pytest.mark.asyncio
+    async def test_stages_receive_provider_context(
+        self, ephemeral_stages, context, tmp_path
+    ):
+        cfg = HomegrownProviderConfig(stages=["out_creating"])
+        provider = HomegrownProvider(cfg)
+        out = tmp_path / "out.mp4"
+
+        with patch.object(
+            _OutputCreatingStage, "run", new=AsyncMock(return_value=None)
+        ) as mock_run:
+            # Mock doesn't actually write; we expect provider to fail validation.
+            ok = await provider.run(str(tmp_path / "in.mp4"), str(out), context)
+
+        assert ok is False
+        assert mock_run.await_count == 1
+        # First arg: artifacts; second: ctx
+        artifacts = mock_run.await_args.args[0]
+        assert artifacts["input_path"] == str(tmp_path / "in.mp4")
+        assert artifacts["output_path"] == str(out)
+        ctx_arg = mock_run.await_args.args[1]
+        assert ctx_arg.team_name == "flash"

--- a/video_grouper/ball_tracking/config.py
+++ b/video_grouper/ball_tracking/config.py
@@ -2,15 +2,63 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class AutocamGuiProviderConfig(BaseModel):
     """Config for the ``autocam_gui`` provider (drives Once AutoCam GUI)."""
 
     executable: Optional[str] = None
+
+
+class HomegrownProviderConfig(BaseModel):
+    """Config for the ``homegrown`` provider — our in-house ball-tracking pipeline.
+
+    The ``stages`` list defines the order of processing phases. Each name
+    must match a registered :class:`ProcessingStage`. The default list
+    matches the plan: stitch correction, detect, track, render.
+
+    All stages share this single config object — they pull whichever
+    fields they need. Future PRs may split per-stage sub-models if
+    options grow.
+    """
+
+    enabled_stages: List[str] = Field(
+        default_factory=lambda: ["stitch_correct", "detect", "track", "render"],
+        alias="stages",
+    )
+
+    # stitch_correct
+    stitch_profile_path: Optional[str] = None
+
+    # detect
+    model_path: Optional[str] = None
+    device: str = "cuda:0"
+    detect_confidence: float = 0.45
+    detect_frame_interval: int = 4
+
+    # track
+    track_kalman_gate: float = 200.0
+    track_max_missing: int = 15
+
+    # render
+    render_ema: float = 0.975
+    render_lead_room: float = 0.15
+    render_output_width: int = 1920
+    render_output_height: int = 1080
+    render_fov_deg: float = 50.0
+
+    model_config = {"validate_by_name": True}
+
+    @field_validator("enabled_stages", mode="before")
+    @classmethod
+    def _split_csv_stages(cls, v: Any) -> Any:
+        """Accept a CSV string from INI as well as a list."""
+        if isinstance(v, str):
+            return [s.strip() for s in v.split(",") if s.strip()]
+        return v
 
 
 class BallTrackingConfig(BaseModel):
@@ -31,6 +79,9 @@ class BallTrackingConfig(BaseModel):
     provider: str = "autocam_gui"
     autocam_gui: AutocamGuiProviderConfig = Field(
         default_factory=AutocamGuiProviderConfig, alias="AUTOCAM_GUI"
+    )
+    homegrown: HomegrownProviderConfig = Field(
+        default_factory=HomegrownProviderConfig, alias="HOMEGROWN"
     )
     per_team: dict[str, str] = Field(default_factory=dict, alias="PER_TEAM")
 

--- a/video_grouper/ball_tracking/providers/homegrown/__init__.py
+++ b/video_grouper/ball_tracking/providers/homegrown/__init__.py
@@ -1,0 +1,20 @@
+"""``homegrown`` provider — our in-house ball-tracking pipeline.
+
+Composed of an ordered list of :class:`ProcessingStage` instances
+(stitch_correct → detect → track → render by default). Each stage is
+registered at import time; the provider runs them in the configured
+order and threads an ``artifacts`` dict between them.
+"""
+
+from .provider import HomegrownProvider
+
+# Import each stage module so its top-level register_stage() call runs.
+from .stages import detect as _detect_stage  # noqa: F401
+from .stages import render as _render_stage  # noqa: F401
+from .stages import stitch_correct as _stitch_correct_stage  # noqa: F401
+from .stages import track as _track_stage  # noqa: F401
+
+from video_grouper.ball_tracking import register_provider
+from video_grouper.ball_tracking.config import HomegrownProviderConfig
+
+register_provider("homegrown", HomegrownProvider, HomegrownProviderConfig)

--- a/video_grouper/ball_tracking/providers/homegrown/provider.py
+++ b/video_grouper/ball_tracking/providers/homegrown/provider.py
@@ -1,0 +1,67 @@
+"""HomegrownProvider — runs an ordered list of :class:`ProcessingStage`."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from video_grouper.ball_tracking.base import BallTrackingProvider, ProviderContext
+from video_grouper.ball_tracking.config import HomegrownProviderConfig
+
+from .stages import create_stage, list_stages
+
+logger = logging.getLogger(__name__)
+
+
+class HomegrownProvider(BallTrackingProvider):
+    def __init__(self, config: HomegrownProviderConfig):
+        self.config = config
+
+    async def run(
+        self, input_path: str, output_path: str, ctx: ProviderContext
+    ) -> bool:
+        # Threaded artifacts dict — stages mutate / replace keys as they go.
+        # Conventional keys:
+        #   input_path:      panoramic source seen by the next stage
+        #   output_path:     where render must finally write
+        #   stitched_path:   set by stitch_correct (and copied to input_path)
+        #   detections_path: per-frame detections JSON written by detect
+        #   trajectory_path: smoothed (x, y) per-frame JSON written by track
+        artifacts: dict[str, Any] = {
+            "input_path": input_path,
+            "output_path": output_path,
+            "group_dir": str(ctx.group_dir),
+        }
+
+        for stage_name in self.config.enabled_stages:
+            try:
+                stage = create_stage(stage_name, self.config)
+            except KeyError:
+                logger.error(
+                    "BALL_TRACKING/homegrown: unknown stage %r; available: %s",
+                    stage_name,
+                    ", ".join(sorted(list_stages())) or "(none)",
+                )
+                return False
+
+            logger.info("BALL_TRACKING/homegrown: running stage %s", stage_name)
+            try:
+                result = await stage.run(artifacts, ctx)
+            except Exception:
+                logger.exception("BALL_TRACKING/homegrown: stage %s failed", stage_name)
+                return False
+
+            if result:
+                artifacts.update(result)
+
+        # The last stage (render) must have written to output_path.
+        out = Path(output_path)
+        if not out.exists() or out.stat().st_size == 0:
+            logger.error(
+                "BALL_TRACKING/homegrown: pipeline finished but output %s "
+                "is missing or empty",
+                output_path,
+            )
+            return False
+        return True

--- a/video_grouper/ball_tracking/providers/homegrown/stages/__init__.py
+++ b/video_grouper/ball_tracking/providers/homegrown/stages/__init__.py
@@ -1,0 +1,34 @@
+"""Processing-stage registry for the homegrown provider.
+
+Each stage module calls :func:`register_stage` at import time. The
+provider iterates ``config.enabled_stages`` and looks each name up here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import ProcessingStage
+
+_STAGE_REGISTRY: dict[str, type[ProcessingStage]] = {}
+
+
+def register_stage(name: str, stage_class: type[ProcessingStage]) -> None:
+    _STAGE_REGISTRY[name] = stage_class
+
+
+def create_stage(name: str, provider_config: Any) -> ProcessingStage:
+    cls = _STAGE_REGISTRY[name]
+    return cls(provider_config)
+
+
+def list_stages() -> list[str]:
+    return list(_STAGE_REGISTRY.keys())
+
+
+__all__ = [
+    "ProcessingStage",
+    "create_stage",
+    "list_stages",
+    "register_stage",
+]

--- a/video_grouper/ball_tracking/providers/homegrown/stages/base.py
+++ b/video_grouper/ball_tracking/providers/homegrown/stages/base.py
@@ -1,0 +1,33 @@
+"""Base contract every homegrown processing stage must implement."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from video_grouper.ball_tracking.base import ProviderContext
+from video_grouper.ball_tracking.config import HomegrownProviderConfig
+
+
+class ProcessingStage(ABC):
+    """One phase of the homegrown pipeline.
+
+    Stages are constructed once per provider invocation with the parent
+    :class:`HomegrownProviderConfig`. Each stage's :meth:`run` receives
+    the live ``artifacts`` dict (see :mod:`provider` for the conventional
+    keys) and returns a dict of updates to merge in. Returning ``None``
+    means "no changes".
+
+    Concrete subclasses set the class-level ``name`` to their registry
+    key (matching the string in ``config.ball_tracking.HOMEGROWN.stages``).
+    """
+
+    name: ClassVar[str]
+
+    def __init__(self, provider_config: HomegrownProviderConfig):
+        self.provider_config = provider_config
+
+    @abstractmethod
+    async def run(
+        self, artifacts: dict[str, Any], ctx: ProviderContext
+    ) -> dict[str, Any] | None: ...

--- a/video_grouper/ball_tracking/providers/homegrown/stages/detect.py
+++ b/video_grouper/ball_tracking/providers/homegrown/stages/detect.py
@@ -33,16 +33,20 @@ def _run_detection(
     frame_interval: int,
     use_gpu: bool,
 ) -> int:
-    """Sync helper: run detection, write JSON. Returns detection count."""
+    """Sync helper: run detection, write JSON. Returns detection count.
+
+    Uses ``importlib.import_module`` rather than a ``from … import`` to keep
+    the heavy training-pipeline deps (torch, ultralytics, opencv) outside
+    PyInstaller's static modulegraph. Otherwise the service / tray exes
+    balloon past NSIS's 32-bit mmap ceiling at install time.
+    """
+    import importlib
     from pathlib import Path as _Path
 
-    from training.inference.external_ball_detector import (
-        create_session,
-        detect_video,
-    )
+    ext_ball = importlib.import_module("training.inference.external_ball_detector")
 
-    sess = create_session(_Path(model_path), use_gpu=use_gpu)
-    detections = detect_video(
+    sess = ext_ball.create_session(_Path(model_path), use_gpu=use_gpu)
+    detections = ext_ball.detect_video(
         _Path(video_path),
         sess,
         frame_interval=frame_interval,

--- a/video_grouper/ball_tracking/providers/homegrown/stages/detect.py
+++ b/video_grouper/ball_tracking/providers/homegrown/stages/detect.py
@@ -1,0 +1,88 @@
+"""Detection stage — run the homegrown ball detector on each frame.
+
+Wraps :mod:`training.inference.external_ball_detector`. Outputs
+per-frame detections to a ``detections.json`` next to the source.
+The result is a list of ``{frame_idx, cx, cy, w, h, conf}`` dicts in
+panoramic pixel coords.
+
+Heavy deps (``onnxruntime``, ``cv2``) are imported lazily inside the
+sync helper so the tray app doesn't load them unless this stage runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from video_grouper.ball_tracking.base import ProviderContext
+
+from . import register_stage
+from .base import ProcessingStage
+
+logger = logging.getLogger(__name__)
+
+
+def _run_detection(
+    video_path: str,
+    output_json_path: str,
+    model_path: str,
+    confidence: float,
+    frame_interval: int,
+    use_gpu: bool,
+) -> int:
+    """Sync helper: run detection, write JSON. Returns detection count."""
+    from pathlib import Path as _Path
+
+    from training.inference.external_ball_detector import (
+        create_session,
+        detect_video,
+    )
+
+    sess = create_session(_Path(model_path), use_gpu=use_gpu)
+    detections = detect_video(
+        _Path(video_path),
+        sess,
+        frame_interval=frame_interval,
+        conf_threshold=confidence,
+    )
+
+    with open(output_json_path, "w", encoding="utf-8") as f:
+        json.dump(detections, f)
+
+    return len(detections)
+
+
+class DetectStage(ProcessingStage):
+    name = "detect"
+
+    async def run(
+        self, artifacts: dict[str, Any], ctx: ProviderContext
+    ) -> dict[str, Any] | None:
+        model_path = self.provider_config.model_path
+        if not model_path:
+            raise RuntimeError(
+                "detect: model_path is not configured "
+                "(set [BALL_TRACKING.HOMEGROWN] model_path in config.ini)"
+            )
+
+        in_path = Path(artifacts["input_path"])
+        detections_path = in_path.with_name("detections.json")
+
+        use_gpu = self.provider_config.device.startswith(("cuda", "gpu"))
+        count = await asyncio.to_thread(
+            _run_detection,
+            str(in_path),
+            str(detections_path),
+            model_path,
+            self.provider_config.detect_confidence,
+            self.provider_config.detect_frame_interval,
+            use_gpu,
+        )
+        logger.info("detect: wrote %d detections to %s", count, detections_path)
+        return {"detections_path": str(detections_path)}
+
+
+register_stage(DetectStage.name, DetectStage)

--- a/video_grouper/ball_tracking/providers/homegrown/stages/render.py
+++ b/video_grouper/ball_tracking/providers/homegrown/stages/render.py
@@ -1,0 +1,139 @@
+"""Render stage — broadcast-style virtual camera following the trajectory.
+
+Reads the panoramic source + ``trajectory.json``, smooths the trajectory
+with EMA, and writes a 1920×1080 mp4 by cropping a virtual-camera
+window centred on the EMA-smoothed ball position.
+
+This is a deliberately straightforward implementation: a fixed crop
+size, simple EMA smoothing, and pan-only (no dewarp). The plan calls
+out the sophisticated trajectory-following renderer (lead-room,
+zone-based zoom, hold-on-out-of-bounds) as a follow-up "once we see
+real outputs" — those refinements layer on top of this foundation.
+
+Heavy deps (``cv2``, ``av``) are imported lazily.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from video_grouper.ball_tracking.base import ProviderContext
+
+from . import register_stage
+from .base import ProcessingStage
+
+logger = logging.getLogger(__name__)
+
+
+def _smooth_trajectory(
+    trajectory: list[list[float] | None], ema: float
+) -> list[tuple[float, float] | None]:
+    """EMA-smooth the trajectory, holding the last position when missing."""
+    smoothed: list[tuple[float, float] | None] = []
+    last: tuple[float, float] | None = None
+    for point in trajectory:
+        if point is None:
+            smoothed.append(last)
+            continue
+        x, y = float(point[0]), float(point[1])
+        if last is None:
+            last = (x, y)
+        else:
+            last = (last[0] * ema + x * (1 - ema), last[1] * ema + y * (1 - ema))
+        smoothed.append(last)
+    return smoothed
+
+
+def _render_video(
+    input_path: str,
+    output_path: str,
+    trajectory_path: str,
+    out_width: int,
+    out_height: int,
+    ema: float,
+) -> None:
+    """Sync helper: pan-crop the source around the EMA-smoothed ball."""
+    import av
+
+    with open(trajectory_path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+    smoothed = _smooth_trajectory(raw, ema)
+
+    with av.open(input_path) as in_container:
+        in_video = in_container.streams.video[0]
+        src_w = in_video.width
+        src_h = in_video.height
+
+        # Vertical centre stays fixed (broadcast cameras don't tilt much
+        # for a flat field). Horizontal pans with the ball.
+        cy_target = src_h // 2
+
+        with av.open(output_path, mode="w") as out_container:
+            out_stream = out_container.add_stream("h264", rate=in_video.average_rate)
+            out_stream.width = out_width
+            out_stream.height = out_height
+            out_stream.pix_fmt = "yuv420p"
+
+            half_w = out_width // 2
+            half_h = out_height // 2
+
+            # Default centre when we have no trajectory yet.
+            fallback = (src_w / 2.0, float(cy_target))
+
+            for frame_idx, frame in enumerate(in_container.decode(in_video)):
+                pos = (
+                    smoothed[frame_idx]
+                    if frame_idx < len(smoothed) and smoothed[frame_idx] is not None
+                    else fallback
+                )
+                cx, _cy = pos
+
+                # Clamp so the crop stays inside the source frame.
+                left = max(0, min(int(round(cx)) - half_w, src_w - out_width))
+                top = max(0, min(cy_target - half_h, src_h - out_height))
+
+                rgb = frame.to_ndarray(format="rgb24")
+                cropped = rgb[top : top + out_height, left : left + out_width]
+
+                new_frame = av.VideoFrame.from_ndarray(cropped, format="rgb24")
+                new_frame.pts = frame.pts
+                for packet in out_stream.encode(new_frame):
+                    out_container.mux(packet)
+
+            for packet in out_stream.encode():
+                out_container.mux(packet)
+
+
+class RenderStage(ProcessingStage):
+    name = "render"
+
+    async def run(
+        self, artifacts: dict[str, Any], ctx: ProviderContext
+    ) -> dict[str, Any] | None:
+        trajectory_path = artifacts.get("trajectory_path")
+        if not trajectory_path:
+            raise RuntimeError(
+                "render: trajectory_path missing — was the track stage skipped?"
+            )
+
+        in_path = Path(artifacts["input_path"])
+        out_path = Path(artifacts["output_path"])
+
+        await asyncio.to_thread(
+            _render_video,
+            str(in_path),
+            str(out_path),
+            trajectory_path,
+            self.provider_config.render_output_width,
+            self.provider_config.render_output_height,
+            self.provider_config.render_ema,
+        )
+        logger.info("render: wrote broadcast-style output to %s", out_path)
+        return None  # output_path is already in artifacts
+
+
+register_stage(RenderStage.name, RenderStage)

--- a/video_grouper/ball_tracking/providers/homegrown/stages/stitch_correct.py
+++ b/video_grouper/ball_tracking/providers/homegrown/stages/stitch_correct.py
@@ -1,0 +1,111 @@
+"""Stitch-correction stage — apply per-row dx shift to fix dual-lens seam.
+
+Reads the panoramic input video, applies
+:func:`video_grouper.utils.stitch_remap.apply_shift_to_frame_rgb` per
+frame using the configured calibration profile, and writes a corrected
+mp4 alongside the input. Subsequent stages consume the corrected video
+via the ``input_path`` artifact.
+
+Pass-through (no work, no error) when the profile path isn't configured
+or the file isn't loadable — that mirrors the existing soccer-cam
+convention of treating stitch correction as an opt-in calibration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+from video_grouper.ball_tracking.base import ProviderContext
+
+from . import register_stage
+from .base import ProcessingStage
+
+logger = logging.getLogger(__name__)
+
+
+def _correct_video(input_path: str, output_path: str, profile_path: str) -> bool:
+    """Sync helper: read input, apply per-row dx shift, write output.
+
+    Returns True on success, False on any failure (caller decides what to do).
+    """
+    import av  # lazy: PyAV is heavy
+
+    from video_grouper.utils.stitch_remap import (
+        apply_shift_to_frame_rgb,
+        build_dx_lookup,
+        load_profile,
+    )
+
+    profile = load_profile(profile_path)
+    if profile is None:
+        logger.warning(
+            "stitch_correct: profile not loadable at %s; skipping correction",
+            profile_path,
+        )
+        return False
+
+    try:
+        with av.open(input_path) as in_container:
+            in_video = in_container.streams.video[0]
+            dx_lookup = build_dx_lookup(profile, in_video.width, in_video.height)
+            seam_x = int(profile.seam_x * (in_video.width / profile.source_width))
+
+            with av.open(output_path, mode="w") as out_container:
+                out_video = out_container.add_stream("h264", rate=in_video.average_rate)
+                out_video.width = in_video.width
+                out_video.height = in_video.height
+                out_video.pix_fmt = "yuv420p"
+
+                for frame in in_container.decode(in_video):
+                    rgb = frame.to_ndarray(format="rgb24")
+                    corrected = apply_shift_to_frame_rgb(rgb, dx_lookup, seam_x)
+                    new_frame = av.VideoFrame.from_ndarray(corrected, format="rgb24")
+                    new_frame.pts = frame.pts
+                    for packet in out_video.encode(new_frame):
+                        out_container.mux(packet)
+
+                for packet in out_video.encode():
+                    out_container.mux(packet)
+        return True
+    except Exception:
+        logger.exception("stitch_correct: encoding failed for %s", input_path)
+        return False
+
+
+class StitchCorrectStage(ProcessingStage):
+    name = "stitch_correct"
+
+    async def run(
+        self, artifacts: dict[str, Any], ctx: ProviderContext
+    ) -> dict[str, Any] | None:
+        profile_path = self.provider_config.stitch_profile_path
+        if not profile_path:
+            logger.info(
+                "stitch_correct: no stitch_profile_path configured; passing through"
+            )
+            return None
+
+        in_path = Path(artifacts["input_path"])
+        out_path = in_path.with_name(f"{in_path.stem}.stitched.mp4")
+
+        success = await asyncio.to_thread(
+            _correct_video, str(in_path), str(out_path), profile_path
+        )
+        if not success:
+            logger.warning(
+                "stitch_correct: correction failed; downstream stages will use "
+                "the uncorrected source"
+            )
+            return None
+
+        # Subsequent stages should consume the corrected video.
+        return {
+            "stitched_path": str(out_path),
+            "input_path": str(out_path),
+        }
+
+
+register_stage(StitchCorrectStage.name, StitchCorrectStage)

--- a/video_grouper/ball_tracking/providers/homegrown/stages/track.py
+++ b/video_grouper/ball_tracking/providers/homegrown/stages/track.py
@@ -28,8 +28,16 @@ def _run_tracking(
     gate_distance: float,
     max_missing: int,
 ) -> int:
-    """Sync helper: load detections, run tracker, write trajectory JSON."""
-    from training.inference.ball_tracker import BallTracker, Detection
+    """Sync helper: load detections, run tracker, write trajectory JSON.
+
+    See :func:`detect._run_detection` for why we go through
+    ``importlib.import_module`` instead of a static ``from … import``.
+    """
+    import importlib
+
+    bt_module = importlib.import_module("training.inference.ball_tracker")
+    BallTracker = bt_module.BallTracker
+    Detection = bt_module.Detection
 
     with open(detections_path, "r", encoding="utf-8") as f:
         per_frame: list[dict] = json.load(f)

--- a/video_grouper/ball_tracking/providers/homegrown/stages/track.py
+++ b/video_grouper/ball_tracking/providers/homegrown/stages/track.py
@@ -1,0 +1,107 @@
+"""Tracking stage — link per-frame detections into a smoothed trajectory.
+
+Wraps :mod:`training.inference.ball_tracker`. Reads ``detections.json``,
+runs the Kalman filter tracker, picks the longest valid track, and
+writes a per-frame ``trajectory.json`` (one ``[x, y]`` row per source
+frame; ``None`` when no estimate is available).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from video_grouper.ball_tracking.base import ProviderContext
+
+from . import register_stage
+from .base import ProcessingStage
+
+logger = logging.getLogger(__name__)
+
+
+def _run_tracking(
+    detections_path: str,
+    output_json_path: str,
+    gate_distance: float,
+    max_missing: int,
+) -> int:
+    """Sync helper: load detections, run tracker, write trajectory JSON."""
+    from training.inference.ball_tracker import BallTracker, Detection
+
+    with open(detections_path, "r", encoding="utf-8") as f:
+        per_frame: list[dict] = json.load(f)
+
+    tracker = BallTracker(gate_distance=gate_distance, max_missing=max_missing)
+
+    # Group detections by frame_idx for the per-frame update loop.
+    by_frame: dict[int, list[Detection]] = {}
+    for d in per_frame:
+        frame_idx = int(d["frame_idx"])
+        by_frame.setdefault(frame_idx, []).append(
+            Detection(
+                x=float(d["cx"]),
+                y=float(d["cy"]),
+                confidence=float(d["conf"]),
+                frame_idx=frame_idx,
+            )
+        )
+    if not by_frame:
+        logger.warning("track: no detections to track")
+        with open(output_json_path, "w", encoding="utf-8") as f:
+            json.dump([], f)
+        return 0
+
+    last_frame = max(by_frame)
+    for frame_idx in range(last_frame + 1):
+        tracker.update(frame_idx, by_frame.get(frame_idx, []))
+
+    best = tracker.get_best_track() if hasattr(tracker, "get_best_track") else None
+    trajectory: list[list[float] | None] = [None] * (last_frame + 1)
+    if best is not None and getattr(best, "detections", None):
+        for det in best.detections:
+            trajectory[det.frame_idx] = [det.x, det.y]
+        for frame_idx, x, y in getattr(best, "predictions", []):
+            if 0 <= frame_idx < len(trajectory) and trajectory[frame_idx] is None:
+                trajectory[frame_idx] = [float(x), float(y)]
+
+    with open(output_json_path, "w", encoding="utf-8") as f:
+        json.dump(trajectory, f)
+
+    populated = sum(1 for p in trajectory if p is not None)
+    return populated
+
+
+class TrackStage(ProcessingStage):
+    name = "track"
+
+    async def run(
+        self, artifacts: dict[str, Any], ctx: ProviderContext
+    ) -> dict[str, Any] | None:
+        detections_path = artifacts.get("detections_path")
+        if not detections_path:
+            raise RuntimeError(
+                "track: detections_path missing — was the detect stage skipped?"
+            )
+
+        in_path = Path(artifacts["input_path"])
+        trajectory_path = in_path.with_name("trajectory.json")
+
+        populated = await asyncio.to_thread(
+            _run_tracking,
+            detections_path,
+            str(trajectory_path),
+            self.provider_config.track_kalman_gate,
+            self.provider_config.track_max_missing,
+        )
+        logger.info(
+            "track: wrote trajectory with %d populated frames to %s",
+            populated,
+            trajectory_path,
+        )
+        return {"trajectory_path": str(trajectory_path)}
+
+
+register_stage(TrackStage.name, TrackStage)

--- a/video_grouper/ball_tracking/register_providers.py
+++ b/video_grouper/ball_tracking/register_providers.py
@@ -9,3 +9,4 @@ from __future__ import annotations
 
 # noqa: F401 — imports are for side effects (registration on import)
 from video_grouper.ball_tracking.providers import autocam_gui  # noqa: F401
+from video_grouper.ball_tracking.providers import homegrown  # noqa: F401

--- a/video_grouper/config.ini.dist
+++ b/video_grouper/config.ini.dist
@@ -83,12 +83,34 @@ privacy_status = private
 
 
 
-[AUTOCAM]
-# Whether to enable autocam processing
+[BALL_TRACKING]
+# Master switch — when false, video stops at trimmed and skips straight to upload
 enabled = true
 
-# The path to the autocam executable
+# Which ball-tracking provider to run. Options: autocam_gui, homegrown
+provider = autocam_gui
+
+[BALL_TRACKING.AUTOCAM_GUI]
+# Path to the Once Sport AutoCam executable (used when provider = autocam_gui)
 executable = /path/to/autocam
+
+[BALL_TRACKING.HOMEGROWN]
+# Pipeline stages, in order (used when provider = homegrown).
+# Comment out a stage name to skip it.
+stages = stitch_correct, detect, track, render
+
+# Path to the homegrown ball-detection model (required when provider = homegrown)
+# model_path =
+# device = cuda:0
+
+# Optional path to the per-camera stitch calibration profile.
+# When unset, stitch_correct passes the source video through unchanged.
+# stitch_profile_path =
+
+# [BALL_TRACKING.PER_TEAM]
+# # Per-team override of the default provider. Key = MatchInfo team_name.
+# # flash = homegrown
+# # heat = autocam_gui
 
 # Playlist configuration for processed videos
 [YOUTUBE.PLAYLIST.PROCESSED]


### PR DESCRIPTION
## Summary
- New `homegrown` provider behind the existing `BallTrackingProvider` hook. Selecting `provider = homegrown` runs the ordered stage list `stitch_correct → detect → track → render` against the trimmed panoramic source.
- Four real stage implementations: stitch-correct uses `video_grouper.utils.stitch_remap`, detect/track wrap the existing `training/inference/` code, and render does a pan-only crop with EMA smoothing.
- New config section `[BALL_TRACKING.HOMEGROWN]` with sane defaults; `config.ini.dist` and simulator/e2e configs migrated from `[AUTOCAM]` to the new shape.

## Background
PR #3 of Track 2 — completes the plan's Files-to-create list. The hook now has both providers (`autocam_gui` + `homegrown`) and a fully composable sub-stage pipeline inside the homegrown one.

The render stage is the deliberately-simple foundation called out in the plan: fixed 1920×1080 window, EMA smoothing, no dewarp / lead-room / zone-zoom. Per the plan's "Out of scope" note, the sophisticated broadcast-style renderer is the explicit follow-up "once we see real outputs."

Heavy deps (PyAV, onnxruntime, filterpy, the `training/inference/*` imports) are loaded lazily inside each stage's sync helper, so the tray app doesn't pull them in unless `provider = homegrown`.

## Test plan
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] 17 new unit tests pass: registration, default stage list + CSV parsing, ordered stage execution, unknown-stage / exception / empty-output failure modes, per-stage argument validation, `BallTrackingConfig.resolve_provider_for("homegrown")` via top-level + per-team override
- [x] Full unit suite: 831 passed, 16 pre-existing failures unchanged (`TTT.plugin_signing_public_keys` list-roundtrip — unrelated)
- [ ] **Manual end-to-end on real footage**: configure a homegrown model path + stitch profile path, run the migration tool, point a Flash game at `provider = homegrown`, and watch each stage write its artifact (`stitched.mp4`, `detections.json`, `trajectory.json`, final `*.mp4`)
- [ ] **Stage swap smoke**: with `stages = detect, track, render` (skip stitch), verify the pipeline still completes when no profile is configured
- [ ] **Iterative renderer tuning** is its own follow-up — produce a real game video first, then design lead-room / zone-zoom / hold-on-OOB on top of this foundation

🤖 Generated with [Claude Code](https://claude.com/claude-code)