### PR TITLE
Highlight reel polish: 409-aware claim, blocker reporting, idempotent upload

### DIFF
--- a/tests/test_highlight_reel_processor.py
+++ b/tests/test_highlight_reel_processor.py
@@ -129,6 +129,7 @@ async def test_happy_path_renders_uploads_and_reports(
     ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
     ttt_client.get_highlight_game_clips = MagicMock(return_value=game_clips)
     ttt_client.claim_highlight = MagicMock(return_value=reel)
+    ttt_client.get_highlight = MagicMock(return_value=reel)
     ttt_client.complete_highlight = MagicMock(return_value=reel)
     ttt_client.fail_highlight = MagicMock()
 
@@ -140,7 +141,7 @@ async def test_happy_path_renders_uploads_and_reports(
     while processor._processing:
         await asyncio.sleep(0.01)
 
-    ttt_client.claim_highlight.assert_called_once_with("reel-1")
+    ttt_client.claim_highlight.assert_called_once_with("reel-1", "cam-xyz")
     ttt_client.complete_highlight.assert_called_once()
     kwargs = ttt_client.complete_highlight.call_args.kwargs
     assert kwargs["youtube_video_id"] == "YT_REEL_123"
@@ -236,6 +237,7 @@ async def test_upload_failure_marks_reel_failed(
     ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
     ttt_client.get_highlight_game_clips = MagicMock(return_value=game_clips)
     ttt_client.claim_highlight = MagicMock()
+    ttt_client.get_highlight = MagicMock(return_value=reel)
     ttt_client.complete_highlight = MagicMock()
     ttt_client.fail_highlight = MagicMock()
 
@@ -277,6 +279,7 @@ async def test_idempotency_within_single_poll(
     ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
     ttt_client.get_highlight_game_clips = MagicMock(return_value=game_clips)
     ttt_client.claim_highlight = MagicMock(return_value=reel)
+    ttt_client.get_highlight = MagicMock(return_value=reel)
     ttt_client.complete_highlight = MagicMock(return_value=reel)
     ttt_client.fail_highlight = MagicMock()
 
@@ -348,6 +351,7 @@ async def test_progress_emitted_per_stage(
     ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
     ttt_client.get_highlight_game_clips = MagicMock(return_value=game_clips)
     ttt_client.claim_highlight = MagicMock(return_value=reel)
+    ttt_client.get_highlight = MagicMock(return_value=reel)
     ttt_client.complete_highlight = MagicMock(return_value=reel)
     ttt_client.fail_highlight = MagicMock()
     ttt_client.update_highlight_progress = MagicMock()
@@ -436,6 +440,7 @@ async def test_upload_returns_none_marks_reel_failed(
     ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
     ttt_client.get_highlight_game_clips = MagicMock(return_value=game_clips)
     ttt_client.claim_highlight = MagicMock()
+    ttt_client.get_highlight = MagicMock(return_value=reel)
     ttt_client.complete_highlight = MagicMock()
     ttt_client.fail_highlight = MagicMock()
 
@@ -472,6 +477,7 @@ async def test_upload_on_progress_throttle_emits_at_5_percent_steps(
     ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
     ttt_client.get_highlight_game_clips = MagicMock(return_value=game_clips)
     ttt_client.claim_highlight = MagicMock()
+    ttt_client.get_highlight = MagicMock(return_value=reel)
     ttt_client.complete_highlight = MagicMock()
     ttt_client.fail_highlight = MagicMock()
     ttt_client.update_highlight_progress = MagicMock()
@@ -532,4 +538,125 @@ async def test_upload_on_progress_throttle_emits_at_5_percent_steps(
     assert 12 not in uploading_emits
 
     ttt_client.complete_highlight.assert_called_once()
+    ttt_client.fail_highlight.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skip_reports_blocker_once_per_session(tmp_path):
+    """When a clip's source is missing, report_blocker is called exactly once per
+    session even if discover_work fires multiple times for the same reel."""
+    # game-A is present; game-B is NOT staged → reel skips on clip 1.
+    _stage_recording(tmp_path, "game-A")
+
+    reel = {"id": "reel-blocker", "title": "Missing source", "status": "pending"}
+    game_clips = [_make_clip(0, "game-A"), _make_clip(1, "game-B")]
+
+    ttt_client = MagicMock()
+    ttt_client.is_authenticated = MagicMock(return_value=True)
+    ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
+    ttt_client.get_highlight_game_clips = MagicMock(return_value=game_clips)
+    ttt_client.claim_highlight = MagicMock()
+    ttt_client.report_blocker = MagicMock(return_value=reel)
+    ttt_client.complete_highlight = MagicMock()
+    ttt_client.fail_highlight = MagicMock()
+
+    processor = _make_processor(tmp_path, ttt_client=ttt_client)
+
+    # First poll — reel-blocker is new, should report blocker once.
+    await processor.discover_work()
+    await asyncio.sleep(0)
+    while processor._processing:
+        await asyncio.sleep(0.01)
+
+    # Second poll — same reel still pending, already in _already_skipped.
+    await processor.discover_work()
+    await asyncio.sleep(0)
+    while processor._processing:
+        await asyncio.sleep(0.01)
+
+    ttt_client.claim_highlight.assert_not_called()
+    ttt_client.report_blocker.assert_called_once()
+    call_args = ttt_client.report_blocker.call_args
+    assert call_args[0][0] == "reel-blocker"
+    assert call_args[0][1] == "cam-xyz"
+    assert "game-B" in call_args[0][2]
+
+
+@pytest.mark.asyncio
+async def test_claim_409_skips_rendering(
+    tmp_path, stub_trim_video, stub_combine_videos
+):
+    """When claim_highlight returns None (409 from TTT), the processor must not
+    render, upload, or call complete_highlight / fail_highlight."""
+    _stage_recording(tmp_path, "game-A")
+
+    reel = {"id": "reel-409", "title": "Already claimed", "status": "pending"}
+    game_clips = [_make_clip(0, "game-A")]
+
+    ttt_client = MagicMock()
+    ttt_client.is_authenticated = MagicMock(return_value=True)
+    ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
+    ttt_client.get_highlight_game_clips = MagicMock(return_value=game_clips)
+    # Simulate 409 — another camera-manager already claimed the reel.
+    ttt_client.claim_highlight = MagicMock(return_value=None)
+    ttt_client.complete_highlight = MagicMock()
+    ttt_client.fail_highlight = MagicMock()
+
+    yt = MagicMock()
+    yt.upload_video = MagicMock(return_value="YT_SHOULD_NOT_BE_CALLED")
+
+    processor = _make_processor(tmp_path, ttt_client=ttt_client, youtube_uploader=yt)
+    await processor.discover_work()
+    await asyncio.sleep(0)
+    while processor._processing:
+        await asyncio.sleep(0.01)
+
+    ttt_client.claim_highlight.assert_called_once_with("reel-409", "cam-xyz")
+    yt.upload_video.assert_not_called()
+    ttt_client.complete_highlight.assert_not_called()
+    ttt_client.fail_highlight.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_idempotent_upload_when_youtube_video_id_present(
+    tmp_path, stub_trim_video, stub_combine_videos
+):
+    """When get_highlight returns a reel that already has youtube_video_id set
+    (a prior run uploaded but complete_highlight PATCH failed), the processor
+    must NOT upload again but MUST call complete_highlight with the existing id."""
+    _stage_recording(tmp_path, "game-A")
+
+    reel = {"id": "reel-idem", "title": "Already uploaded", "status": "generating"}
+    game_clips = [_make_clip(0, "game-A")]
+
+    # The pending reel (from get_pending_highlights) has no youtube_video_id.
+    # But get_highlight (called just before upload) reveals it was already uploaded.
+    reel_with_yt = dict(reel, youtube_video_id="YT_EXISTING_456")
+
+    ttt_client = MagicMock()
+    ttt_client.is_authenticated = MagicMock(return_value=True)
+    ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
+    ttt_client.get_highlight_game_clips = MagicMock(return_value=game_clips)
+    ttt_client.claim_highlight = MagicMock(return_value=reel)
+    # get_highlight reveals the previously uploaded video id.
+    ttt_client.get_highlight = MagicMock(return_value=reel_with_yt)
+    ttt_client.complete_highlight = MagicMock(return_value=reel_with_yt)
+    ttt_client.fail_highlight = MagicMock()
+
+    yt = MagicMock()
+    yt.upload_video = MagicMock(return_value="YT_NEW_SHOULD_NOT_BE_CALLED")
+
+    processor = _make_processor(tmp_path, ttt_client=ttt_client, youtube_uploader=yt)
+    await processor.discover_work()
+    await asyncio.sleep(0)
+    while processor._processing:
+        await asyncio.sleep(0.01)
+
+    # Upload must be skipped.
+    yt.upload_video.assert_not_called()
+    # complete_highlight must be called with the EXISTING youtube_video_id.
+    ttt_client.complete_highlight.assert_called_once()
+    kwargs = ttt_client.complete_highlight.call_args.kwargs
+    assert kwargs["youtube_video_id"] == "YT_EXISTING_456"
+    assert kwargs["file_path"].endswith(".mp4")
     ttt_client.fail_highlight.assert_not_called()

--- a/video_grouper/api_integrations/mock_ttt_api.py
+++ b/video_grouper/api_integrations/mock_ttt_api.py
@@ -150,12 +150,35 @@ class MockTTTApiClient:
     def get_highlight_game_clips(self, reel_id: str) -> list[dict[str, Any]]:
         return list(self._highlight_game_clips.get(reel_id, []))
 
-    def claim_highlight(self, reel_id: str) -> dict[str, Any]:
+    def get_highlight(self, reel_id: str) -> dict[str, Any]:
         for r in self._highlights:
             if r["id"] == reel_id:
+                return dict(r)
+        return {"id": reel_id, "status": "pending"}
+
+    def claim_highlight(self, reel_id: str, camera_id: str) -> Optional[dict[str, Any]]:
+        """Return updated reel on success; return None if already claimed (409)."""
+        for r in self._highlights:
+            if r["id"] == reel_id:
+                if r.get("status") != "pending":
+                    return None
                 r["status"] = "generating"
-                return r
-        return {"id": reel_id, "status": "generating"}
+                r["claimed_by_camera_id"] = camera_id
+                return dict(r)
+        return {
+            "id": reel_id,
+            "status": "generating",
+            "claimed_by_camera_id": camera_id,
+        }
+
+    def report_blocker(
+        self, reel_id: str, camera_id: str, reason: str
+    ) -> Optional[dict[str, Any]]:
+        for r in self._highlights:
+            if r["id"] == reel_id:
+                r["unrenderable_reason"] = reason[:500]
+                return dict(r)
+        return {"id": reel_id, "unrenderable_reason": reason[:500]}
 
     def update_highlight_progress(
         self,

--- a/video_grouper/api_integrations/ttt_api.py
+++ b/video_grouper/api_integrations/ttt_api.py
@@ -435,11 +435,63 @@ class TTTApiClient:
         logger.debug("Fetching game clips for highlight reel %s", reel_id)
         return self._request("GET", url)
 
-    def claim_highlight(self, reel_id: str) -> dict[str, Any]:
-        """Mark a highlight reel as in-progress (status='generating')."""
+    def get_highlight(self, reel_id: str) -> dict[str, Any]:
+        """Fetch the current state of a single highlight reel.
+
+        GET {api_base_url}/api/highlights/{reel_id}
+
+        Used for the idempotent-upload check: if a previous run uploaded to
+        YouTube but failed to PATCH complete, the reel may already carry a
+        ``youtube_video_id`` that we can reuse rather than uploading again.
+        """
         url = f"{self.api_base_url}/api/highlights/{reel_id}"
+        logger.debug("Fetching highlight reel %s", reel_id)
+        return self._request("GET", url)
+
+    def claim_highlight(self, reel_id: str, camera_id: str) -> Optional[dict[str, Any]]:
+        """Atomically transition a highlight reel from pending → generating.
+
+        POST {api_base_url}/api/highlights/{reel_id}/claim
+        body: {"camera_id": <camera_id>}
+
+        Returns the updated reel dict on 200.
+        Returns None on 409 (reel already claimed by another camera-manager or
+        no longer pending) — callers should check for None and skip rendering.
+        """
+        url = f"{self.api_base_url}/api/highlights/{reel_id}/claim"
+        body = {"camera_id": camera_id}
         logger.debug("Claiming highlight reel %s", reel_id)
-        return self._request("PATCH", url, json={"status": "generating"})
+        try:
+            return self._request("POST", url, json=body)
+        except TTTApiError as exc:
+            if exc.status_code == 409:
+                logger.info(
+                    "reel %s already claimed by another camera-manager (409)", reel_id
+                )
+                return None
+            raise
+
+    def report_blocker(
+        self, reel_id: str, camera_id: str, reason: str
+    ) -> Optional[dict[str, Any]]:
+        """Report that this install cannot render the reel (e.g. missing source video).
+
+        POST {api_base_url}/api/highlights/{reel_id}/report-blocker
+        body: {"camera_id": <camera_id>, "reason": <text up to 500 chars>}
+
+        Returns the response dict on success. On non-2xx, logs at WARNING and
+        returns None — a failed blocker report must not kill the render loop.
+        """
+        url = f"{self.api_base_url}/api/highlights/{reel_id}/report-blocker"
+        body = {"camera_id": camera_id, "reason": reason[:500]}
+        logger.debug("Reporting blocker for reel %s: %s", reel_id, reason)
+        try:
+            return self._request("POST", url, json=body)
+        except Exception as exc:
+            logger.warning(
+                "HIGHLIGHT_REEL: failed to report blocker for reel %s: %s", reel_id, exc
+            )
+            return None
 
     def update_highlight_progress(
         self,

--- a/video_grouper/task_processors/highlight_reel_processor.py
+++ b/video_grouper/task_processors/highlight_reel_processor.py
@@ -176,6 +176,13 @@ class HighlightReelProcessor(PollingProcessor):
                 )
                 if not resolved_dir:
                     if reel_id not in self._already_skipped:
+                        reason = (
+                            f"Clip {idx} source unavailable: "
+                            f"recording_group_dir is None"
+                            if recording_group_dir is None
+                            else f"Clip {idx} source dir not found on this camera-manager: "
+                            f"{recording_group_dir}"
+                        )
                         logger.info(
                             "HIGHLIGHT_REEL: reel %s skipped — clip %d source not local "
                             "(recording_group_dir=%r)",
@@ -184,10 +191,17 @@ class HighlightReelProcessor(PollingProcessor):
                             recording_group_dir,
                         )
                         self._already_skipped.add(reel_id)
+                        await asyncio.to_thread(
+                            self.ttt_client.report_blocker,
+                            reel_id,
+                            self.config.ttt.camera_id,
+                            reason,
+                        )
                     return
                 combined = find_combined_video(resolved_dir)
                 if not combined:
                     if reel_id not in self._already_skipped:
+                        reason = f"Clip {idx} combined.mp4 not found in {resolved_dir}"
                         logger.info(
                             "HIGHLIGHT_REEL: reel %s skipped — clip %d combined.mp4 missing in %s",
                             reel_id,
@@ -195,6 +209,12 @@ class HighlightReelProcessor(PollingProcessor):
                             resolved_dir,
                         )
                         self._already_skipped.add(reel_id)
+                        await asyncio.to_thread(
+                            self.ttt_client.report_blocker,
+                            reel_id,
+                            self.config.ttt.camera_id,
+                            reason,
+                        )
                     return
                 resolved_sources.append((clip, combined))
 
@@ -202,8 +222,19 @@ class HighlightReelProcessor(PollingProcessor):
             # future state change re-logs.
             self._already_skipped.discard(reel_id)
 
-            # Claim the reel.
-            await asyncio.to_thread(self.ttt_client.claim_highlight, reel_id)
+            # Claim the reel atomically. Returns None when another camera-manager
+            # already claimed it (409) — skip without rendering in that case.
+            camera_id = getattr(self.config.ttt, "camera_id", None) or ""
+            claim_result = await asyncio.to_thread(
+                self.ttt_client.claim_highlight, reel_id, camera_id
+            )
+            if claim_result is None:
+                logger.info(
+                    "HIGHLIGHT_REEL: reel %s already claimed by another camera-manager"
+                    " — skipping",
+                    reel_id,
+                )
+                return
             claimed = True
             logger.info(
                 "HIGHLIGHT_REEL: claimed reel %s (%d clips)",
@@ -256,6 +287,43 @@ class HighlightReelProcessor(PollingProcessor):
             await self._report_progress(reel_id, "concatenating", 100)
 
             final_output_path = task.output_path
+
+            # Idempotent-upload guard: if a prior run uploaded to YouTube but
+            # failed to PATCH complete (transient TTT outage), the reel already
+            # carries a youtube_video_id. Reuse it instead of creating an orphan.
+            try:
+                latest_reel = await asyncio.to_thread(
+                    self.ttt_client.get_highlight, reel_id
+                )
+                existing_yt_id = (latest_reel or {}).get("youtube_video_id")
+            except Exception as exc:
+                logger.warning(
+                    "HIGHLIGHT_REEL: could not refetch reel %s for idempotent check,"
+                    " proceeding with upload: %s",
+                    reel_id,
+                    exc,
+                )
+                existing_yt_id = None
+
+            if existing_yt_id:
+                logger.warning(
+                    "HIGHLIGHT_REEL: reel %s already has youtube_video_id=%s"
+                    " — skipping re-upload, marking ready",
+                    reel_id,
+                    existing_yt_id,
+                )
+                await asyncio.to_thread(
+                    self.ttt_client.complete_highlight,
+                    reel_id,
+                    file_path=final_output_path,
+                    youtube_video_id=existing_yt_id,
+                )
+                logger.info(
+                    "HIGHLIGHT_REEL: reel %s ready (youtube_video_id=%s, idempotent)",
+                    reel_id,
+                    existing_yt_id,
+                )
+                return
 
             # Upload to YouTube. on_progress is called on the uploader's thread
             # so it cannot await — schedule the PATCH back on this loop instead.


### PR DESCRIPTION
## Summary

Consumes the new TTT-side endpoints shipped in [mblakley/team-tech-tools#19](https://github.com/mblakley/team-tech-tools/pull/19).

Three behavioral changes to `HighlightReelProcessor`:

1. **409-aware claim**. Switch from PATCH `status='generating'` to `POST /api/highlights/{id}/claim`, which now does a server-side atomic conditional UPDATE. On 409 ("already claimed by another camera-manager") `claim_highlight` returns `None`; the processor logs and skips the reel. Prevents the race where two camera-managers both render and upload duplicate YouTube videos.
2. **Blocker reporting**. When a reel is skipped because clip sources aren't local (`recording_group_dir` None, dir missing on this install, or `combined.mp4` missing in the dir), `POST /api/highlights/{id}/report-blocker` so TTT can show a coach-facing reason. Reported exactly once per reel per session — dedupes via the existing `_already_skipped` set, which is pruned each poll so a retried reel can re-report.
3. **Idempotent upload**. Before YouTube upload, refetch the reel via `GET /api/highlights/{id}`. If a previous run uploaded successfully but the `complete_highlight` PATCH failed (transient TTT outage), the reel already carries `youtube_video_id` — reuse it instead of creating an orphan video on retry.

New `get_highlight(reel_id)` TTT API client method backs the idempotent-upload guard.

## Tests

15/15 passing — 3 new:
- `test_skip_reports_blocker_once_per_session`
- `test_claim_409_skips_rendering`
- `test_idempotent_upload_when_youtube_video_id_present`

`mock_ttt_api.py` mirrors all the new shapes (claim takes camera_id and returns None when not pending; get_highlight + report_blocker added).

## Test plan

- [x] All 15 highlight reel processor tests pass
- [x] Full non-integration suite green (`uv run pytest -m "not integration and not e2e"`)
- [x] Ruff format + check clean
- [ ] Live verification after merge: pause one camera-manager mid-render, restart it, confirm it doesn't re-upload (idempotent path); also confirm a clip with no local source produces a coach-visible warning in TTT (blocker path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)