### PR TITLE
ci: scope tag triggers to version tags + fix native loader build

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,7 +3,7 @@ name: Build Docker Container
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]*'
     branches: [ main ]
     paths:
       - 'video_grouper/**'

--- a/.github/workflows/build-native-loader.yml
+++ b/.github/workflows/build-native-loader.yml
@@ -65,8 +65,25 @@ jobs:
           python build_native_loader.py build_ext --inplace
 
       - name: Verify the artifact loads
+        # Load the compiled extension by file path so we don't trigger
+        # video_grouper/__init__.py — this step intentionally installs
+        # only the build-time deps (cython, cryptography), not the full
+        # package's runtime deps (pydantic et al.).
+        shell: bash
         run: |
-          python -c "from video_grouper.ball_tracking import _secure_loader_native as m; assert callable(m.canonical_json); print('OK')"
+          python -c "
+          import glob, importlib.util, os
+          matches = glob.glob('video_grouper/ball_tracking/_secure_loader_native*.${{ matrix.ext }}')
+          assert matches, 'native extension not found'
+          ext_path = matches[0]
+          spec = importlib.util.spec_from_file_location('_secure_loader_native', ext_path)
+          m = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(m)
+          assert callable(m.canonical_json), 'canonical_json not exported'
+          size = os.path.getsize(ext_path)
+          assert size > 50_000, f'compiled module suspiciously small: {size} bytes'
+          print(f'OK: {ext_path} ({size} bytes)')
+          "
 
       - name: Verify decompilation does not recover security logic (Phase 5 acceptance)
         # uncompyle6 / decompyle3 only work on .pyc bytecode — confirms our
@@ -76,15 +93,6 @@ jobs:
           if command -v uncompyle6 >/dev/null 2>&1; then
             ! python -c "import uncompyle6"  # any import error is fine; we just need to assert .pyx isn't a .pyc target
           fi
-          # Sanity: the compiled extension exists and has a non-trivial size.
-          python -c "
-          import importlib.util, os
-          spec = importlib.util.find_spec('video_grouper.ball_tracking._secure_loader_native')
-          assert spec is not None and spec.origin, 'native extension not found'
-          size = os.path.getsize(spec.origin)
-          assert size > 50_000, f'compiled module suspiciously small: {size} bytes'
-          print(f'native extension at {spec.origin} ({size} bytes)')
-          "
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-native-loader.yml
+++ b/.github/workflows/build-native-loader.yml
@@ -8,7 +8,7 @@ name: Build Native Secure Loader
 on:
   push:
     branches: [main]
-    tags: ['v*']
+    tags: ['v[0-9]*']
     paths:
       - 'video_grouper/ball_tracking/_secure_loader_native.pyx'
       - 'build_native_loader.py'

--- a/.github/workflows/build-windows-service.yml
+++ b/.github/workflows/build-windows-service.yml
@@ -3,7 +3,7 @@ name: Build Windows Service
 on:
   push:
     branches: [ main ]
-    tags: [ 'v*' ]
+    tags: [ 'v[0-9]*' ]
   pull_request:
     branches: [ main ]
 

--- a/build_native_loader.py
+++ b/build_native_loader.py
@@ -30,6 +30,7 @@ extensions = [
 
 setup(
     name="video-grouper-native-loader",
+    packages=[],
     ext_modules=cythonize(
         extensions,
         compiler_directives={


### PR DESCRIPTION
## Summary
- Tightened `tags: ['v*']` → `tags: ['v[0-9]*']` in all three workflows (`build-docker`, `build-native-loader`, `build-windows-service`). The old glob matched `validate-model-*` tags, triggering release-only workflows on non-version tags.
- Added `packages=[]` to `setup()` in `build_native_loader.py` so setuptools' flat-layout auto-discovery doesn't bail on the four top-level dirs.

## Why CI failed on the PR #34 merge
The `validate-model-0.0.2` tag matched `v*` and fired all three workflows:
- **Build Native Secure Loader**: setuptools refused: *"Multiple top-level packages discovered in a flat-layout"*. Underlying bug — would also bite a real `v1.0.0` tag.
- **Build Windows Service**: version extraction did `-replace 'refs/tags/v', ''` literally, producing `alidate-model-0.0.2`; NSIS rejected it.
- **Build Docker**: silently succeeded but pushed `dockerhub/video-grouper:alidate-model-0.0.2` to DockerHub.

## Test plan
- [x] Verified `python build_native_loader.py build_ext --inplace` succeeds locally on Windows after the `packages=[]` fix
- [ ] Confirm CI passes on this PR