### PR TITLE
Auto-claim camera-manager on TTT sign-in

### DIFF
--- a/tests/test_ttt_api.py
+++ b/tests/test_ttt_api.py
@@ -69,6 +69,98 @@ class TestTTTApiClient(unittest.TestCase):
             call_args[0], ("GET", "https://api.test.com/api/device-link/me")
         )
 
+    def test_register_as_camera_manager_returns_rows(self):
+        data = [
+            {
+                "id": "cm-1",
+                "team_id": "team-1",
+                "user_id": "u-1",
+                "email": "coach@example.com",
+                "name": "Coach Smith",
+                "created_at": "2026-05-26T00:00:00Z",
+            },
+            {
+                "id": "cm-2",
+                "team_id": "team-2",
+                "user_id": "u-1",
+                "email": "coach@example.com",
+                "name": "Coach Smith",
+                "created_at": "2026-05-26T00:00:00Z",
+            },
+        ]
+        self.client._http.request = Mock(return_value=_mock_response(200, data))
+        result = self.client.register_as_camera_manager()
+        self.assertEqual(result, data)
+        call_args = self.client._http.request.call_args
+        self.assertEqual(
+            call_args[0],
+            ("POST", "https://api.test.com/api/device-link/register-camera-manager"),
+        )
+        # Bearer auth header should be attached (standard POST pattern).
+        headers = call_args[1]["headers"]
+        self.assertEqual(headers["Authorization"], "Bearer test-jwt-token")
+
+    def test_register_as_camera_manager_zero_teams_returns_empty(self):
+        self.client._http.request = Mock(return_value=_mock_response(200, []))
+        result = self.client.register_as_camera_manager()
+        self.assertEqual(result, [])
+
+    def test_register_as_camera_manager_raises_on_network_error(self):
+        import httpx
+
+        self.client._http.request = Mock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+        with self.assertRaises(httpx.ConnectError):
+            self.client.register_as_camera_manager()
+
+    def test_register_as_camera_manager_raises_on_5xx(self):
+        self.client._http.request = Mock(
+            return_value=_mock_response(503, text="Service Unavailable")
+        )
+        with self.assertRaises(TTTApiError) as ctx:
+            self.client.register_as_camera_manager()
+        self.assertEqual(ctx.exception.status_code, 503)
+
+    def test_register_as_camera_manager_coerces_204_to_empty_list(self):
+        """If the server ever returns 204 No Content, callers still get a list."""
+        self.client._http.request = Mock(return_value=_mock_response(204))
+        result = self.client.register_as_camera_manager()
+        self.assertEqual(result, [])
+
+    def test_register_as_camera_manager_refreshes_expired_token(self):
+        """_ensure_auth() must refresh stale tokens before the POST fires."""
+        # Force the access token to look expired.
+        self.client._expires_at = time.time() - 60
+        # Refresh succeeds.
+        refresh_data = {
+            "access_token": "new-jwt",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        }
+        # Patch _store_auth_response so we don't have to forge a real JWT.
+        original_store = self.client._store_auth_response
+
+        def _store(data):
+            self.client._access_token = data["access_token"]
+            self.client._refresh_token_value = data["refresh_token"]
+            self.client._expires_at = time.time() + 3600
+
+        self.client._store_auth_response = _store
+        try:
+            self.client._http.post = Mock(
+                return_value=_mock_response(200, refresh_data)
+            )
+            self.client._http.request = Mock(return_value=_mock_response(200, []))
+            self.client.register_as_camera_manager()
+            # Refresh was attempted before the register request.
+            self.client._http.post.assert_called_once()
+            # The register request used the refreshed bearer token.
+            headers = self.client._http.request.call_args[1]["headers"]
+            self.assertEqual(headers["Authorization"], "Bearer new-jwt")
+        finally:
+            self.client._store_auth_response = original_store
+
     def test_get_pending_clip_requests(self):
         data = [{"id": "cr1", "status": "pending"}]
         self.client._http.request = Mock(return_value=_mock_response(200, data))

--- a/tests/web/test_auth_server.py
+++ b/tests/web/test_auth_server.py
@@ -346,11 +346,19 @@ def test_receive_token_persists_tokens_and_returns_success(storage, client):
     exp = int(time.time()) + 3600
     jwt = _make_jwt(sub="user-abc", exp=exp)
 
-    resp = client.post(
-        "/receive-token",
-        json={"access_token": jwt},
-        headers=_SAME_ORIGIN,
-    )
+    # Stub get_team_assignments so auto-claim doesn't try real network I/O.
+    # Returning a non-empty list also skips the register POST.
+    with patch.object(
+        TTTApiClient,
+        "get_team_assignments",
+        autospec=True,
+        return_value=[{"camera_manager_id": "cm-1", "team_id": "t-1"}],
+    ):
+        resp = client.post(
+            "/receive-token",
+            json={"access_token": jwt},
+            headers=_SAME_ORIGIN,
+        )
     assert resp.status_code == 200
     assert "Signed in" in resp.text
 
@@ -410,11 +418,18 @@ def test_receive_token_post_accepts_same_origin_referer(storage, client):
     same-origin navigations and we accept either signal."""
     exp = int(time.time()) + 3600
     jwt = _make_jwt(sub="user-ref", exp=exp)
-    resp = client.post(
-        "/receive-token",
-        json={"access_token": jwt},
-        headers={"referer": "http://localhost:8765/callback"},
-    )
+    # Stub auto-claim's GET so it doesn't try real network.
+    with patch.object(
+        TTTApiClient,
+        "get_team_assignments",
+        autospec=True,
+        return_value=[{"camera_manager_id": "cm-1"}],
+    ):
+        resp = client.post(
+            "/receive-token",
+            json={"access_token": jwt},
+            headers={"referer": "http://localhost:8765/callback"},
+        )
     assert resp.status_code == 200
     assert (storage / "ttt" / "tokens.json").exists()
 
@@ -558,7 +573,19 @@ def test_login_password_success_persists_tokens_and_redirects(storage, client):
         self._expires_at = float(exp)
         self._save_tokens()
 
-    with patch.object(TTTApiClient, "login", autospec=True, side_effect=fake_login):
+    # Auto-claim runs after sign-in succeeds and would otherwise hit the
+    # network for /api/device-link/me. Stub it to return a pre-existing
+    # assignment so register_as_camera_manager is skipped entirely; this
+    # test only cares about token persistence.
+    with (
+        patch.object(TTTApiClient, "login", autospec=True, side_effect=fake_login),
+        patch.object(
+            TTTApiClient,
+            "get_team_assignments",
+            autospec=True,
+            return_value=[{"camera_manager_id": "cm-1", "team_id": "t-1"}],
+        ),
+    ):
         resp = client.post(
             "/login/password",
             data={"email": "pw@example.com", "password": "hunter2"},
@@ -738,3 +765,317 @@ def test_supabase_internal_url_blank_falls_back_to_external(storage):
         create_app(cfg, str(storage))
 
     assert captured["supabase_url"] == "http://prod.example.com"
+
+
+# ---------------------------------------------------------------------------
+# Audit 2.2: auto-claim camera-manager on sign-in
+# ---------------------------------------------------------------------------
+
+
+def test_auto_claim_skipped_when_not_authenticated(storage):
+    """Helper is a no-op if the client somehow has no valid token yet."""
+    from video_grouper.web.auth_server import auto_claim_camera_manager
+
+    fake = type(
+        "FakeClient",
+        (),
+        {
+            "is_authenticated": lambda self: False,
+            "get_team_assignments": lambda self: pytest.fail(
+                "get_team_assignments must not be called when not authenticated"
+            ),
+            "register_as_camera_manager": lambda self: pytest.fail(
+                "register_as_camera_manager must not be called when not authenticated"
+            ),
+        },
+    )()
+    auto_claim_camera_manager(fake)
+
+
+def test_auto_claim_calls_register_when_assignments_empty(storage):
+    from video_grouper.web.auth_server import auto_claim_camera_manager
+
+    calls: dict[str, int] = {"get": 0, "register": 0}
+
+    class Fake:
+        def is_authenticated(self):
+            return True
+
+        def get_team_assignments(self):
+            calls["get"] += 1
+            return []
+
+        def register_as_camera_manager(self):
+            calls["register"] += 1
+            return [{"id": "cm-1", "team_id": "team-1"}]
+
+    auto_claim_camera_manager(Fake())
+    assert calls == {"get": 1, "register": 1}
+
+
+def test_auto_claim_skips_register_when_assignments_present(storage):
+    from video_grouper.web.auth_server import auto_claim_camera_manager
+
+    calls: dict[str, int] = {"get": 0, "register": 0}
+
+    class Fake:
+        def is_authenticated(self):
+            return True
+
+        def get_team_assignments(self):
+            calls["get"] += 1
+            return [{"camera_manager_id": "cm-1", "team_id": "team-1"}]
+
+        def register_as_camera_manager(self):
+            calls["register"] += 1
+            return []
+
+    auto_claim_camera_manager(Fake())
+    assert calls == {"get": 1, "register": 0}
+
+
+def test_auto_claim_swallows_get_failure(storage):
+    """Network error on get_team_assignments must not raise — sign-in
+    completes regardless. Register is not attempted in this case."""
+    from video_grouper.web.auth_server import auto_claim_camera_manager
+
+    calls = {"register": 0}
+
+    class Fake:
+        def is_authenticated(self):
+            return True
+
+        def get_team_assignments(self):
+            raise TTTApiError("network down", status_code=None)
+
+        def register_as_camera_manager(self):
+            calls["register"] += 1
+            return []
+
+    # Must not raise.
+    auto_claim_camera_manager(Fake())
+    assert calls["register"] == 0
+
+
+def test_auto_claim_swallows_register_failure(storage):
+    from video_grouper.web.auth_server import auto_claim_camera_manager
+
+    class Fake:
+        def is_authenticated(self):
+            return True
+
+        def get_team_assignments(self):
+            return []
+
+        def register_as_camera_manager(self):
+            raise TTTApiError("server down", status_code=500)
+
+    # Must not raise.
+    auto_claim_camera_manager(Fake())
+
+
+def test_auto_claim_swallows_arbitrary_exceptions(storage):
+    """Defense-in-depth: even a bug in the API client (e.g. AttributeError)
+    must not break sign-in."""
+    from video_grouper.web.auth_server import auto_claim_camera_manager
+
+    class Fake:
+        def is_authenticated(self):
+            return True
+
+        def get_team_assignments(self):
+            raise RuntimeError("unexpected client bug")
+
+        def register_as_camera_manager(self):
+            raise AssertionError("should not be called")
+
+    auto_claim_camera_manager(Fake())
+
+
+def test_login_password_triggers_auto_claim_when_no_assignments(storage, client):
+    """End-to-end: POST /login/password runs auth, then auto_claim fires:
+    GET /api/device-link/me returns [] → POST register-camera-manager fires once."""
+    exp = int(time.time()) + 3600
+    jwt = _make_jwt(sub="user-pw", exp=exp, email="pw@example.com")
+
+    def fake_login(self, email, password):
+        self._access_token = jwt
+        self._refresh_token_value = "r"
+        self._expires_at = float(exp)
+        self._save_tokens()
+
+    calls = {"get": 0, "register": 0}
+
+    def fake_get(self):
+        calls["get"] += 1
+        return []
+
+    def fake_register(self):
+        calls["register"] += 1
+        return [{"id": "cm-1", "team_id": "team-1"}]
+
+    with (
+        patch.object(TTTApiClient, "login", autospec=True, side_effect=fake_login),
+        patch.object(
+            TTTApiClient, "get_team_assignments", autospec=True, side_effect=fake_get
+        ),
+        patch.object(
+            TTTApiClient,
+            "register_as_camera_manager",
+            autospec=True,
+            side_effect=fake_register,
+        ),
+    ):
+        resp = client.post(
+            "/login/password",
+            data={"email": "pw@example.com", "password": "hunter2"},
+            headers=_SAME_ORIGIN,
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert calls == {"get": 1, "register": 1}
+
+
+def test_login_password_skips_auto_claim_when_assignments_present(storage, client):
+    exp = int(time.time()) + 3600
+    jwt = _make_jwt(sub="user-pw", exp=exp)
+
+    def fake_login(self, email, password):
+        self._access_token = jwt
+        self._refresh_token_value = "r"
+        self._expires_at = float(exp)
+        self._save_tokens()
+
+    calls = {"get": 0, "register": 0}
+
+    def fake_get(self):
+        calls["get"] += 1
+        return [{"camera_manager_id": "cm-1", "team_id": "team-1"}]
+
+    def fake_register(self):
+        calls["register"] += 1
+        return []
+
+    with (
+        patch.object(TTTApiClient, "login", autospec=True, side_effect=fake_login),
+        patch.object(
+            TTTApiClient, "get_team_assignments", autospec=True, side_effect=fake_get
+        ),
+        patch.object(
+            TTTApiClient,
+            "register_as_camera_manager",
+            autospec=True,
+            side_effect=fake_register,
+        ),
+    ):
+        resp = client.post(
+            "/login/password",
+            data={"email": "pw@example.com", "password": "hunter2"},
+            headers=_SAME_ORIGIN,
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert calls == {"get": 1, "register": 0}
+
+
+def test_login_password_completes_when_auto_claim_raises(storage, client):
+    """Sign-in must succeed even if both auto_claim probes blow up."""
+    exp = int(time.time()) + 3600
+    jwt = _make_jwt(sub="user-pw", exp=exp)
+
+    def fake_login(self, email, password):
+        self._access_token = jwt
+        self._refresh_token_value = "r"
+        self._expires_at = float(exp)
+        self._save_tokens()
+
+    with (
+        patch.object(TTTApiClient, "login", autospec=True, side_effect=fake_login),
+        patch.object(
+            TTTApiClient,
+            "get_team_assignments",
+            autospec=True,
+            side_effect=TTTApiError("boom"),
+        ),
+        patch.object(
+            TTTApiClient,
+            "register_as_camera_manager",
+            autospec=True,
+            side_effect=TTTApiError("also boom"),
+        ),
+    ):
+        resp = client.post(
+            "/login/password",
+            data={"email": "pw@example.com", "password": "hunter2"},
+            headers=_SAME_ORIGIN,
+            follow_redirects=False,
+        )
+
+    # 303 = sign-in succeeded; auto_claim failure didn't propagate.
+    assert resp.status_code == 303
+    # Tokens still persisted.
+    saved = json.loads((storage / "ttt" / "tokens.json").read_text(encoding="utf-8"))
+    assert saved["access_token"] == jwt
+
+
+def test_receive_token_triggers_auto_claim_when_no_assignments(storage, client):
+    """OAuth flow (/receive-token) also auto-claims camera-manager."""
+    exp = int(time.time()) + 3600
+    jwt = _make_jwt(sub="user-oauth", exp=exp)
+
+    calls = {"get": 0, "register": 0}
+
+    def fake_get(self):
+        calls["get"] += 1
+        return []
+
+    def fake_register(self):
+        calls["register"] += 1
+        return [{"id": "cm-1", "team_id": "team-oauth"}]
+
+    with (
+        patch.object(
+            TTTApiClient, "get_team_assignments", autospec=True, side_effect=fake_get
+        ),
+        patch.object(
+            TTTApiClient,
+            "register_as_camera_manager",
+            autospec=True,
+            side_effect=fake_register,
+        ),
+    ):
+        resp = client.post(
+            "/receive-token",
+            json={"access_token": jwt},
+            headers=_SAME_ORIGIN,
+        )
+
+    assert resp.status_code == 200
+    assert "Signed in" in resp.text
+    assert calls == {"get": 1, "register": 1}
+
+
+def test_receive_token_completes_when_auto_claim_raises(storage, client):
+    """OAuth sign-in must not fail because of an auto-claim error."""
+    exp = int(time.time()) + 3600
+    jwt = _make_jwt(sub="user-oauth", exp=exp)
+
+    with patch.object(
+        TTTApiClient,
+        "get_team_assignments",
+        autospec=True,
+        side_effect=TTTApiError("network reset"),
+    ):
+        resp = client.post(
+            "/receive-token",
+            json={"access_token": jwt},
+            headers=_SAME_ORIGIN,
+        )
+
+    assert resp.status_code == 200
+    assert "Signed in" in resp.text
+    # Token still persisted.
+    saved = json.loads((storage / "ttt" / "tokens.json").read_text(encoding="utf-8"))
+    assert saved["access_token"] == jwt

--- a/video_grouper/api_integrations/mock_ttt_api.py
+++ b/video_grouper/api_integrations/mock_ttt_api.py
@@ -87,6 +87,22 @@ class MockTTTApiClient:
         self._acknowledged_commands: list[str] = []
         self._completed_commands: list[dict[str, Any]] = []
 
+        # Tracks calls to register_as_camera_manager so tests can assert
+        # the post-sign-in claim fired exactly once. ``register_response``
+        # is what subsequent calls return; defaults to the same single-team
+        # shape used by get_team_assignments() but tests can override.
+        self.register_camera_manager_call_count: int = 0
+        self.register_camera_manager_response: list[dict[str, Any]] = [
+            {
+                "id": str(uuid.uuid4()),
+                "team_id": MOCK_TEAM_ID,
+                "user_id": MOCK_USER_ID,
+                "email": "coach@example.com",
+                "name": "Coach Smith",
+                "created_at": self._base_time.isoformat(),
+            }
+        ]
+
         logger.info("MockTTTApiClient initialized with base_time=%s", self._base_time)
 
     # ------------------------------------------------------------------
@@ -115,6 +131,16 @@ class MockTTTApiClient:
                 "team_name": "Hawks",
             }
         ]
+
+    def register_as_camera_manager(self) -> list[dict[str, Any]]:
+        """Mock auto-claim — returns the configured response and counts calls."""
+        self.register_camera_manager_call_count += 1
+        logger.debug(
+            "Mock register_as_camera_manager call #%d",
+            self.register_camera_manager_call_count,
+        )
+        # Return a shallow copy so callers can't mutate the canned response.
+        return list(self.register_camera_manager_response)
 
     def get_pending_clip_requests(self) -> list[dict[str, Any]]:
         return [r for r in self._clip_requests if r["status"] == "pending"]

--- a/video_grouper/api_integrations/ttt_api.py
+++ b/video_grouper/api_integrations/ttt_api.py
@@ -366,6 +366,24 @@ class TTTApiClient:
         logger.debug("Fetching team assignments from %s", url)
         return self._request("GET", url)
 
+    def register_as_camera_manager(self) -> list[dict[str, Any]]:
+        """Auto-claim camera-manager status for every team the user belongs to.
+
+        POST {api_base_url}/api/device-link/register-camera-manager
+
+        Idempotent: the server iterates approved team_members rows for the
+        caller, creates the missing camera_managers rows, and returns the
+        union of existing + newly-created rows. Each entry has
+        ``id``, ``team_id``, ``user_id``, ``email``, ``name``, ``created_at``.
+
+        Returns ``[]`` when the user has zero approved team memberships.
+        """
+        url = f"{self.api_base_url}/api/device-link/register-camera-manager"
+        logger.debug("Registering as camera manager via %s", url)
+        result = self._request("POST", url)
+        # 204 maps to None upstream; coerce so callers always get a list.
+        return result if isinstance(result, list) else []
+
     def get_pending_clip_requests(self) -> Any:
         """Get pending clip requests for linked teams.
 

--- a/video_grouper/video_grouper_app.py
+++ b/video_grouper/video_grouper_app.py
@@ -305,6 +305,14 @@ class VideoGrouperApp:
                         logger.info("TTT API client authenticated")
                     except Exception as e:
                         logger.error(f"TTT login failed: {e}")
+                    else:
+                        # Auto-claim camera-manager rows for every team the
+                        # signed-in user is on. Best-effort; never blocks startup.
+                        from video_grouper.web.auth_server import (
+                            auto_claim_camera_manager,
+                        )
+
+                        auto_claim_camera_manager(ttt_client)
 
                 # Initialize plugin manager
                 try:
@@ -456,6 +464,12 @@ class VideoGrouperApp:
                             )
                         except Exception as e:
                             logger.error(f"TTT login failed for job processor: {e}")
+                        else:
+                            from video_grouper.web.auth_server import (
+                                auto_claim_camera_manager,
+                            )
+
+                            auto_claim_camera_manager(ttt_client)
 
                 from video_grouper.task_processors.ttt_job_processor import (
                     TTTJobProcessor,

--- a/video_grouper/web/auth_server.py
+++ b/video_grouper/web/auth_server.py
@@ -294,6 +294,52 @@ def _resolve_url(override: str, fallback: str) -> str:
     return override.strip() if override and override.strip() else fallback
 
 
+def auto_claim_camera_manager(client: TTTApiClient) -> None:
+    """After a successful TTT sign-in, auto-claim camera-manager for the user's teams.
+
+    Calls ``GET /api/device-link/me`` first; if the user already has any
+    assignments we skip the register POST (idempotent on the server, but
+    the GET is cheaper than re-walking the user's team_members rows).
+    When ``GET`` returns empty, POSTs ``/api/device-link/register-camera-manager``
+    so every team the signed-in user is approved on gets a camera_managers row.
+
+    All failures are swallowed and logged at WARNING — this is a
+    best-effort bookkeeping step that must never block sign-in. The
+    network call sits inline with sign-in (no polling loop, per the
+    inline-pipeline-push convention).
+    """
+    if not client.is_authenticated():
+        logger.debug("Skipping camera-manager auto-claim: client not authenticated")
+        return
+    try:
+        existing = client.get_team_assignments()
+    except TTTApiError as exc:
+        logger.warning(
+            "Camera-manager auto-claim skipped: get_team_assignments failed: %s", exc
+        )
+        return
+    except Exception as exc:  # noqa: BLE001 — best-effort, must not block sign-in
+        logger.warning(
+            "Camera-manager auto-claim skipped: get_team_assignments raised: %s", exc
+        )
+        return
+    if existing:
+        logger.debug(
+            "Camera-manager auto-claim skipped: user already has %d assignment(s)",
+            len(existing),
+        )
+        return
+    try:
+        rows = client.register_as_camera_manager()
+    except TTTApiError as exc:
+        logger.warning("Camera-manager auto-claim failed: %s", exc)
+        return
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.warning("Camera-manager auto-claim raised: %s", exc)
+        return
+    logger.info("Camera-manager auto-claim returned %d row(s)", len(rows))
+
+
 # In-memory OAuth state store for the YouTube flow. Maps an
 # unguessable random ``state`` token to the wizard's chosen
 # ``storage_path`` (so the callback writes ``token.json`` to the
@@ -900,6 +946,7 @@ def create_app(
                 status_code=401,
             )
         logger.info("Password sign-in complete for %s", email)
+        auto_claim_camera_manager(client)
         return RedirectResponse(url="/", status_code=303)
 
     @app.post("/login/magic")
@@ -945,6 +992,7 @@ def create_app(
                 status_code=400,
             )
         logger.info("OAuth sign-in complete; tokens persisted")
+        auto_claim_camera_manager(client)
         return HTMLResponse(_SUCCESS_PAGE)
 
     @app.post("/auth/youtube/upload-credentials", response_class=HTMLResponse)


### PR DESCRIPTION
## Summary
- Calls the new TTT endpoint `POST /api/device-link/register-camera-manager` after every TTT sign-in path so the user automatically becomes a camera manager for every team they're approved on. Companion to TTT [PR #23](https://github.com/mblakley/team-tech-tools/pull/23).
- Probes `GET /api/device-link/me` first — if the user already has assignments, the helper skips the POST.
- Failures are swallowed (logged at WARNING) so TTT being down never blocks the soccer-cam sign-in flow.

## Hook sites
Every TTT sign-in path now calls `auto_claim_camera_manager(client)`:
- `web/auth_server.py:949` — `/login/password` (email + password)
- `web/auth_server.py:995` — `/receive-token` (OAuth + magic-link)
- `video_grouper_app.py:315` and `:472` — headless startup login

## Test plan
- [x] `uv run ruff check video_grouper/ tests/` → all checks passed
- [x] `uv run ruff format --check` → 244 files already formatted
- [x] `uv run pytest -m "not integration and not e2e"` → 1035 passed, 1 skipped (17 new tests)
- [x] Negative paths exercised: zero teams (`[]`), TTT down (helper logs, sign-in completes), token expired (existing refresh kicks in), 5xx, network error, arbitrary client bug
- [ ] Real-device manual test after TTT PR #23 merges: install this build, sign in to TTT prod, verify camera_managers rows appear via `/api/device-link/me` and the JWT `camera_manager_ids` claim is populated on next session refresh

## Constraints respected
- One feature branch, one commit (per `[Phased work single branch]`)
- Targets `main` (per `[soccer-cam base branch is main]`, not `development`)
- No model names or specific premium artifacts named (per OSS hygiene memos)
- Inline call pattern matching `[Inline pipeline push]` — no polling loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)