### PR TITLE
Route highlight reels by source — render moment-tagger reels (Phase C)

### DIFF
--- a/tests/test_highlight_reel_processor.py
+++ b/tests/test_highlight_reel_processor.py
@@ -64,6 +64,27 @@ def _make_clip(idx: int, group_dir: str, start: int = 10, end: int = 20):
     }
 
 
+def _make_moment_clip(
+    idx: int, group_dir: str | None, start: float = 110.5, end: float = 140.5
+):
+    """A minimal moment-clip dict shaped like get_highlight_moment_clips returns.
+
+    Moment clips use float clip_start_offset/clip_end_offset (absolute
+    offsets into the source combined.mp4) instead of int start_time/end_time.
+    """
+    return {
+        "id": f"mclip-{idx}",
+        "moment_tag_id": f"tag-{idx}",
+        "game_session_id": "gs-1",
+        "clip_start_offset": start,
+        "clip_end_offset": end,
+        "clip_duration": end - start,
+        "status": "ready",
+        "recording_group_dir": group_dir,
+        "sequence_order": idx,
+    }
+
+
 @pytest.fixture
 def stub_combine_videos():
     """Stub combine_videos to write a fake output and return True.
@@ -659,4 +680,318 @@ async def test_idempotent_upload_when_youtube_video_id_present(
     kwargs = ttt_client.complete_highlight.call_args.kwargs
     assert kwargs["youtube_video_id"] == "YT_EXISTING_456"
     assert kwargs["file_path"].endswith(".mp4")
+    ttt_client.fail_highlight.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Moment-tagger reel path (source='moment_tagger')
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_moment_reel_happy_path_renders_uploads_and_reports(
+    tmp_path, stub_trim_video, stub_combine_videos
+):
+    """A moment-tagger reel routes through get_highlight_moment_clips, trims
+    using clip_start_offset/clip_end_offset, then claims → concat → upload →
+    complete. The game-clip endpoint must NOT be called for this reel."""
+    _stage_recording(tmp_path, "game-A")
+
+    reel = {
+        "id": "reel-m1",
+        "title": "Bob's moments",
+        "player_name": "Bob",
+        "status": "pending",
+        "source": "moment_tagger",
+    }
+    moment_clips = [
+        _make_moment_clip(0, "game-A", start=110.5, end=140.5),
+        _make_moment_clip(1, "game-A", start=200.0, end=220.0),
+    ]
+
+    ttt_client = MagicMock()
+    ttt_client.is_authenticated = MagicMock(return_value=True)
+    ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
+    ttt_client.get_highlight_moment_clips = MagicMock(return_value=moment_clips)
+    ttt_client.get_highlight_game_clips = MagicMock(
+        side_effect=AssertionError("game-clips endpoint must not be called")
+    )
+    ttt_client.claim_highlight = MagicMock(return_value=reel)
+    ttt_client.get_highlight = MagicMock(return_value=reel)
+    ttt_client.complete_highlight = MagicMock(return_value=reel)
+    ttt_client.fail_highlight = MagicMock()
+
+    processor = _make_processor(tmp_path, ttt_client=ttt_client)
+
+    await processor.discover_work()
+    await asyncio.sleep(0)
+    while processor._processing:
+        await asyncio.sleep(0.01)
+
+    ttt_client.get_highlight_moment_clips.assert_called_once_with("reel-m1")
+    ttt_client.get_highlight_game_clips.assert_not_called()
+    ttt_client.claim_highlight.assert_called_once_with("reel-m1", "cam-xyz")
+    ttt_client.complete_highlight.assert_called_once()
+    kwargs = ttt_client.complete_highlight.call_args.kwargs
+    assert kwargs["youtube_video_id"] == "YT_REEL_123"
+    assert kwargs["file_path"].endswith(".mp4")
+    ttt_client.fail_highlight.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_moment_reel_uses_clip_offsets_for_trim(tmp_path, stub_combine_videos):
+    """Verify trim_video is called with float clip_start_offset/clip_end_offset
+    (not start_time/end_time) — and that sub-second precision survives."""
+    _stage_recording(tmp_path, "game-A")
+
+    reel = {
+        "id": "reel-m-trim",
+        "title": "Trim args",
+        "status": "pending",
+        "source": "moment_tagger",
+    }
+    # Pick offsets with sub-second precision to make sure formatting preserves them.
+    moment_clips = [_make_moment_clip(0, "game-A", start=110.123, end=140.456)]
+
+    ttt_client = MagicMock()
+    ttt_client.is_authenticated = MagicMock(return_value=True)
+    ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
+    ttt_client.get_highlight_moment_clips = MagicMock(return_value=moment_clips)
+    ttt_client.claim_highlight = MagicMock(return_value=reel)
+    ttt_client.get_highlight = MagicMock(return_value=reel)
+    ttt_client.complete_highlight = MagicMock()
+    ttt_client.fail_highlight = MagicMock()
+
+    captured: list[tuple[str, str, str, str]] = []
+
+    async def _capture_trim(src: str, dst: str, start: str, duration: str) -> bool:
+        captured.append((src, dst, start, duration))
+        with open(dst, "wb") as fh:
+            fh.write(b"\x00" * 16)
+        return True
+
+    with patch(
+        "video_grouper.task_processors.highlight_reel_processor.trim_video",
+        side_effect=_capture_trim,
+    ):
+        processor = _make_processor(tmp_path, ttt_client=ttt_client)
+        await processor.discover_work()
+        await asyncio.sleep(0)
+        while processor._processing:
+            await asyncio.sleep(0.01)
+
+    assert len(captured) == 1
+    _src, _dst, start_str, duration_str = captured[0]
+    # 110.123 formatted to 3 decimals.
+    assert start_str == "110.123"
+    # duration = 140.456 - 110.123 = 30.333
+    assert duration_str == "30.333"
+    ttt_client.fail_highlight.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_moment_reel_source_missing_locally_does_not_claim(
+    tmp_path, stub_trim_video, stub_combine_videos
+):
+    """When a moment_clip's recording_group_dir doesn't resolve, the reel
+    stays pending — no claim, no fail, but report_blocker fires once."""
+    _stage_recording(tmp_path, "game-A")
+
+    reel = {
+        "id": "reel-m-skip",
+        "title": "Missing source",
+        "status": "pending",
+        "source": "moment_tagger",
+    }
+    moment_clips = [
+        _make_moment_clip(0, "game-A"),
+        _make_moment_clip(1, "game-Z"),  # not staged
+    ]
+
+    ttt_client = MagicMock()
+    ttt_client.is_authenticated = MagicMock(return_value=True)
+    ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
+    ttt_client.get_highlight_moment_clips = MagicMock(return_value=moment_clips)
+    ttt_client.claim_highlight = MagicMock()
+    ttt_client.report_blocker = MagicMock(return_value=reel)
+    ttt_client.complete_highlight = MagicMock()
+    ttt_client.fail_highlight = MagicMock()
+
+    processor = _make_processor(tmp_path, ttt_client=ttt_client)
+
+    await processor.discover_work()
+    await asyncio.sleep(0)
+    while processor._processing:
+        await asyncio.sleep(0.01)
+
+    ttt_client.claim_highlight.assert_not_called()
+    ttt_client.complete_highlight.assert_not_called()
+    ttt_client.fail_highlight.assert_not_called()
+    ttt_client.report_blocker.assert_called_once()
+    assert "game-Z" in ttt_client.report_blocker.call_args[0][2]
+
+
+@pytest.mark.asyncio
+async def test_moment_reel_recording_group_dir_none_does_not_claim(
+    tmp_path, stub_trim_video, stub_combine_videos
+):
+    """When a moment_clip has recording_group_dir=None (game_session has no
+    recording_group_dir), the reel skips without claim/fail and reports
+    a blocker explaining the None value."""
+    _stage_recording(tmp_path, "game-A")
+
+    reel = {
+        "id": "reel-m-none",
+        "title": "Null rgd",
+        "status": "pending",
+        "source": "moment_tagger",
+    }
+    moment_clips = [_make_moment_clip(0, None)]
+
+    ttt_client = MagicMock()
+    ttt_client.is_authenticated = MagicMock(return_value=True)
+    ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
+    ttt_client.get_highlight_moment_clips = MagicMock(return_value=moment_clips)
+    ttt_client.claim_highlight = MagicMock()
+    ttt_client.report_blocker = MagicMock(return_value=reel)
+    ttt_client.complete_highlight = MagicMock()
+    ttt_client.fail_highlight = MagicMock()
+
+    processor = _make_processor(tmp_path, ttt_client=ttt_client)
+
+    await processor.discover_work()
+    await asyncio.sleep(0)
+    while processor._processing:
+        await asyncio.sleep(0.01)
+
+    ttt_client.claim_highlight.assert_not_called()
+    ttt_client.fail_highlight.assert_not_called()
+    ttt_client.report_blocker.assert_called_once()
+    # The "None" branch produces a distinct reason string.
+    assert "is None" in ttt_client.report_blocker.call_args[0][2]
+
+
+@pytest.mark.asyncio
+async def test_moment_reel_render_failure_marks_reel_failed(tmp_path, stub_trim_video):
+    """When combine_videos returns False for a moment reel, the reel is
+    failed with an error message — same as the game-clip path."""
+    _stage_recording(tmp_path, "game-A")
+
+    reel = {
+        "id": "reel-m-flop",
+        "title": "Concat flop",
+        "status": "pending",
+        "source": "moment_tagger",
+    }
+    moment_clips = [_make_moment_clip(0, "game-A")]
+
+    ttt_client = MagicMock()
+    ttt_client.is_authenticated = MagicMock(return_value=True)
+    ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
+    ttt_client.get_highlight_moment_clips = MagicMock(return_value=moment_clips)
+    ttt_client.claim_highlight = MagicMock(return_value=reel)
+    ttt_client.complete_highlight = MagicMock()
+    ttt_client.fail_highlight = MagicMock()
+
+    async def _bad_combine(file_list_path: str, output_path: str) -> bool:
+        return False
+
+    processor = _make_processor(tmp_path, ttt_client=ttt_client)
+
+    with patch(
+        "video_grouper.task_processors.tasks.clips.highlight_compilation_task.combine_videos",
+        side_effect=_bad_combine,
+    ):
+        await processor.discover_work()
+        await asyncio.sleep(0)
+        while processor._processing:
+            await asyncio.sleep(0.01)
+
+    ttt_client.claim_highlight.assert_called_once()
+    ttt_client.complete_highlight.assert_not_called()
+    ttt_client.fail_highlight.assert_called_once()
+    err = ttt_client.fail_highlight.call_args[0][1]
+    assert "combine_videos failed" in err
+
+
+@pytest.mark.asyncio
+async def test_routing_mixed_sources_in_single_poll(
+    tmp_path, stub_trim_video, stub_combine_videos
+):
+    """A poll cycle with both a 'manual' reel AND a 'moment_tagger' reel
+    routes each to the correct endpoint."""
+    _stage_recording(tmp_path, "game-A")
+
+    manual_reel = {
+        "id": "reel-manual",
+        "title": "Manual",
+        "status": "pending",
+        # Omitting source defaults to manual.
+    }
+    moment_reel = {
+        "id": "reel-moment",
+        "title": "Auto",
+        "status": "pending",
+        "source": "moment_tagger",
+    }
+
+    ttt_client = MagicMock()
+    ttt_client.is_authenticated = MagicMock(return_value=True)
+    ttt_client.get_pending_highlights = MagicMock(
+        return_value=[manual_reel, moment_reel]
+    )
+    ttt_client.get_highlight_game_clips = MagicMock(
+        return_value=[_make_clip(0, "game-A")]
+    )
+    ttt_client.get_highlight_moment_clips = MagicMock(
+        return_value=[_make_moment_clip(0, "game-A")]
+    )
+    ttt_client.claim_highlight = MagicMock(side_effect=lambda rid, cid: {"id": rid})
+    ttt_client.get_highlight = MagicMock(side_effect=lambda rid: {"id": rid})
+    ttt_client.complete_highlight = MagicMock()
+    ttt_client.fail_highlight = MagicMock()
+
+    processor = _make_processor(tmp_path, ttt_client=ttt_client)
+    await processor.discover_work()
+    await asyncio.sleep(0)
+    while processor._processing:
+        await asyncio.sleep(0.01)
+
+    # Manual reel hit the game-clips endpoint exactly once.
+    ttt_client.get_highlight_game_clips.assert_called_once_with("reel-manual")
+    # Moment reel hit the moment-clips endpoint exactly once.
+    ttt_client.get_highlight_moment_clips.assert_called_once_with("reel-moment")
+    # Both reels were claimed and completed (no fails).
+    assert ttt_client.claim_highlight.call_count == 2
+    assert ttt_client.complete_highlight.call_count == 2
+    ttt_client.fail_highlight.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_moment_reel_empty_clips_skips_without_claim(tmp_path):
+    """A moment-tagger reel with zero linked clips logs + returns without
+    claiming or failing — same shape as the empty game-clip path."""
+    reel = {
+        "id": "reel-m-empty",
+        "title": "Empty",
+        "status": "pending",
+        "source": "moment_tagger",
+    }
+
+    ttt_client = MagicMock()
+    ttt_client.is_authenticated = MagicMock(return_value=True)
+    ttt_client.get_pending_highlights = MagicMock(return_value=[reel])
+    ttt_client.get_highlight_moment_clips = MagicMock(return_value=[])
+    ttt_client.claim_highlight = MagicMock()
+    ttt_client.complete_highlight = MagicMock()
+    ttt_client.fail_highlight = MagicMock()
+
+    processor = _make_processor(tmp_path, ttt_client=ttt_client)
+    await processor.discover_work()
+    await asyncio.sleep(0)
+    while processor._processing:
+        await asyncio.sleep(0.01)
+
+    ttt_client.get_highlight_moment_clips.assert_called_once()
+    ttt_client.claim_highlight.assert_not_called()
     ttt_client.fail_highlight.assert_not_called()

--- a/video_grouper/api_integrations/mock_ttt_api.py
+++ b/video_grouper/api_integrations/mock_ttt_api.py
@@ -80,6 +80,7 @@ class MockTTTApiClient:
         self._clip_requests: list[dict[str, Any]] = []
         self._highlights: list[dict[str, Any]] = []
         self._highlight_game_clips: dict[str, list[dict[str, Any]]] = {}
+        self._highlight_moment_clips: dict[str, list[dict[str, Any]]] = {}
         self._recordings: dict[str, dict[str, Any]] = {}
         self._recording_statuses: list[dict[str, Any]] = []
         self._pending_commands: list[dict[str, Any]] = []
@@ -175,6 +176,9 @@ class MockTTTApiClient:
 
     def get_highlight_game_clips(self, reel_id: str) -> list[dict[str, Any]]:
         return list(self._highlight_game_clips.get(reel_id, []))
+
+    def get_highlight_moment_clips(self, reel_id: str) -> list[dict[str, Any]]:
+        return list(self._highlight_moment_clips.get(reel_id, []))
 
     def get_highlight(self, reel_id: str) -> dict[str, Any]:
         for r in self._highlights:

--- a/video_grouper/api_integrations/ttt_api.py
+++ b/video_grouper/api_integrations/ttt_api.py
@@ -453,6 +453,21 @@ class TTTApiClient:
         logger.debug("Fetching game clips for highlight reel %s", reel_id)
         return self._request("GET", url)
 
+    def get_highlight_moment_clips(self, reel_id: str) -> list[dict[str, Any]]:
+        """Get the moment clips linked to a moment-tagger highlight reel.
+
+        GET {api_base_url}/api/highlights/{reel_id}/moment-clips
+
+        Used when the polled reel has ``source='moment_tagger'``. Each item
+        carries ``clip_start_offset`` / ``clip_end_offset`` (absolute offsets
+        into the source ``combined.mp4``) plus ``recording_group_dir`` so this
+        install can locate the source file. Ordered by the junction
+        ``sequence_order``.
+        """
+        url = f"{self.api_base_url}/api/highlights/{reel_id}/moment-clips"
+        logger.debug("Fetching moment clips for highlight reel %s", reel_id)
+        return self._request("GET", url)
+
     def get_highlight(self, reel_id: str) -> dict[str, Any]:
         """Fetch the current state of a single highlight reel.
 

--- a/video_grouper/task_processors/highlight_reel_processor.py
+++ b/video_grouper/task_processors/highlight_reel_processor.py
@@ -130,46 +130,104 @@ class HighlightReelProcessor(PollingProcessor):
             task.add_done_callback(self._render_tasks.discard)
 
     async def _process_reel(self, reel: dict) -> None:
-        """Process a single highlight reel end-to-end."""
+        """Dispatch + run the correct render path based on the reel's source.
+
+        - ``source='manual'`` (default) — user-curated game-clip reel, fetched
+          from ``GET /api/highlights/{id}/game-clips``. Each clip carries
+          int ``start_time``/``end_time`` seconds + ``recording_group_dir``.
+        - ``source='moment_tagger'`` — auto-created from tagged moments,
+          fetched from ``GET /api/highlights/{id}/moment-clips``. Each clip
+          carries float ``clip_start_offset``/``clip_end_offset`` seconds +
+          ``recording_group_dir`` (joined from the parent game_session).
+
+        Everything from claim → trim → concat → upload → PATCH ready is
+        identical between the two paths and lives in
+        ``_process_reel_from_clips``; only the fetch + per-clip offset
+        extraction differ.
+
+        ``_processing.discard(reel_id)`` runs in our ``finally`` here so the
+        processor never leaks the reel_id even if the helpers raise.
+        """
+        reel_id = reel["id"]
+        try:
+            source = reel.get("source", "manual")
+            if source == "moment_tagger":
+                clips_fn = self.ttt_client.get_highlight_moment_clips
+                fetch_label = "MOMENT_REEL"
+
+                def extract_offsets(clip: dict) -> tuple[float, float]:
+                    start = clip.get("clip_start_offset")
+                    end = clip.get("clip_end_offset")
+                    if start is None or end is None:
+                        raise ValueError(
+                            f"moment_clip {clip.get('id')} missing clip_start_offset"
+                            f" / clip_end_offset (got start={start!r}, end={end!r})"
+                        )
+                    return float(start), float(end)
+            else:
+                clips_fn = self.ttt_client.get_highlight_game_clips
+                fetch_label = "HIGHLIGHT_REEL"
+
+                def extract_offsets(clip: dict) -> tuple[float, float]:
+                    return float(clip["start_time"]), float(clip["end_time"])
+
+            try:
+                clips = await asyncio.to_thread(clips_fn, reel_id)
+            except Exception as e:
+                logger.error(
+                    "%s: failed to fetch clips for %s: %s", fetch_label, reel_id, e
+                )
+                return
+
+            if not clips:
+                logger.warning(
+                    "%s: reel %s has no clips, skipping", fetch_label, reel_id
+                )
+                return
+
+            await self._process_reel_from_clips(reel, clips, extract_offsets)
+        finally:
+            self._processing.discard(reel_id)
+
+    async def _process_reel_from_clips(
+        self,
+        reel: dict,
+        clips: list[dict],
+        extract_offsets,
+    ) -> None:
+        """Shared render pipeline: resolve sources → claim → trim → concat →
+        upload → PATCH ready (or report blocker / fail).
+
+        ``extract_offsets(clip) -> (start_seconds, end_seconds)`` adapts the
+        per-clip shape (game_clips use int start_time/end_time; moment_clips
+        use float clip_start_offset/clip_end_offset). Everything else is
+        identical between the two reel sources.
+
+        Caller (``_process_reel``) owns the ``_processing.discard(reel_id)``
+        cleanup so we don't double-discard.
+        """
         reel_id = reel["id"]
         tmpdir: Optional[str] = None
         final_output_path: Optional[str] = None
         claimed = False
 
         try:
-            # Fetch the ordered game-clips for this reel.
-            try:
-                game_clips = await asyncio.to_thread(
-                    self.ttt_client.get_highlight_game_clips, reel_id
-                )
-            except Exception as e:
-                logger.error(
-                    "HIGHLIGHT_REEL: failed to fetch game clips for %s: %s", reel_id, e
-                )
-                return
-
-            if not game_clips:
-                logger.warning(
-                    "HIGHLIGHT_REEL: reel %s has no game clips, skipping", reel_id
-                )
-                return
-
             # Defensive dedup: TTT should return each clip once, but if the
             # backend ever leaks duplicates we don't want to render them.
             seen: set = set()
             deduped: list[dict] = []
-            for clip in game_clips:
+            for clip in clips:
                 cid = clip.get("id")
                 if cid and cid not in seen:
                     seen.add(cid)
                     deduped.append(clip)
-            game_clips = deduped
+            clips = deduped
 
             # Resolve every clip's source BEFORE claiming. If any are missing on
             # this install, another camera-manager may have them — bare return,
             # no claim, no fail.
             resolved_sources = []
-            for idx, clip in enumerate(game_clips):
+            for idx, clip in enumerate(clips):
                 recording_group_dir = clip.get("recording_group_dir")
                 resolved_dir = resolve_recording_dir(
                     self.storage_path, recording_group_dir
@@ -251,8 +309,7 @@ class HighlightReelProcessor(PollingProcessor):
             tmpdir = tempfile.mkdtemp(prefix=f"reel-{reel_id}-")
             trimmed_paths: list[str] = []
             for idx, (clip, source) in enumerate(resolved_sources):
-                start = float(clip["start_time"])
-                end = float(clip["end_time"])
+                start, end = extract_offsets(clip)
                 duration = end - start
                 if duration <= 0:
                     raise ValueError(
@@ -401,4 +458,3 @@ class HighlightReelProcessor(PollingProcessor):
         finally:
             if tmpdir:
                 shutil.rmtree(tmpdir, ignore_errors=True)
-            self._processing.discard(reel_id)


### PR DESCRIPTION
## Summary
- Soccer-cam's `HighlightReelProcessor` now routes on `highlight_reels.source` (added by TTT Phase A).
- `source='manual'` → existing game-clip render path (unchanged).
- `source='moment_tagger'` → new path: fetches `moment_clips` via new TTT endpoint, trims each from local `combined.mp4` using `clip_start_offset`/`clip_end_offset`, concatenates, uploads to YouTube as unlisted, PATCHes the reel ready.
- Companion to TTT PR `feature/highlight-reel-moment-clips-endpoint` which adds the new endpoint.

## Refactor
- Extracted shared claim → trim → concat → upload → PATCH flow into `_process_reel_from_clips(reel, clips, extract_offsets)`. The only per-source variation is the offset extraction closure (4 lines per branch). Avoids ~270 LOC duplication that would have invited drift.
- `_processing.discard()` moved to dispatcher's `finally` for resilience.

## Test plan
- [x] Lint + format clean
- [x] 22 highlight_reel_processor tests pass (7 new): moment-reel happy path, sub-second offset precision, source-not-local skip-no-claim, render failure, mixed-sources routing in one poll, empty reel
- [x] 1011 full unit suite passes — no regressions (pre-existing collection errors in `test_tray.py` / `test_autocam_*.py` are environmental PyQt6/psutil deps, unrelated)
- [ ] **Manual verification (post-merge)** — requires real soccer-cam install + real game video + tagged moments:
  1. Tag 3 moments in moment-tagger for a real game
  2. Soccer-cam syncs offsets → creates moment_clips
  3. Soccer-cam POSTs full game video to TTT → Phase A's hook auto-creates moment-tagger reel
  4. Watch `~/AppData/Local/VideoGrouper/logs/video_grouper.log` for `MOMENT_REEL:` log lines and the trim/concat/upload sequence
  5. Verify in TTT: reel card flips pending → generating → ready with YouTube URL
  6. Open YouTube URL: unlisted, runtime ≈ Σ(end-start), contents = trimmed segments in tagged_at order

## Targets `main` (per `[soccer-cam base branch is main]`)
🤖 Generated with [Claude Code](https://claude.com/claude-code)