### PR TITLE
docker: GPU-capable Linux image (multi-stage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ docker compose build
 docker compose up -d
 ```
 
+The image is GPU-capable: ball detection runs on a CUDA GPU when one is exposed via `--gpus all` (or the compose `deploy.resources` reservation), otherwise it falls back to CPU. See [video_grouper/docs/docker/README.md](video_grouper/docs/docker/README.md) for prerequisites and verification.
+
 ## Configuration
 
 Edit `config.ini` with your settings. At minimum you need:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker compose build
 docker compose up -d
 ```
 
-The image is GPU-capable: ball detection runs on a CUDA GPU when one is exposed via `--gpus all` (or the compose `deploy.resources` reservation), otherwise it falls back to CPU. See [video_grouper/docs/docker/README.md](video_grouper/docs/docker/README.md) for prerequisites and verification.
+The image is GPU-capable: ball detection auto-detects an available CUDA GPU and otherwise falls back to CPU — the same image runs on either host. To expose a host GPU to the container, use `docker run --gpus all video-grouper` or add the standard NVIDIA `deploy.resources.reservations.devices` block to your compose file. See [video_grouper/docs/docker/README.md](video_grouper/docs/docker/README.md) for prerequisites and verification.
 
 ## Configuration
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,13 @@ services:
       - ./video_grouper/config.ini:/app/config.ini
     environment:
       - PYTHONUNBUFFERED=1
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
 
   reolink-simulator:
     profiles:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,13 +11,6 @@ services:
       - ./video_grouper/config.ini:/app/config.ini
     environment:
       - PYTHONUNBUFFERED=1
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
 
   reolink-simulator:
     profiles:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pillow>=11.3.0",
     "numpy>=2.2.0",
     "opencv-python-headless>=4.13.0",
-    "onnxruntime-gpu>=1.24.4; sys_platform == 'win32'",
+    "onnxruntime-gpu>=1.24.4",
     "uvicorn>=0.42.0",
     "fastapi>=0.135.2",
     "av>=17.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1278,15 +1278,19 @@ name = "onnxruntime-gpu"
 version = "1.24.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "flatbuffers", marker = "sys_platform == 'win32'" },
-    { name = "numpy", marker = "sys_platform == 'win32'" },
-    { name = "packaging", marker = "sys_platform == 'win32'" },
-    { name = "protobuf", marker = "sys_platform == 'win32'" },
-    { name = "sympy", marker = "sys_platform == 'win32'" },
+    { name = "flatbuffers", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "packaging", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "protobuf", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/4e/56d11203d7a35e7d6a5ea735f5fecb8673537038c07323e8d3090a896547/onnxruntime_gpu-1.24.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbdaa73f9055fb2a177425edbed651a1843a6239f9d5430e284f4e5f65440a33", size = 252763446, upload-time = "2026-03-17T22:04:09.515Z" },
     { url = "https://files.pythonhosted.org/packages/fa/bc/35f3a37226d7a28c84b8b456f52237ccd39eb7111114bcf9ac340178e1ec/onnxruntime_gpu-1.24.4-cp313-cp313-win_amd64.whl", hash = "sha256:6be8bf2048777c517fca33eb61e114969fa326619feaa789d8c75f24337ea762", size = 207198775, upload-time = "2026-03-17T21:58:48.768Z" },
+    { url = "https://files.pythonhosted.org/packages/37/83/0c851882051b38f245f44b4a51d6232b95b8cd5d334b2c1260f2d796834f/onnxruntime_gpu-1.24.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4b348a078ced73fc577d21b83992fd2187edd10c233729c8d01b000b8543525", size = 252774594, upload-time = "2026-03-17T22:04:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5b/82b27f766b64f97c9a98b772dc07b608e900bd2faafdfa176b86d20be7f8/onnxruntime_gpu-1.24.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:af9dd7ef92d94c75e5523cf070e180f3d8cdbb2fc007dcea97ba71b03e3b96d6", size = 252765395, upload-time = "2026-03-17T22:04:37.305Z" },
     { url = "https://files.pythonhosted.org/packages/5d/95/fa8c48e03790c979167d08164b34a8442c7074bca4c7253b4455497025de/onnxruntime_gpu-1.24.4-cp314-cp314-win_amd64.whl", hash = "sha256:4dde3d2f1039060c42b12fd446fc0da5b836cc65dceb4020ca60a04cffa1d90d", size = 209597109, upload-time = "2026-03-17T21:58:58.136Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/98/7707edefcecf69d6c45b83a83f13ac58257017b4eaf58772668d302f849f/onnxruntime_gpu-1.24.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:097c6f53e99ee35f21d0fdba76ca283b92465a0e364c6f0209cb9653c424e2a4", size = 252776951, upload-time = "2026-03-17T22:04:49.715Z" },
 ]
 
 [[package]]
@@ -2352,7 +2356,7 @@ dependencies = [
     { name = "httpx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "icalendar", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "onnxruntime-gpu", marker = "sys_platform == 'win32'" },
+    { name = "onnxruntime-gpu", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "opencv-python-headless", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pillow", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pycryptodome", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -2426,7 +2430,7 @@ requires-dist = [
     { name = "lapx", marker = "extra == 'ml'", specifier = ">=0.5.0" },
     { name = "numpy", specifier = ">=2.2.0" },
     { name = "numpy", marker = "extra == 'ml'", specifier = ">=2.2.0" },
-    { name = "onnxruntime-gpu", marker = "sys_platform == 'win32'", specifier = ">=1.24.4" },
+    { name = "onnxruntime-gpu", specifier = ">=1.24.4" },
     { name = "opencv-python", marker = "extra == 'ml'", specifier = ">=4.13.0" },
     { name = "opencv-python-headless", specifier = ">=4.13.0" },
     { name = "pillow", specifier = ">=11.3.0" },

--- a/video_grouper/Dockerfile
+++ b/video_grouper/Dockerfile
@@ -1,45 +1,74 @@
-FROM python:3.13-slim
+# Multi-stage GPU-capable image. Single tag works on hosts with or
+# without an NVIDIA GPU — onnxruntime falls back to CPUExecutionProvider
+# when CUDA isn't available. To actually use the GPU on a capable host,
+# pass `--gpus all` (docker run) or set deploy.resources.reservations.devices
+# (docker compose).
 
-# Build arguments for versioning
-ARG VERSION=0.0.0
-ARG BUILD_NUMBER=0
+ARG CUDA_BASE=nvidia/cuda:12.6.3-runtime-ubuntu22.04
+ARG PYTHON_VERSION=3.13
 
-# Install ffmpeg
+# ─── Builder ──────────────────────────────────────────────────────────
+FROM ${CUDA_BASE} AS builder
+
+ARG PYTHON_VERSION
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ffmpeg && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends \
+        software-properties-common ca-certificates curl && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} python${PYTHON_VERSION}-venv && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -sf /usr/bin/python${PYTHON_VERSION} /usr/local/bin/python
 
-# Set up working directory
+# uv standalone installer (no pip bootstrap)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    ln -sf /root/.local/bin/uv /usr/local/bin/uv
+
 WORKDIR /app
 
-# Install uv, our package manager
-RUN pip install uv
-
-# Copy dependency definitions and README to leverage Docker cache
 COPY pyproject.toml uv.lock README.md ./
-
-# Install dependencies only (skip local package build for now)
-RUN uv sync --no-install-project
-
-# Copy the application source code
 COPY video_grouper/ ./video_grouper/
 
-# Now install the local package
-RUN uv pip install -e .
+# Build a self-contained .venv with only runtime deps (no dev/tray/service extras).
+# --frozen requires uv.lock to match pyproject.toml.
+RUN uv sync --frozen --no-dev
 
-# Create version.py with build arguments. This will overwrite any existing version.py
-RUN echo '"""' > /app/video_grouper/version.py && \
-    echo 'Version information for VideoGrouper.' >> /app/video_grouper/version.py && \
-    echo 'This file is automatically updated during the build process.' >> /app/video_grouper/version.py && \
-    echo '"""' >> /app/video_grouper/version.py && \
-    echo '' >> /app/video_grouper/version.py && \
-    echo "VERSION = '${VERSION}'" >> /app/video_grouper/version.py && \
-    echo "BUILD_NUMBER = '${BUILD_NUMBER}'" >> /app/video_grouper/version.py
+# ─── Runtime ──────────────────────────────────────────────────────────
+FROM ${CUDA_BASE} AS runtime
 
-# Set version as environment variable for runtime access
+ARG VERSION=0.0.0
+ARG BUILD_NUMBER=0
+ARG PYTHON_VERSION
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Only the interpreter in the runtime stage. PyAV bundles libav* via wheel —
+# no system ffmpeg needed. software-properties-common is purged after we're
+# done with deadsnakes to keep the image small.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        software-properties-common ca-certificates && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends python${PYTHON_VERSION} && \
+    apt-get purge -y software-properties-common && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -sf /usr/bin/python${PYTHON_VERSION} /usr/local/bin/python
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY video_grouper/ /app/video_grouper/
+
+ENV PATH="/app/.venv/bin:${PATH}"
+
+RUN printf '"""Version information for VideoGrouper."""\nVERSION = "%s"\nBUILD_NUMBER = "%s"\nFULL_VERSION = f"{VERSION}+{BUILD_NUMBER}"\n__version__ = VERSION\n__version_full__ = FULL_VERSION\n' \
+        "${VERSION}" "${BUILD_NUMBER}" > /app/video_grouper/version.py
+
 ENV VERSION=${VERSION}
 ENV BUILD_NUMBER=${BUILD_NUMBER}
 
-# Set the entry point to run the application module
 CMD ["python", "-m", "video_grouper"]

--- a/video_grouper/Dockerfile
+++ b/video_grouper/Dockerfile
@@ -3,8 +3,13 @@
 # when CUDA isn't available. To actually use the GPU on a capable host,
 # pass `--gpus all` (docker run) or set deploy.resources.reservations.devices
 # (docker compose).
+#
+# Sized down by basing on the `:base` CUDA image (driver stub + apt repo
+# config only, no actual CUDA libs) and apt-installing only the specific
+# runtime libraries onnxruntime-gpu needs: cudart and cublas. cuDNN is
+# bundled inside the ORT wheel itself.
 
-ARG CUDA_BASE=nvidia/cuda:12.6.3-runtime-ubuntu22.04
+ARG CUDA_BASE=nvidia/cuda:12.6.3-base-ubuntu22.04
 ARG PYTHON_VERSION=3.13
 
 # ─── Builder ──────────────────────────────────────────────────────────
@@ -36,6 +41,10 @@ COPY video_grouper/ ./video_grouper/
 # --frozen requires uv.lock to match pyproject.toml.
 RUN uv sync --frozen --no-dev
 
+# Strip debug symbols from compiled extensions (~100-200 MB savings on
+# onnxruntime, opencv, av, numpy, pillow).
+RUN find /app/.venv -name "*.so*" -type f -exec strip --strip-unneeded {} + 2>/dev/null || true
+
 # ─── Runtime ──────────────────────────────────────────────────────────
 FROM ${CUDA_BASE} AS runtime
 
@@ -44,18 +53,24 @@ ARG BUILD_NUMBER=0
 ARG PYTHON_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Only the interpreter in the runtime stage. PyAV bundles libav* via wheel —
-# no system ffmpeg needed. software-properties-common is purged after we're
-# done with deadsnakes to keep the image small.
+# Install only what's needed at runtime:
+#   - python interpreter (deadsnakes)
+#   - cuda-cudart-12-6 (CUDA runtime API — required by onnxruntime-gpu)
+#   - libcublas-12-6 (BLAS for matmul; cuDNN is bundled in the ORT wheel)
+# software-properties-common is purged after we're done with the PPA.
+# PyAV bundles libavcodec/libavformat — no system ffmpeg needed.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         software-properties-common ca-certificates && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
-    apt-get install -y --no-install-recommends python${PYTHON_VERSION} && \
+    apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} \
+        cuda-cudart-12-6 \
+        libcublas-12-6 && \
     apt-get purge -y software-properties-common && \
     apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     ln -sf /usr/bin/python${PYTHON_VERSION} /usr/local/bin/python
 
 WORKDIR /app

--- a/video_grouper/docs/docker/README.md
+++ b/video_grouper/docs/docker/README.md
@@ -70,20 +70,35 @@ The image is GPU-capable: ONNX-based ball detection runs on a CUDA GPU when one 
 ### Sanity-check the host can expose its GPU to a container
 
 ```bash
-docker run --rm --gpus all nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04 nvidia-smi
+docker run --rm --gpus all nvidia/cuda:12.6.3-base-ubuntu22.04 nvidia-smi
 ```
 
 If the GPU table prints, the host is configured correctly.
 
 ### Run with GPU access
 
+The container falls back to CPU when no GPU is exposed to it, so the same image works on either host. To actually use a GPU, the host must expose it explicitly:
+
 ```bash
 # docker run
 docker run --rm --gpus all video-grouper
-
-# docker compose (already includes the device reservation in docker-compose.yaml)
-docker compose up
 ```
+
+To use GPU under `docker compose`, add the standard NVIDIA reservation block to your local `docker-compose.yaml` (or a compose override):
+
+```yaml
+services:
+  video-grouper:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+```
+
+This block is intentionally NOT in the default `docker-compose.yaml` because compose hard-fails on hosts without an NVIDIA runtime — keeping it out lets the same compose file work for everyone.
 
 ### Enabling ball detection
 

--- a/video_grouper/docs/docker/README.md
+++ b/video_grouper/docs/docker/README.md
@@ -1,90 +1,210 @@
 # Docker Setup for VideoGrouper
 
-This document explains how to use VideoGrouper with Docker.
+This document explains how to run VideoGrouper in Docker on Linux (or Windows via Docker Desktop's WSL2 backend). It covers:
 
-## Prerequisites
+- [Quick start](#quick-start) — get the pipeline running, no ball detection
+- [Volume mounts](#volume-mounts) — where data goes in and out
+- [Ball detection (homegrown ONNX, GPU-capable)](#ball-detection-homegrown-onnx-gpu-capable) — the licensed inference path
+- [GPU acceleration](#gpu-acceleration) — when the container should use a CUDA GPU
+- [Troubleshooting](#troubleshooting)
 
-- Docker
-- Docker Compose
+---
 
-## Configuration
+## Quick start
 
-1. Create a `config.ini` file in the video_grouper directory of the project (you can copy from `video_grouper/config.ini.dist`)
-2. Ensure the `storage_path` in the config points to `/shared_data` (this is mounted as a volume)
-
-## Files Included in Docker Image
-
-The Docker image includes only the necessary files to run VideoGrouper:
-
-- `video_grouper/__init__.py`
-- `video_grouper/__main__.py` (consolidated entry point)
-- `video_grouper/video_grouper.py`
-- `video_grouper/ffmpeg_utils.py`
-- `video_grouper/models.py`
-- `video_grouper/match_info.ini.dist`
-- `video_grouper/cameras/` directory
-- Auto-generated `video_grouper/version.py`
-
-## Running with Docker Compose
+Bring up the pipeline against your camera with no ball detection:
 
 ```bash
-# Build and start the container
-docker-compose up -d
+# 1. Create a config from the template
+mkdir -p shared_data
+cp video_grouper/config.ini.dist shared_data/config.ini
+# edit shared_data/config.ini: set [CAMERA.default] device_ip / username / password,
+# [STORAGE] path = /shared_data, [YOUTUBE] credentials, etc.
+# Make sure [BALL_TRACKING] enabled = false (default) for now.
 
-# View logs
-docker-compose logs -f
+# 2. Build (or pull) and run
+docker compose build
+docker compose up -d
 
-# Stop the container
-docker-compose down
+# 3. Watch the logs
+docker compose logs -f video-grouper
 ```
 
-## Building with Version Information
+The container polls the camera, downloads new clips, combines/trims them, prompts for game start/end via NTFY, and uploads to YouTube. Standard pipeline.
 
-You can specify version information when building:
+To rebuild from a specific version tag:
 
 ```bash
-docker build -t video-grouper \
+docker build \
   --build-arg VERSION=1.0.0 \
   --build-arg BUILD_NUMBER=123 \
-  -f video_grouper/Dockerfile .
+  -t video-grouper -f video_grouper/Dockerfile .
 ```
 
-## Volume Mounts
+---
 
-The Docker setup includes two volume mounts:
+## Volume mounts
 
-1. `./shared_data:/shared_data` - For storing downloaded and processed videos
-2. `./video_grouper/config.ini:/app/config.ini` - For the application configuration
+The default `docker-compose.yaml` mounts two paths:
 
-Make sure these directories exist and have the correct permissions.
+```yaml
+volumes:
+  - ./shared_data:/shared_data            # queue state + TTT auth tokens
+  - ./video_grouper/config.ini:/app/config.ini
+```
 
-## GPU Acceleration (Optional)
+What lives where:
 
-The image is GPU-capable: ONNX-based ball detection runs on a CUDA GPU when one is available, otherwise it transparently falls back to CPU. The same image works on GPU and non-GPU hosts — no separate tag.
+| Path inside container | Holds |
+|---|---|
+| `/shared_data/<game>/` | Per-game video directory (downloaded clips, combined MP4, trimmed MP4, `state.json`, **and the ball-tracking outputs `detections.json` + `trajectory.json` if enabled**) |
+| `/shared_data/*_queue_state.json` | Persisted async queues (download / video / upload / ball-tracking) |
+| `/shared_data/ttt/tokens.json` | Cached Supabase access + refresh tokens (see ball detection below) |
+| `/app/config.ini` | Application configuration (read-only is fine) |
+
+**There is no separate "output" volume** — ball detection writes its `detections.json` and `trajectory.json` into the same per-game directory as the input video. Mount whatever directory tree holds your games; outputs land alongside inputs.
+
+If your game videos live elsewhere (e.g., a NAS mount), change `STORAGE.path` in `config.ini` to wherever you mount it (e.g., `/mnt/games`) and add the matching volume to compose.
+
+---
+
+## Ball detection (homegrown ONNX, GPU-capable)
+
+Soccer-cam ships a homegrown ball-detection provider that runs an ONNX model via onnxruntime. The model is **licensed** — fetched at runtime via Team Tech Tools using the user's account, decrypted in memory, and never written to disk. Premium tier required.
+
+### Prerequisites
+
+1. A Team Tech Tools account (`https://teamtechtools.com`) with the ball-detection entitlement.
+2. The encrypted model artifact accessible from where the container runs. Public release URLs:
+   - `https://github.com/mblakley/soccer-cam/releases/download/model-vX.Y.Z/model-vX.Y.Z.enc`
+   - The container fetches this URL automatically — you don't need to download it manually.
+3. (Optional) An NVIDIA GPU exposed to the container. CPU works too, just slower; see [GPU acceleration](#gpu-acceleration).
+
+### Configure `config.ini`
+
+Two sections need to be set up. Replace the placeholder values with your TTT credentials.
+
+```ini
+[BALL_TRACKING]
+enabled = true
+provider = homegrown
+
+[BALL_TRACKING.HOMEGROWN]
+# Triggers the licensed/encrypted path (vs. local plaintext model_path for testing)
+model_key = premium.video.ball_detection
+device = cuda:0           # cuda:0 prefers GPU; falls back to CPU automatically. Use 'cpu' to force CPU.
+stages = stitch_correct, detect, track, render
+
+[TTT]
+enabled = true
+supabase_url = https://<your-supabase-project>.supabase.co
+anon_key = <your-supabase-anon-key>
+api_base_url = https://api.teamtechtools.com
+email = <your-ttt-email>
+password = <your-ttt-password>
+# plugin_signing_public_keys = ["...hex..."]   # optional override; default ships in code
+```
+
+Email + password are used for the **first** authentication only — after that, Supabase access + refresh tokens are persisted to `/shared_data/ttt/tokens.json` and refreshed automatically. You can clear `password` from `config.ini` once tokens exist if you don't want it stored at rest.
+
+### Run
+
+CPU mode (works everywhere):
+
+```bash
+docker compose up -d
+```
+
+GPU mode (requires NVIDIA Container Toolkit on the host; Docker Desktop on Windows ships it):
+
+```bash
+docker run --rm --gpus all \
+  -v $(pwd)/shared_data:/shared_data \
+  -v $(pwd)/video_grouper/config.ini:/app/config.ini \
+  video-grouper
+```
+
+Or, to keep using `docker compose` with GPU, append a `deploy.resources.reservations.devices` block to your local `docker-compose.yaml` (it's intentionally not in the default — see [GPU acceleration](#gpu-acceleration)).
+
+### What happens at runtime
+
+When a game reaches the ball-tracking stage:
+
+1. `TTTApiClient` loads tokens from `/shared_data/ttt/tokens.json` (or signs in with email/password if no tokens yet).
+2. `SecureLoader.acquire("premium.video.ball_detection")` calls `POST {api_base_url}/api/models/premium.video.ball_detection/license` with the JWT.
+3. TTT returns a signed license + the AES-GCM key.
+4. `SecureLoader` downloads the `.enc` artifact from `artifact_url` (the GitHub release), verifies the SHA-256, and decrypts in memory.
+5. The decrypted ONNX model is loaded into `onnxruntime.InferenceSession` with the available execution providers (`[CUDA, CPU]` if GPU exposed, `[CPU]` otherwise).
+6. The detect stage runs `detect_balls()` per frame, writing `detections.json` to the game directory.
+7. The track stage consumes `detections.json` and writes `trajectory.json`.
+8. The render stage produces the broadcast-perspective output video.
+
+Plaintext model bytes never touch the disk.
+
+### Verify it actually loaded the model and picked the right execution provider
+
+After a game runs through, check the logs:
+
+```bash
+docker compose logs video-grouper | grep -E "ONNX session using|licensed.*tier"
+# Expected on a GPU host:
+#   detect: licensed premium.video.ball_detection v0.1.0 (premium, provider=CUDAExecutionProvider)
+#   ONNX session using: ['CUDAExecutionProvider', 'CPUExecutionProvider']
+# Expected on a CPU host:
+#   detect: licensed premium.video.ball_detection v0.1.0 (premium, provider=CPUExecutionProvider)
+#   ONNX session using: ['CPUExecutionProvider']
+```
+
+And confirm outputs landed in the per-game directory:
+
+```bash
+ls -la shared_data/<your-game>/
+# detections.json    <- per-frame detections
+# trajectory.json    <- smoothed ball track
+```
+
+### Local testing without TTT licensing
+
+For development, skip TTT and point at a plain ONNX file:
+
+```ini
+[BALL_TRACKING.HOMEGROWN]
+model_path = /models/ball_detector.onnx   # plain .onnx, no encryption
+device = cuda:0
+# leave model_key unset
+```
+
+Add a volume mount for the model directory:
+
+```yaml
+volumes:
+  - ./models:/models:ro
+```
+
+This bypasses `SecureLoader` entirely — useful for inference tuning or running against a custom model.
+
+---
+
+## GPU acceleration
+
+The image is GPU-capable. When CUDA is available inside the container, ball detection runs on the GPU. Otherwise it falls back to `CPUExecutionProvider`. **Same image either way** — no `:gpu`/`:cpu` tag split.
 
 ### Prerequisites for GPU
 
-- NVIDIA driver (Linux) or current NVIDIA Windows driver (for Docker Desktop / WSL2)
-- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed on the host (Linux); Docker Desktop ships it preinstalled in its WSL2 backend (Windows)
+- **Linux host:** NVIDIA driver + [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
+- **Windows host (Docker Desktop):** current NVIDIA Windows driver. Docker Desktop ships the WSL2 GPU passthrough preinstalled — nothing to install inside WSL.
 
-### Sanity-check the host can expose its GPU to a container
+Sanity-check the host can expose its GPU to a container:
 
 ```bash
 docker run --rm --gpus all nvidia/cuda:12.6.3-base-ubuntu22.04 nvidia-smi
 ```
 
-If the GPU table prints, the host is configured correctly.
+If the GPU table prints, the host is configured.
 
-### Run with GPU access
+### Adding GPU to compose
 
-The container falls back to CPU when no GPU is exposed to it, so the same image works on either host. To actually use a GPU, the host must expose it explicitly:
-
-```bash
-# docker run
-docker run --rm --gpus all video-grouper
-```
-
-To use GPU under `docker compose`, add the standard NVIDIA reservation block to your local `docker-compose.yaml` (or a compose override):
+The default `docker-compose.yaml` does **not** request a GPU because compose hard-fails on hosts without an NVIDIA runtime. To use GPU under compose, add this to your local override:
 
 ```yaml
 services:
@@ -98,31 +218,42 @@ services:
               capabilities: [gpu]
 ```
 
-This block is intentionally NOT in the default `docker-compose.yaml` because compose hard-fails on hosts without an NVIDIA runtime — keeping it out lets the same compose file work for everyone.
+Or pass `--gpus all` to `docker run` directly (works on every host with the toolkit installed).
 
-### Enabling ball detection
+### Forcing CPU on a GPU host
 
-Ball detection is opt-in via `config.ini`:
+Two ways:
 
-```ini
-[BALL_TRACKING]
-enabled = true
-provider = homegrown
+- Drop `--gpus all` (or remove the `deploy.resources` block) — the container won't see the GPU.
+- Set `device = cpu` in `[BALL_TRACKING.HOMEGROWN]` — the inference session is built with CPU-only providers regardless of host.
 
-[BALL_TRACKING.HOMEGROWN]
-device = cuda:0   # use cpu to force the CPU execution provider
-```
+---
 
-### Verifying the GPU is actually being used
+## Troubleshooting
 
-Once a game reaches the ball-tracking stage, the inference session logs which execution provider it picked:
+### `nvidia-container-cli: initialization error: WSL environment detected but no adapters were found`
 
-```bash
-docker compose logs video-grouper | grep "ONNX session using"
-# GPU host:  ONNX session using: ['CUDAExecutionProvider', 'CPUExecutionProvider']
-# CPU host:  ONNX session using: ['CPUExecutionProvider']
-```
+The host doesn't have a usable NVIDIA driver. On Windows, install the latest NVIDIA Game Ready / Studio driver and restart Docker Desktop. Or just run without `--gpus all` — ORT will use CPU.
 
-### Falling back to CPU
+### `detect: model_key is set but TTT integration is disabled`
 
-Drop the `--gpus all` flag (or set `device = cpu` in `[BALL_TRACKING.HOMEGROWN]`). No code change needed; ORT picks `CPUExecutionProvider` automatically.
+`[BALL_TRACKING.HOMEGROWN] model_key` is set but `[TTT] enabled` is `false`. Either flip TTT on (and configure credentials) or use `model_path` instead for local testing.
+
+### `License signature did not validate against any known key`
+
+The container's `plugin_signing_public_keys` doesn't include the key the TTT backend signed the license with. Either:
+
+- The default in code is stale — check for a soccer-cam release that ships the new key, or
+- Your TTT instance is signing with a non-default key — set `[TTT] plugin_signing_public_keys = ["<hex>"]` to override.
+
+### `Artifact SHA-256 does not match license manifest`
+
+The `.enc` artifact at `artifact_url` was modified or replaced after the license was issued. Re-acquire (clear `/shared_data/ttt/tokens.json` and restart so a fresh license is requested).
+
+### `Configuration file not found at /app/shared_data/config.ini`
+
+Either the `./shared_data:/shared_data` volume isn't mounted, or `config.ini` isn't inside it. The default compose file mounts `./video_grouper/config.ini:/app/config.ini` — that path also works.
+
+### Container starts but `ONNX session using` never appears in logs
+
+Ball-tracking only runs once a game reaches the `trimmed` state. If you don't have a fully-downloaded game yet, no inference will happen. Check the queue state files in `/shared_data/` to see what stage games are at.

--- a/video_grouper/docs/docker/README.md
+++ b/video_grouper/docs/docker/README.md
@@ -56,4 +56,58 @@ The Docker setup includes two volume mounts:
 1. `./shared_data:/shared_data` - For storing downloaded and processed videos
 2. `./video_grouper/config.ini:/app/config.ini` - For the application configuration
 
-Make sure these directories exist and have the correct permissions. 
+Make sure these directories exist and have the correct permissions.
+
+## GPU Acceleration (Optional)
+
+The image is GPU-capable: ONNX-based ball detection runs on a CUDA GPU when one is available, otherwise it transparently falls back to CPU. The same image works on GPU and non-GPU hosts — no separate tag.
+
+### Prerequisites for GPU
+
+- NVIDIA driver (Linux) or current NVIDIA Windows driver (for Docker Desktop / WSL2)
+- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed on the host (Linux); Docker Desktop ships it preinstalled in its WSL2 backend (Windows)
+
+### Sanity-check the host can expose its GPU to a container
+
+```bash
+docker run --rm --gpus all nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04 nvidia-smi
+```
+
+If the GPU table prints, the host is configured correctly.
+
+### Run with GPU access
+
+```bash
+# docker run
+docker run --rm --gpus all video-grouper
+
+# docker compose (already includes the device reservation in docker-compose.yaml)
+docker compose up
+```
+
+### Enabling ball detection
+
+Ball detection is opt-in via `config.ini`:
+
+```ini
+[BALL_TRACKING]
+enabled = true
+provider = homegrown
+
+[BALL_TRACKING.HOMEGROWN]
+device = cuda:0   # use cpu to force the CPU execution provider
+```
+
+### Verifying the GPU is actually being used
+
+Once a game reaches the ball-tracking stage, the inference session logs which execution provider it picked:
+
+```bash
+docker compose logs video-grouper | grep "ONNX session using"
+# GPU host:  ONNX session using: ['CUDAExecutionProvider', 'CPUExecutionProvider']
+# CPU host:  ONNX session using: ['CPUExecutionProvider']
+```
+
+### Falling back to CPU
+
+Drop the `--gpus all` flag (or set `device = cpu` in `[BALL_TRACKING.HOMEGROWN]`). No code change needed; ORT picks `CPUExecutionProvider` automatically.


### PR DESCRIPTION
## Summary
- The Linux Docker container had no inference framework at all (`onnxruntime-gpu` was gated `sys_platform == 'win32'` in `pyproject.toml:29`). Any Linux user enabling ball tracking with the homegrown provider would hit `ImportError`.
- Single image now serves both GPU and CPU hosts: ORT silently falls back to `CPUExecutionProvider` when CUDA isn't available. No `:gpu`/`:cpu` tag split.
- Multi-stage build keeps final size at **2.89 GB** (down from previous ~500 MB CPU-only image, but ORT-GPU is genuinely large; 6.91 GB → 5.47 GB → 2.89 GB through three rounds of optimization).
- Base: `nvidia/cuda:12.6.3-base-ubuntu22.04` (driver stub + apt repo config only) + selective apt-install of `cuda-cudart-12-6` + `libcublas-12-6`. cuDNN is bundled in the ORT 1.24 wheel.
- Strip debug symbols from compiled extensions in the .venv.
- No system ffmpeg: PyAV bundles `libavcodec`/`libavformat` via wheel and no code uses subprocess ffmpeg (verified via grep).
- Also fixes a latent bug in the version.py overwrite step that would have crashed `python -m video_grouper` startup in **every** prior container — the overwrite stripped the `__version__`/`__version_full__` dunder aliases that `video_grouper/__init__.py:6` imports.
- `docker-compose.yaml` gets `deploy.resources.reservations.devices` for nvidia GPUs.

## Final size breakdown
- `/app/.venv` 929 MB (mostly `onnxruntime` 400 MB + opencv 158 MB + PyAV 104 MB)
- `/usr/local/cuda-12.6` 726 MB (cudart + cublas only)
- ubuntu22.04 + python3.13 + system ~1.2 GB

## Test plan
- [x] `docker build` succeeds; image is 2.89 GB
- [x] `docker run video-grouper:gpu-test python -c "import onnxruntime; ..."` returns `['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider']`
- [x] Full import chain loads (`video_grouper` → `video_grouper_app` → `inference.ball_detector` → `ball_tracking.providers.homegrown.stages.detect`)
- [ ] **`--gpus all` runtime not verified** — dev machine has no NVIDIA driver. Needs verification on a real GPU host (e.g., a training worker): `docker run --rm --gpus all <image> python -c "import onnxruntime; sess = onnxruntime.InferenceSession(...)"` should report `CUDAExecutionProvider` actually selected.
- [ ] Verify CI `Build Docker Container` workflow succeeds and pushes the new image to DockerHub.