### PR TITLE
Add ruff baseline, mypy infrastructure, and lint CI gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,43 @@
+name: Lint
+
+# Runs ruff (check + format) and mypy on every PR targeting main, plus
+# every push to main itself. This is the gate that catches regressions
+# in already-clean modules; deferred per-module ignore_errors entries in
+# pyproject.toml are tracked separately.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: ruff + mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # uv handles its own Python install and bundles the project venv;
+      # matches how scripts/smoke_real_service.py runs locally.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+
+      - name: Sync project dependencies
+        # --frozen to honor uv.lock; --no-install-project skips compiling
+        # the package itself (mypy and ruff don't need it built).
+        run: uv sync --frozen --no-install-project
+
+      - name: ruff check
+        run: uv run --with ruff ruff check .
+
+      - name: ruff format check
+        run: uv run --with ruff ruff format --check .
+
+      - name: mypy
+        run: uv run mypy video_grouper/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,16 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+
+  # Mypy runs via uv so it sees the project's dependency env (third-party
+  # type stubs, our pyproject.toml [tool.mypy] overrides).
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: uv run mypy video_grouper/
+        language: system
+        pass_filenames: false
+        # Limit to video_grouper/ source so a tools/ or training/ edit
+        # doesn't trigger a full project check.
+        files: ^video_grouper/.*\.py$

--- a/create_icon.py
+++ b/create_icon.py
@@ -1,5 +1,6 @@
-from PIL import Image, ImageDraw
 import os
+
+from PIL import Image, ImageDraw
 
 
 def create_soccer_cam_icon():

--- a/download_reolink_game.py
+++ b/download_reolink_game.py
@@ -7,7 +7,6 @@ import sys
 import time
 from datetime import datetime
 
-
 CAMERA_IP = "192.168.86.200"
 USERNAME = "admin"
 PASSWORD = "mblakley82"

--- a/process_with_ntfy.py
+++ b/process_with_ntfy.py
@@ -3,15 +3,16 @@
 Script to manually trigger NTFY processing for a specific directory.
 """
 
-import asyncio
 import argparse
+import asyncio
 import sys
 from pathlib import Path
-from video_grouper.video_grouper_app import VideoGrouperApp
-from video_grouper.utils.paths import get_shared_data_path
-from video_grouper.utils.locking import FileLock
+
 from video_grouper.utils.config import load_config
-from video_grouper.utils.logger import setup_logging, get_logger
+from video_grouper.utils.locking import FileLock
+from video_grouper.utils.logger import get_logger, setup_logging
+from video_grouper.utils.paths import get_shared_data_path
+from video_grouper.video_grouper_app import VideoGrouperApp
 
 # Configure logging
 setup_logging(level="INFO", app_name="video_grouper_ntfy")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,185 @@ line-ending = "auto"
 # format is fine.
 "reolink-firmware-patching/**/*.py" = ["UP031"]
 
+[tool.mypy]
+# Type-check video_grouper/ as the production target. tools/ is one-off
+# scripts and training/ is research code -- not in scope for this baseline.
+python_version = "3.13"
+strict_optional = true
+warn_unused_ignores = true
+# Don't require type annotations on every def yet -- that's a separate
+# follow-up. The goal here is establishing the gate, not boiling the ocean.
+disallow_untyped_defs = false
+no_implicit_optional = false
+# Stay quiet about ML/CV vendor libs whose stubs are incomplete; the rest
+# of the modules below are listed by name so we don't accidentally silence
+# typos in our own imports.
+exclude = [
+    "tools/",
+    "training/",
+    "reolink-firmware-patching/",
+    "scripts/",
+]
+
+# --- Third-party modules without stubs ---
+# Listed explicitly per memory feedback: name the modules so a typo in our
+# own import doesn't get silently swallowed by a blanket ignore.
+
+# Computer-vision and ML stack
+[[tool.mypy.overrides]]
+module = [
+    "cv2",
+    "cv2.*",
+    "onnxruntime",
+    "onnxruntime.*",
+    "torch",
+    "torch.*",
+    "torchvision",
+    "torchvision.*",
+    "ultralytics",
+    "ultralytics.*",
+    "supervision",
+    "supervision.*",
+    "av",
+    "av.*",
+    "lapx",
+    "lapx.*",
+    "filterpy",
+    "filterpy.*",
+    "scipy",
+    "scipy.*",
+]
+ignore_missing_imports = true
+
+# Windows-only / pywin32 modules (Linux CI can't see them, and pywin32
+# ships no PEP 561 marker so they appear untyped on Windows too)
+[[tool.mypy.overrides]]
+module = [
+    "win32event",
+    "win32service",
+    "win32serviceutil",
+    "win32timezone",
+    "win32gui",
+    "win32con",
+    "win32api",
+    "win32process",
+    "servicemanager",
+    "pywintypes",
+    "pythoncom",
+    "pywinauto",
+    "pywinauto.*",
+]
+ignore_missing_imports = true
+
+# PyQt6 -- optional tray dep, not installed in the CI lint container
+[[tool.mypy.overrides]]
+module = [
+    "PyQt6",
+    "PyQt6.*",
+]
+ignore_missing_imports = true
+
+# Google APIs (no stubs published)
+[[tool.mypy.overrides]]
+module = [
+    "google",
+    "google.*",
+    "googleapiclient",
+    "googleapiclient.*",
+    "google_auth_oauthlib",
+    "google_auth_oauthlib.*",
+]
+ignore_missing_imports = true
+
+# Misc third-party deps without stubs
+[[tool.mypy.overrides]]
+module = [
+    "aiofiles",
+    "aiofiles.*",
+    "dateutil",
+    "dateutil.*",
+    "psutil",
+    "pytz",
+    "requests",
+    "requests.*",
+    "selenium",
+    "selenium.*",
+    "webdriver_manager",
+    "webdriver_manager.*",
+    "icalendar",
+    "icalendar.*",
+    "Crypto",
+    "Crypto.*",
+    "tenacity",
+    "tenacity.*",
+]
+ignore_missing_imports = true
+
+# --- Deferred per-module type-fix work ---
+# These modules have pre-existing type errors (mostly Optional/None
+# threaded through constructor signatures, missing collection annotations,
+# and TypedDict drift). The plan is to reclaim them module-by-module
+# under a separate "type-cleanup" track so new code in CLEAN modules
+# stays gated, but we don't block the infrastructure rollout on a
+# 283-error backlog. Each module here is a follow-up task.
+[[tool.mypy.overrides]]
+module = [
+    "video_grouper.api_integrations.cloud_sync",
+    "video_grouper.api_integrations.command_executor",
+    "video_grouper.api_integrations.mock_ntfy_api",
+    "video_grouper.api_integrations.mock_ntfy_communication",
+    "video_grouper.api_integrations.mock_playmetrics",
+    "video_grouper.api_integrations.mock_ttt_api",
+    "video_grouper.api_integrations.ntfy",
+    "video_grouper.api_integrations.teamsnap",
+    "video_grouper.ball_tracking.providers.homegrown.stages.render",
+    "video_grouper.ball_tracking.secure_loader",
+    "video_grouper.cameras.base",
+    "video_grouper.cameras.dahua",
+    "video_grouper.cameras.reolink",
+    "video_grouper.cameras.reolink_download",
+    "video_grouper.models.directory_state",
+    "video_grouper.models.recording_file",
+    "video_grouper.task_processors.ball_tracking_processor",
+    "video_grouper.task_processors.base_polling_processor",
+    "video_grouper.task_processors.base_queue_processor",
+    "video_grouper.task_processors.camera_poller",
+    "video_grouper.task_processors.clip_request_processor",
+    "video_grouper.task_processors.download_processor",
+    "video_grouper.task_processors.ntfy_processor",
+    "video_grouper.task_processors.register_tasks",
+    "video_grouper.task_processors.services.match_info_service",
+    "video_grouper.task_processors.services.ntfy_service",
+    "video_grouper.task_processors.services.teamsnap_service",
+    "video_grouper.task_processors.services.ttt_question_service",
+    "video_grouper.task_processors.state_auditor",
+    "video_grouper.task_processors.task_registry",
+    "video_grouper.task_processors.tasks.ball_tracking.base",
+    "video_grouper.task_processors.tasks.clip.clip_request_task",
+    "video_grouper.task_processors.tasks.download.dahua_download_task",
+    "video_grouper.task_processors.tasks.ntfy.base_ntfy_task",
+    "video_grouper.task_processors.tasks.ntfy.game_end_task",
+    "video_grouper.task_processors.tasks.ntfy.game_start_task",
+    "video_grouper.task_processors.tasks.ntfy.task_factory",
+    "video_grouper.task_processors.tasks.ntfy.team_info_task",
+    "video_grouper.task_processors.tasks.ntfy.was_there_a_match_task",
+    "video_grouper.task_processors.tasks.upload.youtube_upload_task",
+    "video_grouper.task_processors.tasks.video.combine_task",
+    "video_grouper.task_processors.tasks.video.trim_task",
+    "video_grouper.task_processors.upload_processor",
+    "video_grouper.task_processors.video_processor",
+    "video_grouper.tray.autocam_automation",
+    "video_grouper.tray.main",
+    "video_grouper.update.update_manager",
+    "video_grouper.utils.config",
+    "video_grouper.utils.youtube_upload",
+    "video_grouper.video_grouper_app",
+    "video_grouper.web.auth_server",
+    "video_grouper.web.config_editor",
+    "video_grouper.web.setup.router",
+]
+ignore_errors = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
@@ -159,6 +338,7 @@ torchvision = { index = "pytorch-cu126" }
 [dependency-groups]
 dev = [
     "aiohttp>=3.13.3",
+    "mypy>=2.1.0",
     "pytest>=8.4.1",
     "pytest-asyncio>=1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,18 @@ path = "video_grouper/version.py"
 target-version = "py313"
 
 [tool.ruff.lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
-select = ["E4", "E7", "E9", "F"]
-ignore = []
+# Enable a curated set of rules — matches TTT backend config style.
+# - E4/E7/E9: pycodestyle errors (imports, statement, syntax)
+# - F:       Pyflakes (undefined names, unused imports/vars)
+# - B:       flake8-bugbear (likely-buggy patterns)
+# - I:       isort (import sorting)
+# - C4:      flake8-comprehensions (clearer comprehensions)
+# - UP:      pyupgrade (modern Python idioms; py313 target)
+select = ["E4", "E7", "E9", "F", "B", "I", "C4", "UP"]
+ignore = [
+    # B008: function-call-as-default — FastAPI/Pydantic Depends(), Field() rely on this idiom.
+    "B008",
+]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
@@ -104,7 +113,18 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.ruff.lint.per-file-ignores]
-"tests/test_service.py" = ["E402"] 
+"tests/test_service.py" = ["E402"]
+# Tests/e2e inspect_* are interactive window-dumper scripts; their EnumWindows
+# callbacks are invoked synchronously so the closure-over-loop-var pattern is
+# safe, but ruff's B023 can't see that.
+"tests/e2e/inspect_*.py" = ["B023"]
+# Training is research/experiment code (per memory [Scope experiments tight]).
+# B007 unused loop var, B023 lambda-over-loop-var, UP031 percent format are
+# fine for short-lived experimental scripts; not worth churning.
+"training/**/*.py" = ["B007", "B023", "UP031"]
+# Firmware reverse-engineering scripts: short-lived debug tools, percent
+# format is fine.
+"reolink-firmware-patching/**/*.py" = ["UP031"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,12 @@ line-ending = "auto"
 # Type-check video_grouper/ as the production target. tools/ is one-off
 # scripts and training/ is research code -- not in scope for this baseline.
 python_version = "3.13"
+# Production runs on Windows (tray, service, AutoCam parenting). Pinning
+# the platform here means mypy sees winreg + pywin32-shaped stdlib stubs
+# even on Linux CI, matching what the code will actually execute against.
+# The pyproject [tool.uv] environments list includes linux too, but the
+# linux variant is for Docker / dev only and shares the same type surface.
+platform = "win32"
 strict_optional = true
 warn_unused_ignores = true
 # Don't require type annotations on every def yet -- that's a separate
@@ -177,9 +183,11 @@ module = [
 ignore_missing_imports = true
 
 # Windows-only / pywin32 modules (Linux CI can't see them, and pywin32
-# ships no PEP 561 marker so they appear untyped on Windows too)
+# ships no PEP 561 marker so they appear untyped on Windows too).
+# Includes the winreg stdlib module which only exists on Windows.
 [[tool.mypy.overrides]]
 module = [
+    "winreg",
     "win32event",
     "win32service",
     "win32serviceutil",

--- a/reolink-firmware-patching/pak/extract.py
+++ b/reolink-firmware-patching/pak/extract.py
@@ -1,12 +1,12 @@
-import struct
 import os
+import struct
 
 PAK = "IPC_NT15NA416MP.4867_2505072124.Reolink-Duo-3-PoE.16MP.REOLINK.pak"
 OUT = "sections"
 os.makedirs(OUT, exist_ok=True)
 
 data = open(PAK, "rb").read()
-print("file size: 0x%x" % len(data))
+print(f"file size: 0x{len(data):x}")
 print("header magic:", data[:4].hex())
 print(
     "hdr field@0x04 (8B):",

--- a/reolink-firmware-patching/pak/pak_repack.py
+++ b/reolink-firmware-patching/pak/pak_repack.py
@@ -31,7 +31,9 @@ Examples:
 
 import struct
 import sys
-from reolink_crc import compute as compute_reolink_crc, CRC_FIELD_OFFSET
+
+from reolink_crc import CRC_FIELD_OFFSET
+from reolink_crc import compute as compute_reolink_crc
 
 HEADER_SIZE = 0x18
 ENTRY_SIZE = 0x48

--- a/run.py
+++ b/run.py
@@ -3,9 +3,9 @@
 Simple wrapper script to run the video_grouper application.
 """
 
+import asyncio
 import os
 import sys
-import asyncio
 
 # Add the current directory to the Python path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/scripts/smoke_full_pipeline.py
+++ b/scripts/smoke_full_pipeline.py
@@ -39,19 +39,18 @@ import sys
 import uuid
 from pathlib import Path
 from typing import Any
-from urllib.request import Request, urlopen
 from urllib.error import HTTPError
+from urllib.request import Request, urlopen
 
 import psycopg2
 import psycopg2.extras
 from playwright.sync_api import sync_playwright
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from video_grouper.api_integrations.ttt_api import TTTApiClient  # noqa: E402
 from video_grouper.task_processors.highlight_reel_processor import (  # noqa: E402
     HighlightReelProcessor,
 )
-from video_grouper.api_integrations.ttt_api import TTTApiClient  # noqa: E402
-
 
 TTT_BASE = "http://localhost:8000"
 FRONTEND_BASE = "http://localhost:3000"
@@ -336,7 +335,7 @@ def main() -> int:
     offsets = [(30.0, 15.0, 45.0), (60.0, 45.0, 75.0), (120.0, 105.0, 135.0)]
     tag_ids = [r["id"] for r in rows[:3]]
     clip_ids = []
-    for tag_id, (off, start, end) in zip(tag_ids, offsets):
+    for tag_id, (off, start, end) in zip(tag_ids, offsets, strict=False):
         db_exec(
             "UPDATE coaching_sessions.moment_tags SET video_offset_seconds = %s WHERE id = %s",
             (off, tag_id),

--- a/scripts/smoke_moment_reel_pipeline.py
+++ b/scripts/smoke_moment_reel_pipeline.py
@@ -23,8 +23,8 @@ import sys
 import uuid
 from pathlib import Path
 from typing import Any
-from urllib.request import Request, urlopen
 from urllib.error import HTTPError
+from urllib.request import Request, urlopen
 
 import psycopg2
 import psycopg2.extras
@@ -34,7 +34,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from video_grouper.task_processors.highlight_reel_processor import (  # noqa: E402
     HighlightReelProcessor,
 )
-
 
 # ------------------------------------------------------------------- constants
 TTT_BASE = "http://localhost:8000"
@@ -263,7 +262,7 @@ async def main() -> int:
     # ----- 4. simulate soccer-cam's per-clip render: create moment_clips rows
     banner("4. Simulate soccer-cam moment_clips (3 rows with start/end offsets)")
     clip_ids = []
-    for i, (tag_id, m) in enumerate(zip(tag_ids, MOMENTS)):
+    for i, (tag_id, m) in enumerate(zip(tag_ids, MOMENTS, strict=False)):
         clip_id = str(uuid.uuid4())
         db_exec(
             """

--- a/scripts/smoke_real_service.py
+++ b/scripts/smoke_real_service.py
@@ -48,7 +48,7 @@ import subprocess
 import sys
 import time
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError
@@ -491,7 +491,7 @@ def build_storage_tree(
                 "skip": False,
                 "screenshot_path": None,
                 "group_dir": str(group_dir),
-                "last_updated": datetime.now(timezone.utc).isoformat(),
+                "last_updated": datetime.now(UTC).isoformat(),
                 "error_message": None,
             }
         },
@@ -792,7 +792,7 @@ def main() -> int:
     # Recording start: ~10 minutes ago. Tags taken now will fall at offsets
     # roughly 9-10 minutes in (we don't depend on this exactly since
     # video_offset_seconds is computed by the service from wall-clock).
-    recording_start = datetime.now(timezone.utc) - timedelta(minutes=10)
+    recording_start = datetime.now(UTC) - timedelta(minutes=10)
     recording_dir_name = SMOKE_MARKER + recording_start.astimezone().strftime(
         "%Y.%m.%d-%H.%M.%S"
     )

--- a/test_unified_ntfy_state.py
+++ b/test_unified_ntfy_state.py
@@ -4,17 +4,16 @@ Test script to verify unified NTFY state management.
 """
 
 import asyncio
-import sys
-import os
 import json
+import os
+import sys
 
 # Add the project root to the path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from video_grouper.task_processors.services.ntfy_service import NtfyService
 from video_grouper.utils.config import NtfyConfig
-
-from video_grouper.utils.logger import setup_logging, get_logger
+from video_grouper.utils.logger import get_logger, setup_logging
 
 # Set up logging
 setup_logging(level="DEBUG", app_name="test_ntfy")
@@ -72,7 +71,7 @@ async def test_unified_state():
     print(f"✓ Unified state file: {state_file_path}")
 
     if os.path.exists(state_file_path):
-        with open(state_file_path, "r") as f:
+        with open(state_file_path) as f:
             state = json.load(f)
         print(f"✓ State file contains: {list(state.keys())}")
         assert "pending_tasks" in state

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,17 @@
 import sys
-from unittest.mock import Mock, patch, AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 # pytest-qt (loaded at plugin discovery) imports PyQt6, whose DLLs collide
 # with onnxruntime-gpu's DLL load on Windows. Stub onnxruntime before any
 # test module tries to import it — unit tests already mock InferenceSession.
 sys.modules.setdefault("onnxruntime", MagicMock())
 
+import asyncio  # noqa: E402
+import configparser  # noqa: E402
+import tempfile  # noqa: E402
+
 import pytest  # noqa: E402
 import pytest_asyncio  # noqa: E402
-import asyncio  # noqa: E402
-import tempfile  # noqa: E402
-import configparser  # noqa: E402
 
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/tests/e2e/inspect_autocam.py
+++ b/tests/e2e/inspect_autocam.py
@@ -3,9 +3,10 @@ Standalone script to inspect the Autocam GUI and find correct control identifier
 Run this directly: uv run python tests/e2e/inspect_autocam.py
 """
 
-import time
 import subprocess
 import sys
+import time
+
 from pywinauto import Desktop
 from pywinauto.application import Application
 

--- a/tests/e2e/inspect_processing_setup.py
+++ b/tests/e2e/inspect_processing_setup.py
@@ -3,12 +3,12 @@ Standalone script to inspect Autocam's Processing Setup dialog.
 Run: uv run python tests/e2e/inspect_processing_setup.py
 """
 
-import time
 import subprocess
 import sys
+import time
+
 import win32gui
 from pywinauto import Desktop
-
 
 AUTOCAM_EXE = r"C:\Users\markb\AppData\Local\Programs\Autocam\GUI.exe"
 

--- a/tests/e2e/inspect_settings_window.py
+++ b/tests/e2e/inspect_settings_window.py
@@ -3,12 +3,12 @@ Inspect SettingsWindow AFTER loading source/destination files.
 Run: uv run python tests/e2e/inspect_settings_window.py
 """
 
-import time
 import subprocess
 import sys
+import time
+
 import win32gui
 from pywinauto import Desktop
-
 
 AUTOCAM_EXE = r"C:\Users\markb\AppData\Local\Programs\Autocam\GUI.exe"
 TEST_INPUT = r"C:\Users\markb\projects\soccer-cam\tests\e2e\test_clips\clip_01.mp4"

--- a/tests/e2e/kill_test_processes.py
+++ b/tests/e2e/kill_test_processes.py
@@ -155,7 +155,7 @@ def kill_pids_from_file():
 
     try:
         if pid_file.exists():
-            with open(pid_file, "r") as f:
+            with open(pid_file) as f:
                 pids = json.load(f)
         else:
             logger.info("No PID file found")

--- a/tests/e2e/test_runner.py
+++ b/tests/e2e/test_runner.py
@@ -8,6 +8,7 @@ as a subprocess and monitors its progress through log files.
 """
 
 import asyncio
+import json
 import logging
 import os
 import shutil
@@ -17,8 +18,6 @@ import sys
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Optional
-import json
 
 import pytest
 
@@ -78,9 +77,9 @@ class E2ETestRunner:
         setup_logging_from_config(self.config)
 
         # Process management
-        self.video_grouper_process: Optional[subprocess.Popen] = None
-        self.tray_process: Optional[subprocess.Popen] = None
-        self.processes_to_cleanup: List[subprocess.Popen] = []
+        self.video_grouper_process: subprocess.Popen | None = None
+        self.tray_process: subprocess.Popen | None = None
+        self.processes_to_cleanup: list[subprocess.Popen] = []
 
         # PID tracking file for persistent process management
         self.pid_file = self.project_root / "tests/e2e/test_pids.json"
@@ -117,19 +116,19 @@ class E2ETestRunner:
         }
 
         # Stage timestamps for timeout tracking
-        self.stage_timestamps: Dict[str, datetime] = {}
+        self.stage_timestamps: dict[str, datetime] = {}
 
         # Multi-group completion tracking: counts how many times key events occur.
         # With 2 groups, each count must reach 2 for the pipeline to be complete.
         self.expected_group_count = 2
-        self.multi_group_counts: Dict[str, int] = {
+        self.multi_group_counts: dict[str, int] = {
             "groups_created": 0,
             "combines_completed": 0,
             "trims_completed": 0,
             "autocams_completed": 0,
             "uploads_completed": 0,
         }
-        self.multi_group_patterns: Dict[str, List[str]] = {
+        self.multi_group_patterns: dict[str, list[str]] = {
             "groups_created": ["Created new group directory"],
             "combines_completed": [
                 "VIDEO: Successfully completed task: CombineTask",
@@ -274,7 +273,7 @@ class E2ETestRunner:
             # Load existing PIDs
             pids = {}
             if self.pid_file.exists():
-                with open(self.pid_file, "r") as f:
+                with open(self.pid_file) as f:
                     pids = json.load(f)
 
             # Add new process
@@ -292,7 +291,7 @@ class E2ETestRunner:
         """Kill any processes whose PIDs are stored in the PID file."""
         try:
             if self.pid_file.exists():
-                with open(self.pid_file, "r") as f:
+                with open(self.pid_file) as f:
                     pids = json.load(f)
             else:
                 logger.info("No PID file found")
@@ -558,7 +557,7 @@ class E2ETestRunner:
                         # Read the files before deletion
                         for key, file_path in youtube_credentials_backup.items():
                             if file_path.exists():
-                                with open(file_path, "r") as f:
+                                with open(file_path) as f:
                                     youtube_credentials_backup[key] = f.read()
 
                     shutil.rmtree(self.test_data_path)
@@ -1021,7 +1020,7 @@ class E2ETestRunner:
         """Read the contents of a log file."""
         try:
             if log_path.exists():
-                with open(log_path, "r", encoding="utf-8") as f:
+                with open(log_path, encoding="utf-8") as f:
                     return f.read()
             return ""
         except Exception as e:
@@ -1044,7 +1043,7 @@ class E2ETestRunner:
                 return False
 
             # Read the NTFY service state
-            with open(ntfy_state_file, "r", encoding="utf-8") as f:
+            with open(ntfy_state_file, encoding="utf-8") as f:
                 state = json.load(f)
 
             # Check for pending tasks with "waiting_for_input" status
@@ -1065,7 +1064,7 @@ class E2ETestRunner:
             logger.error(f"Error checking NTFY service state: {e}")
             return False
 
-    def _check_match_info_completion(self, group_dir: str) -> Dict[str, bool]:
+    def _check_match_info_completion(self, group_dir: str) -> dict[str, bool]:
         """
         Check if match_info.ini is properly populated with team info and timing info.
 
@@ -1126,7 +1125,7 @@ class E2ETestRunner:
 
         return False
 
-    def _update_pipeline_progress(self, log_content: str) -> Dict[str, bool]:
+    def _update_pipeline_progress(self, log_content: str) -> dict[str, bool]:
         """Update pipeline progress based on log content."""
         # Also check tray agent logs for autocam processing
         tray_log_path = self.test_logs_path / "tray_subprocess.log"
@@ -1261,7 +1260,7 @@ class E2ETestRunner:
         all_valid = True
 
         for i, (group_dir, expected_opponent) in enumerate(
-            zip(group_dirs, expected_opponents)
+            zip(group_dirs, expected_opponents, strict=False)
         ):
             config = configparser.ConfigParser()
             config.read(group_dir / "match_info.ini", encoding="utf-8")

--- a/tests/integration/test_camera_emulator.py
+++ b/tests/integration/test_camera_emulator.py
@@ -6,11 +6,11 @@ DahuaCamera/ReolinkCamera clients against it. No Docker required.
 
 import os
 import sys
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
 from aiohttp import web
-from datetime import datetime, timedelta, timezone
 
 # Add simulator to path so its modules can import each other.
 # The simulator was extracted to github.com/mblakley/camera-simulator.
@@ -75,8 +75,8 @@ async def dahua_server(clips_dir, tmp_path):
     """Start an in-process Dahua simulator server."""
     import collections
 
-    from storage import StorageManager
     from dahua.http_api import setup_routes
+    from storage import StorageManager
 
     storage = StorageManager(
         recordings_dir=str(tmp_path / "recordings"),
@@ -103,8 +103,8 @@ async def reolink_server(clips_dir, tmp_path):
     """Start an in-process Reolink simulator server."""
     import collections
 
-    from storage import StorageManager
     from reolink.http_api import setup_routes
+    from storage import StorageManager
 
     storage = StorageManager(
         recordings_dir=str(tmp_path / "recordings"),
@@ -168,8 +168,8 @@ class TestDahuaEmulator:
             password="testpass",
         )
         camera = DahuaCamera(config=config, storage_path=str(tmp_path))
-        start = datetime.now(timezone.utc) - timedelta(hours=24)
-        end = datetime.now(timezone.utc)
+        start = datetime.now(UTC) - timedelta(hours=24)
+        end = datetime.now(UTC)
         files = await camera.get_file_list(start, end)
         assert len(files) == 6
         for f in files:
@@ -187,8 +187,8 @@ class TestDahuaEmulator:
             password="testpass",
         )
         camera = DahuaCamera(config=config, storage_path=str(tmp_path))
-        start = datetime.now(timezone.utc) - timedelta(hours=24)
-        end = datetime.now(timezone.utc)
+        start = datetime.now(UTC) - timedelta(hours=24)
+        end = datetime.now(UTC)
         files = await camera.get_file_list(start, end)
         assert len(files) > 0
 
@@ -205,8 +205,8 @@ class TestDahuaEmulator:
             password="testpass",
         )
         camera = DahuaCamera(config=config, storage_path=str(tmp_path))
-        start = datetime.now(timezone.utc) - timedelta(hours=24)
-        end = datetime.now(timezone.utc)
+        start = datetime.now(UTC) - timedelta(hours=24)
+        end = datetime.now(UTC)
         files = await camera.get_file_list(start, end)
         assert len(files) > 0
 
@@ -276,8 +276,8 @@ class TestReolinkEmulator:
             channel=0,
         )
         camera = ReolinkCamera(config=config, storage_path=str(tmp_path))
-        start = datetime.now(timezone.utc) - timedelta(hours=24)
-        end = datetime.now(timezone.utc)
+        start = datetime.now(UTC) - timedelta(hours=24)
+        end = datetime.now(UTC)
         files = await camera.get_file_list(start, end)
         assert len(files) == 6
         for f in files:
@@ -296,8 +296,8 @@ class TestReolinkEmulator:
             channel=0,
         )
         camera = ReolinkCamera(config=config, storage_path=str(tmp_path))
-        start = datetime.now(timezone.utc) - timedelta(hours=24)
-        end = datetime.now(timezone.utc)
+        start = datetime.now(UTC) - timedelta(hours=24)
+        end = datetime.now(UTC)
         files = await camera.get_file_list(start, end)
         assert len(files) > 0
 

--- a/tests/integration/test_camera_poller_integration.py
+++ b/tests/integration/test_camera_poller_integration.py
@@ -13,33 +13,34 @@ This test verifies:
 9. Queue handoffs and error handling
 """
 
+import asyncio
+import json
 import os
 import tempfile
-import json
-import asyncio
-from unittest.mock import Mock, AsyncMock
 from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
 import pytest
 import pytz
-from pathlib import Path
 
+from video_grouper.models import RecordingFile
 from video_grouper.task_processors.camera_poller import CameraPoller
 from video_grouper.task_processors.download_processor import DownloadProcessor
-from video_grouper.models import RecordingFile
 from video_grouper.utils.config import (
-    Config,
-    CameraConfig,
-    TeamSnapConfig,
-    PlayMetricsConfig,
-    NtfyConfig,
-    YouTubeConfig,
-    AutocamConfig,
-    CloudSyncConfig,
     AppConfig,
-    StorageConfig,
-    RecordingConfig,
-    ProcessingConfig,
+    AutocamConfig,
+    CameraConfig,
+    CloudSyncConfig,
+    Config,
     LoggingConfig,
+    NtfyConfig,
+    PlayMetricsConfig,
+    ProcessingConfig,
+    RecordingConfig,
+    StorageConfig,
+    TeamSnapConfig,
+    YouTubeConfig,
 )
 
 
@@ -214,7 +215,7 @@ class TestCameraPollerIntegration:
             )
 
             # Check state file content
-            with open(state_file, "r") as f:
+            with open(state_file) as f:
                 state_data = json.load(f)
                 # State should be empty after processing is complete
                 assert len(state_data["queue"]) == 0, (
@@ -501,7 +502,7 @@ class TestCameraPollerIntegration:
             )
             assert os.path.exists(state_file), "State file should exist"
 
-            with open(state_file, "r") as f:
+            with open(state_file) as f:
                 state_data = json.load(f)
 
                 # State should contain the queued item
@@ -516,7 +517,7 @@ class TestCameraPollerIntegration:
             await asyncio.sleep(2)
 
             # Verify state is empty after processing
-            with open(state_file, "r") as f:
+            with open(state_file) as f:
                 final_state = json.load(f)
                 assert len(final_state["queue"]) == 0, (
                     "State should be empty after processing"
@@ -830,7 +831,7 @@ class TestCameraPollerIntegration:
             )
             assert os.path.exists(state_file), "State file should exist"
 
-            with open(state_file, "r") as f:
+            with open(state_file) as f:
                 state_data = json.load(f)
                 assert len(state_data["queue"]) == 0, (
                     "State should be empty after all processing"

--- a/tests/integration/test_download_video_integration.py
+++ b/tests/integration/test_download_video_integration.py
@@ -10,32 +10,33 @@ This test verifies:
 6. Video processing tasks are created and executed
 """
 
+import asyncio
+import json
 import os
 import tempfile
-import json
-import asyncio
-from unittest.mock import Mock, AsyncMock
 from datetime import datetime
-import pytest
 from pathlib import Path
+from unittest.mock import AsyncMock, Mock
 
+import pytest
+
+from video_grouper.models import RecordingFile
 from video_grouper.task_processors.download_processor import DownloadProcessor
 from video_grouper.task_processors.video_processor import VideoProcessor
-from video_grouper.models import RecordingFile
 from video_grouper.utils.config import (
-    Config,
-    CameraConfig,
-    TeamSnapConfig,
-    PlayMetricsConfig,
-    NtfyConfig,
-    YouTubeConfig,
-    AutocamConfig,
-    CloudSyncConfig,
     AppConfig,
-    StorageConfig,
-    RecordingConfig,
-    ProcessingConfig,
+    AutocamConfig,
+    CameraConfig,
+    CloudSyncConfig,
+    Config,
     LoggingConfig,
+    NtfyConfig,
+    PlayMetricsConfig,
+    ProcessingConfig,
+    RecordingConfig,
+    StorageConfig,
+    TeamSnapConfig,
+    YouTubeConfig,
 )
 
 
@@ -196,7 +197,7 @@ class TestDownloadVideoIntegration:
             # Note: Video state file may not exist if no tasks were queued due to missing files
 
             # Check state file contents
-            with open(download_state_file, "r") as f:
+            with open(download_state_file) as f:
                 download_state = json.load(f)
                 assert len(download_state["queue"]) == 0, (
                     "Download state should be empty after processing"
@@ -356,7 +357,7 @@ class TestDownloadVideoIntegration:
                 setup_storage_environment, "download_queue_state.json"
             )
 
-            with open(download_state_file, "r") as f:
+            with open(download_state_file) as f:
                 download_state = json.load(f)
                 assert len(download_state["queue"]) == 0, (
                     "Download state should be empty after processing"
@@ -473,7 +474,7 @@ class TestDownloadVideoIntegration:
             )
             # Note: Video state file may not exist if no tasks were queued
 
-            with open(download_state_file, "r") as f:
+            with open(download_state_file) as f:
                 download_state = json.load(f)
 
                 # State should contain the queued item
@@ -488,7 +489,7 @@ class TestDownloadVideoIntegration:
             await asyncio.sleep(2)
 
             # Verify state is empty after processing
-            with open(download_state_file, "r") as f:
+            with open(download_state_file) as f:
                 final_download_state = json.load(f)
                 assert len(final_download_state["queue"]) == 0, (
                     "Download state should be empty after processing"
@@ -574,7 +575,7 @@ class TestDownloadVideoIntegration:
                 setup_storage_environment, "download_queue_state.json"
             )
 
-            with open(download_state_file, "r") as f:
+            with open(download_state_file) as f:
                 download_state = json.load(f)
                 assert len(download_state["queue"]) == 0, (
                     "Download state should be empty after all processing"

--- a/tests/integration/test_full_pipeline_e2e.py
+++ b/tests/integration/test_full_pipeline_e2e.py
@@ -12,36 +12,37 @@ recording groups, verifying:
 - Two groups process sequentially through video queue
 """
 
-import os
-import json
 import asyncio
+import json
+import os
 import tempfile
-from unittest.mock import Mock, AsyncMock, patch
 from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
 
+from video_grouper.models import RecordingFile
 from video_grouper.task_processors.camera_poller import CameraPoller
 from video_grouper.task_processors.download_processor import DownloadProcessor
-from video_grouper.task_processors.video_processor import VideoProcessor
-from video_grouper.task_processors.upload_processor import UploadProcessor
 from video_grouper.task_processors.ntfy_processor import NtfyProcessor
-from video_grouper.task_processors.tasks.video import CombineTask
 from video_grouper.task_processors.tasks.upload import YoutubeUploadTask
-from video_grouper.models import RecordingFile
+from video_grouper.task_processors.tasks.video import CombineTask
+from video_grouper.task_processors.upload_processor import UploadProcessor
+from video_grouper.task_processors.video_processor import VideoProcessor
 from video_grouper.utils.config import (
-    Config,
-    CameraConfig,
-    TeamSnapConfig,
-    PlayMetricsConfig,
-    NtfyConfig,
-    YouTubeConfig,
-    AutocamConfig,
-    CloudSyncConfig,
     AppConfig,
-    StorageConfig,
-    RecordingConfig,
-    ProcessingConfig,
+    AutocamConfig,
+    CameraConfig,
+    CloudSyncConfig,
+    Config,
     LoggingConfig,
+    NtfyConfig,
+    PlayMetricsConfig,
+    ProcessingConfig,
+    RecordingConfig,
+    StorageConfig,
+    TeamSnapConfig,
+    YouTubeConfig,
 )
 from video_grouper.utils.logger import close_loggers
 
@@ -74,8 +75,8 @@ def mock_httpx():
 @pytest.fixture
 def temp_storage():
     """Create a temporary storage directory."""
-    import time
     import shutil
+    import time
 
     with tempfile.TemporaryDirectory() as temp_dir:
         yield temp_dir

--- a/tests/integration/test_ntfy_integration.py
+++ b/tests/integration/test_ntfy_integration.py
@@ -1,5 +1,7 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
-from unittest.mock import patch, AsyncMock
+
 from video_grouper.api_integrations.ntfy import NtfyAPI
 from video_grouper.utils.config import NtfyConfig
 

--- a/tests/integration/test_playmetrics_integration.py
+++ b/tests/integration/test_playmetrics_integration.py
@@ -1,6 +1,8 @@
-import pytest
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
+
+import pytest
+
 from video_grouper.api_integrations.playmetrics import PlayMetricsAPI
 from video_grouper.utils.config import PlayMetricsConfig
 
@@ -56,7 +58,7 @@ async def test_get_team_events(mock_config):
     api = PlayMetricsAPI(mock_config, app_config)
 
     # Create mock event data
-    game_time = datetime(2025, 6, 22, 14, 0, 0, tzinfo=timezone.utc)
+    game_time = datetime(2025, 6, 22, 14, 0, 0, tzinfo=UTC)
     mock_events = [
         {
             "id": "1",
@@ -93,7 +95,7 @@ async def test_find_game_for_recording(mock_config):
     api = PlayMetricsAPI(mock_config, app_config)
 
     # Create mock event data
-    game_time = datetime(2025, 6, 22, 14, 0, 0, tzinfo=timezone.utc)
+    game_time = datetime(2025, 6, 22, 14, 0, 0, tzinfo=UTC)
     mock_events = [
         {
             "id": "1",
@@ -150,7 +152,7 @@ async def test_populate_match_info(mock_config):
     api = PlayMetricsAPI(mock_config, app_config)
 
     # Create mock game data
-    game_time = datetime(2025, 6, 22, 14, 0, 0, tzinfo=timezone.utc)
+    game_time = datetime(2025, 6, 22, 14, 0, 0, tzinfo=UTC)
     mock_game = {
         "id": "1",
         "title": "Game vs Test Opponent",

--- a/tests/integration/test_teamsnap_integration.py
+++ b/tests/integration/test_teamsnap_integration.py
@@ -4,7 +4,8 @@ Test script for the TeamSnap API integration.
 """
 
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
+
 from video_grouper.api_integrations.teamsnap import TeamSnapAPI
 from video_grouper.utils.config import TeamSnapConfig, TeamSnapTeamConfig
 
@@ -31,7 +32,7 @@ class TestTeamSnapIntegration(unittest.TestCase):
         self.sample_game = {
             "id": "12345",
             "team_id": "test_team_id",
-            "start_date": (datetime.now(timezone.utc) + timedelta(days=1))
+            "start_date": (datetime.now(UTC) + timedelta(days=1))
             .isoformat()
             .replace("+00:00", "Z"),
             "opponent_name": "Opponent Team",
@@ -66,8 +67,8 @@ class TestTeamSnapIntegration(unittest.TestCase):
         self.assertEqual(len(games), 1)
 
         # Verify games are a subset of events
-        game_ids = set(game.get("id") for game in games if game.get("id"))
-        event_ids = set(event.get("id") for event in events if event.get("id"))
+        game_ids = {game.get("id") for game in games if game.get("id")}
+        event_ids = {event.get("id") for event in events if event.get("id")}
         self.assertTrue(game_ids.issubset(event_ids))
 
     def test_find_game_for_recording(self):

--- a/tests/integration/ttt/test_ttt_integration.py
+++ b/tests/integration/ttt/test_ttt_integration.py
@@ -8,7 +8,7 @@ Section D: Auth edge cases (need live TTT backend)
 
 import tempfile
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -159,23 +159,23 @@ class TestRecordingPipelineWorkflow:
 
     def test_01_register_recordings(self, ttt_client):
         """Register new recording files, get recording IDs back."""
-        ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
         files = [
             {
                 "file_name": f"integ_test_{ts}_001.mp4",
                 "file_group": f"integ-test-{ts}",
                 "file_size_bytes": 1073741824,
                 "duration_seconds": 1800.0,
-                "recording_start": datetime.now(timezone.utc).isoformat(),
-                "recording_end": datetime.now(timezone.utc).isoformat(),
+                "recording_start": datetime.now(UTC).isoformat(),
+                "recording_end": datetime.now(UTC).isoformat(),
             },
             {
                 "file_name": f"integ_test_{ts}_002.mp4",
                 "file_group": f"integ-test-{ts}",
                 "file_size_bytes": 1073741824,
                 "duration_seconds": 1800.0,
-                "recording_start": datetime.now(timezone.utc).isoformat(),
-                "recording_end": datetime.now(timezone.utc).isoformat(),
+                "recording_start": datetime.now(UTC).isoformat(),
+                "recording_end": datetime.now(UTC).isoformat(),
             },
         ]
         result = ttt_client.register_recordings(CAMERA_ID, TEAM_ID, files)
@@ -248,14 +248,14 @@ class TestRecordingPipelineWorkflow:
 
     def test_11_recording_pipeline_failure(self, ttt_client):
         """Register a recording and report download failure with error message."""
-        ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
         files = [
             {
                 "file_name": f"integ_fail_{ts}.mp4",
                 "file_group": f"integ-fail-{ts}",
                 "file_size_bytes": 500000000,
-                "recording_start": datetime.now(timezone.utc).isoformat(),
-                "recording_end": datetime.now(timezone.utc).isoformat(),
+                "recording_start": datetime.now(UTC).isoformat(),
+                "recording_end": datetime.now(UTC).isoformat(),
             }
         ]
         registered = ttt_client.register_recordings(CAMERA_ID, TEAM_ID, files)
@@ -487,14 +487,14 @@ class TestErrorDisplayWorkflows:
     def test_01_recording_failure_creates_alert(self, ttt_client):
         """Pipeline failure triggers a recording_failed alert in TTT."""
         # Register a recording and fail it
-        ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
         files = [
             {
                 "file_name": f"alert_test_{ts}.mp4",
                 "file_group": f"alert-test-{ts}",
                 "file_size_bytes": 100000,
-                "recording_start": datetime.now(timezone.utc).isoformat(),
-                "recording_end": datetime.now(timezone.utc).isoformat(),
+                "recording_start": datetime.now(UTC).isoformat(),
+                "recording_end": datetime.now(UTC).isoformat(),
             }
         ]
         registered = ttt_client.register_recordings(CAMERA_ID, TEAM_ID, files)
@@ -729,7 +729,7 @@ class TestGameSessionManagement:
 
     def test_01_create_game_session(self, ttt_client):
         """Create a game session with unique recording_group_dir."""
-        ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
         result = ttt_client.create_game_session(
             TEAM_ID,
             f"/recordings/integ-test-{ts}",
@@ -1131,7 +1131,7 @@ class TestCapabilities:
     def test_get_capabilities(self, ttt_client):
         """Get feature flags for the current user."""
         result = ttt_client.get_capabilities()
-        assert isinstance(result, (dict, list))
+        assert isinstance(result, dict | list)
 
     def test_get_available_plugins(self, ttt_client):
         """Get list of available plugins."""

--- a/tests/test_autocam_automation.py
+++ b/tests/test_autocam_automation.py
@@ -2,14 +2,15 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from video_grouper.tray.autocam_automation import (
-    run_autocam_on_file,
+    _execute_autocam_gui_automation,
     _validate_autocam_inputs,
     _wait_for_completion_and_cleanup,
-    _execute_autocam_gui_automation,
+    run_autocam_on_file,
 )
 
 

--- a/tests/test_autocam_resume.py
+++ b/tests/test_autocam_resume.py
@@ -18,8 +18,8 @@ import pytest
 
 from video_grouper.models.directory_state import DirectoryState
 from video_grouper.tray.autocam_automation import (
-    _live_autocam_pids,
     _execute_autocam_gui_automation,
+    _live_autocam_pids,
 )
 
 

--- a/tests/test_ball_tracking_secure_loader.py
+++ b/tests/test_ball_tracking_secure_loader.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import hashlib
 from datetime import UTC, datetime, timedelta
-from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -88,7 +87,7 @@ def _build_license_response(
     wrapped_key: bytes,
     *,
     user_id: str = USER_ID,
-    expires_at: Optional[datetime] = None,
+    expires_at: datetime | None = None,
     artifact_url: str = "https://cdn.example/balldet-1.0.0.enc",
     tier: str = "free",
     version: str = VERSION,

--- a/tests/test_base_queue_processor.py
+++ b/tests/test_base_queue_processor.py
@@ -10,7 +10,6 @@ from video_grouper.task_processors.base_queue_processor import QueueProcessor
 from video_grouper.task_processors.queue_type import QueueType
 from video_grouper.task_processors.tasks.base_task import BaseTask
 
-
 # ---------------------------------------------------------------------------
 # Minimal concrete implementations for testing
 # ---------------------------------------------------------------------------

--- a/tests/test_camera_config.py
+++ b/tests/test_camera_config.py
@@ -1,10 +1,9 @@
 """Tests for camera configuration push methods (get/apply settings, password change)."""
 
-import pytest
 import httpx
+import pytest
 
 from video_grouper.utils.config import CameraConfig
-
 
 # ── Helpers ────────────────────────────────────────────────────────
 
@@ -522,6 +521,7 @@ class TestProbeDahua:
     @pytest.mark.asyncio
     async def test_success(self, monkeypatch):
         from unittest.mock import AsyncMock, MagicMock, patch
+
         from video_grouper.cameras import discovery
 
         response_text = (
@@ -555,6 +555,7 @@ class TestProbeDahua:
     @pytest.mark.asyncio
     async def test_connection_refused(self, monkeypatch):
         from unittest.mock import AsyncMock, patch
+
         from video_grouper.cameras import discovery
 
         mock_client = AsyncMock()
@@ -575,6 +576,7 @@ class TestProbeDahua:
     @pytest.mark.asyncio
     async def test_bad_credentials(self, monkeypatch):
         from unittest.mock import AsyncMock, MagicMock, patch
+
         from video_grouper.cameras import discovery
 
         mock_response = MagicMock()

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -1,19 +1,18 @@
 """Tests for camera auto-discovery and Reolink configuration."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 
 from video_grouper.cameras.discovery import (
     DiscoveredCamera,
     _extract_ips_from_probe_match,
+    change_password,
+    configure_always_record,
     discover_onvif_devices,
     probe_reolink,
-    configure_always_record,
-    change_password,
 )
-
 
 # ── Helpers ───────────────────────────────────────────────────────────
 

--- a/tests/test_camera_poller.py
+++ b/tests/test_camera_poller.py
@@ -2,33 +2,32 @@
 
 import os
 import tempfile
-from unittest.mock import Mock, AsyncMock, patch
 from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
 import pytz
 
-from pathlib import Path
-
+from video_grouper.models import DirectoryState, RecordingFile
 from video_grouper.task_processors.camera_poller import (
     CameraPoller,
     find_group_directory,
 )
-from video_grouper.models import RecordingFile
-from video_grouper.models import DirectoryState
 from video_grouper.utils.config import (
-    Config,
-    CameraConfig,
-    TeamSnapConfig,
-    PlayMetricsConfig,
-    NtfyConfig,
-    YouTubeConfig,
-    AutocamConfig,
-    CloudSyncConfig,
     AppConfig,
-    StorageConfig,
-    RecordingConfig,
-    ProcessingConfig,
+    AutocamConfig,
+    CameraConfig,
+    CloudSyncConfig,
+    Config,
     LoggingConfig,
+    NtfyConfig,
+    PlayMetricsConfig,
+    ProcessingConfig,
+    RecordingConfig,
+    StorageConfig,
+    TeamSnapConfig,
+    YouTubeConfig,
 )
 
 
@@ -614,7 +613,7 @@ class TestHomeRecordingDeletion:
 
         await poller._handle_deletion_response("yes, delete home recordings")
 
-        with open(poller._cleanup_state_path, "r") as f:
+        with open(poller._cleanup_state_path) as f:
             state = json.load(f)
         assert state["approved"] is True
 

--- a/tests/test_clip_request_processor.py
+++ b/tests/test_clip_request_processor.py
@@ -7,7 +7,6 @@ import pytest
 
 from video_grouper.task_processors.clip_request_processor import ClipRequestProcessor
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_clip_tasks.py
+++ b/tests/test_clip_tasks.py
@@ -1,16 +1,16 @@
 """Tests for clip extraction and highlight compilation tasks."""
 
-import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from video_grouper.task_processors.queue_type import QueueType
 from video_grouper.task_processors.tasks.clips.clip_extraction_task import (
     ClipExtractionTask,
 )
 from video_grouper.task_processors.tasks.clips.highlight_compilation_task import (
     HighlightCompilationTask,
 )
-from video_grouper.task_processors.queue_type import QueueType
-
 
 # ---------------------------------------------------------------------------
 # ClipExtractionTask

--- a/tests/test_cloud_sync.py
+++ b/tests/test_cloud_sync.py
@@ -1,15 +1,16 @@
-import pytest
-from unittest.mock import patch, MagicMock, mock_open
-from pathlib import Path
+import base64
 import configparser
 import json
-import base64
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from video_grouper.api_integrations.cloud_sync import CloudSync, GoogleAuthProvider
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import rsa, padding
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.backends import default_backend
 
 
 @pytest.fixture

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -1,11 +1,12 @@
 """Tests for the CommandExecutor module."""
 
-import pytest
 from unittest.mock import MagicMock
 
+import pytest
+
 from video_grouper.api_integrations.command_executor import (
-    CommandExecutor,
     SUPPORTED_COMMANDS,
+    CommandExecutor,
 )
 
 

--- a/tests/test_config_command_line.py
+++ b/tests/test_config_command_line.py
@@ -1,8 +1,10 @@
-import pytest
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, MagicMock, AsyncMock
-from video_grouper.__main__ import parse_arguments, load_application_config
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from video_grouper.__main__ import load_application_config, parse_arguments
 from video_grouper.utils.config import Config
 
 

--- a/tests/test_connected_filtering.py
+++ b/tests/test_connected_filtering.py
@@ -6,7 +6,7 @@ Test that the TeamSnap integration respects the connected camera filtering rule.
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 # Add the parent directory to the path so we can import the video_grouper package
@@ -72,7 +72,7 @@ class TestConnectedFiltering(unittest.TestCase):
         mock_get_games.return_value = self.games
 
         # Create a recording timespan that overlaps with the first game
-        recording_start = datetime(2025, 3, 8, 17, 15, 0, tzinfo=timezone.utc)
+        recording_start = datetime(2025, 3, 8, 17, 15, 0, tzinfo=UTC)
         recording_end = recording_start + timedelta(minutes=60)
 
         # Test that no game is found when the camera is connected
@@ -90,7 +90,7 @@ class TestConnectedFiltering(unittest.TestCase):
         mock_get_games.return_value = self.games
 
         # Create a recording timespan that overlaps with the first game
-        recording_start = datetime(2025, 3, 8, 17, 15, 0, tzinfo=timezone.utc)
+        recording_start = datetime(2025, 3, 8, 17, 15, 0, tzinfo=UTC)
         recording_end = recording_start + timedelta(minutes=60)
 
         # Test that a game is found when the camera is disconnected

--- a/tests/test_dahua_camera.py
+++ b/tests/test_dahua_camera.py
@@ -1,10 +1,11 @@
-import os
-import pytest
 import logging
+import os
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import httpx
-from unittest.mock import patch
+import pytest
+
 from video_grouper.cameras.dahua import DahuaCamera
 from video_grouper.utils.config import CameraConfig
 

--- a/tests/test_download_processor.py
+++ b/tests/test_download_processor.py
@@ -1,28 +1,29 @@
 """Tests for the DownloadProcessor."""
 
-import tempfile
-from unittest.mock import Mock, AsyncMock, patch
-from datetime import datetime
-import pytest
 import os
+import tempfile
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
 
-from video_grouper.task_processors.download_processor import DownloadProcessor
+import pytest
+
 from video_grouper.models import RecordingFile
+from video_grouper.task_processors.download_processor import DownloadProcessor
 from video_grouper.task_processors.tasks.video import CombineTask
 from video_grouper.utils.config import (
-    Config,
-    CameraConfig,
-    TeamSnapConfig,
-    PlayMetricsConfig,
-    NtfyConfig,
-    YouTubeConfig,
-    AutocamConfig,
-    CloudSyncConfig,
     AppConfig,
-    StorageConfig,
-    RecordingConfig,
-    ProcessingConfig,
+    AutocamConfig,
+    CameraConfig,
+    CloudSyncConfig,
+    Config,
     LoggingConfig,
+    NtfyConfig,
+    PlayMetricsConfig,
+    ProcessingConfig,
+    RecordingConfig,
+    StorageConfig,
+    TeamSnapConfig,
+    YouTubeConfig,
 )
 
 

--- a/tests/test_ffmpeg_utils.py
+++ b/tests/test_ffmpeg_utils.py
@@ -1,12 +1,14 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
 from video_grouper.utils.ffmpeg_utils import (
     async_convert_file,
     combine_videos,
+    create_screenshot,
     get_video_duration,
     trim_video,
     verify_ffmpeg_install,
-    create_screenshot,
 )
 
 

--- a/tests/test_game_selection.py
+++ b/tests/test_game_selection.py
@@ -2,14 +2,14 @@
 Tests for the shared game selection logic (proximity guard + midpoint heuristic).
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from video_grouper.utils.game_selection import select_best_game
 
 
 def _utc(*args):
     """Create a UTC-aware datetime."""
-    return datetime(*args, tzinfo=timezone.utc)
+    return datetime(*args, tzinfo=UTC)
 
 
 class TestSelectBestGame:

--- a/tests/test_match_info.py
+++ b/tests/test_match_info.py
@@ -1,6 +1,7 @@
+import configparser
 import os
 import tempfile
-import configparser
+
 from video_grouper.models import MatchInfo
 
 
@@ -48,13 +49,13 @@ class TestMatchInfo:
             ("opponent_team_name", {"opponent_team_name": "Unknown"}),
             ("location", {"location": "Unknown"}),
         ]:
-            defaults = dict(
-                my_team_name="Team A",
-                opponent_team_name="Team B",
-                location="Home",
-                start_time_offset="00:10:00",
-                total_duration="01:30:00",
-            )
+            defaults = {
+                "my_team_name": "Team A",
+                "opponent_team_name": "Team B",
+                "location": "Home",
+                "start_time_offset": "00:10:00",
+                "total_duration": "01:30:00",
+            }
             defaults.update(kwargs)
             mi = MatchInfo(**defaults)
             assert mi.is_populated() is False, (

--- a/tests/test_moment_api_client.py
+++ b/tests/test_moment_api_client.py
@@ -1,9 +1,10 @@
 """Unit tests for MomentApiClient with mocked httpx."""
 
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
 import pytest
 import pytest_asyncio
-import httpx
-from unittest.mock import AsyncMock, MagicMock
 
 from video_grouper.api_integrations.moment_api_client import MomentApiClient
 

--- a/tests/test_node_role.py
+++ b/tests/test_node_role.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 
-from video_grouper.video_grouper_app import VideoGrouperApp
 from video_grouper.utils.config import (
     AppConfig,
     AutocamConfig,
@@ -21,6 +20,7 @@ from video_grouper.utils.config import (
     TeamSnapConfig,
     YouTubeConfig,
 )
+from video_grouper.video_grouper_app import VideoGrouperApp
 
 
 def _config(temp_storage, role: str = "standalone") -> Config:

--- a/tests/test_ntfy_processor.py
+++ b/tests/test_ntfy_processor.py
@@ -3,14 +3,15 @@ Tests for NTFY Queue Processor.
 """
 
 import asyncio
-import pytest
 import tempfile
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
+
+from video_grouper.task_processors.base_queue_processor import QueueProcessor
 from video_grouper.task_processors.ntfy_processor import NtfyProcessor
 from video_grouper.task_processors.services.ntfy_service import NtfyService
 from video_grouper.utils.config import Config
-from video_grouper.task_processors.base_queue_processor import QueueProcessor
 
 
 @pytest.fixture

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -6,12 +6,11 @@ from unittest.mock import MagicMock, patch
 from video_grouper.utils.config import (
     Config,
     PlayMetricsTeamConfig,
-    create_default_config,
     config_needs_onboarding,
+    create_default_config,
     load_config,
     save_config,
 )
-
 
 # ---------------------------------------------------------------------------
 # create_default_config

--- a/tests/test_playmetrics_calendar.py
+++ b/tests/test_playmetrics_calendar.py
@@ -5,7 +5,7 @@ been replaced with HTTP-mocked equivalents that exercise the same public
 contract (login → fetch calendars → parse → match recordings).
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -280,7 +280,7 @@ class TestPlayMetricsParser:
 class TestPlayMetricsFindGame:
     def test_find_game_for_recording_match(self):
         api = _make_api()
-        game_time = datetime(2026, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
+        game_time = datetime(2026, 6, 15, 14, 0, 0, tzinfo=UTC)
         events = [
             {
                 "id": "1",
@@ -308,7 +308,7 @@ class TestPlayMetricsFindGame:
 
     def test_find_game_for_recording_no_match(self):
         api = _make_api()
-        game_time = datetime(2026, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
+        game_time = datetime(2026, 6, 15, 14, 0, 0, tzinfo=UTC)
         api.get_games = MagicMock(
             return_value=[
                 {
@@ -327,7 +327,7 @@ class TestPlayMetricsFindGame:
 
     def test_populate_match_info_writes_fields(self):
         api = _make_api()
-        game_time = datetime(2026, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
+        game_time = datetime(2026, 6, 15, 14, 0, 0, tzinfo=UTC)
         api.find_game_for_recording = MagicMock(
             return_value={
                 "id": "1",

--- a/tests/test_reolink_camera.py
+++ b/tests/test_reolink_camera.py
@@ -1,9 +1,9 @@
-import pytest
 import logging
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 
 from video_grouper.cameras.reolink import ReolinkCamera
 from video_grouper.utils.config import CameraConfig

--- a/tests/test_reolink_download.py
+++ b/tests/test_reolink_download.py
@@ -34,7 +34,6 @@ from video_grouper.cameras.reolink_download import (
     _to_annex_b,
 )
 
-
 # ── Helper: build synthetic BcMedia packets ──────────────────────────
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,6 +1,6 @@
 import sys
-from unittest.mock import MagicMock
 from pathlib import Path
+from unittest.mock import MagicMock
 
 # Add the project root to the Python path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2,26 +2,26 @@
 Tests for the new service classes in task_processors/services.
 """
 
-import pytest
 import os
 import tempfile
-from unittest.mock import Mock, AsyncMock, patch
 from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 
 from video_grouper.task_processors.services import (
-    TeamSnapService,
-    PlayMetricsService,
-    NtfyService,
-    MatchInfoService,
     CleanupService,
+    MatchInfoService,
+    NtfyService,
+    PlayMetricsService,
+    TeamSnapService,
 )
 from video_grouper.utils.config import (
+    NtfyConfig,
+    PlayMetricsConfig,
     TeamSnapConfig,
     TeamSnapTeamConfig,
-    PlayMetricsConfig,
-    NtfyConfig,
 )
-
 
 # Configure pytest for async tests
 pytest_plugins = ("pytest_asyncio",)

--- a/tests/test_state_auditor_enhanced.py
+++ b/tests/test_state_auditor_enhanced.py
@@ -2,26 +2,27 @@
 Tests for the enhanced StateAuditor with service integrations.
 """
 
-import pytest
 import tempfile
-from unittest.mock import Mock, AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
+
+from video_grouper.ball_tracking.config import BallTrackingConfig
 from video_grouper.task_processors.state_auditor import StateAuditor
 from video_grouper.utils.config import (
-    Config,
-    TeamSnapConfig,
-    PlayMetricsConfig,
-    NtfyConfig,
-    CloudSyncConfig,
-    YouTubeConfig,
     AppConfig,
     CameraConfig,
-    StorageConfig,
-    RecordingConfig,
-    ProcessingConfig,
+    CloudSyncConfig,
+    Config,
     LoggingConfig,
+    NtfyConfig,
+    PlayMetricsConfig,
+    ProcessingConfig,
+    RecordingConfig,
+    StorageConfig,
+    TeamSnapConfig,
+    YouTubeConfig,
 )
-from video_grouper.ball_tracking.config import BallTrackingConfig
 
 
 @pytest.fixture

--- a/tests/test_stitch_remap.py
+++ b/tests/test_stitch_remap.py
@@ -16,7 +16,6 @@ from video_grouper.utils.stitch_remap import (
     write_profile,
 )
 
-
 SAMPLE_PROFILE = StitchProfile(
     source_width=7680,
     source_height=2160,

--- a/tests/test_system_metrics.py
+++ b/tests/test_system_metrics.py
@@ -1,6 +1,6 @@
 """Tests for system metrics collection."""
 
-from video_grouper.utils.system_metrics import get_system_metrics, get_disk_free_gb
+from video_grouper.utils.system_metrics import get_disk_free_gb, get_system_metrics
 
 
 def test_get_system_metrics_returns_dict():

--- a/tests/test_teamsnap.py
+++ b/tests/test_teamsnap.py
@@ -6,7 +6,7 @@ Tests for the TeamSnap API integration.
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 # Add the parent directory to the path so we can import the video_grouper package
@@ -170,7 +170,7 @@ class TestTeamSnapAPI(unittest.TestCase):
         mock_get_games.return_value = self.games
 
         # Create a recording timespan that overlaps with the first game
-        recording_start = datetime(2025, 3, 8, 17, 15, 0, tzinfo=timezone.utc)
+        recording_start = datetime(2025, 3, 8, 17, 15, 0, tzinfo=UTC)
         recording_end = recording_start + timedelta(minutes=60)
 
         # Call the method
@@ -182,7 +182,7 @@ class TestTeamSnapAPI(unittest.TestCase):
         self.assertEqual(game["opponent_name"], "Opponent 1")
 
         # Test case 2: No game found
-        recording_start = datetime(2025, 3, 10, 17, 15, 0, tzinfo=timezone.utc)
+        recording_start = datetime(2025, 3, 10, 17, 15, 0, tzinfo=UTC)
         recording_end = recording_start + timedelta(minutes=60)
 
         game = self.api.find_game_for_recording(recording_start, recording_end)
@@ -205,7 +205,7 @@ class TestTeamSnapAPI(unittest.TestCase):
         }
 
         # Create a recording timespan
-        recording_start = datetime(2025, 3, 8, 17, 15, 0, tzinfo=timezone.utc)
+        recording_start = datetime(2025, 3, 8, 17, 15, 0, tzinfo=UTC)
         recording_end = recording_start + timedelta(minutes=60)
 
         # Create an empty match info dictionary

--- a/tests/test_teamsnap_dev_portal_automation.py
+++ b/tests/test_teamsnap_dev_portal_automation.py
@@ -6,7 +6,7 @@ without Chrome. The point of these tests is to lock in the contract
 turns a successful page into a TeamSnapCredentials object).
 """
 
-from typing import Callable
+from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
@@ -17,7 +17,6 @@ from video_grouper.api_integrations.teamsnap_dev_portal_automation import (
     TeamSnapAutomationError,
     obtain_teamsnap_credentials,
 )
-
 
 # ---------------------------------------------------------------------------
 # Tiny fake driver — strongly typed enough to exercise the SUT

--- a/tests/test_timestamp_matcher.py
+++ b/tests/test_timestamp_matcher.py
@@ -1,6 +1,6 @@
 """Unit tests for the timestamp matcher — pure offset computation functions."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -35,7 +35,7 @@ class TestComputeCombinedOffset:
             _make_recording("2026-01-15 10:30:00", "2026-01-15 11:00:00"),
         ]
         # Tag at 10:10 UTC (= 10:10 local since we use same tz)
-        tag = datetime(2026, 1, 15, 10, 10, 0, tzinfo=timezone.utc)
+        tag = datetime(2026, 1, 15, 10, 10, 0, tzinfo=UTC)
         offset = compute_combined_offset(tag, files, camera_timezone="UTC")
         assert offset == pytest.approx(600.0)  # 10 minutes
 
@@ -44,19 +44,19 @@ class TestComputeCombinedOffset:
             _make_recording("2026-01-15 10:00:00", "2026-01-15 10:30:00"),
             _make_recording("2026-01-15 10:30:00", "2026-01-15 11:00:00"),
         ]
-        tag = datetime(2026, 1, 15, 10, 45, 0, tzinfo=timezone.utc)
+        tag = datetime(2026, 1, 15, 10, 45, 0, tzinfo=UTC)
         offset = compute_combined_offset(tag, files, camera_timezone="UTC")
         # 30 min (first file) + 15 min into second file = 45 min = 2700s
         assert offset == pytest.approx(2700.0)
 
     def test_tag_before_all_files_returns_none(self):
         files = [_make_recording("2026-01-15 10:00:00", "2026-01-15 10:30:00")]
-        tag = datetime(2026, 1, 15, 9, 50, 0, tzinfo=timezone.utc)
+        tag = datetime(2026, 1, 15, 9, 50, 0, tzinfo=UTC)
         assert compute_combined_offset(tag, files, camera_timezone="UTC") is None
 
     def test_tag_after_all_files_returns_none(self):
         files = [_make_recording("2026-01-15 10:00:00", "2026-01-15 10:30:00")]
-        tag = datetime(2026, 1, 15, 11, 0, 0, tzinfo=timezone.utc)
+        tag = datetime(2026, 1, 15, 11, 0, 0, tzinfo=UTC)
         assert compute_combined_offset(tag, files, camera_timezone="UTC") is None
 
     def test_tag_in_gap_within_tolerance_snaps(self):
@@ -65,7 +65,7 @@ class TestComputeCombinedOffset:
             _make_recording("2026-01-15 10:30:03", "2026-01-15 11:00:00"),
         ]
         # Tag falls in the 3-second gap
-        tag = datetime(2026, 1, 15, 10, 30, 1, tzinfo=timezone.utc)
+        tag = datetime(2026, 1, 15, 10, 30, 1, tzinfo=UTC)
         offset = compute_combined_offset(tag, files, camera_timezone="UTC")
         # Should snap to end of first file = 1800s
         assert offset == pytest.approx(1800.0)
@@ -77,15 +77,13 @@ class TestComputeCombinedOffset:
             _make_recording("2026-01-15 10:20:00", "2026-01-15 10:30:00"),
         ]
         # Tag at 10:25 — skipped file excluded, so combined = 10min (file1) + 5min into file3
-        tag = datetime(2026, 1, 15, 10, 25, 0, tzinfo=timezone.utc)
+        tag = datetime(2026, 1, 15, 10, 25, 0, tzinfo=UTC)
         offset = compute_combined_offset(tag, files, camera_timezone="UTC")
         assert offset == pytest.approx(900.0)  # 600 + 300
 
     def test_empty_files_returns_none(self):
         assert (
-            compute_combined_offset(
-                datetime.now(timezone.utc), [], camera_timezone="UTC"
-            )
+            compute_combined_offset(datetime.now(UTC), [], camera_timezone="UTC")
             is None
         )
 
@@ -94,7 +92,7 @@ class TestComputeCombinedOffset:
             _make_recording("2026-01-15 10:00:00", "2026-01-15 10:30:00"),
             _make_recording("2026-01-15 10:30:00", "2026-01-15 11:00:00"),
         ]
-        tag = datetime(2026, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        tag = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
         offset = compute_combined_offset(tag, files, camera_timezone="UTC")
         # Exactly at boundary — falls in both files, first match wins (end of file 1)
         assert offset is not None
@@ -102,7 +100,7 @@ class TestComputeCombinedOffset:
 
     def test_tag_just_after_last_file_within_tolerance(self):
         files = [_make_recording("2026-01-15 10:00:00", "2026-01-15 10:30:00")]
-        tag = datetime(2026, 1, 15, 10, 30, 2, tzinfo=timezone.utc)
+        tag = datetime(2026, 1, 15, 10, 30, 2, tzinfo=UTC)
         offset = compute_combined_offset(
             tag, files, camera_timezone="UTC", gap_tolerance_seconds=5.0
         )

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -1,15 +1,17 @@
-import pytest
-from unittest.mock import patch, MagicMock
-from pathlib import Path
 import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 # Add the project root to the Python path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from PyQt6.QtWidgets import QApplication
-from video_grouper.tray.main import SystemTrayIcon
-from video_grouper.utils.config import Config, AppConfig, StorageConfig
+
 from video_grouper.ball_tracking.config import BallTrackingConfig
+from video_grouper.tray.main import SystemTrayIcon
+from video_grouper.utils.config import AppConfig, Config, StorageConfig
 
 
 # We need a QApplication instance to test PyQt components

--- a/tests/test_ttt_job_processor.py
+++ b/tests/test_ttt_job_processor.py
@@ -2,26 +2,26 @@
 
 import asyncio
 import tempfile
-from unittest.mock import Mock, AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from video_grouper.task_processors.ttt_job_processor import TTTJobProcessor
 from video_grouper.utils.config import (
-    Config,
-    CameraConfig,
-    TeamSnapConfig,
-    PlayMetricsConfig,
-    NtfyConfig,
-    YouTubeConfig,
-    AutocamConfig,
-    CloudSyncConfig,
     AppConfig,
-    StorageConfig,
-    RecordingConfig,
-    ProcessingConfig,
+    AutocamConfig,
+    CameraConfig,
+    CloudSyncConfig,
+    Config,
     LoggingConfig,
+    NtfyConfig,
+    PlayMetricsConfig,
+    ProcessingConfig,
+    RecordingConfig,
+    StorageConfig,
+    TeamSnapConfig,
     TTTConfig,
+    YouTubeConfig,
 )
 
 

--- a/tests/test_ttt_reporter.py
+++ b/tests/test_ttt_reporter.py
@@ -1,8 +1,9 @@
 """Tests for the TTT reporter module."""
 
 import asyncio
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from video_grouper.api_integrations.ttt_reporter import TTTReporter
 from video_grouper.utils.error_tracker import ErrorTracker

--- a/tests/test_ttt_reporter_stitch.py
+++ b/tests/test_ttt_reporter_stitch.py
@@ -13,7 +13,6 @@ from types import SimpleNamespace
 
 from video_grouper.api_integrations.ttt_reporter import TTTReporter
 
-
 SAMPLE_PROFILE = {
     "source_width": 7680,
     "source_height": 2160,

--- a/tests/test_upload_processor.py
+++ b/tests/test_upload_processor.py
@@ -2,11 +2,12 @@
 
 import os
 import tempfile
-from unittest.mock import Mock, AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
 
-from video_grouper.task_processors.upload_processor import UploadProcessor
 from video_grouper.task_processors.tasks.upload import YoutubeUploadTask
+from video_grouper.task_processors.upload_processor import UploadProcessor
 
 
 @pytest.fixture

--- a/tests/test_video_grouper_app.py
+++ b/tests/test_video_grouper_app.py
@@ -2,30 +2,31 @@
 
 import os
 import tempfile
-from unittest.mock import Mock, AsyncMock, patch
 from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
 
-from video_grouper.video_grouper_app import VideoGrouperApp
 from video_grouper.models import RecordingFile
-from video_grouper.task_processors.tasks.video import CombineTask
 from video_grouper.task_processors.tasks.upload import YoutubeUploadTask
+from video_grouper.task_processors.tasks.video import CombineTask
 from video_grouper.utils.config import (
-    Config,
-    CameraConfig,
-    TeamSnapConfig,
-    PlayMetricsConfig,
-    NtfyConfig,
-    YouTubeConfig,
-    AutocamConfig,
-    CloudSyncConfig,
     AppConfig,
-    StorageConfig,
-    RecordingConfig,
-    ProcessingConfig,
+    AutocamConfig,
+    CameraConfig,
+    CloudSyncConfig,
+    Config,
     LoggingConfig,
+    NtfyConfig,
+    PlayMetricsConfig,
+    ProcessingConfig,
+    RecordingConfig,
+    StorageConfig,
+    TeamSnapConfig,
+    YouTubeConfig,
 )
 from video_grouper.utils.logger import close_loggers
+from video_grouper.video_grouper_app import VideoGrouperApp
 
 
 @pytest.fixture(autouse=True)
@@ -39,8 +40,8 @@ def cleanup_loggers():
 @pytest.fixture
 def temp_storage():
     """Create a temporary storage directory for testing."""
-    import time
     import shutil
+    import time
 
     with tempfile.TemporaryDirectory() as temp_dir:
         yield temp_dir
@@ -493,8 +494,8 @@ class TestBallTrackingPlacement:
 
     def _config_with_ball_tracking(self, temp_storage, *, enabled, provider):
         """Build a Config that toggles ball_tracking + provider."""
-        from video_grouper.utils.config import Config
         from video_grouper.ball_tracking.config import BallTrackingConfig
+        from video_grouper.utils.config import Config
 
         return Config(
             cameras=[

--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -2,11 +2,12 @@
 
 import asyncio
 import tempfile
-from unittest.mock import Mock, AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
 
-from video_grouper.task_processors.video_processor import VideoProcessor
 from video_grouper.task_processors.tasks import CombineTask, TrimTask
+from video_grouper.task_processors.video_processor import VideoProcessor
 
 
 @pytest.fixture

--- a/tests/test_youtube_config.py
+++ b/tests/test_youtube_config.py
@@ -2,27 +2,28 @@
 Tests for YouTube configuration functionality, specifically playlist mapping.
 """
 
-import pytest
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from video_grouper.utils.config import (
-    load_config,
-    save_config,
+    AppConfig,
+    AutocamConfig,
+    CameraConfig,
+    CloudSyncConfig,
+    Config,
+    LoggingConfig,
+    NtfyConfig,
+    PlayMetricsConfig,
+    ProcessingConfig,
+    RecordingConfig,
+    StorageConfig,
+    TeamSnapConfig,
     YouTubeConfig,
     YouTubePlaylistMapConfig,
-    Config,
-    CameraConfig,
-    StorageConfig,
-    RecordingConfig,
-    ProcessingConfig,
-    LoggingConfig,
-    AppConfig,
-    TeamSnapConfig,
-    PlayMetricsConfig,
-    NtfyConfig,
-    AutocamConfig,
-    CloudSyncConfig,
+    load_config,
+    save_config,
 )
 
 

--- a/tests/test_youtube_playlist_functionality.py
+++ b/tests/test_youtube_playlist_functionality.py
@@ -4,18 +4,17 @@ Tests for YouTube playlist functionality with full mocking.
 These tests focus on the core playlist logic without complex file system dependencies.
 """
 
-import os
-import pytest
 import configparser
-from unittest.mock import patch, AsyncMock, MagicMock, mock_open
+import os
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
+import pytest
+
+from video_grouper.models import DirectoryState, MatchInfo
+from video_grouper.task_processors.services.ntfy_service import NtfyService
 from video_grouper.task_processors.tasks.upload.youtube_upload_task import (
     YoutubeUploadTask,
 )
-from video_grouper.task_processors.services.ntfy_service import NtfyService
-from video_grouper.models import MatchInfo
-from video_grouper.models import DirectoryState
-
 
 # Correct patch targets for dependencies used within YoutubeUploadTask
 YT_UPLOAD_TASK_PATH = "video_grouper.task_processors.tasks.upload.youtube_upload_task"
@@ -72,8 +71,8 @@ async def test_youtube_upload_task_coordination_with_state_playlist(
     # Create a valid config object
     from video_grouper.utils.config import (
         Config,
-        YouTubeConfig,
         NtfyConfig,
+        YouTubeConfig,
         YouTubePlaylistMapConfig,
     )
 
@@ -168,8 +167,8 @@ async def test_youtube_upload_task_coordination_with_config_mapping(
     # Create config with playlist mapping
     from video_grouper.utils.config import (
         Config,
-        YouTubeConfig,
         NtfyConfig,
+        YouTubeConfig,
         YouTubePlaylistMapConfig,
     )
 
@@ -256,8 +255,8 @@ async def test_youtube_upload_task_requests_playlist_when_not_found(
     # Mock config to have no playlist mapping
     from video_grouper.utils.config import (
         Config,
-        YouTubeConfig,
         NtfyConfig,
+        YouTubeConfig,
         YouTubePlaylistMapConfig,
     )
 
@@ -327,8 +326,8 @@ async def test_youtube_upload_task_skips_request_if_already_waiting(
     # Mock config to have no playlist mapping
     from video_grouper.utils.config import (
         Config,
-        YouTubeConfig,
         NtfyConfig,
+        YouTubeConfig,
         YouTubePlaylistMapConfig,
     )
 

--- a/tests/web/test_config_editor.py
+++ b/tests/web/test_config_editor.py
@@ -8,7 +8,6 @@ from fastapi.testclient import TestClient
 from video_grouper.utils.config import TTTConfig, load_config
 from video_grouper.web.auth_server import create_app
 
-
 # Same-origin header so auth_server's middleware accepts the editor's
 # POSTs (rejected without Origin/Referer after the OAuth-state CSRF fix).
 _SAME_ORIGIN = {"origin": "http://localhost:8765"}

--- a/tests/web/test_setup_wizard.py
+++ b/tests/web/test_setup_wizard.py
@@ -8,7 +8,6 @@ from fastapi.testclient import TestClient
 from video_grouper.utils.config import TTTConfig, load_config
 from video_grouper.web.auth_server import create_app
 
-
 # Same-origin Origin header so auth_server's middleware accepts the
 # wizard's POSTs (host_and_origin_check rejects state-changing requests
 # with no Origin/Referer).

--- a/tests/web/test_worker_api.py
+++ b/tests/web/test_worker_api.py
@@ -9,7 +9,6 @@ from video_grouper.utils.config import TTTConfig
 from video_grouper.web.auth_server import create_app
 from video_grouper.web.worker_api import enqueue_task
 
-
 # auth_server's middleware requires same-origin Origin/Referer on every
 # state-changing method; bake it into the test client so each POST/PUT
 # is treated as a same-origin browser request.

--- a/tests/web/test_youtube_oauth.py
+++ b/tests/web/test_youtube_oauth.py
@@ -16,7 +16,6 @@ from video_grouper.web.auth_server import (
     create_app,
 )
 
-
 _DESKTOP_CLIENT_SECRET = {
     "installed": {
         "client_id": "fake-client.apps.googleusercontent.com",

--- a/tools/migrate_autocam_to_ball_tracking.py
+++ b/tools/migrate_autocam_to_ball_tracking.py
@@ -44,7 +44,7 @@ def migrate_state_files(storage_path: Path) -> tuple[int, int]:
     for state_file in storage_path.rglob("state.json"):
         scanned += 1
         try:
-            with open(state_file, "r", encoding="utf-8") as f:
+            with open(state_file, encoding="utf-8") as f:
                 data = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
             logger.warning("Skipping unreadable state.json at %s: %s", state_file, e)

--- a/training/annotation/tracking_loss_generator.py
+++ b/training/annotation/tracking_loss_generator.py
@@ -272,7 +272,7 @@ def _build_tile_indices(
         if segment_game_map:
             # Log game clusters
             clusters: dict[int, list] = defaultdict(list)
-            for seg, (ci, gs) in segment_game_map.items():
+            for seg, (ci, _gs) in segment_game_map.items():
                 t = _parse_segment_time(seg)
                 if t:
                     clusters[ci].append((t[0], t[1], seg))

--- a/training/annotation_server.py
+++ b/training/annotation_server.py
@@ -12,7 +12,7 @@ import asyncio
 import json
 import logging
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
@@ -205,7 +205,7 @@ async def submit_results(game_id: str, packet_results: PacketResults):
             "ball_position": result.ball_position,
             "duration_ms": result.duration_ms,
             "reviewer": "phone",
-            "submitted_at": datetime.now(timezone.utc).isoformat(),
+            "submitted_at": datetime.now(UTC).isoformat(),
         }
         if result.auto_skipped:
             entry["auto_skipped"] = True
@@ -788,7 +788,7 @@ async def submit_ball_verify_result(result: dict):
             "frame_idx": result["frame_idx"],
             "verdict": result["verdict"],
             "notes": result.get("notes", ""),
-            "submitted_at": datetime.now(timezone.utc).isoformat(),
+            "submitted_at": datetime.now(UTC).isoformat(),
         }
     )
     results.sort(key=lambda r: r["frame_idx"])
@@ -1030,7 +1030,7 @@ def submit_gap_result(packet_id: str, result: dict):
             "tile_stem": tile_stem,
             "action": result.get("action", ""),
             "ball_position": result.get("ball_position"),
-            "submitted_at": datetime.now(timezone.utc).isoformat(),
+            "submitted_at": datetime.now(UTC).isoformat(),
         }
     )
 
@@ -1423,6 +1423,7 @@ def _ensure_sample_packs(gm, game_dir: Path, samples: list[dict]):
 async def get_phase_frame(game_id: str, segment: str, frame_idx: int):
     """Serve a full panoramic frame stitched from tiles, downscaled for the browser."""
     import cv2
+
     from training.data_prep.game_manifest import GameManifest
     from training.tasks.field_boundary import reconstruct_panoramic
 

--- a/training/data_prep/bootstrap_labels.py
+++ b/training/data_prep/bootstrap_labels.py
@@ -87,7 +87,7 @@ def bootstrap_labels(
         # YOLO handles batched inference natively -- uses all cores
         results = model(batch_strs, conf=confidence, verbose=False)
 
-        for tile_path, result in zip(batch_paths, results):
+        for tile_path, result in zip(batch_paths, results, strict=False):
             stats["tiles_processed"] += 1
 
             detections = []

--- a/training/data_prep/bootstrap_persons.py
+++ b/training/data_prep/bootstrap_persons.py
@@ -89,7 +89,7 @@ def bootstrap_persons(
 
         results = model(batch_strs, conf=confidence, verbose=False)
 
-        for tile_path, result in zip(batch_paths, results):
+        for tile_path, result in zip(batch_paths, results, strict=False):
             stats["tiles_processed"] += 1
 
             detections = []

--- a/training/data_prep/frame_diff_detector.py
+++ b/training/data_prep/frame_diff_detector.py
@@ -269,7 +269,7 @@ def main():
         logger.info("Saved %d detections to %s", len(detections), args.output)
     else:
         # Print summary
-        frames_with_dets = len(set(d["frame_idx"] for d in detections))
+        frames_with_dets = len({d["frame_idx"] for d in detections})
         logger.info(
             "Summary: %d detections across %d frames", len(detections), frames_with_dets
         )

--- a/training/data_prep/game_manifest.py
+++ b/training/data_prep/game_manifest.py
@@ -443,7 +443,7 @@ class GameManifest:
         col_names = [
             c[1] for c in self.conn.execute("PRAGMA table_info(ball_events)").fetchall()
         ]
-        return [dict(zip(col_names, row)) for row in rows]
+        return [dict(zip(col_names, row, strict=False)) for row in rows]
 
     # ------------------------------------------------------------------
     # Game phases (pre_game, first_half, halftime, second_half, post_game)
@@ -614,9 +614,10 @@ def remap_legacy_labels(conn, video_dir, frame_interval: int = 4):
     Returns:
         dict with remap stats
     """
-    import cv2
     import re
     from pathlib import Path
+
+    import cv2
 
     video_dir = Path(video_dir)
     tile_re = re.compile(r"^(.+)_frame_(\d{6})_r(\d+)_c(\d+)$")

--- a/training/data_prep/game_registry.py
+++ b/training/data_prep/game_registry.py
@@ -130,9 +130,7 @@ def _detect_video_format(gdir: Path) -> tuple[str, list[Path]]:
         return "gopro", gopro
 
     # Processed combined video
-    processed = [f for f in gdir.glob("*raw*.mp4")] + [
-        f for f in gdir.glob("combined*.mp4")
-    ]
+    processed = list(gdir.glob("*raw*.mp4")) + list(gdir.glob("combined*.mp4"))
     if processed:
         return "processed", processed
 

--- a/training/data_prep/manifest_dataset.py
+++ b/training/data_prep/manifest_dataset.py
@@ -23,9 +23,11 @@ Usage:
     model.train(data="training_sets/v3.1/dataset.yaml", trainer=ManifestTrainer, ...)
 """
 
+import logging
 import math
 import random
 import re
+import shutil
 import sqlite3
 import time
 from collections import defaultdict
@@ -33,10 +35,6 @@ from pathlib import Path
 
 import cv2
 import numpy as np
-
-import logging
-import shutil
-
 from ultralytics.data.dataset import YOLODataset
 from ultralytics.models.yolo.detect.train import DetectionTrainer
 from ultralytics.utils import LOGGER, colorstr
@@ -78,10 +76,10 @@ def _resolve_pack_path(pack_file: str) -> str:
         games_idx = parts.index("games")
         game_id = parts[games_idx + 1]
         pack_name = parts[-1]
-    except (ValueError, IndexError):
+    except (ValueError, IndexError) as exc:
         raise FileNotFoundError(
             f"Pack file not found and can't parse game_id: {pack_file}"
-        )
+        ) from exc
 
     archive_packs = _get_archive_tile_packs()
     archive_path = archive_packs / game_id / pack_name

--- a/training/data_prep/map_share.py
+++ b/training/data_prep/map_share.py
@@ -1,8 +1,8 @@
 """Map network share using Windows WNet API (works in any session context)."""
 
 import ctypes
-from ctypes import wintypes
 import os
+from ctypes import wintypes
 
 mpr = ctypes.WinDLL("mpr")
 

--- a/training/data_prep/tile_laptop.py
+++ b/training/data_prep/tile_laptop.py
@@ -18,9 +18,9 @@ import time
 import zipfile
 from pathlib import Path
 
-import psutil
 import cv2
 import numpy as np
+import psutil
 
 try:
     import av

--- a/training/data_prep/trajectory_analyzer.py
+++ b/training/data_prep/trajectory_analyzer.py
@@ -549,7 +549,7 @@ def analyze_game(
             seg_trajs[t.segment].append(t)
 
         dominant_set: set[int] = set()
-        for seg, seg_ts in seg_trajs.items():
+        for _seg, seg_ts in seg_trajs.items():
             ranked = sorted(
                 seg_ts, key=lambda x: x.length * x.max_displacement, reverse=True
             )
@@ -591,7 +591,7 @@ def analyze_game(
                 seg_trajs_e[t.segment].append(t)
 
             combined_set: set[int] = set()
-            for seg, seg_ts in seg_trajs_e.items():
+            for _seg, seg_ts in seg_trajs_e.items():
                 ranked = sorted(seg_ts, key=lambda x: x.score_combined, reverse=True)
                 for t in ranked[:top_k]:
                     combined_set.add(id(t))
@@ -632,7 +632,7 @@ def analyze_game(
                 seg_trajs_f[t.segment].append(t)
 
             stitch_set: set[int] = set()
-            for seg, seg_ts in seg_trajs_f.items():
+            for _seg, seg_ts in seg_trajs_f.items():
                 ranked = sorted(
                     seg_ts, key=lambda x: x.length * x.max_displacement, reverse=True
                 )

--- a/training/data_prep/trajectory_gaps.py
+++ b/training/data_prep/trajectory_gaps.py
@@ -189,7 +189,7 @@ def build_trajectories_from_manifest(
         seg_frames[seg] = sorted(set(seg_frames[seg]))
 
     # Auto-detect frame interval
-    all_fi = sorted(set(fi for _, fi in frame_dets))
+    all_fi = sorted({fi for _, fi in frame_dets})
     if len(all_fi) >= 2:
         gaps = [all_fi[i + 1] - all_fi[i] for i in range(min(100, len(all_fi) - 1))]
         gaps = [g for g in gaps if g > 0]

--- a/training/data_prep/verify_tiles.py
+++ b/training/data_prep/verify_tiles.py
@@ -117,7 +117,7 @@ def verify_from_manifest(
         seg_reports[seg_id] = sr
 
     # Check incomplete frames from manifest
-    for seg_id, frame_idx, tile_count in manifest.get_incomplete_frames(conn, game_id):
+    for seg_id, frame_idx, _tile_count in manifest.get_incomplete_frames(conn, game_id):
         if seg_id in seg_reports:
             seg_reports[seg_id].incomplete_frames.append(frame_idx)
             # Get specific missing tiles
@@ -443,7 +443,7 @@ def print_gap_summary(all_reports: list[GameReport], registry: dict):
     logger.info(
         "\n=== GAP SUMMARY: %d issues across %d games ===",
         len(gaps),
-        len(set(g["game_id"] for g in gaps)),
+        len({g["game_id"] for g in gaps}),
     )
     logger.info("")
 

--- a/training/distributed/dask_coordinator.py
+++ b/training/distributed/dask_coordinator.py
@@ -108,7 +108,7 @@ def tile_segment(video_path, game_id, tiles_base, frame_interval):
     tiles_dir = Path(tiles_base) / game_id
     tiles_dir.mkdir(parents=True, exist_ok=True)
 
-    from label_job import TILE_SIZE, NUM_COLS, NUM_ROWS, STEP_X, STEP_Y
+    from label_job import NUM_COLS, NUM_ROWS, STEP_X, STEP_Y, TILE_SIZE
 
     cap = cv2.VideoCapture(str(video))
     if not cap.isOpened():

--- a/training/distributed/extract_shards.py
+++ b/training/distributed/extract_shards.py
@@ -24,7 +24,7 @@ print("Phase 1: Copying tars to local disk...", flush=True)
 start = time.time()
 n = 0
 total_bytes = 0
-for root, dirs, files in os.walk(share):
+for root, _dirs, files in os.walk(share):
     for f in sorted(files):
         if not f.endswith(".tar"):
             continue
@@ -51,7 +51,7 @@ print(f"Phase 1 done: {n} tars, {mb:.0f} MB in {elapsed:.0f}s", flush=True)
 print("Phase 2: Extracting locally...", flush=True)
 start2 = time.time()
 extracted = 0
-for root, dirs, files in os.walk(tars_local):
+for root, _dirs, files in os.walk(tars_local):
     for f in sorted(files):
         if not f.endswith(".tar"):
             continue

--- a/training/distributed/go.py
+++ b/training/distributed/go.py
@@ -24,7 +24,7 @@ os.makedirs(local, exist_ok=True)
 print("Phase 1: Copying tars from share...", flush=True)
 start = time.time()
 n = 0
-for root, dirs, files in os.walk(share):
+for root, _dirs, files in os.walk(share):
     for f in sorted(files):
         if not f.endswith(".tar"):
             continue
@@ -47,7 +47,7 @@ print(f"Phase 1 done: {n} tars in {time.time() - start:.0f}s", flush=True)
 print("Phase 2: Extracting...", flush=True)
 start2 = time.time()
 n2 = 0
-for root, dirs, files in os.walk(cache):
+for root, _dirs, files in os.walk(cache):
     for f in sorted(files):
         if not f.endswith(".tar"):
             continue

--- a/training/distributed/map_share.py
+++ b/training/distributed/map_share.py
@@ -1,8 +1,8 @@
 """Map network share using Windows WNet API (works in any session context)."""
 
 import ctypes
-from ctypes import wintypes
 import os
+from ctypes import wintypes
 
 mpr = ctypes.WinDLL("mpr")
 

--- a/training/distributed/remote_train.py
+++ b/training/distributed/remote_train.py
@@ -1,7 +1,7 @@
 """Remote training script — maps share via WNet, then trains YOLO."""
 
-import sys
 import os
+import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from map_share import map_share  # noqa: E402

--- a/training/distributed/worker.py
+++ b/training/distributed/worker.py
@@ -246,14 +246,14 @@ def do_tile(game_id: str, video_path: Path, frame_interval: int = 4):
 
     try:
         from training.distributed.label_job import (
-            TILE_SIZE,
             NUM_COLS,
             NUM_ROWS,
             STEP_X,
             STEP_Y,
+            TILE_SIZE,
         )
     except ImportError:
-        from label_job import TILE_SIZE, NUM_COLS, NUM_ROWS, STEP_X, STEP_Y
+        from label_job import NUM_COLS, NUM_ROWS, STEP_X, STEP_Y, TILE_SIZE
 
     seg_id = video_path.stem
     tiles_dir = Path(TILES_DIR) / game_id

--- a/training/experiments/confidence_threshold_sweep.py
+++ b/training/experiments/confidence_threshold_sweep.py
@@ -147,7 +147,7 @@ def sweep_thresholds(
 
         # Per-region breakdown
         region_stats = {}
-        for region_name, row_filter in [
+        for region_name, _row_filter in [
             ("r0_far", lambda m: m["row"] == 0),
             ("r1_mid", lambda m: m["row"] == 1),
             ("r2_near", lambda m: m["row"] == 2),

--- a/training/experiments/exp1_onnx_gaps.py
+++ b/training/experiments/exp1_onnx_gaps.py
@@ -68,7 +68,7 @@ def find_gaps_in_game(game_id: str) -> list[dict]:
         seg_frames[seg] = sorted(set(seg_frames[seg]))
 
     # Auto-detect frame interval
-    all_fi = sorted(set(fi for _, fi in frame_dets))
+    all_fi = sorted({fi for _, fi in frame_dets})
     if len(all_fi) >= 2:
         gaps = [all_fi[i + 1] - all_fi[i] for i in range(min(100, len(all_fi) - 1))]
         gaps = [g for g in gaps if g > 0]

--- a/training/experiments/exp3_framediff_masked.py
+++ b/training/experiments/exp3_framediff_masked.py
@@ -6,13 +6,14 @@ non-player objects (hopefully the ball).
 Uses person detection on r0 region to build masks.
 """
 
-import cv2
 import json
 import logging
-import numpy as np
 import time
 from collections import defaultdict
 from pathlib import Path
+
+import cv2
+import numpy as np
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 logger = logging.getLogger(__name__)

--- a/training/experiments/exp3b_fullscale.py
+++ b/training/experiments/exp3b_fullscale.py
@@ -4,13 +4,14 @@ For each gap from Exp 1, seek to that frame, check for motion blob
 near the predicted position. Record matches with color/shape analysis.
 """
 
-import cv2
 import json
 import logging
-import numpy as np
 import time
 from collections import defaultdict
 from pathlib import Path
+
+import cv2
+import numpy as np
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 logger = logging.getLogger(__name__)

--- a/training/experiments/exp_allrow_gaps.py
+++ b/training/experiments/exp_allrow_gaps.py
@@ -64,7 +64,7 @@ def find_gaps_in_game(game_id: str) -> list[dict]:
         seg_frames[seg] = sorted(set(seg_frames[seg]))
 
     # Auto-detect frame interval
-    all_fi = sorted(set(fi for _, fi in frame_dets))
+    all_fi = sorted({fi for _, fi in frame_dets})
     if len(all_fi) >= 2:
         gaps_list = [
             all_fi[i + 1] - all_fi[i] for i in range(min(100, len(all_fi) - 1))

--- a/training/experiments/small_ball_experiments.py
+++ b/training/experiments/small_ball_experiments.py
@@ -1,8 +1,9 @@
 """Experiments for detecting small balls in the far field."""
 
+from pathlib import Path
+
 import cv2
 import numpy as np
-from pathlib import Path
 
 video_dir = Path("F:/Heat_2012s/05.31.2024 - vs Fairport (home)")
 seg = next(f for f in video_dir.iterdir() if f.suffix == ".mp4" and "[F]" in f.name)
@@ -137,7 +138,7 @@ for fi in sorted(frame_groups.keys()):
             continue
         best_idx = -1
         best_dist = 60.0
-        for j, (bx, by, ba) in enumerate(blobs):
+        for j, (bx, by, _ba) in enumerate(blobs):
             if used[j]:
                 continue
             dist = ((bx - last_x) ** 2 + (by - last_y) ** 2) ** 0.5
@@ -152,7 +153,7 @@ for fi in sorted(frame_groups.keys()):
         else:
             if len(traj) >= 3:
                 trajectories.append(traj)
-    for j, (bx, by, ba) in enumerate(blobs):
+    for j, (bx, by, _ba) in enumerate(blobs):
         if not used[j]:
             new_active.append([(fi, bx, by)])
     active = new_active

--- a/training/flywheel/coverage.py
+++ b/training/flywheel/coverage.py
@@ -66,7 +66,7 @@ def measure_game_coverage(
 
     # Auto-detect frame interval
     if frame_interval is None:
-        all_fi = sorted(set(fi for _, fi in frame_dets))
+        all_fi = sorted({fi for _, fi in frame_dets})
         if len(all_fi) >= 2:
             deltas = [
                 all_fi[i + 1] - all_fi[i] for i in range(min(100, len(all_fi) - 1))
@@ -278,7 +278,7 @@ def _count_out_of_play_frames(conn: sqlite3.Connection) -> int:
 
     total = 0
     out_start = None
-    for segment, frame_idx, event_type in events:
+    for _segment, frame_idx, event_type in events:
         if event_type == "out_of_play":
             out_start = frame_idx
         elif event_type == "back_in_play" and out_start is not None:

--- a/training/flywheel/runner.py
+++ b/training/flywheel/runner.py
@@ -18,7 +18,7 @@ import shutil
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from training.flywheel.coverage import measure_all_games
@@ -64,7 +64,7 @@ def load_state() -> dict:
 
 def save_state(state: dict):
     """Persist flywheel state to disk."""
-    state["last_updated"] = datetime.now(timezone.utc).isoformat()
+    state["last_updated"] = datetime.now(UTC).isoformat()
     STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(STATE_PATH, "w") as f:
         json.dump(state, f, indent=2)
@@ -442,7 +442,7 @@ def step_evaluate(state: dict) -> dict:
     state["history"].append(
         {
             "cycle": state["cycle"],
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": datetime.now(UTC).isoformat(),
             "coverage": avg_coverage,
             "total_gaps": state["total_gaps"],
             "long_gaps": state["long_gaps"],
@@ -485,7 +485,7 @@ STEP_FUNCTIONS = {
 def run_cycle(state: dict) -> dict:
     """Run one full cycle through all steps."""
     state["cycle"] += 1
-    state["started"] = datetime.now(timezone.utc).isoformat()
+    state["started"] = datetime.now(UTC).isoformat()
     logger.info("=== Starting cycle %d ===", state["cycle"])
 
     for i, step_name in enumerate(STEPS):

--- a/training/label_qa_prep.py
+++ b/training/label_qa_prep.py
@@ -76,7 +76,7 @@ def sample_positives(
 
     # Proportional sampling per segment
     sampled = []
-    for seg, seg_rows in by_segment.items():
+    for _seg, seg_rows in by_segment.items():
         seg_target = max(1, int(total_target * len(seg_rows) / len(rows)))
         seg_sample = random.sample(seg_rows, min(seg_target, len(seg_rows)))
         sampled.extend(seg_sample)
@@ -305,7 +305,7 @@ def create_phase_frames(
     phase_dir.mkdir(parents=True, exist_ok=True)
     created = 0
 
-    for seg_name, ts_start, ts_end in selected:
+    for seg_name, ts_start, _ts_end in selected:
         # Find a frame_idx in the middle of this segment
         frame_rows = conn.execute(
             """SELECT DISTINCT frame_idx FROM labels

--- a/training/pipeline/__main__.py
+++ b/training/pipeline/__main__.py
@@ -257,8 +257,8 @@ def cmd_unskip(args):
 
 def cmd_enqueue(args):
     from training.pipeline.config import load_config
-    from training.pipeline.registry import GameRegistry
     from training.pipeline.queue import WorkQueue
+    from training.pipeline.registry import GameRegistry
 
     cfg = load_config()
     q = WorkQueue(cfg.paths.work_queue_db)
@@ -397,8 +397,9 @@ def main():
 
     # File logging for long-running commands (serve, run)
     if args.command in ("serve", "run"):
-        from pathlib import Path
         from logging.handlers import RotatingFileHandler
+        from pathlib import Path
+
         from training.pipeline.config import load_config
 
         cfg = load_config()

--- a/training/pipeline/api.py
+++ b/training/pipeline/api.py
@@ -21,8 +21,8 @@ import threading
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
-from starlette.responses import Response
 from pydantic import BaseModel
+from starlette.responses import Response
 
 from training.pipeline.queue import WorkQueue
 from training.pipeline.registry import GameRegistry

--- a/training/pipeline/generate_review.py
+++ b/training/pipeline/generate_review.py
@@ -89,7 +89,7 @@ def _find_trajectory_breaks(conn, game_id, frame_interval=4):
         tracks[(seg, row, col)].append((fidx, cx, cy, w, h, conf, stem))
 
     breaks = []
-    for key, detections in tracks.items():
+    for _key, detections in tracks.items():
         if len(detections) < 3:
             continue  # need some track history
 

--- a/training/pipeline/machine_manager.py
+++ b/training/pipeline/machine_manager.py
@@ -170,7 +170,11 @@ Invoke-Command -ComputerName {hostname} -Credential $cred -ScriptBlock {{
 
     def pull_file(self, hostname: str, remote_path: str, local_path: str) -> bool:
         """Copy a file from a remote machine to the server."""
-        src = f"\\\\{hostname}\\D$\\{remote_path.lstrip('D:/').lstrip('D:\\\\')}"
+        # Strip the "D:/" or "D:\" drive prefix before re-rooting onto the
+        # admin share. removeprefix removes the literal string (not the
+        # character set lstrip would have stripped).
+        cleaned = remote_path.removeprefix("D:/").removeprefix("D:\\")
+        src = f"\\\\{hostname}\\D$\\{cleaned}"
         script = f"""
 Copy-Item -LiteralPath "{src}" -Destination "{local_path}" -Force
 if (Test-Path "{local_path}") {{
@@ -184,7 +188,8 @@ if (Test-Path "{local_path}") {{
 
     def push_directory(self, hostname: str, local_dir: str, remote_dir: str) -> bool:
         """Copy a directory to a remote machine using robocopy."""
-        dest = f"\\\\{hostname}\\D$\\{remote_dir.lstrip('D:/').lstrip('D:\\\\')}"
+        cleaned = remote_dir.removeprefix("D:/").removeprefix("D:\\")
+        dest = f"\\\\{hostname}\\D$\\{cleaned}"
         script = f"""
 robocopy "{local_dir}" "{dest}" /E /Z /J /R:3 /W:5 /NP /NFL /NDL
 if ($LASTEXITCODE -le 7) {{ Write-Output "OK" }} else {{ Write-Output "FAILED" }}

--- a/training/pipeline/orchestrator.py
+++ b/training/pipeline/orchestrator.py
@@ -479,7 +479,7 @@ class Orchestrator:
         if task_type == "stage":
             return self.cfg.server.hostname
         if task_type == "train":
-            for name, m in self.cfg.machines.items():
+            for _name, m in self.cfg.machines.items():
                 if "train" in m.capabilities:
                     return m.hostname
         return None
@@ -637,7 +637,7 @@ class Orchestrator:
         # Sort oldest first
         reclaimable.sort(key=lambda x: x[0])
 
-        for mtime, pack in reclaimable:
+        for _mtime, pack in reclaimable:
             if freed >= target_free - (total - used):
                 break
             size = pack.stat().st_size

--- a/training/review_packet_generator.py
+++ b/training/review_packet_generator.py
@@ -245,7 +245,7 @@ def generate_review_packet(
         "frames": [],
     }
 
-    for sel, filename in zip(selections, filenames):
+    for sel, filename in zip(selections, filenames, strict=False):
         manifest["frames"].append(
             {
                 "frame_idx": sel.frame_idx,

--- a/training/tasks/__init__.py
+++ b/training/tasks/__init__.py
@@ -10,7 +10,7 @@ Task handlers are registered here and dispatched by the worker.
 """
 
 import logging
-from typing import Callable
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/training/tasks/field_boundary.py
+++ b/training/tasks/field_boundary.py
@@ -299,9 +299,9 @@ def _detect_with_onnx(pano: np.ndarray, manifest: GameManifest) -> dict | None:
     """
     try:
         from video_grouper.inference.field_detector import (
+            build_field_polygon,
             create_field_session,
             detect_field_keypoints,
-            build_field_polygon,
         )
     except ImportError as e:
         logger.warning("ONNX field detector not available: %s", e)

--- a/training/tasks/generate_review.py
+++ b/training/tasks/generate_review.py
@@ -74,8 +74,8 @@ def run_generate_review(
         review_dir.mkdir(parents=True, exist_ok=True)
 
         # Build filmstrip of the dominant track (evenly spaced samples)
-        from training.tasks.sonnet_qa import _get_trajectory_sample_frames
         from training.data_prep.trajectory_gaps import build_gap_filmstrip
+        from training.tasks.sonnet_qa import _get_trajectory_sample_frames
 
         traj_tuples = [(p["fi"], p["seg"], p["px"], p["py"]) for p in track_points]
         sample_frames = _get_trajectory_sample_frames(

--- a/training/tasks/sonnet_qa.py
+++ b/training/tasks/sonnet_qa.py
@@ -167,11 +167,11 @@ def _run_qa(manifest, task_io, cfg, game_id: str) -> dict:
 
     try:
         from training.data_prep.trajectory_gaps import (
+            build_gap_filmstrip,
             build_trajectories_from_manifest,
-            stitch_game_ball_track,
             find_gap_candidates,
             gap_to_tile_stem,
-            build_gap_filmstrip,
+            stitch_game_ball_track,
         )
 
         has_phases = bool(manifest.get_phases())

--- a/training/tasks/tile.py
+++ b/training/tasks/tile.py
@@ -271,10 +271,11 @@ def _tile_segment_to_pack(
       2. Encoder pool: JPEG-encodes tiles across multiple cores
       3. Writer (main thread): writes encoded tiles to pack in order
     """
-    import cv2
     import queue
     import threading
     from concurrent.futures import ThreadPoolExecutor
+
+    import cv2
 
     cap = cv2.VideoCapture(str(video_path), cv2.CAP_FFMPEG)
     if not cap.isOpened():
@@ -382,7 +383,7 @@ def _tile_segment_to_pack(
 
             # Write results in frame order (maintains sequential pack offsets)
             for frame_idx, tiles_info, futures in frame_jobs:
-                for (row, col), future in zip(tiles_info, futures):
+                for (row, col), future in zip(tiles_info, futures, strict=False):
                     jpeg_bytes = future.result()
                     if jpeg_bytes is None:
                         continue

--- a/training/worker/__main__.py
+++ b/training/worker/__main__.py
@@ -38,7 +38,7 @@ def cmd_run(args):
 
             # Find this machine in config
             caps = []
-            for name, machine in cfg.machines.items():
+            for _name, machine in cfg.machines.items():
                 if machine.hostname == hostname:
                     caps = machine.capabilities
                     break

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,10 @@ version = 1
 revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
-    "sys_platform == 'win32'",
-    "sys_platform == 'linux'",
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version < '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'linux'",
+    "python_full_version < '3.15' and sys_platform == 'linux'",
 ]
 supported-markers = [
     "sys_platform == 'win32'",
@@ -137,6 +139,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/81/0bb853e76e4f6e9a1855d569003c59e19ffac45f7079d91505d1bb212f92/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1", size = 1233750, upload-time = "2026-05-17T17:47:34.731Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/4cf705beeccc08754d0bbda99aefff26110e209b9a07ac8a6b60eec48531/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6", size = 1235942, upload-time = "2026-05-17T17:47:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c8/ee097e437ea27dd2b8b227865c875492b585650a5802a22d82b304c8201b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2", size = 1442517, upload-time = "2026-05-17T17:47:38.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/bd/68063442838f1ba68ec72b5436430bc75b3bb17a1a3c3063f09b0c05ae2b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903", size = 1254081, upload-time = "2026-05-17T17:47:39.826Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e2/1e520793bc6a4e4524a6ab022391e827825eaa0c3811828bfdc6852eca26/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261", size = 1259910, upload-time = "2026-05-17T17:47:41.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/49b60f467979979cfe6913b43948ff25bca971ad0591d181812f163a988e/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027", size = 1250678, upload-time = "2026-05-17T17:47:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ba/66ab9555de6275677566f6574e5ef6c29cb185ea866f643bc06f8280a8ee/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937", size = 1301603, upload-time = "2026-05-17T17:47:46.256Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/6aca9b9abc710014b2be9059689e5dd1679339e78f567ffb4d255a9e2050/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c", size = 1410332, upload-time = "2026-05-17T17:47:47.899Z" },
+    { url = "https://files.pythonhosted.org/packages/47/68/2f76594432a22581ecf878b5e75a9b8601c24b2241cf0bbeb1e21fcf370c/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b", size = 1509979, upload-time = "2026-05-17T17:47:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ac/a93c9b58292653f6c595752f677a08e608f903b710594909e9231a389b3b/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab", size = 1505002, upload-time = "2026-05-17T17:47:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2e/b278f68c497ee2f1d1576cbbef8db5281cd4a5f2db040537592ac9c8862e/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3", size = 1456231, upload-time = "2026-05-17T17:47:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/419be1c566a4c504cd8fd60ce2f84e790f295495c0f327cfaeadf3d51012/ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38", size = 1058668, upload-time = "2026-05-17T17:47:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6f/c9d4d549295ed05111aeb8853232d1afd9d0a179fddb01eeffbb3a4a6842/ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c", size = 1101075, upload-time = "2026-05-17T17:48:00.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8e/d00c5ab30c58222e07d62956fca86c59d91b9ad32997e633c38b526623a3/ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb", size = 1075347, upload-time = "2026-05-17T17:48:01.753Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
 ]
 
 [[package]]
@@ -887,6 +925,47 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1045,6 +1124,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "librt", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_python_implementation != 'PyPy' and sys_platform == 'win32')" },
+    { name = "mypy-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pathspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
+    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -1344,6 +1463,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -2415,6 +2543,7 @@ tray = [
 [package.dev-dependencies]
 dev = [
     { name = "aiohttp", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "mypy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pytest", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pytest-asyncio", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -2470,6 +2599,7 @@ provides-extras = ["dev", "metrics", "ml", "service", "tray"]
 [package.metadata.requires-dev]
 dev = [
     { name = "aiohttp", specifier = ">=3.13.3" },
+    { name = "mypy", specifier = ">=2.1.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
 ]

--- a/video_grouper/__init__.py
+++ b/video_grouper/__init__.py
@@ -2,7 +2,7 @@
 Video Grouper - A tool for managing and processing soccer game recordings from IP cameras.
 """
 
-from .video_grouper_app import VideoGrouperApp
 from .version import __version__, __version_full__
+from .video_grouper_app import VideoGrouperApp
 
 __all__ = ["VideoGrouperApp", "__version__", "__version_full__"]

--- a/video_grouper/__main__.py
+++ b/video_grouper/__main__.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
+import argparse
+import asyncio
 import os
 import sys
-import asyncio
-import argparse
 from pathlib import Path
-from video_grouper.video_grouper_app import VideoGrouperApp
-from video_grouper.utils.paths import get_shared_data_path
+
+from video_grouper.utils.config import create_default_config, load_config
 from video_grouper.utils.locking import FileLock
-from video_grouper.utils.config import load_config, create_default_config
-from video_grouper.utils.logger import setup_logging, get_logger
+from video_grouper.utils.logger import get_logger, setup_logging
+from video_grouper.utils.paths import get_shared_data_path
+from video_grouper.video_grouper_app import VideoGrouperApp
 
 # Configure basic logging first, will be updated with config later
 setup_logging(level="INFO", app_name="video_grouper")

--- a/video_grouper/__main__.py
+++ b/video_grouper/__main__.py
@@ -20,7 +20,7 @@ parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, parent_dir)
 
 # Global variable to track tasks
-tasks = []
+tasks: list[asyncio.Task[None]] = []
 
 
 def parse_arguments():

--- a/video_grouper/api_integrations/base.py
+++ b/video_grouper/api_integrations/base.py
@@ -2,7 +2,7 @@
 Base types for API integrations.
 """
 
-from typing import TypedDict, Union
+from typing import TypedDict
 
 
 class ApiResponse(TypedDict, total=False):
@@ -12,7 +12,7 @@ class ApiResponse(TypedDict, total=False):
     success: bool
     status_code: int
     message: str
-    data: Union[dict, list, str, int, float, bool, None]
+    data: dict | list | str | int | float | bool | None
 
     # Error fields
     error: str
@@ -31,4 +31,4 @@ class ApiResponse(TypedDict, total=False):
     rate_limit_reset: str
 
     # Custom response fields
-    custom_fields: dict[str, Union[str, int, float, bool, list, dict]]
+    custom_fields: dict[str, str | int | float | bool | list | dict]

--- a/video_grouper/api_integrations/cloud_sync.py
+++ b/video_grouper/api_integrations/cloud_sync.py
@@ -1,15 +1,16 @@
+import asyncio
 import base64
+import configparser
 import json
 import logging
-import requests
-from pathlib import Path
-from typing import Dict, Any, Optional
-import configparser
-import asyncio
-from cryptography.hazmat.primitives.asymmetric import rsa, padding
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.backends import default_backend
 import secrets
+from pathlib import Path
+from typing import Any
+
+import requests
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.padding import PKCS7
 
@@ -46,7 +47,7 @@ class CloudSync:
         self.username = username
         self.password = password
 
-    def encrypt_config(self, config_data: Dict[str, Any]) -> Dict[str, Any]:
+    def encrypt_config(self, config_data: dict[str, Any]) -> dict[str, Any]:
         """
         Encrypt configuration data using hybrid encryption (RSA + AES).
 
@@ -145,8 +146,8 @@ class CloudSync:
             return False
 
     async def _make_async_request(
-        self, payload: Dict[str, Any]
-    ) -> Optional[requests.Response]:
+        self, payload: dict[str, Any]
+    ) -> requests.Response | None:
         """
         Make an asynchronous HTTP request.
 
@@ -182,7 +183,7 @@ class GoogleAuthProvider:
     """
 
     @staticmethod
-    async def authenticate() -> Optional[Dict[str, str]]:
+    async def authenticate() -> dict[str, str] | None:
         """
         Authenticate with Google OAuth.
 

--- a/video_grouper/api_integrations/mock_ntfy_api.py
+++ b/video_grouper/api_integrations/mock_ntfy_api.py
@@ -5,13 +5,14 @@ This module provides a mock implementation of the NTFY API that simulates
 successful notification sends without actually contacting the external server.
 """
 
-import os
-import logging
 import asyncio
+import logging
+import os
 from datetime import datetime
-from typing import Dict, List, Any
-from video_grouper.utils.config import NtfyConfig
+from typing import Any
+
 from video_grouper.api_integrations.mock_ntfy_communication import mock_ntfy_comm
+from video_grouper.utils.config import NtfyConfig
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +62,10 @@ class MockNtfyAPI:
         self,
         message: str,
         title: str = None,
-        tags: List[str] = None,
+        tags: list[str] = None,
         priority: int = None,
         image_path: str = None,
-        actions: List[Dict[str, Any]] = None,
+        actions: list[dict[str, Any]] = None,
     ) -> bool:
         """
         Simulate sending a notification successfully.
@@ -153,7 +154,7 @@ class MockNtfyAPI:
 
     async def wait_for_response(
         self, message_id: str, timeout: float = 60.0
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Simulate waiting for a response.
 
@@ -189,8 +190,8 @@ class MockNtfyAPI:
         self,
         group_dir: str,
         combined_video_path: str,
-        existing_info: Dict[str, str] = None,
-    ) -> Dict[str, str]:
+        existing_info: dict[str, str] = None,
+    ) -> dict[str, str]:
         """
         Send notifications about missing team information fields.
 
@@ -254,7 +255,7 @@ class MockNtfyAPI:
         logger.info("Mock NTFY API shutdown")
         self._initialized = False
 
-    def get_sent_notifications(self) -> List[Dict[str, Any]]:
+    def get_sent_notifications(self) -> list[dict[str, Any]]:
         """Get list of sent notifications for testing/debugging."""
         return self._sent_notifications.copy()
 

--- a/video_grouper/api_integrations/mock_ntfy_communication.py
+++ b/video_grouper/api_integrations/mock_ntfy_communication.py
@@ -6,9 +6,10 @@ and NTFY response service to simulate the complete user interaction flow.
 """
 
 import logging
-from datetime import datetime
-from typing import Dict, List, Optional, Any, Callable
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -21,13 +22,13 @@ class MockNtfyMessage:
     topic: str
     message: str
     title: str
-    tags: List[str]
+    tags: list[str]
     priority: int
-    image_path: Optional[str]
-    actions: List[Dict[str, Any]]
+    image_path: str | None
+    actions: list[dict[str, Any]]
     sent_at: str
-    response: Optional[str] = None
-    responded_at: Optional[str] = None
+    response: str | None = None
+    responded_at: str | None = None
 
 
 class MockNtfyCommunication:
@@ -51,8 +52,8 @@ class MockNtfyCommunication:
         if self._initialized:
             return
 
-        self._messages: Dict[str, MockNtfyMessage] = {}
-        self._response_callbacks: List[Callable[[MockNtfyMessage], None]] = []
+        self._messages: dict[str, MockNtfyMessage] = {}
+        self._response_callbacks: list[Callable[[MockNtfyMessage], None]] = []
         self._message_counter = 0
         self._initialized = True
         logger.info("Mock NTFY communication system initialized")
@@ -62,10 +63,10 @@ class MockNtfyCommunication:
         topic: str,
         message: str,
         title: str,
-        tags: List[str],
+        tags: list[str],
         priority: int,
-        image_path: Optional[str],
-        actions: List[Dict[str, Any]],
+        image_path: str | None,
+        actions: list[dict[str, Any]],
     ) -> str:
         """
         Send a mock NTFY message.
@@ -112,7 +113,7 @@ class MockNtfyCommunication:
 
         return message_id
 
-    def get_pending_messages(self, topic: str) -> List[MockNtfyMessage]:
+    def get_pending_messages(self, topic: str) -> list[MockNtfyMessage]:
         """
         Get pending messages for a topic.
 
@@ -150,9 +151,7 @@ class MockNtfyCommunication:
         logger.info(f"Mock NTFY: Response received for {message_id}: {response}")
         return True
 
-    def wait_for_response(
-        self, message_id: str, timeout: float = 60.0
-    ) -> Optional[str]:
+    def wait_for_response(self, message_id: str, timeout: float = 60.0) -> str | None:
         """
         Wait for a response to a message.
 
@@ -191,7 +190,7 @@ class MockNtfyCommunication:
         self._response_callbacks.append(callback)
         logger.info("Mock NTFY: Response callback registered")
 
-    def get_message(self, message_id: str) -> Optional[MockNtfyMessage]:
+    def get_message(self, message_id: str) -> MockNtfyMessage | None:
         """
         Get a specific message by ID.
 

--- a/video_grouper/api_integrations/mock_playmetrics.py
+++ b/video_grouper/api_integrations/mock_playmetrics.py
@@ -7,7 +7,6 @@ realistic test data for comprehensive end-to-end testing scenarios.
 
 import logging
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +44,7 @@ class MockPlayMetricsAPI:
 
     def find_game_for_recording(
         self, recording_start: datetime, recording_end: datetime
-    ) -> Optional[Dict[str, Union[str, datetime]]]:
+    ) -> dict[str, str | datetime] | None:
         """Find a game for the recording timeframe."""
         if not self.logged_in:
             logger.warning("Mock PlayMetrics: Not logged in, cannot find games")
@@ -88,13 +87,13 @@ class MockPlayMetricsAPI:
 
     def get_team_schedule(
         self, team_id: str, start_date: datetime, end_date: datetime
-    ) -> List[Dict[str, Union[str, datetime]]]:
+    ) -> list[dict[str, str | datetime]]:
         """Get team schedule within a date range."""
         # For testing, just return our mock game if it's within the range
         mock_game = self.find_game_for_recording(start_date, end_date)
         return [mock_game] if mock_game else []
 
-    def get_teams(self) -> List[Dict[str, Union[str, int]]]:
+    def get_teams(self) -> list[dict[str, str | int]]:
         """Get list of teams for the authenticated user."""
         return [
             {
@@ -105,7 +104,7 @@ class MockPlayMetricsAPI:
             }
         ]
 
-    def get_team_info(self, team_id: str) -> Dict[str, Union[str, int]]:
+    def get_team_info(self, team_id: str) -> dict[str, str | int]:
         """Get information about a specific team."""
         return {
             "id": team_id,
@@ -145,7 +144,7 @@ class MockPlayMetricsService:
 
     def find_game_for_recording(
         self, recording_start: datetime, recording_end: datetime
-    ) -> Optional[Dict[str, Union[str, datetime]]]:
+    ) -> dict[str, str | datetime] | None:
         """Find a game for the recording timeframe."""
         if not self.enabled or not self.api:
             return None
@@ -161,7 +160,7 @@ class MockPlayMetricsService:
         """Get the configured team name."""
         return getattr(self.config, "team_name", "Lightning")
 
-    def get_team_names(self) -> List[str]:
+    def get_team_names(self) -> list[str]:
         """Get list of team names."""
         teams = getattr(self.config, "teams", [])
         if teams:

--- a/video_grouper/api_integrations/mock_teamsnap.py
+++ b/video_grouper/api_integrations/mock_teamsnap.py
@@ -12,8 +12,8 @@ recording group is assigned the correct game:
 """
 
 import logging
-from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional, TypedDict, Union
+from datetime import UTC, datetime, timedelta
+from typing import TypedDict
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class MockTeamSnapEvent(TypedDict, total=False):
     team_name: str
 
     # Custom fields
-    custom_fields: dict[str, Union[str, int, float, bool]]
+    custom_fields: dict[str, str | int | float | bool]
 
 
 class MockTeamSnapAPI:
@@ -131,7 +131,7 @@ class MockTeamSnapAPI:
 
     def find_game_for_recording(
         self, recording_start: datetime, recording_end: datetime
-    ) -> Optional[MockTeamSnapEvent]:
+    ) -> MockTeamSnapEvent | None:
         """Find the best game for the recording using shared selection logic."""
         logger.info(
             f"Mock TeamSnap: Looking for games between {recording_start} and {recording_end}"
@@ -139,9 +139,9 @@ class MockTeamSnapAPI:
 
         # Ensure recording times are timezone-aware (UTC)
         if recording_start.tzinfo is None:
-            recording_start = recording_start.replace(tzinfo=timezone.utc)
+            recording_start = recording_start.replace(tzinfo=UTC)
         if recording_end.tzinfo is None:
-            recording_end = recording_end.replace(tzinfo=timezone.utc)
+            recording_end = recording_end.replace(tzinfo=UTC)
 
         # Parse pre-generated games into (game, start_utc, end_utc) tuples
         candidates = []
@@ -150,9 +150,9 @@ class MockTeamSnapAPI:
             game_end = datetime.fromisoformat(game["end_date"])
 
             if game_start.tzinfo is None:
-                game_start = game_start.replace(tzinfo=timezone.utc)
+                game_start = game_start.replace(tzinfo=UTC)
             if game_end.tzinfo is None:
-                game_end = game_end.replace(tzinfo=timezone.utc)
+                game_end = game_end.replace(tzinfo=UTC)
 
             candidates.append((game, game_start, game_end))
 
@@ -165,7 +165,7 @@ class MockTeamSnapAPI:
             game_label_fn=lambda g: g.get("name", "Unknown"),
         )
 
-    def get_teams(self) -> List[Dict[str, Union[str, int]]]:
+    def get_teams(self) -> list[dict[str, str | int]]:
         """Get list of teams for the authenticated user."""
         return [
             {
@@ -179,11 +179,11 @@ class MockTeamSnapAPI:
 
     def get_events_for_team(
         self, team_id: str, start_date: datetime, end_date: datetime
-    ) -> List[MockTeamSnapEvent]:
+    ) -> list[MockTeamSnapEvent]:
         """Get events for a specific team within a date range."""
         return list(self._games)
 
-    def get_team_info(self, team_id: str) -> Dict[str, Union[str, int]]:
+    def get_team_info(self, team_id: str) -> dict[str, str | int]:
         """Get information about a specific team."""
         return {
             "id": team_id,
@@ -234,7 +234,7 @@ class MockTeamSnapService:
 
     def find_game_for_recording(
         self, recording_start: datetime, recording_end: datetime
-    ) -> Optional[Dict[str, Union[str, int, bool]]]:
+    ) -> dict[str, str | int | bool] | None:
         """Find a game for the recording timeframe."""
         if not self.enabled or not self.api:
             return None

--- a/video_grouper/api_integrations/mock_ttt_api.py
+++ b/video_grouper/api_integrations/mock_ttt_api.py
@@ -12,8 +12,8 @@ Two pre-generated games are created at init, timed to align with the simulator's
 
 import logging
 import uuid
-from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +27,8 @@ class MockTTTApiClient:
     Provides the same public interface as TTTApiClient for E2E testing.
     """
 
-    def __init__(self, base_time: Optional[datetime] = None, **kwargs: Any) -> None:
-        self._base_time = base_time or datetime.now(timezone.utc)
+    def __init__(self, base_time: datetime | None = None, **kwargs: Any) -> None:
+        self._base_time = base_time or datetime.now(UTC)
         self._authenticated = True
 
         # Pre-generate two games aligned with simulator groups
@@ -154,7 +154,7 @@ class MockTTTApiClient:
         return {"id": request_id, "status": "in_progress"}
 
     def fulfill_clip_request(
-        self, request_id: str, url: str, notes: Optional[str] = None
+        self, request_id: str, url: str, notes: str | None = None
     ) -> dict[str, Any]:
         for r in self._clip_requests:
             if r["id"] == request_id:
@@ -169,7 +169,7 @@ class MockTTTApiClient:
     # ------------------------------------------------------------------
 
     def get_pending_highlights(
-        self, camera_id: Optional[str] = None
+        self, camera_id: str | None = None
     ) -> list[dict[str, Any]]:
         # camera_id is accepted but ignored (mirrors v1 TTT behavior).
         return [r for r in self._highlights if r.get("status") == "pending"]
@@ -186,7 +186,7 @@ class MockTTTApiClient:
                 return dict(r)
         return {"id": reel_id, "status": "pending"}
 
-    def claim_highlight(self, reel_id: str, camera_id: str) -> Optional[dict[str, Any]]:
+    def claim_highlight(self, reel_id: str, camera_id: str) -> dict[str, Any] | None:
         """Return updated reel on success; return None if already claimed (409)."""
         for r in self._highlights:
             if r["id"] == reel_id:
@@ -203,7 +203,7 @@ class MockTTTApiClient:
 
     def report_blocker(
         self, reel_id: str, camera_id: str, reason: str
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         for r in self._highlights:
             if r["id"] == reel_id:
                 r["unrenderable_reason"] = reason[:500]
@@ -230,7 +230,7 @@ class MockTTTApiClient:
         reel_id: str,
         *,
         file_path: str,
-        youtube_video_id: Optional[str],
+        youtube_video_id: str | None,
     ) -> dict[str, Any]:
         for r in self._highlights:
             if r["id"] == reel_id:
@@ -260,8 +260,8 @@ class MockTTTApiClient:
     def get_schedule(
         self,
         team_id: str,
-        start_date: Optional[str] = None,
-        end_date: Optional[str] = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
     ) -> list[dict[str, Any]]:
         logger.debug("Mock get_schedule for team %s", team_id)
         return list(self._games)
@@ -295,7 +295,7 @@ class MockTTTApiClient:
     def get_game_sessions(
         self,
         team_id: str,
-        recording_group_dir: Optional[str] = None,
+        recording_group_dir: str | None = None,
     ) -> list[dict[str, Any]]:
         sessions = list(self._game_sessions.values())
         if recording_group_dir:
@@ -312,7 +312,7 @@ class MockTTTApiClient:
         recording_group_dir: str,
         game_date: str,
         opponent_name: str,
-        video_youtube_id: Optional[str] = None,
+        video_youtube_id: str | None = None,
         status: str = "recording_complete",
     ) -> dict[str, Any]:
         session_id = str(uuid.uuid4())
@@ -438,9 +438,9 @@ class MockTTTApiClient:
         recording_id: str,
         stage: str,
         status: str,
-        error_message: Optional[str] = None,
-        youtube_url: Optional[str] = None,
-        youtube_video_id: Optional[str] = None,
+        error_message: str | None = None,
+        youtube_url: str | None = None,
+        youtube_video_id: str | None = None,
     ) -> dict[str, Any]:
         logger.debug(
             "Mock update_recording_status %s: %s=%s", recording_id, stage, status
@@ -458,7 +458,7 @@ class MockTTTApiClient:
             self._recordings[recording_id][f"{stage}_status"] = status
         return entry
 
-    def get_high_water_mark(self, camera_id: str) -> Optional[str]:
+    def get_high_water_mark(self, camera_id: str) -> str | None:
         logger.debug("Mock get_high_water_mark for camera %s", camera_id)
         # Return the latest recording_end among all recordings for this camera
         latest = None
@@ -479,7 +479,7 @@ class MockTTTApiClient:
     # Command polling & auto-record rules
     # ------------------------------------------------------------------
 
-    def get_auto_record_rules(self, camera_id: str) -> Optional[dict[str, Any]]:
+    def get_auto_record_rules(self, camera_id: str) -> dict[str, Any] | None:
         logger.debug("Mock get_auto_record_rules for camera %s", camera_id)
         return self._auto_record_rules or None
 

--- a/video_grouper/api_integrations/moment_api_client.py
+++ b/video_grouper/api_integrations/moment_api_client.py
@@ -9,7 +9,7 @@ gate, per the api-namespaces convention in TTT).
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 
@@ -48,7 +48,7 @@ class MomentApiClient:
 
     async def get_game_session_by_dir(
         self, recording_group_dir: str
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Find a game session by its recording_group_dir."""
         try:
             resp = await self._client.get(
@@ -87,8 +87,8 @@ class MomentApiClient:
         self,
         tag_id: str,
         video_offset: float,
-        trimmed_offset: Optional[float] = None,
-    ) -> Optional[dict[str, Any]]:
+        trimmed_offset: float | None = None,
+    ) -> dict[str, Any] | None:
         """Update a moment tag's computed offsets.
 
         PATCH /api/internal/moment-tags/{tag_id} — see TTT
@@ -115,10 +115,10 @@ class MomentApiClient:
         self,
         moment_tag_id: str,
         game_session_id: str,
-        clip_start: Optional[float] = None,
-        clip_end: Optional[float] = None,
+        clip_start: float | None = None,
+        clip_end: float | None = None,
         clip_duration: float = 30.0,
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Create a moment clip record."""
         payload: dict[str, Any] = {
             "moment_tag_id": moment_tag_id,
@@ -141,10 +141,10 @@ class MomentApiClient:
         self,
         clip_id: str,
         *,
-        status: Optional[str] = None,
-        file_path: Optional[str] = None,
-        youtube_video_id: Optional[str] = None,
-    ) -> Optional[dict[str, Any]]:
+        status: str | None = None,
+        file_path: str | None = None,
+        youtube_video_id: str | None = None,
+    ) -> dict[str, Any] | None:
         """Update a moment clip's status, file_path, or youtube_video_id."""
         payload: dict[str, Any] = {}
         if status is not None:
@@ -193,10 +193,10 @@ class MomentApiClient:
         self,
         highlight_id: str,
         *,
-        status: Optional[str] = None,
-        file_path: Optional[str] = None,
-        youtube_video_id: Optional[str] = None,
-    ) -> Optional[dict[str, Any]]:
+        status: str | None = None,
+        file_path: str | None = None,
+        youtube_video_id: str | None = None,
+    ) -> dict[str, Any] | None:
         """Update a highlight reel's status, file_path, or youtube_video_id."""
         payload: dict[str, Any] = {}
         if status is not None:

--- a/video_grouper/api_integrations/ntfy.py
+++ b/video_grouper/api_integrations/ntfy.py
@@ -5,26 +5,28 @@ This module provides functionality to send notifications with screenshots to use
 and receive responses to identify when a game starts and ends.
 """
 
-import os
-import logging
-import json
 import asyncio
-import httpx
-import uuid
-import time
-from datetime import datetime, timedelta
-from typing import Dict, Optional, List, Any
-from pathlib import Path
-from video_grouper.utils.ffmpeg_utils import create_screenshot, get_video_duration
-from video_grouper.utils.config import NtfyConfig
+import json
+import logging
+import os
 import re
+import time
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from video_grouper.utils.config import NtfyConfig
+from video_grouper.utils.ffmpeg_utils import create_screenshot, get_video_duration
 
 logger = logging.getLogger(__name__)
 
 
 async def compress_image(
     input_path: str,
-    output_path: Optional[str] = None,
+    output_path: str | None = None,
     quality: int = 60,
     max_width: int = 800,
 ) -> str:
@@ -269,7 +271,7 @@ class NtfyAPI:
                 )
                 await asyncio.sleep(10)  # Wait before retrying
 
-    async def _process_response(self, response_data: Dict[str, Any]):
+    async def _process_response(self, response_data: dict[str, Any]):
         """Process a response from the NTFY topic."""
         try:
             # Log all responses for debugging
@@ -547,7 +549,7 @@ class NtfyAPI:
 
     async def ask_game_start_time(
         self, combined_video_path: str, group_dir: str, time_offset_minutes: int = 5
-    ) -> Optional[str]:
+    ) -> str | None:
         """Send notification about the need to set game start time."""
         if not self.enabled:
             logger.warning(
@@ -585,7 +587,7 @@ class NtfyAPI:
         group_dir: str,
         start_time_offset: str,
         time_offset_minutes: int = 5,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Send notification about the need to set game end time."""
         if not self.enabled:
             logger.warning(
@@ -621,10 +623,10 @@ class NtfyAPI:
         self,
         message: str,
         title: str = None,
-        tags: List[str] = None,
+        tags: list[str] = None,
         priority: int = None,
         image_path: str = None,
-        actions: List[Dict[str, Any]] = None,
+        actions: list[dict[str, Any]] = None,
     ) -> bool:
         """
         Send a notification to the NTFY topic.
@@ -734,7 +736,7 @@ class NtfyAPI:
 
     async def wait_for_response(
         self, message_id: str, timeout: float = 60.0
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Wait for a response to a specific message.
 
@@ -751,7 +753,7 @@ class NtfyAPI:
                     self.pending_messages[message_id], timeout=timeout
                 )
                 return response
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning(
                     f"Timed out waiting for response to message {message_id}"
                 )
@@ -765,8 +767,8 @@ class NtfyAPI:
         self,
         group_dir: str,
         combined_video_path: str,
-        existing_info: Dict[str, str] = None,
-    ) -> Dict[str, str]:
+        existing_info: dict[str, str] = None,
+    ) -> dict[str, str]:
         """
         Send notifications about missing team information fields.
 
@@ -848,8 +850,8 @@ class NtfyAPI:
         self,
         combined_video_path: str,
         group_dir: str,
-        game_options: List[Dict[str, Any]],
-    ) -> Optional[Dict[str, Any]]:
+        game_options: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
         """
         Send notification asking the user to resolve a conflict between games from different sources.
 
@@ -882,7 +884,7 @@ class NtfyAPI:
         if combined_video_path and os.path.exists(combined_video_path):
             try:
                 duration = await get_video_duration(combined_video_path)
-                if duration and isinstance(duration, (int, float)) and duration > 0:
+                if duration and isinstance(duration, int | float) and duration > 0:
                     mid_point = int(duration) // 2
                     time_offset = str(timedelta(seconds=mid_point)).split(".")[0]
             except Exception as e:
@@ -1029,7 +1031,7 @@ class NtfyAPI:
                 )
                 return None
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning("Timed out waiting for game conflict resolution")
             self._cleanup_pending_message(message_id)
             return None

--- a/video_grouper/api_integrations/ntfy_response.py
+++ b/video_grouper/api_integrations/ntfy_response.py
@@ -7,7 +7,7 @@ controlled inputs to simulate user interaction during E2E testing.
 
 import asyncio
 import logging
-from typing import Optional, Dict
+
 from video_grouper.api_integrations.mock_ntfy_communication import mock_ntfy_comm
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class NtfyResponseService:
         self.response_url = f"{server_url}/{topic}"
 
         # Per-type message counters for controlled responses
-        self.message_counts: Dict[str, int] = {
+        self.message_counts: dict[str, int] = {
             "game_start": 0,
             "game_end": 0,
             "team_info": 0,
@@ -128,8 +128,9 @@ class NtfyResponseService:
 
     async def _subscribe_to_real_ntfy(self):
         """Subscribe to real NTFY topic and respond to messages."""
-        import httpx
         import json
+
+        import httpx
 
         subscription_url = f"{self.server_url}/{self.topic}/json"
         response_url = f"{self.server_url}/{self.topic}"
@@ -260,7 +261,7 @@ class NtfyResponseService:
 
         return False
 
-    def _get_response_for_message(self, title: str, message: str) -> Optional[str]:
+    def _get_response_for_message(self, title: str, message: str) -> str | None:
         """Get the appropriate response for the message based on per-type counters."""
         title_lower = title.lower()
         message_lower = message.lower()

--- a/video_grouper/api_integrations/playmetrics.py
+++ b/video_grouper/api_integrations/playmetrics.py
@@ -30,8 +30,8 @@ from __future__ import annotations
 import json
 import logging
 import os
-from datetime import datetime, timedelta, timezone
-from typing import Any, List, Optional, TypedDict
+from datetime import UTC, datetime, timedelta
+from typing import Any, TypedDict
 from urllib.parse import quote
 
 import pytz
@@ -64,7 +64,7 @@ _DEFAULT_TZ = "America/New_York"
 class TeamInfo(TypedDict, total=False):
     id: str
     name: str
-    calendar_url: Optional[str]
+    calendar_url: str | None
     role_id: str
 
 
@@ -77,12 +77,12 @@ class GameInfo(TypedDict, total=False):
     end_time: datetime
     is_game: bool
     is_home: bool
-    opponent: Optional[str]
+    opponent: str | None
     my_team_name: str
     time: str
 
 
-def _get_firebase_api_key() -> Optional[str]:
+def _get_firebase_api_key() -> str | None:
     """Read the Firebase Web API key, checking build-time secrets first.
 
     Returns None (instead of raising) so the integration can degrade
@@ -144,22 +144,22 @@ class PlayMetricsAPI:
             self.team_name = getattr(config, "team_name", "Test Team")
 
         # Optional pre-supplied refresh_token + role_id (skips signInWithPassword)
-        self.refresh_token: Optional[str] = getattr(config, "refresh_token", None)
-        self.current_role_id: Optional[str] = getattr(config, "current_role_id", None)
+        self.refresh_token: str | None = getattr(config, "refresh_token", None)
+        self.current_role_id: str | None = getattr(config, "current_role_id", None)
 
         # Cached short-lived auth state
-        self._id_token: Optional[str] = None
-        self._id_token_expires_at: Optional[datetime] = None
-        self._access_key: Optional[str] = None
-        self._roles: Optional[List[dict]] = None
+        self._id_token: str | None = None
+        self._id_token_expires_at: datetime | None = None
+        self._access_key: str | None = None
+        self._roles: list[dict] | None = None
 
         # Public flag — preserved from the legacy class so callers that
         # check `api.logged_in` keep working.
         self.logged_in = False
 
         # Cache for events to avoid redundant fetches within a single run
-        self.events_cache: List[GameInfo] = []
-        self.last_cache_update: Optional[datetime] = None
+        self.events_cache: list[GameInfo] = []
+        self.last_cache_update: datetime | None = None
         self.cache_duration = timedelta(hours=1)
 
     # ------------------------------------------------------------------
@@ -254,7 +254,7 @@ class PlayMetricsAPI:
         return bool(
             self._id_token
             and self._id_token_expires_at
-            and datetime.now(timezone.utc) < self._id_token_expires_at
+            and datetime.now(UTC) < self._id_token_expires_at
         )
 
     def _sign_in_with_password(self) -> None:
@@ -274,7 +274,7 @@ class PlayMetricsAPI:
         self._id_token = data["idToken"]
         self.refresh_token = data["refreshToken"]
         expires_in = int(data.get("expiresIn", 3600))
-        self._id_token_expires_at = datetime.now(timezone.utc) + timedelta(
+        self._id_token_expires_at = datetime.now(UTC) + timedelta(
             seconds=expires_in - 60
         )
         self._access_key = None  # Bound to id_token, invalidate cached key
@@ -298,12 +298,12 @@ class PlayMetricsAPI:
         if new_refresh:
             self.refresh_token = new_refresh
         expires_in = int(data.get("expires_in", 3600))
-        self._id_token_expires_at = datetime.now(timezone.utc) + timedelta(
+        self._id_token_expires_at = datetime.now(UTC) + timedelta(
             seconds=expires_in - 60
         )
         self._access_key = None
 
-    def _fetch_roles(self) -> List[dict]:
+    def _fetch_roles(self) -> list[dict]:
         """Discover the roles available to the current user.
 
         ``POST /firebase/user/login`` with an empty body returns a
@@ -323,7 +323,7 @@ class PlayMetricsAPI:
         payload = response.json()
         return payload.get("roles") or []
 
-    def _pick_role_for_team(self, roles: List[dict]) -> str:
+    def _pick_role_for_team(self, roles: list[dict]) -> str:
         """Pick the role whose club_name is a prefix of the configured team_name.
 
         PlayMetrics roles are scoped by club, not by team. The configured team
@@ -382,7 +382,7 @@ class PlayMetricsAPI:
     # Calendar fetch
     # ------------------------------------------------------------------
 
-    def _fetch_calendars(self, start_date: datetime, end_date: datetime) -> List[dict]:
+    def _fetch_calendars(self, start_date: datetime, end_date: datetime) -> list[dict]:
         """Fetch raw calendar JSON for the given window.
 
         Retries once on 401 by refreshing both id_token and access_key.
@@ -446,7 +446,7 @@ class PlayMetricsAPI:
     # Public API: teams + events
     # ------------------------------------------------------------------
 
-    def get_available_teams(self) -> List[TeamInfo]:
+    def get_available_teams(self) -> list[TeamInfo]:
         """Return every team visible to the user, across all roles.
 
         Used by the tray onboarding wizard to populate the team picker.
@@ -461,7 +461,7 @@ class PlayMetricsAPI:
             return []
 
         seen: set = set()
-        teams: List[TeamInfo] = []
+        teams: list[TeamInfo] = []
 
         # Iterate every role (not just the current one) so the picker
         # shows everything the user has access to.
@@ -526,7 +526,7 @@ class PlayMetricsAPI:
 
         return teams
 
-    def get_events(self) -> List[GameInfo]:
+    def get_events(self) -> list[GameInfo]:
         """Return all events (games + practices) for the configured team."""
         if not self.enabled:
             logger.warning("PlayMetrics integration not enabled")
@@ -573,7 +573,7 @@ class PlayMetricsAPI:
         self.last_cache_update = datetime.now()
         return events
 
-    def get_games(self) -> List[GameInfo]:
+    def get_games(self) -> list[GameInfo]:
         """Return only the game events from the configured team's calendar."""
         events = self.get_events()
         games = [e for e in events if e.get("is_game")]
@@ -582,7 +582,7 @@ class PlayMetricsAPI:
 
     def find_game_for_recording(
         self, recording_start: datetime, recording_end: datetime
-    ) -> Optional[GameInfo]:
+    ) -> GameInfo | None:
         """Return the calendar game that best matches a recording timespan."""
         if not self.enabled:
             return None
@@ -596,8 +596,8 @@ class PlayMetricsAPI:
             recording_start = local_tz.localize(recording_start)
         if recording_end.tzinfo is None:
             recording_end = local_tz.localize(recording_end)
-        recording_start = recording_start.astimezone(timezone.utc)
-        recording_end = recording_end.astimezone(timezone.utc)
+        recording_start = recording_start.astimezone(UTC)
+        recording_end = recording_end.astimezone(UTC)
 
         candidates = []
         for game in games:
@@ -606,14 +606,14 @@ class PlayMetricsAPI:
             if not game_start:
                 continue
             if game_start.tzinfo is None:
-                game_start = game_start.replace(tzinfo=timezone.utc)
+                game_start = game_start.replace(tzinfo=UTC)
             else:
-                game_start = game_start.astimezone(timezone.utc)
+                game_start = game_start.astimezone(UTC)
             if game_end:
                 if game_end.tzinfo is None:
-                    game_end = game_end.replace(tzinfo=timezone.utc)
+                    game_end = game_end.replace(tzinfo=UTC)
                 else:
-                    game_end = game_end.astimezone(timezone.utc)
+                    game_end = game_end.astimezone(UTC)
             else:
                 game_end = game_start + timedelta(hours=2)
             candidates.append((game, game_start, game_end))
@@ -651,14 +651,14 @@ class PlayMetricsAPI:
     # Response parser — ported verbatim from the legacy implementation
     # ------------------------------------------------------------------
 
-    def _parse_api_calendars(self, data: Any) -> List[GameInfo]:
+    def _parse_api_calendars(self, data: Any) -> list[GameInfo]:
         """Parse PlayMetrics calendar JSON into GameInfo dicts.
 
         Filters games to the configured team_id when one is set so the
         caller only sees its own games. Practices are returned alongside
         games (as ``is_game=False``) for parity with the legacy parser.
         """
-        events: List[GameInfo] = []
+        events: list[GameInfo] = []
         local_tz = self._get_configured_timezone()
 
         if not isinstance(data, list):
@@ -714,7 +714,7 @@ class PlayMetricsAPI:
 
     def _parse_game_dict(
         self, game: dict, team_name_in_response: str, local_tz
-    ) -> Optional[GameInfo]:
+    ) -> GameInfo | None:
         start_str = (
             game.get("start_datetime") or game.get("start_date") or game.get("date")
         )
@@ -774,7 +774,7 @@ class PlayMetricsAPI:
 
     def _parse_practice_dict(
         self, practice: dict, team_name_in_response: str, local_tz
-    ) -> Optional[GameInfo]:
+    ) -> GameInfo | None:
         start_str = (
             practice.get("start_datetime")
             or practice.get("start_date")

--- a/video_grouper/api_integrations/teamsnap.py
+++ b/video_grouper/api_integrations/teamsnap.py
@@ -2,13 +2,13 @@
 TeamSnap API integration for video_grouper.
 """
 
-import re
-
-import requests
-from datetime import datetime, timedelta
 import logging
-from typing import Dict, List, Optional, TypedDict, Union
+import re
+from datetime import datetime, timedelta
+from typing import TypedDict
+
 import pytz
+import requests
 
 from video_grouper.utils.config import TeamSnapConfig, TeamSnapTeamConfig
 
@@ -39,7 +39,7 @@ class TeamSnapEvent(TypedDict, total=False):
     team_name: str
 
     # Custom fields
-    custom_fields: dict[str, Union[str, int, float, bool]]
+    custom_fields: dict[str, str | int | float | bool]
 
 
 class TeamSnapGame(TeamSnapEvent):
@@ -170,8 +170,8 @@ class TeamSnapAPI:
             return False
 
     def _make_api_request(
-        self, url: str, method: str = "GET", params: Dict = None, json_data: Dict = None
-    ) -> Optional[Dict]:
+        self, url: str, method: str = "GET", params: dict = None, json_data: dict = None
+    ) -> dict | None:
         """
         Make a request to the TeamSnap API.
 
@@ -272,7 +272,7 @@ class TeamSnapAPI:
                     self.endpoints[rel] = href
                     logger.debug(f"Discovered endpoint: {rel} -> {href}")
 
-    def _find_link_by_rel(self, collection: Dict, rel: str) -> Optional[str]:
+    def _find_link_by_rel(self, collection: dict, rel: str) -> str | None:
         """
         Find a link in a collection by its rel attribute.
 
@@ -290,7 +290,7 @@ class TeamSnapAPI:
 
         return None
 
-    def _find_link_in_item(self, item: Dict, rel: str) -> Optional[str]:
+    def _find_link_in_item(self, item: dict, rel: str) -> str | None:
         """
         Find a link in an item by its rel attribute.
 
@@ -308,7 +308,7 @@ class TeamSnapAPI:
 
         return None
 
-    def _extract_data_from_item(self, item: Dict) -> TeamSnapEvent:
+    def _extract_data_from_item(self, item: dict) -> TeamSnapEvent:
         """
         Extract data fields from a Collection+JSON item.
 
@@ -329,7 +329,7 @@ class TeamSnapAPI:
 
         return result
 
-    def get_team_events(self) -> List[TeamSnapEvent]:
+    def get_team_events(self) -> list[TeamSnapEvent]:
         """
         Get events for the configured team.
 
@@ -370,7 +370,7 @@ class TeamSnapAPI:
         logger.info(f"Found {len(events)} team events")
         return events
 
-    def get_games(self) -> List[TeamSnapGame]:
+    def get_games(self) -> list[TeamSnapGame]:
         """
         Get games for the configured team.
 
@@ -407,7 +407,7 @@ class TeamSnapAPI:
 
     def find_game_for_recording(
         self, recording_start: datetime, recording_end: datetime
-    ) -> Optional[TeamSnapGame]:
+    ) -> TeamSnapGame | None:
         """
         Find a game that corresponds to a recording timespan.
 
@@ -683,7 +683,7 @@ class TeamSnapAPI:
             logger.error(f"TeamSnap connection test failed with exception: {e}")
             return False
 
-    def get_teams(self) -> List[TeamSnapEvent]:
+    def get_teams(self) -> list[TeamSnapEvent]:
         """
         Get all teams accessible to the user.
 

--- a/video_grouper/api_integrations/teamsnap_dev_portal_automation.py
+++ b/video_grouper/api_integrations/teamsnap_dev_portal_automation.py
@@ -41,7 +41,6 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import Optional
 
 from selenium import webdriver
 from selenium.common.exceptions import (
@@ -230,7 +229,7 @@ def obtain_teamsnap_credentials(
             pass
 
 
-def _find_existing_app(driver, app_name: str) -> Optional[str]:
+def _find_existing_app(driver, app_name: str) -> str | None:
     """Return the existing application id if one named ``app_name`` exists.
 
     Walks the listing table and matches on the first cell text. Returns

--- a/video_grouper/api_integrations/ttt_api.py
+++ b/video_grouper/api_integrations/ttt_api.py
@@ -10,7 +10,7 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 
@@ -23,8 +23,8 @@ class TTTApiError(Exception):
     def __init__(
         self,
         message: str,
-        status_code: Optional[int] = None,
-        response_body: Optional[str] = None,
+        status_code: int | None = None,
+        response_body: str | None = None,
     ):
         self.status_code = status_code
         self.response_body = response_body
@@ -70,9 +70,9 @@ class TTTApiClient:
         self._token_dir = self.storage_path / "ttt"
         self._token_file = self._token_dir / "tokens.json"
 
-        self._access_token: Optional[str] = None
-        self._refresh_token_value: Optional[str] = None
-        self._expires_at: Optional[float] = None
+        self._access_token: str | None = None
+        self._refresh_token_value: str | None = None
+        self._expires_at: float | None = None
 
         self._http = httpx.Client(timeout=30.0)
 
@@ -224,7 +224,7 @@ class TTTApiClient:
             return False
         return time.time() < self._expires_at
 
-    def current_user_id(self) -> Optional[str]:
+    def current_user_id(self) -> str | None:
         """Return the authenticated user's id (JWT `sub` claim), or None."""
         if not self._access_token:
             return None
@@ -289,8 +289,8 @@ class TTTApiClient:
     def list_model_versions(
         self,
         model_key: str,
-        channel: Optional[str] = None,
-        pipeline_version: Optional[str] = None,
+        channel: str | None = None,
+        pipeline_version: str | None = None,
     ) -> list[dict[str, Any]]:
         """List model versions the current user is entitled to.
 
@@ -308,8 +308,8 @@ class TTTApiClient:
     def acquire_model_license(
         self,
         model_key: str,
-        channel: Optional[str] = None,
-        pipeline_version: Optional[str] = None,
+        channel: str | None = None,
+        pipeline_version: str | None = None,
     ) -> dict[str, Any]:
         """Request a license for the named model.
 
@@ -406,7 +406,7 @@ class TTTApiClient:
         self,
         request_id: str,
         url: str,
-        notes: Optional[str] = None,
+        notes: str | None = None,
     ) -> Any:
         """Mark a clip request as fulfilled with the result URL.
 
@@ -424,7 +424,7 @@ class TTTApiClient:
     # ------------------------------------------------------------------
 
     def get_pending_highlights(
-        self, camera_id: Optional[str] = None
+        self, camera_id: str | None = None
     ) -> list[dict[str, Any]]:
         """List the current user's highlight reels with status=pending.
 
@@ -481,7 +481,7 @@ class TTTApiClient:
         logger.debug("Fetching highlight reel %s", reel_id)
         return self._request("GET", url)
 
-    def claim_highlight(self, reel_id: str, camera_id: str) -> Optional[dict[str, Any]]:
+    def claim_highlight(self, reel_id: str, camera_id: str) -> dict[str, Any] | None:
         """Atomically transition a highlight reel from pending → generating.
 
         POST {api_base_url}/api/highlights/{reel_id}/claim
@@ -506,7 +506,7 @@ class TTTApiClient:
 
     def report_blocker(
         self, reel_id: str, camera_id: str, reason: str
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Report that this install cannot render the reel (e.g. missing source video).
 
         POST {api_base_url}/api/highlights/{reel_id}/report-blocker
@@ -556,7 +556,7 @@ class TTTApiClient:
         reel_id: str,
         *,
         file_path: str,
-        youtube_video_id: Optional[str],
+        youtube_video_id: str | None,
     ) -> dict[str, Any]:
         """Mark a highlight reel as rendered + uploaded (status='ready')."""
         url = f"{self.api_base_url}/api/highlights/{reel_id}"
@@ -586,8 +586,8 @@ class TTTApiClient:
     def get_schedule(
         self,
         team_id: str,
-        start_date: Optional[str] = None,
-        end_date: Optional[str] = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
     ) -> list[dict[str, Any]]:
         """Get team schedule within a date range.
 
@@ -631,7 +631,7 @@ class TTTApiClient:
     def get_game_sessions(
         self,
         team_id: str,
-        recording_group_dir: Optional[str] = None,
+        recording_group_dir: str | None = None,
     ) -> list[dict[str, Any]]:
         """Get game sessions, optionally filtered by recording group dir.
 
@@ -650,7 +650,7 @@ class TTTApiClient:
         recording_group_dir: str,
         game_date: str,
         opponent_name: str,
-        video_youtube_id: Optional[str] = None,
+        video_youtube_id: str | None = None,
         status: str = "processing",
     ) -> dict[str, Any]:
         """Create a new game session.
@@ -804,9 +804,9 @@ class TTTApiClient:
         self,
         camera_id: str,
         status: str,
-        firmware_version: Optional[str] = None,
-        error_message: Optional[str] = None,
-    ) -> Optional[dict[str, Any]]:
+        firmware_version: str | None = None,
+        error_message: str | None = None,
+    ) -> dict[str, Any] | None:
         """Report camera status to TTT.
 
         PATCH {api_base_url}/api/device-link/camera-status
@@ -820,7 +820,7 @@ class TTTApiClient:
         logger.debug("Updating camera status for %s: %s", camera_id, status)
         return self._request("PATCH", url, json=data)
 
-    def get_camera_config(self, camera_id: str) -> Optional[dict[str, Any]]:
+    def get_camera_config(self, camera_id: str) -> dict[str, Any] | None:
         """Fetch camera config from TTT.
 
         GET {api_base_url}/api/device-link/camera-config
@@ -831,7 +831,7 @@ class TTTApiClient:
 
     def push_camera_config(
         self, camera_id: str, config: dict[str, Any]
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Push local config to TTT for backup/transfer.
 
         PUT {api_base_url}/api/cameras/{camera_id}
@@ -865,10 +865,10 @@ class TTTApiClient:
         recording_id: str,
         stage: str,
         status: str,
-        error_message: Optional[str] = None,
-        youtube_url: Optional[str] = None,
-        youtube_video_id: Optional[str] = None,
-    ) -> Optional[dict[str, Any]]:
+        error_message: str | None = None,
+        youtube_url: str | None = None,
+        youtube_video_id: str | None = None,
+    ) -> dict[str, Any] | None:
         """Update pipeline stage status for a recording.
 
         PATCH {api_base_url}/api/device-link/recordings/{recording_id}/status
@@ -886,7 +886,7 @@ class TTTApiClient:
 
     def enhanced_heartbeat(
         self, service_id: str, metrics: dict
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Send enhanced heartbeat with system metrics.
 
         PATCH {api_base_url}/api/device-link/heartbeat-enhanced
@@ -896,7 +896,7 @@ class TTTApiClient:
         logger.debug("Sending enhanced heartbeat for service %s", service_id)
         return self._request("PATCH", url, json=data)
 
-    def get_auto_record_rules(self, camera_id: str) -> Optional[dict[str, Any]]:
+    def get_auto_record_rules(self, camera_id: str) -> dict[str, Any] | None:
         """Get auto-record rules for a camera.
 
         GET {api_base_url}/api/device-link/auto-record-rules?camera_id=
@@ -905,7 +905,7 @@ class TTTApiClient:
         logger.debug("Fetching auto-record rules for camera %s", camera_id)
         return self._request("GET", url, params={"camera_id": camera_id})
 
-    def get_pending_commands(self, camera_id: str) -> Optional[list[dict[str, Any]]]:
+    def get_pending_commands(self, camera_id: str) -> list[dict[str, Any]] | None:
         """Get pending commands for a camera.
 
         GET {api_base_url}/api/device-link/pending-commands?camera_id=
@@ -914,7 +914,7 @@ class TTTApiClient:
         logger.debug("Fetching pending commands for camera %s", camera_id)
         return self._request("GET", url, params={"camera_id": camera_id})
 
-    def acknowledge_command(self, command_id: str) -> Optional[dict[str, Any]]:
+    def acknowledge_command(self, command_id: str) -> dict[str, Any] | None:
         """Acknowledge receipt of a command.
 
         PATCH {api_base_url}/api/device-link/commands/{command_id}/acknowledge
@@ -923,9 +923,7 @@ class TTTApiClient:
         logger.debug("Acknowledging command %s", command_id)
         return self._request("PATCH", url)
 
-    def complete_command(
-        self, command_id: str, result: dict
-    ) -> Optional[dict[str, Any]]:
+    def complete_command(self, command_id: str, result: dict) -> dict[str, Any] | None:
         """Report command completion.
 
         PATCH {api_base_url}/api/device-link/commands/{command_id}/complete
@@ -934,7 +932,7 @@ class TTTApiClient:
         logger.debug("Completing command %s", command_id)
         return self._request("PATCH", url, json=result)
 
-    def get_high_water_mark(self, camera_id: str) -> Optional[str]:
+    def get_high_water_mark(self, camera_id: str) -> str | None:
         """Get the latest recording timestamp TTT knows about for this camera.
 
         GET {api_base_url}/api/device-link/high-water-mark?camera_id={camera_id}
@@ -1052,7 +1050,7 @@ class TTTApiClient:
     # Device configuration (onboarding)
     # ------------------------------------------------------------------
 
-    def get_device_config(self) -> Optional[dict[str, Any]]:
+    def get_device_config(self) -> dict[str, Any] | None:
         """Retrieve stored device config for this camera manager.
 
         GET {api_base_url}/api/device-link/config

--- a/video_grouper/ball_tracking/config.py
+++ b/video_grouper/ball_tracking/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 class AutocamGuiProviderConfig(BaseModel):
     """Config for the ``autocam_gui`` provider (drives Once AutoCam GUI)."""
 
-    executable: Optional[str] = None
+    executable: str | None = None
 
 
 class HomegrownProviderConfig(BaseModel):
@@ -25,23 +25,23 @@ class HomegrownProviderConfig(BaseModel):
     options grow.
     """
 
-    enabled_stages: List[str] = Field(
+    enabled_stages: list[str] = Field(
         default_factory=lambda: ["stitch_correct", "detect", "track", "render"],
         alias="stages",
     )
 
     # stitch_correct
-    stitch_profile_path: Optional[str] = None
+    stitch_profile_path: str | None = None
 
     # detect — pick exactly one source:
     #   model_key: ask TTT for a license + encrypted artifact (production)
     #   model_path: load a plaintext .onnx from disk (dev / local testing)
-    model_key: Optional[str] = None
-    model_path: Optional[str] = None
-    detect_channel: Optional[str] = (
+    model_key: str | None = None
+    model_path: str | None = None
+    detect_channel: str | None = (
         None  # canary / beta / stable; defaults to stable on TTT
     )
-    detect_pipeline_version: Optional[str] = None
+    detect_pipeline_version: str | None = None
     device: str = "cuda:0"
     detect_confidence: float = 0.45
     detect_frame_interval: int = 4

--- a/video_grouper/ball_tracking/license_state.py
+++ b/video_grouper/ball_tracking/license_state.py
@@ -18,7 +18,6 @@ import logging
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +33,7 @@ class LicenseState:
     expires_at: str  # ISO 8601, what the license manifest claimed
     acquired_at: str  # ISO 8601, when we successfully decrypted
 
-    def days_until_expiry(self, now: Optional[datetime] = None) -> float:
+    def days_until_expiry(self, now: datetime | None = None) -> float:
         check_time = now or datetime.now(UTC)
         try:
             expires = _parse_iso(self.expires_at)
@@ -42,7 +41,7 @@ class LicenseState:
             return -1.0
         return (expires - check_time).total_seconds() / 86400.0
 
-    def status_label(self, now: Optional[datetime] = None) -> str:
+    def status_label(self, now: datetime | None = None) -> str:
         days = self.days_until_expiry(now)
         if days < 0:
             return f"EXPIRED {abs(days):.0f}d ago — re-acquire required"
@@ -77,7 +76,7 @@ def record(
     version: str,
     tier: str,
     expires_at: str,
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> LicenseState:
     """Persist the most-recent successful license. Overwrites prior state."""
     acquired = (now or datetime.now(UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -101,7 +100,7 @@ def record(
     return state
 
 
-def load(storage_path: Path | str) -> Optional[LicenseState]:
+def load(storage_path: Path | str) -> LicenseState | None:
     """Return the persisted state, or None if no license has been acquired."""
     path = _state_path(Path(storage_path))
     if not path.exists():

--- a/video_grouper/ball_tracking/providers/autocam_gui.py
+++ b/video_grouper/ball_tracking/providers/autocam_gui.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Optional
 
 from video_grouper.ball_tracking import register_provider
 from video_grouper.ball_tracking.base import BallTrackingProvider, ProviderContext
@@ -20,10 +19,10 @@ logger = logging.getLogger(__name__)
 
 
 def _invoke_autocam(
-    executable: Optional[str],
+    executable: str | None,
     input_path: str,
     output_path: str,
-    group_dir: Optional[str] = None,
+    group_dir: str | None = None,
 ) -> bool:
     """Lazy-import the GUI driver and run AutoCam on a single file.
 

--- a/video_grouper/ball_tracking/providers/homegrown/__init__.py
+++ b/video_grouper/ball_tracking/providers/homegrown/__init__.py
@@ -6,6 +6,9 @@ registered at import time; the provider runs them in the configured
 order and threads an ``artifacts`` dict between them.
 """
 
+from video_grouper.ball_tracking import register_provider
+from video_grouper.ball_tracking.config import HomegrownProviderConfig
+
 from .provider import HomegrownProvider
 
 # Import each stage module so its top-level register_stage() call runs.
@@ -13,8 +16,5 @@ from .stages import detect as _detect_stage  # noqa: F401
 from .stages import render as _render_stage  # noqa: F401
 from .stages import stitch_correct as _stitch_correct_stage  # noqa: F401
 from .stages import track as _track_stage  # noqa: F401
-
-from video_grouper.ball_tracking import register_provider
-from video_grouper.ball_tracking.config import HomegrownProviderConfig
 
 register_provider("homegrown", HomegrownProvider, HomegrownProviderConfig)

--- a/video_grouper/ball_tracking/providers/homegrown/stages/render.py
+++ b/video_grouper/ball_tracking/providers/homegrown/stages/render.py
@@ -59,7 +59,7 @@ def _render_video(
     """Sync helper: pan-crop the source around the EMA-smoothed ball."""
     import av
 
-    with open(trajectory_path, "r", encoding="utf-8") as f:
+    with open(trajectory_path, encoding="utf-8") as f:
         raw = json.load(f)
     smoothed = _smooth_trajectory(raw, ema)
 

--- a/video_grouper/ball_tracking/providers/homegrown/stages/track.py
+++ b/video_grouper/ball_tracking/providers/homegrown/stages/track.py
@@ -30,7 +30,7 @@ def _run_tracking(
     max_missing: int,
 ) -> int:
     """Sync helper: load detections, run tracker, write trajectory JSON."""
-    with open(detections_path, "r", encoding="utf-8") as f:
+    with open(detections_path, encoding="utf-8") as f:
         per_frame: list[dict] = json.load(f)
 
     tracker = BallTracker(gate_distance=gate_distance, max_missing=max_missing)

--- a/video_grouper/ball_tracking/secure_loader.py
+++ b/video_grouper/ball_tracking/secure_loader.py
@@ -9,7 +9,7 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 from cryptography.exceptions import InvalidSignature, InvalidTag
@@ -100,7 +100,7 @@ def _verify_license(
     license_response: dict,
     public_keys: list[str],
     expected_user_id: str,
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> dict:
     """Validate the license response shape and signature; return the parsed manifest."""
     if _NATIVE_AVAILABLE:
@@ -235,7 +235,7 @@ def _select_providers() -> list[str]:
     return chosen
 
 
-def _download_artifact(url: str, http_client: Optional[httpx.Client] = None) -> bytes:
+def _download_artifact(url: str, http_client: httpx.Client | None = None) -> bytes:
     """Fetch the encrypted artifact bytes from `url`."""
     client = http_client or httpx.Client(timeout=60.0, follow_redirects=True)
     try:
@@ -261,8 +261,8 @@ class SecureLoader:
         self,
         ttt_client,
         public_keys: list[str],
-        http_client: Optional[httpx.Client] = None,
-        state_storage_path: Optional[str] = None,
+        http_client: httpx.Client | None = None,
+        state_storage_path: str | None = None,
     ):
         self._ttt = ttt_client
         self._public_keys = list(public_keys)
@@ -273,8 +273,8 @@ class SecureLoader:
     def acquire(
         self,
         model_key: str,
-        channel: Optional[str] = None,
-        pipeline_version: Optional[str] = None,
+        channel: str | None = None,
+        pipeline_version: str | None = None,
     ) -> LoadedModel:
         if not self._ttt.is_authenticated():
             raise SecureLoaderError("TTT client is not authenticated")

--- a/video_grouper/cameras/base.py
+++ b/video_grouper/cameras/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, TypedDict
 from datetime import datetime
+from typing import Any, TypedDict
 
 
 class CameraUnreachableError(Exception):
@@ -72,7 +72,7 @@ class Camera(ABC):
     @abstractmethod
     async def get_file_list(
         self, start_time: datetime = None, end_time: datetime = None
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Get list of recording files from the camera."""
         pass
 
@@ -110,7 +110,7 @@ class Camera(ABC):
         """Whether this camera supports programmatic file deletion."""
         return False
 
-    async def delete_files(self, file_paths: List[str]) -> int:
+    async def delete_files(self, file_paths: list[str]) -> int:
         """Delete recording files from the camera's storage.
 
         Not all cameras support this. Check supports_file_deletion first.
@@ -129,7 +129,7 @@ class Camera(ABC):
         pass
 
     @abstractmethod
-    def get_connected_timeframes(self) -> List[Tuple[datetime, Optional[datetime]]]:
+    def get_connected_timeframes(self) -> list[tuple[datetime, datetime | None]]:
         """Returns a list of timeframes when the camera was connected.
 
         Each timeframe is a tuple of (start_time, end_time), where end_time is None
@@ -142,7 +142,7 @@ class Camera(ABC):
 
     @property
     @abstractmethod
-    def connection_events(self) -> List[Tuple[datetime, str]]:
+    def connection_events(self) -> list[tuple[datetime, str]]:
         """Get list of connection events."""
         pass
 
@@ -154,7 +154,7 @@ class Camera(ABC):
 
     # ── Configuration push (optional) ─────────────────────────────────
 
-    async def get_current_settings(self) -> List["ConfigResult"]:
+    async def get_current_settings(self) -> list["ConfigResult"]:
         """Read current camera configuration for display.
 
         Returns a list of ConfigResult dicts describing the current state
@@ -162,7 +162,7 @@ class Camera(ABC):
         """
         return []
 
-    async def apply_optimal_settings(self, timezone: str = "") -> List["ConfigResult"]:
+    async def apply_optimal_settings(self, timezone: str = "") -> list["ConfigResult"]:
         """Push optimal settings for 24/7 soccer recording.
 
         Args:

--- a/video_grouper/cameras/dahua.py
+++ b/video_grouper/cameras/dahua.py
@@ -1,18 +1,20 @@
 import json
-import os
-import httpx
 import logging
+import os
 import time
+from datetime import UTC, datetime
+from typing import Any
+
 import aiofiles
-from datetime import datetime
-from typing import List, Tuple, Dict, Any, Optional
+import httpx
 import pytz
 
-from .base import Camera, ConfigResult, DeviceInfo
-from . import register_camera
 from video_grouper.models import ConnectionEvent
 from video_grouper.utils.config import CameraConfig
 from video_grouper.utils.paths import get_camera_state_path
+
+from . import register_camera
+from .base import Camera, ConfigResult, DeviceInfo
 
 # Default timeout for camera HTTP requests (30 seconds connect, 60 seconds read)
 CAMERA_HTTP_TIMEOUT = httpx.Timeout(60.0, connect=30.0)
@@ -31,7 +33,7 @@ class DahuaCamera(Camera):
         self.username = config.username
         self.password = config.password
         self._state_file = get_camera_state_path(storage_path)
-        self._connection_events: List[ConnectionEvent] = []
+        self._connection_events: list[ConnectionEvent] = []
         self._is_connected = False
         self._log_dir = os.path.join(self.storage_path, "camera_http_logs")
         os.makedirs(self._log_dir, exist_ok=True)
@@ -86,10 +88,10 @@ class DahuaCamera(Camera):
         """Load this camera's state from the shared state file."""
         try:
             if os.path.exists(self._state_file):
-                with open(self._state_file, "r") as f:
+                with open(self._state_file) as f:
                     all_state = json.load(f)
                     state = all_state.get(self.config.name, {})
-                    self._connection_events: List[ConnectionEvent] = state.get(
+                    self._connection_events: list[ConnectionEvent] = state.get(
                         "connection_events", []
                     )
                     self._is_connected = state.get("is_connected", False)
@@ -102,7 +104,7 @@ class DahuaCamera(Camera):
             # Load existing state for other cameras
             all_state = {}
             if os.path.exists(self._state_file):
-                with open(self._state_file, "r") as f:
+                with open(self._state_file) as f:
                     all_state = json.load(f)
             all_state[self.config.name] = {
                 "connection_events": self._connection_events,
@@ -138,7 +140,7 @@ class DahuaCamera(Camera):
         self._connection_events.append(event)
         self._save_state()
 
-    def get_connected_timeframes(self) -> List[Tuple[datetime, Optional[datetime]]]:
+    def get_connected_timeframes(self) -> list[tuple[datetime, datetime | None]]:
         """Returns a list of timeframes when the camera was connected."""
         timeframes = []
         start_time = None
@@ -231,7 +233,7 @@ class DahuaCamera(Camera):
 
     async def get_file_list(
         self, start_time: datetime, end_time: datetime
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Get list of recording files from the camera."""
         try:
             auth = httpx.DigestAuth(self.username, self.password)
@@ -493,7 +495,7 @@ class DahuaCamera(Camera):
             logger.error(f"Error stopping recording: {e}")
             return False
 
-    async def delete_files(self, file_paths: List[str]) -> int:
+    async def delete_files(self, file_paths: list[str]) -> int:
         """Delete recording files from the camera. Not yet implemented for Dahua."""
         logger.warning("delete_files not implemented for Dahua cameras")
         return 0
@@ -582,7 +584,7 @@ class DahuaCamera(Camera):
             )
 
     @property
-    def connection_events(self) -> List[Tuple[datetime, str]]:
+    def connection_events(self) -> list[tuple[datetime, str]]:
         """Get list of connection events."""
         # This property might need to be updated or removed if it's used elsewhere,
         # as the internal format has changed. For now, returning an empty list
@@ -639,9 +641,7 @@ class DahuaCamera(Camera):
 
         # Fall back to auto-detect from system clock UTC offset
         try:
-            from datetime import timezone as dt_tz
-
-            offset = datetime.now(dt_tz.utc).astimezone().utcoffset()
+            offset = datetime.now(UTC).astimezone().utcoffset()
             if offset is not None:
                 offset_hours = int(offset.total_seconds() / 3600)
                 return cls._UTC_OFFSET_TO_DAHUA_TZ.get(offset_hours)

--- a/video_grouper/cameras/reolink.py
+++ b/video_grouper/cameras/reolink.py
@@ -1,20 +1,21 @@
 import json
-import os
-import httpx
 import logging
+import os
 import time
-import aiofiles
-from datetime import datetime
-from typing import List, Tuple, Dict, Any, Optional
+from datetime import UTC, datetime
+from typing import Any
 
+import aiofiles
+import httpx
 import pytz
 
-from .base import Camera, ConfigResult, DeviceInfo
-from . import register_camera
-from .reolink_download import download_and_mux
 from video_grouper.models import ConnectionEvent
 from video_grouper.utils.config import CameraConfig
 from video_grouper.utils.paths import get_camera_state_path
+
+from . import register_camera
+from .base import Camera, ConfigResult, DeviceInfo
+from .reolink_download import download_and_mux
 
 # Default timeout for camera HTTP requests (30 seconds connect, 60 seconds read)
 CAMERA_HTTP_TIMEOUT = httpx.Timeout(60.0, connect=30.0)
@@ -33,13 +34,13 @@ class ReolinkCamera(Camera):
         self.password = config.password
         self.channel = config.channel
         self._state_file = get_camera_state_path(storage_path)
-        self._connection_events: List[ConnectionEvent] = []
+        self._connection_events: list[ConnectionEvent] = []
         self._is_connected = False
         self._log_dir = os.path.join(self.storage_path, "camera_http_logs")
         os.makedirs(self._log_dir, exist_ok=True)
         self._client = client
         self.logger = logging.getLogger(__name__)
-        self._token: Optional[str] = None
+        self._token: str | None = None
         self._token_expiry: float = 0
         self._file_sizes: dict[str, int] = {}
         self._load_state()
@@ -98,10 +99,10 @@ class ReolinkCamera(Camera):
         self,
         client: httpx.AsyncClient,
         cmd: str,
-        param: Dict[str, Any],
+        param: dict[str, Any],
         action: int = 0,
         log_name: str = "",
-    ) -> Optional[List[Dict]]:
+    ) -> list[dict] | None:
         """Make an authenticated API call. Returns the JSON response array or None."""
         if not await self._ensure_token(client):
             return None
@@ -123,7 +124,7 @@ class ReolinkCamera(Camera):
         return data
 
     @staticmethod
-    def _datetime_to_reolink(dt: datetime) -> Dict[str, int]:
+    def _datetime_to_reolink(dt: datetime) -> dict[str, int]:
         """Convert a datetime to ReoLink's time dict format."""
         return {
             "year": dt.year,
@@ -135,14 +136,14 @@ class ReolinkCamera(Camera):
         }
 
     @staticmethod
-    def _reolink_to_datetime_str(t: Dict[str, int]) -> str:
+    def _reolink_to_datetime_str(t: dict[str, int]) -> str:
         """Convert ReoLink's time dict to an ISO-style datetime string."""
         return (
             f"{t['year']:04d}-{t['mon']:02d}-{t['day']:02d} "
             f"{t['hour']:02d}:{t['min']:02d}:{t['sec']:02d}"
         )
 
-    def _parse_file_list(self, raw_files: list) -> List[Dict[str, Any]]:
+    def _parse_file_list(self, raw_files: list) -> list[dict[str, Any]]:
         """Parse raw file entries from SearchResult into our file list format."""
         files = []
         for f in raw_files:
@@ -167,7 +168,7 @@ class ReolinkCamera(Camera):
         status_entries: list,
         start_time: datetime,
         end_time: datetime,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Search day-by-day for files on days marked active in the status bitmap.
 
         Reolink's Search API returns a status bitmap (31-char string, one per day)
@@ -237,7 +238,7 @@ class ReolinkCamera(Camera):
     def _load_state(self):
         try:
             if os.path.exists(self._state_file):
-                with open(self._state_file, "r") as f:
+                with open(self._state_file) as f:
                     all_state = json.load(f)
                     state = all_state.get(self.config.name, {})
                     self._connection_events = state.get("connection_events", [])
@@ -249,7 +250,7 @@ class ReolinkCamera(Camera):
         try:
             all_state = {}
             if os.path.exists(self._state_file):
-                with open(self._state_file, "r") as f:
+                with open(self._state_file) as f:
                     all_state = json.load(f)
             all_state[self.config.name] = {
                 "connection_events": self._connection_events,
@@ -283,7 +284,7 @@ class ReolinkCamera(Camera):
         self._connection_events.append(event)
         self._save_state()
 
-    def get_connected_timeframes(self) -> List[Tuple[datetime, Optional[datetime]]]:
+    def get_connected_timeframes(self) -> list[tuple[datetime, datetime | None]]:
         timeframes = []
         start_time = None
 
@@ -353,7 +354,7 @@ class ReolinkCamera(Camera):
 
     # ── Client helper ─────────────────────────────────────────────────
 
-    def _get_client(self) -> Tuple[httpx.AsyncClient, bool]:
+    def _get_client(self) -> tuple[httpx.AsyncClient, bool]:
         """Return (client, should_close) tuple."""
         if self._client:
             return self._client, False
@@ -409,7 +410,7 @@ class ReolinkCamera(Camera):
 
     async def get_file_list(
         self, start_time: datetime, end_time: datetime
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         try:
             client, close_client = self._get_client()
             try:
@@ -593,7 +594,7 @@ class ReolinkCamera(Camera):
             logger.error(f"Error setting recording enabled={enabled}: {e}")
             return False
 
-    async def delete_files(self, file_paths: List[str]) -> int:
+    async def delete_files(self, file_paths: list[str]) -> int:
         """Delete recording files from the camera.
 
         Most Reolink models (including Duo 3 PoE) do not support
@@ -685,7 +686,7 @@ class ReolinkCamera(Camera):
             )
 
     @property
-    def connection_events(self) -> List[Tuple[datetime, str]]:
+    def connection_events(self) -> list[tuple[datetime, str]]:
         return []
 
     @property
@@ -703,9 +704,7 @@ class ReolinkCamera(Camera):
         Uses stdlib only -- no pytz/tzlocal dependency needed.
         """
         try:
-            from datetime import timezone as dt_tz
-
-            offset = datetime.now(dt_tz.utc).astimezone().utcoffset()
+            offset = datetime.now(UTC).astimezone().utcoffset()
             if offset is None:
                 return None
             return -int(offset.total_seconds())

--- a/video_grouper/cameras/reolink_download.py
+++ b/video_grouper/cameras/reolink_download.py
@@ -25,7 +25,6 @@ import socket
 import struct
 import time
 from hashlib import md5
-from typing import Optional
 
 import httpx
 from Crypto.Cipher import AES
@@ -185,7 +184,7 @@ class BcMediaDemuxer:
 
     def __init__(self):
         self._buffer = bytearray()
-        self.video_codec: Optional[str] = None
+        self.video_codec: str | None = None
         self.width: int = 0
         self.height: int = 0
         self.fps: int = 0
@@ -326,11 +325,11 @@ class BaichuanStreamClient:
         self._port = port
         self._username = username
         self._password = password
-        self._reader: Optional[asyncio.StreamReader] = None
-        self._writer: Optional[asyncio.StreamWriter] = None
-        self._aes_key: Optional[bytes] = None
-        self._nonce: Optional[str] = None
-        self._uid: Optional[str] = None
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._aes_key: bytes | None = None
+        self._nonce: str | None = None
+        self._uid: str | None = None
         self._mess_id = 0
         self._session_id = (
             20  # Session counter for replay channelId (camera rejects low values)
@@ -790,7 +789,7 @@ class BaichuanStreamClient:
                     hdr, xml_body, payload = await asyncio.wait_for(
                         self._read_message(), timeout=idle_timeout
                     )
-                except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+                except (TimeoutError, asyncio.IncompleteReadError):
                     if stats["bytes_written"] > 0:
                         logger.info("Download stream ended (idle timeout)")
                     else:
@@ -1074,7 +1073,7 @@ _HTTP_PROBE_BACKOFF = (0.5, 1.5, 4.0, 10.0, 15.0)
 
 async def _probe_http_path(
     client: "httpx.AsyncClient", host: str, url: str
-) -> Optional[bool]:
+) -> bool | None:
     """Decide whether ``url`` is reachable via the patched-firmware HTTP path.
 
     Uses a real 1 KB range GET rather than HEAD — Reolink's nginx
@@ -1145,7 +1144,7 @@ async def _download_via_http_async(
     file_path: str,
     output_mp4: str,
     on_progress=None,
-) -> Optional[bool]:
+) -> bool | None:
     """Try the patched-firmware HTTP fast path.
 
     Returns True on success, False if the camera responded but the download

--- a/video_grouper/models/__init__.py
+++ b/video_grouper/models/__init__.py
@@ -6,9 +6,9 @@ This package contains all the data models used throughout the application.
 
 # Core models
 from .connection_event import ConnectionEvent
+from .directory_state import DirectoryState
 from .match_info import MatchInfo
 from .recording_file import RecordingFile
-from .directory_state import DirectoryState
 
 __all__ = [
     # Core models

--- a/video_grouper/models/directory_state.py
+++ b/video_grouper/models/directory_state.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
+
 import asyncio
-from typing import Optional
-import logging
 import json
+import logging
 import os
 from datetime import datetime
+
 from ..utils.locking import FileLock
 from ..utils.paths import get_state_file_path
 from .recording_file import RecordingFile
@@ -34,8 +35,8 @@ class DirectoryState:
         self.files: dict[str, RecordingFile] = {}
         self._lock = asyncio.Lock()
         self.status: str = "pending"
-        self.error_message: Optional[str] = None
-        self.ttt_recording_id: Optional[str] = None
+        self.error_message: str | None = None
+        self.ttt_recording_id: str | None = None
 
         # Validate directory name format before proceeding
         dir_name = os.path.basename(directory_path)
@@ -59,7 +60,7 @@ class DirectoryState:
             with FileLock(self.state_file_path):
                 if os.path.exists(self.state_file_path):
                     logger.debug(f"Loading directory state from {self.state_file_path}")
-                    with open(self.state_file_path, "r") as f:
+                    with open(self.state_file_path) as f:
                         state_data = json.load(f)
                         self.status = state_data.get("status", "pending")
                         self.error_message = state_data.get("error_message")
@@ -104,7 +105,7 @@ class DirectoryState:
         state_data: dict = {}
         if os.path.exists(self.state_file_path):
             try:
-                with open(self.state_file_path, "r") as f:
+                with open(self.state_file_path) as f:
                     state_data = json.load(f)
             except (json.JSONDecodeError, FileNotFoundError):
                 state_data = {}
@@ -163,17 +164,17 @@ class DirectoryState:
             self._save_state_nolock()
             logger.debug(f"Updated state for {os.path.basename(file_path)}")
 
-    def get_file_by_path(self, file_path: str) -> Optional[RecordingFile]:
+    def get_file_by_path(self, file_path: str) -> RecordingFile | None:
         """Get a file by its full path."""
         return self.files.get(file_path)
 
-    def get_last_file(self) -> Optional[RecordingFile]:
+    def get_last_file(self) -> RecordingFile | None:
         """Returns the last file in the group based on end time."""
         if not self.files:
             return None
         return max(self.files.values(), key=lambda f: f.end_time)
 
-    def get_first_file(self) -> Optional[RecordingFile]:
+    def get_first_file(self) -> RecordingFile | None:
         """Returns the first file in the group based on start time."""
         if not self.files:
             return None
@@ -226,9 +227,7 @@ class DirectoryState:
                 self.files[file_path].skip = True
                 self._save_state_nolock()
 
-    async def update_group_status(
-        self, status: str, error_message: Optional[str] = None
-    ):
+    async def update_group_status(self, status: str, error_message: str | None = None):
         """Update the status of all files in the group."""
         async with self._lock:
             self.status = status
@@ -243,7 +242,7 @@ class DirectoryState:
                 state_data = {"files": {}, "status": "pending", "error_message": None}
                 if os.path.exists(self.state_file_path):
                     try:
-                        with open(self.state_file_path, "r") as f:
+                        with open(self.state_file_path) as f:
                             state_data = json.load(f)
                     except (json.JSONDecodeError, FileNotFoundError):
                         pass
@@ -275,12 +274,12 @@ class DirectoryState:
             "Set ttt_recording_id to '%s' in %s", recording_id, self.state_file_path
         )
 
-    def get_youtube_playlist_name(self) -> Optional[str]:
+    def get_youtube_playlist_name(self) -> str | None:
         """Get the YouTube playlist name from the state."""
         try:
             with FileLock(self.state_file_path):
                 if os.path.exists(self.state_file_path):
-                    with open(self.state_file_path, "r") as f:
+                    with open(self.state_file_path) as f:
                         state_data = json.load(f)
                     return state_data.get("youtube_playlist_name")
         except (json.JSONDecodeError, FileNotFoundError, TimeoutError):
@@ -315,12 +314,12 @@ class DirectoryState:
         """Remove the autocam_run marker (run finished successfully or failed)."""
         self._update_state_field("autocam_run", None)
 
-    def get_autocam_run(self) -> Optional[dict]:
+    def get_autocam_run(self) -> dict | None:
         """Read the autocam_run marker, or None if no run is recorded."""
         try:
             with FileLock(self.state_file_path):
                 if os.path.exists(self.state_file_path):
-                    with open(self.state_file_path, "r") as f:
+                    with open(self.state_file_path) as f:
                         state_data = json.load(f)
                     return state_data.get("autocam_run")
         except (json.JSONDecodeError, FileNotFoundError, TimeoutError):
@@ -338,7 +337,7 @@ class DirectoryState:
                 state_data = {"files": {}, "status": "pending", "error_message": None}
                 if os.path.exists(self.state_file_path):
                     try:
-                        with open(self.state_file_path, "r") as f:
+                        with open(self.state_file_path) as f:
                             state_data = json.load(f)
                     except (json.JSONDecodeError, FileNotFoundError):
                         pass

--- a/video_grouper/models/match_info.py
+++ b/video_grouper/models/match_info.py
@@ -2,17 +2,17 @@
 Match information model for soccer game metadata.
 """
 
+import configparser
+import logging
 import os
 import re
-import logging
-import configparser
-from datetime import datetime
-from typing import Optional, Tuple
 from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
 
 from video_grouper.utils.paths import (
-    get_match_info_path,
     get_match_info_dist_path,
+    get_match_info_path,
     resolve_path,
 )
 
@@ -28,7 +28,7 @@ class MatchInfo:
     location: str
     start_time_offset: str = ""
     total_duration: str = ""
-    date: Optional[datetime] = None
+    date: datetime | None = None
 
     def __hash__(self):
         """Make MatchInfo hashable so it can be used in sets and as dictionary keys."""
@@ -111,8 +111,8 @@ class MatchInfo:
     def get_or_create(
         cls,
         group_dir: str,
-        storage_path: Optional[str] = None,
-    ) -> Tuple[Optional["MatchInfo"], configparser.ConfigParser]:
+        storage_path: str | None = None,
+    ) -> tuple[Optional["MatchInfo"], configparser.ConfigParser]:
         """Get an existing MatchInfo object or create a new one with default values.
 
         Args:
@@ -138,7 +138,7 @@ class MatchInfo:
             if os.path.exists(source_dist_path):
                 try:
                     with (
-                        open(source_dist_path, "r") as src,
+                        open(source_dist_path) as src,
                         open(match_info_path, "w") as dest,
                     ):
                         dest.write(src.read())
@@ -164,7 +164,7 @@ class MatchInfo:
 
     @classmethod
     def update_team_info(
-        cls, group_dir: str, team_info: dict, storage_path: Optional[str] = None
+        cls, group_dir: str, team_info: dict, storage_path: str | None = None
     ) -> Optional["MatchInfo"]:
         """Update team information in the match_info.ini file.
 
@@ -220,9 +220,9 @@ class MatchInfo:
     def update_game_times(
         cls,
         group_dir: str,
-        start_time_offset: Optional[str] = None,
-        total_duration: Optional[str] = None,
-        storage_path: Optional[str] = None,
+        start_time_offset: str | None = None,
+        total_duration: str | None = None,
+        storage_path: str | None = None,
     ) -> Optional["MatchInfo"]:
         """Update game timing information in the match_info.ini file.
 
@@ -328,7 +328,7 @@ class MatchInfo:
         else:
             return ""
 
-    def get_sanitized_names(self) -> Tuple[str, str, str]:
+    def get_sanitized_names(self) -> tuple[str, str, str]:
         """Get sanitized team names and location for use in file names.
 
         Returns:

--- a/video_grouper/models/recording_file.py
+++ b/video_grouper/models/recording_file.py
@@ -5,7 +5,7 @@ Recording file model for camera file tracking.
 import logging
 import os
 from datetime import datetime
-from typing import Optional, TypedDict, Union
+from typing import TypedDict
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class Metadata(TypedDict, total=False):
     resolution: str
 
     # Custom metadata fields
-    custom_fields: dict[str, Union[str, int, float, bool]]
+    custom_fields: dict[str, str | int | float | bool]
 
 
 class RecordingFile:
@@ -34,7 +34,7 @@ class RecordingFile:
         end_time: datetime,
         file_path: str,
         status: str = "pending",
-        metadata: Optional[Metadata] = None,
+        metadata: Metadata | None = None,
         skip: bool = False,
     ):
         """Initialize a recording file.
@@ -56,7 +56,7 @@ class RecordingFile:
         self.skip = skip
         self.group_dir = None
         self.last_updated = datetime.now()
-        self.error_message: Optional[str] = None
+        self.error_message: str | None = None
 
     def __str__(self) -> str:
         """Return a human-readable string representation."""
@@ -78,7 +78,7 @@ class RecordingFile:
             return self.file_path
         return base + ".mp4" if ext.lower() == ".dav" else self.file_path + ".mp4"
 
-    def to_dict(self) -> dict[str, Union[str, int, bool, Metadata, None]]:
+    def to_dict(self) -> dict[str, str | int | bool | Metadata | None]:
         """Convert the recording file to a dictionary for serialization."""
         return {
             "task_type": "recording_file",
@@ -96,7 +96,7 @@ class RecordingFile:
 
     @classmethod
     def from_dict(
-        cls, data: dict[str, Union[str, int, bool, Metadata, None]]
+        cls, data: dict[str, str | int | bool | Metadata | None]
     ) -> "RecordingFile":
         """Create a RecordingFile from a dictionary."""
         start_time = (

--- a/video_grouper/plugins/plugin_verifier.py
+++ b/video_grouper/plugins/plugin_verifier.py
@@ -6,7 +6,6 @@ import logging
 import zipfile
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Optional
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
@@ -49,7 +48,7 @@ def verify_plugin_bundle(
     zip_path: Path,
     public_keys: list[str],
     current_user_id: str,
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> bool:
     """Verify a downloaded plugin zip before extraction.
 
@@ -134,7 +133,7 @@ def verify_extracted_plugin(
     plugin_root: Path,
     public_keys: list[str],
     current_user_id: str,
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> bool:
     """Re-verify a plugin that has already been extracted to disk.
 
@@ -197,7 +196,7 @@ def verify_extracted_plugin(
         return False
 
 
-def read_manifest_expires_at(manifest_path: Path) -> Optional[datetime]:
+def read_manifest_expires_at(manifest_path: Path) -> datetime | None:
     """Read the expires_at timestamp from an on-disk manifest. None on failure."""
     try:
         data = json.loads(manifest_path.read_bytes())

--- a/video_grouper/service/main.py
+++ b/video_grouper/service/main.py
@@ -1,14 +1,14 @@
 """Windows Service wrapper for VideoGrouper."""
 
-import os
-import sys
 import asyncio
 import logging
+import os
+import sys
 
-import win32serviceutil
-import win32service
-import win32event
 import servicemanager
+import win32event
+import win32service
+import win32serviceutil
 import win32timezone  # noqa: F401 - required for pyinstaller
 
 
@@ -46,10 +46,11 @@ class VideoGrouperService(win32serviceutil.ServiceFramework):
 
     def main(self):
         from pathlib import Path
-        from video_grouper.video_grouper_app import VideoGrouperApp
+
         from video_grouper.utils.config import load_config
-        from video_grouper.utils.logger import setup_logging
         from video_grouper.utils.locking import FileLock
+        from video_grouper.utils.logger import setup_logging
+        from video_grouper.video_grouper_app import VideoGrouperApp
 
         setup_logging(level="INFO", app_name="video_grouper")
         logger = logging.getLogger(__name__)

--- a/video_grouper/task_processors/__init__.py
+++ b/video_grouper/task_processors/__init__.py
@@ -1,18 +1,18 @@
 """Task processors package for video grouper application."""
 
+from .ball_tracking_discovery_processor import BallTrackingDiscoveryProcessor
+from .ball_tracking_processor import BallTrackingProcessor
 from .base_polling_processor import PollingProcessor
 from .base_queue_processor import QueueProcessor
 from .camera_poller import CameraPoller
+from .clip_discovery_processor import ClipDiscoveryProcessor
+from .clip_processor import ClipProcessor
 from .download_processor import DownloadProcessor
 from .ntfy_processor import NtfyProcessor
 from .state_auditor import StateAuditor
+from .ttt_job_processor import TTTJobProcessor
 from .upload_processor import UploadProcessor
 from .video_processor import VideoProcessor
-from .ball_tracking_processor import BallTrackingProcessor
-from .ball_tracking_discovery_processor import BallTrackingDiscoveryProcessor
-from .clip_processor import ClipProcessor
-from .clip_discovery_processor import ClipDiscoveryProcessor
-from .ttt_job_processor import TTTJobProcessor
 
 __all__ = [
     "PollingProcessor",

--- a/video_grouper/task_processors/ball_tracking_discovery_processor.py
+++ b/video_grouper/task_processors/ball_tracking_discovery_processor.py
@@ -15,10 +15,11 @@ import logging
 import os
 from pathlib import Path
 
+from video_grouper.utils.config import Config
+
 from .base_polling_processor import PollingProcessor
 from .tasks.ball_tracking import BallTrackingTaskBase
 from .tasks.ball_tracking.utils import get_ball_tracking_io_paths
-from video_grouper.utils.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ class BallTrackingDiscoveryProcessor(PollingProcessor):
                 continue
 
             try:
-                with open(state_file, "r") as f:
+                with open(state_file) as f:
                     state_data = json.load(f)
                 status = state_data.get("status")
             except (json.JSONDecodeError, OSError) as e:

--- a/video_grouper/task_processors/ball_tracking_processor.py
+++ b/video_grouper/task_processors/ball_tracking_processor.py
@@ -14,10 +14,11 @@ import json
 import logging
 from pathlib import Path
 
+from video_grouper.utils.config import Config
+
 from .base_queue_processor import QueueProcessor
 from .queue_type import QueueType
 from .tasks.ball_tracking import BallTrackingTaskBase
-from video_grouper.utils.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ class BallTrackingProcessor(QueueProcessor):
             state_file = item.group_dir / "state.json"
             if state_file.exists():
                 try:
-                    with open(state_file, "r") as f:
+                    with open(state_file) as f:
                         current_status = json.load(f).get("status")
                 except (json.JSONDecodeError, OSError) as e:
                     logger.warning(
@@ -97,12 +98,12 @@ class BallTrackingProcessor(QueueProcessor):
             return
 
         try:
-            with open(state_file, "r") as f:
+            with open(state_file) as f:
                 state_data = json.load(f)
             state_data["status"] = "ball_tracking_complete"
             with open(state_file, "w") as f:
                 json.dump(state_data, f, indent=4)
-        except (json.JSONDecodeError, IOError) as e:
+        except (OSError, json.JSONDecodeError) as e:
             logger.error(
                 "BALL_TRACKING: could not update status for group %s: %s",
                 group_name,

--- a/video_grouper/task_processors/base_queue_processor.py
+++ b/video_grouper/task_processors/base_queue_processor.py
@@ -5,11 +5,11 @@ import json
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+
+from video_grouper.task_processors.tasks.base_task import BaseTask
+from video_grouper.utils.config import Config
 
 from .queue_type import QueueType
-from video_grouper.utils.config import Config
-from video_grouper.task_processors.tasks.base_task import BaseTask
 from .task_registry import task_registry
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ class QueueProcessor(ABC):
         self._shutdown_event = asyncio.Event()
         self._max_retries = 3  # Maximum number of retry attempts
         self._retry_counts = {}  # Track retry counts for each item
-        self._in_progress_item: Optional[BaseTask] = None  # Currently processing item
+        self._in_progress_item: BaseTask | None = None  # Currently processing item
         self._sequence = 0
         self._items_by_key: dict[str, tuple[int, int, BaseTask]] = {}
 
@@ -66,9 +66,9 @@ class QueueProcessor(ABC):
     def _inject_storage_path(self, item: BaseTask) -> None:
         """Ensure the task knows the storage path and config for later execution."""
         if not hasattr(item, "storage_path"):
-            setattr(item, "storage_path", self.storage_path)
+            item.storage_path = self.storage_path
         if not hasattr(item, "config"):
-            setattr(item, "config", self.config)
+            item.config = self.config
 
     def _get_priority(self, item: BaseTask) -> int:
         """Return priority for this item. Lower = higher priority. Default: 2 (normal)."""
@@ -160,7 +160,7 @@ class QueueProcessor(ABC):
                     priority, seq, item = await asyncio.wait_for(
                         self._queue.get(), timeout=5.0
                     )
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     # Timeout - check if we should continue or exit
                     if self._shutdown_event.is_set():
                         logger.info(
@@ -204,8 +204,8 @@ class QueueProcessor(ABC):
                         f"{self.__class__.__name__}: Removed completed item from queue: {item} (queue size: {queue_size})"
                     )
                 except Exception as e:
-                    from video_grouper.utils.youtube_upload import YouTubeQuotaError
                     from video_grouper.cameras.base import CameraUnreachableError
+                    from video_grouper.utils.youtube_upload import YouTubeQuotaError
 
                     if isinstance(e, CameraUnreachableError):
                         # Camera-offline failures aren't the file's fault —
@@ -243,6 +243,7 @@ class QueueProcessor(ABC):
 
                         # Calculate wait: next midnight PT + 5 min buffer
                         from datetime import datetime, timedelta
+
                         import pytz
 
                         now_pt = datetime.now(pytz.timezone("US/Pacific"))
@@ -368,7 +369,7 @@ class QueueProcessor(ABC):
             return
 
         try:
-            with open(state_file, "r") as f:
+            with open(state_file) as f:
                 raw_state = json.load(f)
 
             # Support both new format (dict with "queue" key) and legacy format (plain list)
@@ -457,7 +458,7 @@ class QueueProcessor(ABC):
             return 0
         return self._queue.qsize()
 
-    def get_status(self) -> Dict[str, object]:
+    def get_status(self) -> dict[str, object]:
         """Get processor status information."""
         return {
             "queue_size": self.get_queue_size(),
@@ -490,7 +491,7 @@ class QueueProcessor(ABC):
         """Return a snapshot of all queued items (for inspection, not modification)."""
         return [task for _, _, task in sorted(self._items_by_key.values())]
 
-    def _deserialize_task(self, item_data: Dict[str, object]) -> BaseTask:
+    def _deserialize_task(self, item_data: dict[str, object]) -> BaseTask:
         """
         Deserialize a task from its serialized data.
 

--- a/video_grouper/task_processors/camera_poller.py
+++ b/video_grouper/task_processors/camera_poller.py
@@ -1,17 +1,17 @@
 import json
-import os
 import logging
+import os
 from datetime import datetime, timedelta
-from typing import Optional, List
+
 import pytz
 
 from video_grouper.cameras.base import Camera
+from video_grouper.models import DirectoryState, RecordingFile
 from video_grouper.task_processors.download_processor import DownloadProcessor
 from video_grouper.utils.config import Config
 from video_grouper.utils.paths import get_camera_state_path, get_home_cleanup_state_path
+
 from .base_polling_processor import PollingProcessor
-from video_grouper.models import DirectoryState
-from video_grouper.models import RecordingFile
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ def create_directory(path):
 
 
 def find_group_directory(
-    file_start_time: datetime, storage_path: str, existing_dirs: List[str]
+    file_start_time: datetime, storage_path: str, existing_dirs: list[str]
 ) -> str:
     """
     Finds or creates a group directory for a video file based on its start time.
@@ -330,13 +330,13 @@ class CameraPoller(PollingProcessor):
                 f"CAMERA_POLLER: File sync complete. New high-water mark set to: {latest_end_time}"
             )
 
-    async def _get_latest_processed_time(self) -> Optional[datetime]:
+    async def _get_latest_processed_time(self) -> datetime | None:
         """Get the timestamp of the last processed video file for this camera."""
         state_path = get_camera_state_path(self.storage_path)
         if not os.path.exists(state_path):
             return None
         try:
-            with open(state_path, "r") as f:
+            with open(state_path) as f:
                 all_state = json.load(f)
             cam_state = all_state.get(self.camera.name, {})
             timestamp_str = cam_state.get("latest_video_time")
@@ -392,7 +392,7 @@ class CameraPoller(PollingProcessor):
 
     def _write_cleanup_state(
         self,
-        file_paths: List[str],
+        file_paths: list[str],
         file_infos: list,
         deletion_supported: bool = True,
     ) -> None:
@@ -525,7 +525,7 @@ class CameraPoller(PollingProcessor):
             state_path = get_camera_state_path(self.storage_path)
             all_state = {}
             if os.path.exists(state_path):
-                with open(state_path, "r") as f:
+                with open(state_path) as f:
                     all_state = json.load(f)
             cam_state = all_state.setdefault(self.camera.name, {})
             cam_state["latest_video_time"] = timestamp.strftime(default_date_format)

--- a/video_grouper/task_processors/clip_discovery_processor.py
+++ b/video_grouper/task_processors/clip_discovery_processor.py
@@ -7,6 +7,10 @@ import logging
 import os
 from datetime import datetime
 
+from video_grouper.api_integrations.moment_api_client import MomentApiClient
+from video_grouper.models import DirectoryState, MatchInfo
+from video_grouper.utils.config import Config
+from video_grouper.utils.paths import get_trimmed_video_path
 
 from .base_polling_processor import PollingProcessor
 from .services.timestamp_matcher import (
@@ -16,10 +20,6 @@ from .services.timestamp_matcher import (
 )
 from .tasks.clips.clip_extraction_task import ClipExtractionTask
 from .tasks.clips.highlight_compilation_task import HighlightCompilationTask
-from video_grouper.api_integrations.moment_api_client import MomentApiClient
-from video_grouper.models import DirectoryState, MatchInfo
-from video_grouper.utils.config import Config
-from video_grouper.utils.paths import get_trimmed_video_path
 
 logger = logging.getLogger(__name__)
 

--- a/video_grouper/task_processors/clip_processor.py
+++ b/video_grouper/task_processors/clip_processor.py
@@ -7,15 +7,15 @@ then uploads results to YouTube and updates the API.
 
 import logging
 import os
-from typing import Optional
+
+from video_grouper.api_integrations.moment_api_client import MomentApiClient
+from video_grouper.utils.config import Config
 
 from .base_queue_processor import QueueProcessor
 from .queue_type import QueueType
 from .tasks.base_task import BaseTask
 from .tasks.clips.clip_extraction_task import ClipExtractionTask
 from .tasks.clips.highlight_compilation_task import HighlightCompilationTask
-from video_grouper.api_integrations.moment_api_client import MomentApiClient
-from video_grouper.utils.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ class ClipProcessor(QueueProcessor):
 
     async def _upload_to_youtube(
         self, video_path: str, title: str, description: str
-    ) -> Optional[str]:
+    ) -> str | None:
         """Upload a video to YouTube if the uploader is configured.
 
         Returns the YouTube video ID, or None.

--- a/video_grouper/task_processors/clip_request_processor.py
+++ b/video_grouper/task_processors/clip_request_processor.py
@@ -4,11 +4,10 @@ import asyncio
 import logging
 import os
 import tempfile
-from typing import Optional
 
+from ..utils.config import Config
 from .base_polling_processor import PollingProcessor
 from .recording_locator import find_combined_video, resolve_recording_dir
-from ..utils.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +146,7 @@ class ClipRequestProcessor(PollingProcessor):
 
     async def _upload_via_drive(
         self, req: dict, clip_paths: list[str]
-    ) -> Optional[tuple[str, list[str]]]:
+    ) -> tuple[str, list[str]] | None:
         """Upload clips to Google Drive. Returns (fulfilled_url, upload_paths) or None on failure.
 
         Path A (preferred, flag on): TTT minted a per-requester resumable upload
@@ -212,7 +211,7 @@ class ClipRequestProcessor(PollingProcessor):
 
     async def _upload_via_resumable_url(
         self, req: dict, clip_paths: list[str], upload_block: dict
-    ) -> Optional[tuple[str, list[str]]]:
+    ) -> tuple[str, list[str]] | None:
         """PUT the final clip to a TTT-minted resumable upload URL.
 
         The URL is single-shot so multi-segment requests always compile first.
@@ -256,7 +255,7 @@ class ClipRequestProcessor(PollingProcessor):
 
     async def _upload_via_youtube(
         self, req: dict, clip_paths: list[str]
-    ) -> Optional[tuple[str, list[str]]]:
+    ) -> tuple[str, list[str]] | None:
         """Upload a single video to YouTube. Always produces one video (compiles if multi-segment).
 
         Returns (fulfilled_url, upload_paths) or None on failure.
@@ -335,7 +334,7 @@ class ClipRequestProcessor(PollingProcessor):
                 except OSError:
                     pass
 
-    def _resolve_recording_dir(self, req: dict) -> Optional[str]:
+    def _resolve_recording_dir(self, req: dict) -> str | None:
         """Resolve the recording group directory to an absolute path."""
         game_session = req.get("game_session") or {}
         recording_dir = game_session.get("recording_group_dir")
@@ -348,7 +347,7 @@ class ClipRequestProcessor(PollingProcessor):
             logger.warning(f"Recording dir not found: {recording_dir}")
         return resolved
 
-    def _find_source_video(self, recording_dir: str) -> Optional[str]:
+    def _find_source_video(self, recording_dir: str) -> str | None:
         """Find combined.mp4 in the recording directory tree."""
         return find_combined_video(recording_dir)
 

--- a/video_grouper/task_processors/download_processor.py
+++ b/video_grouper/task_processors/download_processor.py
@@ -1,15 +1,15 @@
-import os
 import logging
+import os
 
 from video_grouper.cameras.base import Camera, CameraUnreachableError
+from video_grouper.models import DirectoryState, RecordingFile
 from video_grouper.task_processors.video_processor import VideoProcessor
-from .base_queue_processor import QueueProcessor
-from video_grouper.models import DirectoryState
-from video_grouper.models import RecordingFile
-from .tasks.video import CombineTask
 from video_grouper.utils.config import Config
 from video_grouper.utils.disk_space import check_disk_space
+
+from .base_queue_processor import QueueProcessor
 from .queue_type import QueueType
+from .tasks.video import CombineTask
 
 logger = logging.getLogger(__name__)
 
@@ -211,8 +211,8 @@ class DownloadProcessor(QueueProcessor):
 
                         # Support both synchronous and asynchronous `add_work` implementations.
                         add_work_result = self.video_processor.add_work(combine_task)
-                        import inspect
                         import asyncio
+                        import inspect
 
                         if inspect.isawaitable(add_work_result):
                             await add_work_result

--- a/video_grouper/task_processors/highlight_reel_processor.py
+++ b/video_grouper/task_processors/highlight_reel_processor.py
@@ -32,13 +32,12 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Optional
 
+from ..utils.config import Config
+from ..utils.ffmpeg_utils import trim_video
 from .base_polling_processor import PollingProcessor
 from .recording_locator import find_combined_video, resolve_recording_dir
 from .tasks.clips.highlight_compilation_task import HighlightCompilationTask
-from ..utils.config import Config
-from ..utils.ffmpeg_utils import trim_video
 
 logger = logging.getLogger(__name__)
 
@@ -207,8 +206,8 @@ class HighlightReelProcessor(PollingProcessor):
         cleanup so we don't double-discard.
         """
         reel_id = reel["id"]
-        tmpdir: Optional[str] = None
-        final_output_path: Optional[str] = None
+        tmpdir: str | None = None
+        final_output_path: str | None = None
         claimed = False
 
         try:

--- a/video_grouper/task_processors/ntfy_processor.py
+++ b/video_grouper/task_processors/ntfy_processor.py
@@ -10,18 +10,19 @@ This processor acts as the central coordinator for NTFY interactions:
 """
 
 import asyncio
-import os
 import logging
-from typing import Dict, Any, Optional
+import os
+from typing import Any
 
+from video_grouper.models import MatchInfo
+from video_grouper.task_processors.services.match_info_service import MatchInfoService
+from video_grouper.utils.config import Config
+from video_grouper.utils.paths import get_combined_video_path
+
+from .base_queue_processor import QueueProcessor
+from .queue_type import QueueType
 from .services.ntfy_service import NtfyService
 from .tasks.ntfy import BaseNtfyTask, NtfyTaskFactory
-from video_grouper.models import MatchInfo
-from .base_queue_processor import QueueProcessor
-from video_grouper.utils.config import Config
-from .queue_type import QueueType
-from video_grouper.task_processors.services.match_info_service import MatchInfoService
-from video_grouper.utils.paths import get_combined_video_path
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class NtfyProcessor(QueueProcessor):
         ntfy_service: NtfyService,
         match_info_service: MatchInfoService,
         poll_interval: int = 30,
-        video_processor: Optional[Any] = None,
+        video_processor: Any | None = None,
     ):
         """
         Initialize the NTFY queue processor.
@@ -63,7 +64,7 @@ class NtfyProcessor(QueueProcessor):
         self.poll_interval = poll_interval
         self.video_processor = video_processor
         self._stopping = False
-        self._response_events: Dict[str, asyncio.Event] = {}
+        self._response_events: dict[str, asyncio.Event] = {}
 
     @property
     def queue_type(self) -> QueueType:
@@ -123,7 +124,7 @@ class NtfyProcessor(QueueProcessor):
                         return
                     try:
                         await asyncio.wait_for(event.wait(), timeout=30.0)
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         logger.debug(f"NTFY: Still waiting for response to {item}")
                         continue
             finally:
@@ -177,7 +178,7 @@ class NtfyProcessor(QueueProcessor):
                 self.ntfy_service.clear_pending_task(group_dir)
 
     async def _recreate_queued_task(
-        self, group_dir: str, task_type: str, metadata: Dict[str, Any]
+        self, group_dir: str, task_type: str, metadata: dict[str, Any]
     ) -> None:
         """Recreate a task that was queued but not sent."""
         logger.info(f"Recreating queued task for {group_dir}: {task_type}")

--- a/video_grouper/task_processors/recording_locator.py
+++ b/video_grouper/task_processors/recording_locator.py
@@ -17,14 +17,13 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
 def resolve_recording_dir(
-    storage_path: str, recording_group_dir: Optional[str]
-) -> Optional[str]:
+    storage_path: str, recording_group_dir: str | None
+) -> str | None:
     """Resolve a TTT-supplied recording_group_dir to a local absolute path.
 
     Returns the absolute directory path if it exists locally, else ``None``.
@@ -43,7 +42,7 @@ def resolve_recording_dir(
     return None
 
 
-def find_combined_video(recording_dir: str) -> Optional[str]:
+def find_combined_video(recording_dir: str) -> str | None:
     """Find ``combined.mp4`` in a recording directory tree.
 
     Looks for ``combined.mp4`` directly inside ``recording_dir``, then one

--- a/video_grouper/task_processors/register_tasks.py
+++ b/video_grouper/task_processors/register_tasks.py
@@ -12,17 +12,17 @@ Entry points pick the right registration:
 * Tray (Windows desktop session)     -> :func:`register_tray_tasks`
 """
 
-from .tasks.video.combine_task import CombineTask
-from .tasks.video.trim_task import TrimTask
-from .tasks.ntfy.game_start_task import GameStartTask
-from .tasks.ntfy.game_end_task import GameEndTask
-from .tasks.ntfy.team_info_task import TeamInfoTask
-from .tasks.upload.youtube_upload_task import YoutubeUploadTask
+from video_grouper.task_processors.task_registry import task_registry
+
 from .tasks.clip.clip_request_task import ClipRequestTask
 from .tasks.clips.clip_extraction_task import ClipExtractionTask
 from .tasks.clips.highlight_compilation_task import HighlightCompilationTask
-
-from video_grouper.task_processors.task_registry import task_registry
+from .tasks.ntfy.game_end_task import GameEndTask
+from .tasks.ntfy.game_start_task import GameStartTask
+from .tasks.ntfy.team_info_task import TeamInfoTask
+from .tasks.upload.youtube_upload_task import YoutubeUploadTask
+from .tasks.video.combine_task import CombineTask
+from .tasks.video.trim_task import TrimTask
 
 
 def _register_common_tasks() -> None:

--- a/video_grouper/task_processors/services/__init__.py
+++ b/video_grouper/task_processors/services/__init__.py
@@ -2,11 +2,11 @@
 Services module for external API integrations.
 """
 
-from .teamsnap_service import TeamSnapService
-from .playmetrics_service import PlayMetricsService
-from .ntfy_service import NtfyService
-from .match_info_service import MatchInfoService
 from .cleanup_service import CleanupService
+from .match_info_service import MatchInfoService
+from .ntfy_service import NtfyService
+from .playmetrics_service import PlayMetricsService
+from .teamsnap_service import TeamSnapService
 
 __all__ = [
     "TeamSnapService",

--- a/video_grouper/task_processors/services/cleanup_service.py
+++ b/video_grouper/task_processors/services/cleanup_service.py
@@ -2,9 +2,8 @@
 Cleanup service for managing file cleanup operations.
 """
 
-import os
 import logging
-from typing import List, Optional
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +24,7 @@ class CleanupService:
         self.storage_path = storage_path
 
     def cleanup_temporary_files(
-        self, group_dir: str, extensions: Optional[List[str]] = None
+        self, group_dir: str, extensions: list[str] | None = None
     ) -> bool:
         """
         Clean up temporary files in a group directory.

--- a/video_grouper/task_processors/services/match_info_service.py
+++ b/video_grouper/task_processors/services/match_info_service.py
@@ -5,14 +5,14 @@ Match information service that coordinates between different data sources.
 import logging
 import os
 import re
-from typing import Dict, List, Optional, Any, Tuple
 from datetime import datetime
+from typing import Any
 
-from .teamsnap_service import TeamSnapService
-from .playmetrics_service import PlayMetricsService
+from video_grouper.models import DirectoryState, MatchInfo
+
 from .ntfy_service import NtfyService
-from video_grouper.models import DirectoryState
-from video_grouper.models import MatchInfo
+from .playmetrics_service import PlayMetricsService
+from .teamsnap_service import TeamSnapService
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class MatchInfoService:
 
     def _get_recording_timespan(
         self, group_dir: str
-    ) -> Optional[Tuple[datetime, datetime]]:
+    ) -> tuple[datetime, datetime] | None:
         """
         Get the recording timespan for a group directory.
 
@@ -103,7 +103,7 @@ class MatchInfoService:
 
     def _parse_timespan_from_filenames(
         self, group_dir: str
-    ) -> Optional[Tuple[datetime, datetime]]:
+    ) -> tuple[datetime, datetime] | None:
         """Scan ``group_dir`` for Reolink clip filenames and extract timespan.
 
         Reolink cameras produce files like
@@ -150,7 +150,7 @@ class MatchInfoService:
 
     def _collect_games_from_apis(
         self, recording_start: datetime, recording_end: datetime
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Collect games from all available APIs.
 
@@ -208,9 +208,7 @@ class MatchInfoService:
 
         return games
 
-    def _select_best_game(
-        self, games: List[Dict[str, Any]]
-    ) -> Optional[Dict[str, Any]]:
+    def _select_best_game(self, games: list[dict[str, Any]]) -> dict[str, Any] | None:
         """
         Select the best game from multiple options.
 
@@ -239,7 +237,7 @@ class MatchInfoService:
         logger.info(f"Selected first game from {len(games)} options")
         return games[0]
 
-    def _convert_game_to_match_info(self, game: Dict[str, Any]) -> Dict[str, str]:
+    def _convert_game_to_match_info(self, game: dict[str, Any]) -> dict[str, str]:
         """
         Convert a game dictionary to match info format.
 
@@ -452,7 +450,7 @@ class MatchInfoService:
         """
         return self.ntfy_service.is_waiting_for_input(group_dir)
 
-    def get_pending_tasks(self) -> Dict[str, Dict[str, Any]]:
+    def get_pending_tasks(self) -> dict[str, dict[str, Any]]:
         """Get all pending tasks."""
         return self.ntfy_service.get_pending_tasks()
 

--- a/video_grouper/task_processors/services/ntfy_service.py
+++ b/video_grouper/task_processors/services/ntfy_service.py
@@ -2,15 +2,16 @@
 NTFY service for interactive user notifications and input.
 """
 
+import asyncio
 import json
 import logging
 import os
-from typing import Dict, Optional, Any, Set, List
 from datetime import datetime
-import asyncio
+from typing import Any
 
 from video_grouper.api_integrations.ntfy import NtfyAPI
 from video_grouper.utils.config import NtfyConfig
+
 from ...utils.paths import get_ntfy_service_state_path
 
 logger = logging.getLogger(__name__)
@@ -38,8 +39,8 @@ class NtfyService:
         self.completion_callback = completion_callback
 
         # State tracking for pending tasks
-        self._pending_tasks: Dict[str, Dict[str, Any]] = {}
-        self._processed_dirs: Set[str] = set()
+        self._pending_tasks: dict[str, dict[str, Any]] = {}
+        self._processed_dirs: set[str] = set()
         self._state_file = get_ntfy_service_state_path(storage_path)
 
         # Buffer for responses that arrived before any task was registered
@@ -60,17 +61,17 @@ class NtfyService:
         # than the listener replay window typically needs.
 
         # For handling direct responses to prompts
-        self._response_events: Dict[str, asyncio.Event] = {}
-        self._response_data: Dict[str, Optional[str]] = {}
+        self._response_events: dict[str, asyncio.Event] = {}
+        self._response_data: dict[str, str | None] = {}
 
         # Generic response handlers for non-task components (e.g. camera poller)
-        self._response_handlers: Dict[str, Any] = {}
+        self._response_handlers: dict[str, Any] = {}
 
         # Track the most recently sent notification's group_dir
         # so responses get routed to the correct group
-        self._last_notified_group_dir: Optional[str] = None
+        self._last_notified_group_dir: str | None = None
 
-        self._state: Dict[str, Any] = {}
+        self._state: dict[str, Any] = {}
         self._lock = asyncio.Lock()
         self._initialized = False
 
@@ -127,7 +128,7 @@ class NtfyService:
         if not os.path.exists(self._state_file):
             return
         try:
-            with open(self._state_file, "r") as f:
+            with open(self._state_file) as f:
                 state = json.load(f)
             self._pending_tasks = state.get("pending_tasks", {})
             self._processed_dirs = set(state.get("processed_dirs", []))
@@ -178,7 +179,7 @@ class NtfyService:
         self._save_state()
 
     def mark_waiting_for_input(
-        self, group_dir: str, task_type: str, metadata: Optional[Dict[str, Any]] = None
+        self, group_dir: str, task_type: str, metadata: dict[str, Any] | None = None
     ) -> None:
         """Mark a directory as waiting for user input."""
         # Convert old metadata structure to new unified structure
@@ -218,7 +219,7 @@ class NtfyService:
                 pass
 
     def mark_failed_to_send(
-        self, group_dir: str, task_type: str, metadata: Optional[Dict[str, Any]] = None
+        self, group_dir: str, task_type: str, metadata: dict[str, Any] | None = None
     ) -> None:
         """Mark a directory as failed to send notification."""
         # Convert old metadata structure to new unified structure
@@ -245,15 +246,15 @@ class NtfyService:
             del self._pending_tasks[group_dir]
             self._save_state()
 
-    def get_pending_tasks(self) -> Dict[str, Dict[str, Any]]:
+    def get_pending_tasks(self) -> dict[str, dict[str, Any]]:
         """Get all pending tasks."""
         return self._pending_tasks.copy()
 
     # For backward compatibility
-    def get_pending_inputs(self) -> Dict[str, Dict[str, Any]]:
+    def get_pending_inputs(self) -> dict[str, dict[str, Any]]:
         return self.get_pending_tasks()
 
-    def get_processed_directories(self) -> Set[str]:
+    def get_processed_directories(self) -> set[str]:
         """Get all processed directories."""
         return self._processed_dirs.copy()
 
@@ -265,10 +266,10 @@ class NtfyService:
         self,
         message: str,
         title: str = None,
-        tags: List[str] = None,
+        tags: list[str] = None,
         priority: int = None,
         image_path: str = None,
-        actions: List[Dict[str, Any]] = None,
+        actions: list[dict[str, Any]] = None,
     ) -> bool:
         """
         Send a notification via NTFY, ensuring the API is initialized first.
@@ -613,7 +614,7 @@ class NtfyService:
         return False
 
     def _response_matches_task(
-        self, group_dir: str, input_type: str, metadata: Dict[str, Any], response: str
+        self, group_dir: str, input_type: str, metadata: dict[str, Any], response: str
     ) -> bool:
         """
         Check if a response matches a specific task.
@@ -693,7 +694,7 @@ class NtfyService:
             return False
 
     async def _process_task_response(
-        self, group_dir: str, input_type: str, metadata: Dict[str, Any], response: str
+        self, group_dir: str, input_type: str, metadata: dict[str, Any], response: str
     ) -> None:
         """
         Process a response for a specific task.

--- a/video_grouper/task_processors/services/playmetrics_service.py
+++ b/video_grouper/task_processors/services/playmetrics_service.py
@@ -3,8 +3,8 @@ PlayMetrics service for match information lookup.
 """
 
 import logging
-from typing import Dict, Optional, Any
 from datetime import datetime
+from typing import Any
 
 from video_grouper.api_integrations.playmetrics import PlayMetricsAPI
 
@@ -105,7 +105,7 @@ class PlayMetricsService:
 
     def find_game_for_recording(
         self, recording_start: datetime, recording_end: datetime
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """
         Find a game that matches the recording timespan.
 

--- a/video_grouper/task_processors/services/teamsnap_service.py
+++ b/video_grouper/task_processors/services/teamsnap_service.py
@@ -3,8 +3,8 @@ TeamSnap service for match information lookup.
 """
 
 import logging
-from typing import Dict, Optional, Any
 from datetime import datetime
+from typing import Any
 
 from video_grouper.api_integrations.teamsnap import TeamSnapAPI
 from video_grouper.utils.config import TeamSnapConfig
@@ -73,7 +73,7 @@ class TeamSnapService:
 
     def find_game_for_recording(
         self, recording_start: datetime, recording_end: datetime
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """
         Find a game that matches the recording timespan.
 

--- a/video_grouper/task_processors/services/timestamp_matcher.py
+++ b/video_grouper/task_processors/services/timestamp_matcher.py
@@ -9,8 +9,6 @@ Given a tag's UTC timestamp and the recording file list, computes:
 
 import logging
 from datetime import datetime
-from typing import Optional
-
 from zoneinfo import ZoneInfo
 
 from video_grouper.models import RecordingFile
@@ -23,7 +21,7 @@ def compute_combined_offset(
     recording_files: list[RecordingFile],
     camera_timezone: str = "America/New_York",
     gap_tolerance_seconds: float = 5.0,
-) -> Optional[float]:
+) -> float | None:
     """Compute the offset (in seconds) into combined.mp4 for a given tag timestamp.
 
     The combined video is a concatenation of all recording files in order.
@@ -97,7 +95,7 @@ def compute_combined_offset(
 def compute_trimmed_offset(
     combined_offset: float,
     start_time_offset: str,
-) -> Optional[float]:
+) -> float | None:
     """Compute the offset into trimmed.mp4 given a combined.mp4 offset.
 
     Args:
@@ -124,7 +122,7 @@ def compute_trimmed_offset(
 def compute_clip_boundaries(
     trimmed_offset: float,
     buffer_seconds: float = 15.0,
-    video_duration: Optional[float] = None,
+    video_duration: float | None = None,
 ) -> tuple[float, float]:
     """Compute clip start/end times around a moment in the trimmed video.
 

--- a/video_grouper/task_processors/state_auditor.py
+++ b/video_grouper/task_processors/state_auditor.py
@@ -1,25 +1,25 @@
-import os
 import logging
+import os
 
-from .base_polling_processor import PollingProcessor
-from .download_processor import DownloadProcessor
-from .video_processor import VideoProcessor
 from ..models import DirectoryState, RecordingFile
 from ..models.match_info import MatchInfo
 from ..task_processors.tasks.video import CombineTask, TrimTask
+from ..utils.config import Config
+from ..utils.ffmpeg_utils import get_video_duration
 from ..utils.paths import (
-    get_state_file_path,
     get_combined_video_path,
     get_match_info_path,
+    get_state_file_path,
 )
-from ..utils.ffmpeg_utils import get_video_duration
+from .base_polling_processor import PollingProcessor
+from .download_processor import DownloadProcessor
 from .services import (
-    NtfyService,
-    MatchInfoService,
     CleanupService,
+    MatchInfoService,
+    NtfyService,
 )
-from .services.mock_services import create_teamsnap_service, create_playmetrics_service
-from ..utils.config import Config
+from .services.mock_services import create_playmetrics_service, create_teamsnap_service
+from .video_processor import VideoProcessor
 
 logger = logging.getLogger(__name__)
 

--- a/video_grouper/task_processors/task_registry.py
+++ b/video_grouper/task_processors/task_registry.py
@@ -3,11 +3,11 @@ Task registry for managing task types and deserialization.
 """
 
 import logging
-from typing import Dict, Type, Optional
 
-from .tasks.base_task import BaseTask
-from .queue_type import QueueType
 from video_grouper.models import RecordingFile
+
+from .queue_type import QueueType
+from .tasks.base_task import BaseTask
 
 logger = logging.getLogger(__name__)
 
@@ -18,10 +18,10 @@ class TaskRegistry:
     """
 
     def __init__(self):
-        self._task_types: Dict[str, Type[BaseTask]] = {}
-        self._queue_task_types: Dict[QueueType, Dict[str, Type[BaseTask]]] = {}
+        self._task_types: dict[str, type[BaseTask]] = {}
+        self._queue_task_types: dict[QueueType, dict[str, type[BaseTask]]] = {}
 
-    def register_task(self, task_class: Type[BaseTask]) -> None:
+    def register_task(self, task_class: type[BaseTask]) -> None:
         """
         Register a task class for deserialization.
 
@@ -78,8 +78,8 @@ class TaskRegistry:
         )
 
     def get_task_class(
-        self, task_type: str, queue_type: Optional[QueueType] = None
-    ) -> Optional[Type[BaseTask]]:
+        self, task_type: str, queue_type: QueueType | None = None
+    ) -> type[BaseTask] | None:
         """
         Get a task class by type.
 
@@ -99,8 +99,8 @@ class TaskRegistry:
         return self._task_types.get(task_type)
 
     def deserialize_task(
-        self, data: Dict[str, object], queue_type: Optional[QueueType] = None
-    ) -> Optional[BaseTask]:
+        self, data: dict[str, object], queue_type: QueueType | None = None
+    ) -> BaseTask | None:
         """
         Deserialize a task from its data.
 

--- a/video_grouper/task_processors/tasks/__init__.py
+++ b/video_grouper/task_processors/tasks/__init__.py
@@ -1,8 +1,8 @@
 """Task implementations for the video processing system."""
 
 # Base classes
-from .base_task import BaseTask
 from ..queue_type import QueueType
+from .base_task import BaseTask
 
 # Download tasks
 from .download import (

--- a/video_grouper/task_processors/tasks/ball_tracking/ball_tracking_task.py
+++ b/video_grouper/task_processors/tasks/ball_tracking/ball_tracking_task.py
@@ -81,9 +81,9 @@ class BallTrackingTask(BallTrackingTaskBase):
 
             # Ensure built-in providers are registered.
             from video_grouper.ball_tracking import (  # noqa: F401
+                create_provider,
                 register_providers,
             )
-            from video_grouper.ball_tracking import create_provider
             from video_grouper.ball_tracking.base import ProviderContext
 
             provider = create_provider(self.provider_name, self.provider_config)

--- a/video_grouper/task_processors/tasks/ball_tracking/base.py
+++ b/video_grouper/task_processors/tasks/ball_tracking/base.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
-from ..base_task import BaseTask
 from ...queue_type import QueueType
+from ..base_task import BaseTask
 
 
 class BallTrackingTaskBase(BaseTask):
@@ -37,10 +37,10 @@ class BallTrackingTaskBase(BaseTask):
         input_path: str,
         output_path: str,
         provider_name: str,
-        provider_config: Dict[str, Any],
+        provider_config: dict[str, Any],
         team_name: str | None = None,
         storage_path: str | None = None,
-        ttt_config: Dict[str, Any] | None = None,
+        ttt_config: dict[str, Any] | None = None,
     ):
         self.group_dir = group_dir
         self.input_path = input_path
@@ -58,7 +58,7 @@ class BallTrackingTaskBase(BaseTask):
     def get_item_path(self) -> str:
         return str(self.group_dir)
 
-    def serialize(self) -> Dict[str, object]:
+    def serialize(self) -> dict[str, object]:
         return {
             "task_type": self.task_type,
             "group_dir": str(self.group_dir),
@@ -72,7 +72,7 @@ class BallTrackingTaskBase(BaseTask):
         }
 
     @classmethod
-    def deserialize(cls, data: Dict[str, object]) -> "BallTrackingTaskBase":
+    def deserialize(cls, data: dict[str, object]) -> BallTrackingTaskBase:
         ttt_cfg = data.get("ttt_config")
         return cls(
             group_dir=Path(data["group_dir"]),
@@ -126,5 +126,5 @@ class BallTrackingTaskBase(BaseTask):
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, object]) -> "BallTrackingTaskBase":
+    def from_dict(cls, data: dict[str, object]) -> BallTrackingTaskBase:
         return cls.deserialize(data)

--- a/video_grouper/task_processors/tasks/ball_tracking/external_ball_tracking_task.py
+++ b/video_grouper/task_processors/tasks/ball_tracking/external_ball_tracking_task.py
@@ -61,9 +61,9 @@ class ExternalBallTrackingTask(BallTrackingTaskBase):
                 return False
 
             from video_grouper.ball_tracking import (  # noqa: F401
+                create_provider,
                 register_providers,
             )
-            from video_grouper.ball_tracking import create_provider
             from video_grouper.ball_tracking.base import ProviderContext
 
             provider = create_provider(self.provider_name, self.provider_config)

--- a/video_grouper/task_processors/tasks/base_task.py
+++ b/video_grouper/task_processors/tasks/base_task.py
@@ -3,7 +3,6 @@ Base class for all tasks.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict
 
 from ..queue_type import QueueType
 
@@ -33,13 +32,13 @@ class BaseTask(ABC):
         pass
 
     @abstractmethod
-    def serialize(self) -> Dict[str, object]:
+    def serialize(self) -> dict[str, object]:
         """Serialize the task for state persistence."""
         pass
 
     @classmethod
     @abstractmethod
-    def deserialize(cls, data: Dict[str, object]) -> "BaseTask":
+    def deserialize(cls, data: dict[str, object]) -> "BaseTask":
         """Deserialize a task from its serialized data."""
         pass
 

--- a/video_grouper/task_processors/tasks/clip/clip_request_task.py
+++ b/video_grouper/task_processors/tasks/clip/clip_request_task.py
@@ -2,10 +2,10 @@
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, Any
+from typing import Any
 
-from ..base_task import BaseTask
 from ...queue_type import QueueType
+from ..base_task import BaseTask
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ class ClipRequestTask(BaseTask):
     def get_item_path(self) -> str:
         return self.recording_group_dir
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         return {
             "task_type": self.task_type,
             "clip_request_id": self.clip_request_id,
@@ -47,7 +47,7 @@ class ClipRequestTask(BaseTask):
         }
 
     @classmethod
-    def deserialize(cls, data: Dict[str, object]) -> "ClipRequestTask":
+    def deserialize(cls, data: dict[str, object]) -> "ClipRequestTask":
         return cls(
             clip_request_id=data["clip_request_id"],
             game_session_id=data["game_session_id"],

--- a/video_grouper/task_processors/tasks/clips/clip_extraction_task.py
+++ b/video_grouper/task_processors/tasks/clips/clip_extraction_task.py
@@ -5,11 +5,12 @@ Task for extracting a single clip from a trimmed video using FFmpeg.
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any
 
-from ..base_task import BaseTask
-from ...queue_type import QueueType
 from video_grouper.utils.ffmpeg_utils import trim_video
+
+from ...queue_type import QueueType
+from ..base_task import BaseTask
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,7 @@ class ClipExtractionTask(BaseTask):
 
         return success
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         return {
             "task_type": self.task_type,
             "tag_id": self.tag_id,
@@ -84,7 +85,7 @@ class ClipExtractionTask(BaseTask):
         }
 
     @classmethod
-    def deserialize(cls, data: Dict[str, Any]) -> "ClipExtractionTask":
+    def deserialize(cls, data: dict[str, Any]) -> "ClipExtractionTask":
         return cls(
             tag_id=data["tag_id"],
             clip_id=data["clip_id"],

--- a/video_grouper/task_processors/tasks/clips/highlight_compilation_task.py
+++ b/video_grouper/task_processors/tasks/clips/highlight_compilation_task.py
@@ -5,11 +5,12 @@ Task for compiling multiple clips into a highlight reel using FFmpeg concat.
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any
 
-from ..base_task import BaseTask
-from ...queue_type import QueueType
 from video_grouper.utils.ffmpeg_utils import combine_videos
+
+from ...queue_type import QueueType
+from ..base_task import BaseTask
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +62,7 @@ class HighlightCompilationTask(BaseTask):
 
         return success
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         return {
             "task_type": self.task_type,
             "highlight_id": self.highlight_id,
@@ -72,7 +73,7 @@ class HighlightCompilationTask(BaseTask):
         }
 
     @classmethod
-    def deserialize(cls, data: Dict[str, Any]) -> "HighlightCompilationTask":
+    def deserialize(cls, data: dict[str, Any]) -> "HighlightCompilationTask":
         return cls(
             highlight_id=data["highlight_id"],
             title=data["title"],

--- a/video_grouper/task_processors/tasks/download/base_download_task.py
+++ b/video_grouper/task_processors/tasks/download/base_download_task.py
@@ -2,14 +2,13 @@
 Base class for download tasks.
 """
 
-import os
 import logging
+import os
 from abc import abstractmethod
-from typing import Dict
 from dataclasses import dataclass
 
-from ..base_task import BaseTask
 from ...queue_type import QueueType
+from ..base_task import BaseTask
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +57,7 @@ class BaseDownloadTask(BaseTask):
         pass
 
     @abstractmethod
-    def get_camera_config(self) -> Dict[str, object]:
+    def get_camera_config(self) -> dict[str, object]:
         """
         Return the camera configuration needed for download.
 
@@ -68,7 +67,7 @@ class BaseDownloadTask(BaseTask):
         pass
 
     @abstractmethod
-    def serialize(self) -> Dict[str, object]:
+    def serialize(self) -> dict[str, object]:
         """
         Serialize the task to a dictionary for state persistence.
 
@@ -87,7 +86,7 @@ class BaseDownloadTask(BaseTask):
         """
         pass
 
-    def to_dict(self) -> Dict[str, object]:
+    def to_dict(self) -> dict[str, object]:
         """
         Convert task to dictionary format (alias for serialize for backward compatibility).
 

--- a/video_grouper/task_processors/tasks/download/dahua_download_task.py
+++ b/video_grouper/task_processors/tasks/download/dahua_download_task.py
@@ -2,14 +2,15 @@
 Dahua download task for downloading files from Dahua cameras.
 """
 
-import os
 import logging
-from typing import Dict, Any
+import os
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
+
+from video_grouper.utils.config import CameraConfig
 
 from .base_download_task import BaseDownloadTask
-from video_grouper.utils.config import CameraConfig
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ class DahuaDownloadTask(BaseDownloadTask):
     start_time: datetime
     end_time: datetime
     file_size: int = 0
-    metadata: Dict[str, Any] = None
+    metadata: dict[str, Any] = None
 
     def __post_init__(self):
         """Initialize metadata if not provided."""
@@ -48,11 +49,11 @@ class DahuaDownloadTask(BaseDownloadTask):
         """Return the remote file path."""
         return self.remote_file_path
 
-    def get_camera_config(self) -> Dict[str, Any]:
+    def get_camera_config(self) -> dict[str, Any]:
         """Return the camera configuration."""
         return self.config.dict()
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         """
         Serialize the task for state persistence.
 
@@ -118,7 +119,7 @@ class DahuaDownloadTask(BaseDownloadTask):
         return f"DahuaDownloadTask({os.path.basename(self.local_file_path)})"
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "DahuaDownloadTask":
+    def from_dict(cls, data: dict[str, Any]) -> "DahuaDownloadTask":
         """
         Create a DahuaDownloadTask from serialized data.
 
@@ -139,7 +140,7 @@ class DahuaDownloadTask(BaseDownloadTask):
         )
 
     @classmethod
-    def deserialize(cls, data: Dict[str, object]) -> "DahuaDownloadTask":
+    def deserialize(cls, data: dict[str, object]) -> "DahuaDownloadTask":
         """
         Deserialize a DahuaDownloadTask from its serialized data.
 

--- a/video_grouper/task_processors/tasks/ntfy/__init__.py
+++ b/video_grouper/task_processors/tasks/ntfy/__init__.py
@@ -6,10 +6,10 @@ types of NTFY tasks like game start time questions, team info requests, etc.
 """
 
 from .base_ntfy_task import BaseNtfyTask, NtfyTaskResult
-from .game_start_task import GameStartTask
 from .game_end_task import GameEndTask
-from .team_info_task import TeamInfoTask
+from .game_start_task import GameStartTask
 from .task_factory import NtfyTaskFactory
+from .team_info_task import TeamInfoTask
 
 __all__ = [
     "BaseNtfyTask",

--- a/video_grouper/task_processors/tasks/ntfy/base_ntfy_task.py
+++ b/video_grouper/task_processors/tasks/ntfy/base_ntfy_task.py
@@ -4,18 +4,18 @@ Base class for NTFY tasks.
 This provides the common interface and functionality for all NTFY tasks.
 """
 
-import os
 import logging
+import os
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional, TypedDict, Union
-from datetime import datetime
 from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, TypedDict
 
 from video_grouper.models import MatchInfo
-from video_grouper.utils.config import Config
-from video_grouper.task_processors.tasks.base_task import BaseTask
 from video_grouper.task_processors.queue_type import QueueType
 from video_grouper.task_processors.services.ntfy_service import NtfyService
+from video_grouper.task_processors.tasks.base_task import BaseTask
+from video_grouper.utils.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ class TaskMetadata(TypedDict, total=False):
     last_response: str
 
     # Custom metadata fields
-    custom_fields: dict[str, Union[str, int, float, bool]]
+    custom_fields: dict[str, str | int | float | bool]
 
 
 @dataclass
@@ -64,7 +64,7 @@ class BaseNtfyTask(BaseTask, ABC):
         group_dir: str,
         config: Config,
         ntfy_service: NtfyService,
-        metadata: Optional[TaskMetadata] = None,
+        metadata: TaskMetadata | None = None,
     ):
         """
         Initialize the base NTFY task.
@@ -95,7 +95,7 @@ class BaseNtfyTask(BaseTask, ABC):
         """Return the path of the item being processed."""
         return self.group_dir
 
-    def serialize(self) -> Dict[str, object]:
+    def serialize(self) -> dict[str, object]:
         """Serialize the task for state persistence."""
         return {
             "task_type": self.get_task_type(),
@@ -157,7 +157,7 @@ class BaseNtfyTask(BaseTask, ABC):
             return False
 
     @abstractmethod
-    async def create_question(self) -> Dict[str, Any]:
+    async def create_question(self) -> dict[str, Any]:
         """
         Create the question data for this task.
 
@@ -191,7 +191,7 @@ class BaseNtfyTask(BaseTask, ABC):
 
     async def generate_screenshot(
         self, video_path: str, time_seconds: int
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Generate a screenshot at the specified time.
 
@@ -203,8 +203,9 @@ class BaseNtfyTask(BaseTask, ABC):
             Path to the generated screenshot, or None if failed
         """
         try:
-            from video_grouper.utils.ffmpeg_utils import create_screenshot
             from datetime import timedelta
+
+            from video_grouper.utils.ffmpeg_utils import create_screenshot
 
             # Convert seconds to time string
             time_str = str(timedelta(seconds=time_seconds)).split(".")[0]
@@ -256,7 +257,7 @@ class BaseNtfyTask(BaseTask, ABC):
     async def _compress_image(
         self,
         input_path: str,
-        output_path: Optional[str] = None,
+        output_path: str | None = None,
         quality: int = 60,
         max_width: int = 800,
     ) -> str:
@@ -311,7 +312,7 @@ class BaseNtfyTask(BaseTask, ABC):
             logger.error(f"Error during image compression: {e}")
             return input_path
 
-    async def get_video_duration(self, video_path: str) -> Optional[int]:
+    async def get_video_duration(self, video_path: str) -> int | None:
         """
         Get video duration in seconds.
 

--- a/video_grouper/task_processors/tasks/ntfy/game_end_task.py
+++ b/video_grouper/task_processors/tasks/ntfy/game_end_task.py
@@ -4,13 +4,14 @@ Game end time NTFY task.
 This task handles asking users about when a game ends in a video.
 """
 
-import os
 import logging
-from typing import Dict, Any, Optional
+import os
+from typing import Any
+
+from video_grouper.task_processors.services.ntfy_service import NtfyService
+from video_grouper.utils.config import Config
 
 from .base_ntfy_task import BaseNtfyTask, NtfyTaskResult
-from video_grouper.utils.config import Config
-from video_grouper.task_processors.services.ntfy_service import NtfyService
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +31,8 @@ class GameEndTask(BaseNtfyTask):
         ntfy_service: NtfyService,
         combined_video_path: str,
         start_time_offset: str,
-        time_offset: Optional[str] = None,
-        time_seconds: Optional[int] = None,
+        time_offset: str | None = None,
+        time_seconds: int | None = None,
     ):
         """
         Initialize the game end task.
@@ -77,7 +78,7 @@ class GameEndTask(BaseNtfyTask):
 
         return NtfyInputType.GAME_END_TIME.value
 
-    async def create_question(self) -> Dict[str, Any]:
+    async def create_question(self) -> dict[str, Any]:
         """
         Create the question data for asking about game end time.
 

--- a/video_grouper/task_processors/tasks/ntfy/game_start_task.py
+++ b/video_grouper/task_processors/tasks/ntfy/game_start_task.py
@@ -4,13 +4,14 @@ Game start time NTFY task.
 This task handles asking users about when a game starts in a video.
 """
 
-import os
 import logging
-from typing import Dict, Any
+import os
+from typing import Any
+
+from video_grouper.task_processors.services.ntfy_service import NtfyService
+from video_grouper.utils.config import Config
 
 from .base_ntfy_task import BaseNtfyTask, NtfyTaskResult
-from video_grouper.utils.config import Config
-from video_grouper.task_processors.services.ntfy_service import NtfyService
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +74,7 @@ class GameStartTask(BaseNtfyTask):
 
         return NtfyInputType.GAME_START_TIME.value
 
-    async def create_question(self) -> Dict[str, Any]:
+    async def create_question(self) -> dict[str, Any]:
         """
         Create the question data for asking about game start time.
 
@@ -242,7 +243,7 @@ class GameStartTask(BaseNtfyTask):
             )
 
     @classmethod
-    def deserialize(cls, data: Dict[str, object]) -> "GameStartTask":
+    def deserialize(cls, data: dict[str, object]) -> "GameStartTask":
         """
         Deserialize a GameStartTask from its serialized data.
 
@@ -260,8 +261,8 @@ class GameStartTask(BaseNtfyTask):
 
         # Create a minimal config and ntfy_service for deserialization
         # These will be properly initialized when the task is executed
-        from video_grouper.utils.config import Config
         from video_grouper.task_processors.services.ntfy_service import NtfyService
+        from video_grouper.utils.config import Config
 
         # Create minimal config with required fields
         config = Config()

--- a/video_grouper/task_processors/tasks/ntfy/task_factory.py
+++ b/video_grouper/task_processors/tasks/ntfy/task_factory.py
@@ -6,13 +6,14 @@ based on task type and metadata.
 """
 
 import logging
-from typing import Dict, Any, Optional
+from typing import Any
 
-from video_grouper.utils.config import Config
 from video_grouper.task_processors.services.ntfy_service import NtfyService
+from video_grouper.utils.config import Config
+
 from .base_ntfy_task import BaseNtfyTask
-from .game_start_task import GameStartTask
 from .game_end_task import GameEndTask
+from .game_start_task import GameStartTask
 from .team_info_task import TeamInfoTask
 from .was_there_a_match_task import WasThereAMatchTask
 
@@ -33,8 +34,8 @@ class NtfyTaskFactory:
         group_dir: str,
         config: Config,
         ntfy_service: NtfyService,
-        metadata: Optional[Dict[str, Any]] = None,
-    ) -> Optional[BaseNtfyTask]:
+        metadata: dict[str, Any] | None = None,
+    ) -> BaseNtfyTask | None:
         """
         Create a task of the specified type.
 
@@ -204,7 +205,7 @@ class NtfyTaskFactory:
         config: Config,
         ntfy_service: NtfyService,
         combined_video_path: str,
-        existing_info: Optional[Dict[str, str]] = None,
+        existing_info: dict[str, str] | None = None,
     ) -> TeamInfoTask:
         """
         Create a team info task.

--- a/video_grouper/task_processors/tasks/ntfy/team_info_task.py
+++ b/video_grouper/task_processors/tasks/ntfy/team_info_task.py
@@ -9,15 +9,16 @@ Asks sequential questions for missing match info fields:
 Each response is written to match_info.ini immediately.
 """
 
-import os
 import logging
-from typing import Dict, Any, Optional, List, Tuple
+import os
+from typing import Any
 
-from .base_ntfy_task import BaseNtfyTask, NtfyTaskResult
+from video_grouper.models.match_info import MatchInfo
+from video_grouper.task_processors.services.ntfy_service import NtfyService
 from video_grouper.utils.config import Config
 from video_grouper.utils.paths import get_combined_video_path, resolve_path
-from video_grouper.task_processors.services.ntfy_service import NtfyService
-from video_grouper.models.match_info import MatchInfo
+
+from .base_ntfy_task import BaseNtfyTask, NtfyTaskResult
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +47,8 @@ class TeamInfoTask(BaseNtfyTask):
         config: Config,
         ntfy_service: NtfyService,
         combined_video_path: str,
-        existing_info: Optional[Dict[str, str]] = None,
-        asking_field: Optional[str] = None,
+        existing_info: dict[str, str] | None = None,
+        asking_field: str | None = None,
     ):
         metadata = {
             "combined_video_path": combined_video_path,
@@ -77,7 +78,7 @@ class TeamInfoTask(BaseNtfyTask):
 
     _PLACEHOLDER_VALUES = {"my team", "opponent", "location", "unknown", ""}
 
-    def _get_missing_fields(self) -> List[str]:
+    def _get_missing_fields(self) -> list[str]:
         """Return field keys from FIELD_SEQUENCE that are still empty or placeholder."""
         match_info = self._load_match_info()
         missing = []
@@ -87,14 +88,14 @@ class TeamInfoTask(BaseNtfyTask):
                 missing.append(field_key)
         return missing
 
-    def _load_match_info(self) -> Optional[MatchInfo]:
+    def _load_match_info(self) -> MatchInfo | None:
         """Load the current MatchInfo for this group."""
         mi, _ = MatchInfo.get_or_create(self.group_dir)
         if mi:
             mi.group_dir = self.group_dir
         return mi
 
-    def _next_field_to_ask(self) -> Optional[str]:
+    def _next_field_to_ask(self) -> str | None:
         """Return the first missing field key, or None if all filled.
 
         If my_team_name is missing but there's only one configured team,
@@ -116,7 +117,7 @@ class TeamInfoTask(BaseNtfyTask):
 
         return missing[0] if missing else None
 
-    def _field_meta(self, field_key: str) -> Tuple[str, Optional[str]]:
+    def _field_meta(self, field_key: str) -> tuple[str, str | None]:
         """Return (label, hint) for a field key."""
         for key, label, hint in FIELD_SEQUENCE:
             if key == field_key:
@@ -127,7 +128,7 @@ class TeamInfoTask(BaseNtfyTask):
     # Team names from config
     # ------------------------------------------------------------------
 
-    def _get_configured_teams(self) -> List[str]:
+    def _get_configured_teams(self) -> list[str]:
         """Get all configured team names from TeamSnap and PlayMetrics."""
         teams = []
         config = self.config
@@ -153,14 +154,15 @@ class TeamInfoTask(BaseNtfyTask):
                     teams.append(pm.team_name)
         return teams
 
-    async def _get_midpoint_screenshot(self) -> Optional[str]:
+    async def _get_midpoint_screenshot(self) -> str | None:
         """Take a screenshot from the middle of the combined video."""
         try:
-            from video_grouper.utils.ffmpeg_utils import (
-                get_video_duration,
-                create_screenshot,
-            )
             from datetime import datetime
+
+            from video_grouper.utils.ffmpeg_utils import (
+                create_screenshot,
+                get_video_duration,
+            )
 
             combined = get_combined_video_path(self.group_dir, self.storage_path)
             if not os.path.exists(combined):
@@ -203,7 +205,7 @@ class TeamInfoTask(BaseNtfyTask):
     # NTFY question / response
     # ------------------------------------------------------------------
 
-    async def create_question(self) -> Dict[str, Any]:
+    async def create_question(self) -> dict[str, Any]:
         # Determine which field to ask about
         field_key = self.asking_field or self._next_field_to_ask()
         if not field_key:
@@ -384,11 +386,11 @@ class TeamInfoTask(BaseNtfyTask):
     # ------------------------------------------------------------------
 
     @classmethod
-    def deserialize(cls, data: Dict[str, Any]) -> "TeamInfoTask":
+    def deserialize(cls, data: dict[str, Any]) -> "TeamInfoTask":
         return cls.from_dict(data)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "TeamInfoTask":
+    def from_dict(cls, data: dict[str, Any]) -> "TeamInfoTask":
         from video_grouper.utils.config import NtfyConfig
 
         ntfy_config_data = data.get("metadata", {}).get("config", {}).get("ntfy", {})
@@ -407,5 +409,5 @@ class TeamInfoTask(BaseNtfyTask):
             asking_field=data.get("metadata", {}).get("asking_field"),
         )
 
-    def get_missing_fields(self) -> List[str]:
+    def get_missing_fields(self) -> list[str]:
         return self._get_missing_fields()

--- a/video_grouper/task_processors/tasks/ntfy/was_there_a_match_task.py
+++ b/video_grouper/task_processors/tasks/ntfy/was_there_a_match_task.py
@@ -4,16 +4,17 @@ Was there a match NTFY task.
 This task asks users if there was actually a match during the recording period.
 """
 
+import json
 import logging
 import os
-import json
-from typing import Dict, Any, Optional
 from datetime import datetime
+from typing import Any
+
+from video_grouper.models import DirectoryState
+from video_grouper.task_processors.services.ntfy_service import NtfyService
+from video_grouper.utils.config import Config
 
 from .base_ntfy_task import BaseNtfyTask, NtfyTaskResult
-from video_grouper.utils.config import Config
-from video_grouper.task_processors.services.ntfy_service import NtfyService
-from video_grouper.models import DirectoryState
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +62,7 @@ class WasThereAMatchTask(BaseNtfyTask):
 
         return NtfyInputType.WAS_THERE_A_MATCH.value
 
-    def _get_recording_timespan(self) -> Optional[tuple[datetime, datetime]]:
+    def _get_recording_timespan(self) -> tuple[datetime, datetime] | None:
         """
         Get the recording timespan from directory state.
 
@@ -101,7 +102,7 @@ class WasThereAMatchTask(BaseNtfyTask):
             logger.error(f"Error getting recording timespan for {self.group_dir}: {e}")
             return None
 
-    async def create_question(self) -> Dict[str, Any]:
+    async def create_question(self) -> dict[str, Any]:
         """
         Create the question data for asking if there was a match.
 
@@ -230,7 +231,7 @@ class WasThereAMatchTask(BaseNtfyTask):
             state_file = os.path.join(self.group_dir, "state.json")
 
             if os.path.exists(state_file):
-                with open(state_file, "r") as f:
+                with open(state_file) as f:
                     state_data = json.load(f)
 
                 state_data["status"] = "not_a_game"
@@ -249,7 +250,7 @@ class WasThereAMatchTask(BaseNtfyTask):
             logger.error(f"Error marking {self.group_dir} as not_a_game: {e}")
 
     @classmethod
-    def deserialize(cls, data: Dict[str, object]) -> "WasThereAMatchTask":
+    def deserialize(cls, data: dict[str, object]) -> "WasThereAMatchTask":
         """
         Deserialize a WasThereAMatchTask from its serialized data.
 

--- a/video_grouper/task_processors/tasks/upload/base_upload_task.py
+++ b/video_grouper/task_processors/tasks/upload/base_upload_task.py
@@ -2,14 +2,13 @@
 Base class for upload tasks.
 """
 
-import os
 import logging
+import os
 from abc import abstractmethod
-from typing import Dict
 from dataclasses import dataclass
 
-from ..base_task import BaseTask
 from ...queue_type import QueueType
+from ..base_task import BaseTask
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +47,7 @@ class BaseUploadTask(BaseTask):
         pass
 
     @abstractmethod
-    def serialize(self) -> Dict[str, object]:
+    def serialize(self) -> dict[str, object]:
         """
         Serialize the task to a dictionary for state persistence.
 
@@ -67,7 +66,7 @@ class BaseUploadTask(BaseTask):
         """
         pass
 
-    def to_dict(self) -> Dict[str, object]:
+    def to_dict(self) -> dict[str, object]:
         """
         Convert task to dictionary format (alias for serialize for backward compatibility).
 

--- a/video_grouper/task_processors/tasks/upload/youtube_upload_task.py
+++ b/video_grouper/task_processors/tasks/upload/youtube_upload_task.py
@@ -2,16 +2,16 @@
 YouTube upload task for uploading videos to YouTube.
 """
 
-import os
 import logging
-from typing import Dict, Any, Optional
+import os
 from dataclasses import dataclass
+from typing import Any
 
+from video_grouper.models import DirectoryState, MatchInfo
+from video_grouper.utils.config import YouTubeConfig
 from video_grouper.utils.paths import resolve_path
 
 from .base_upload_task import BaseUploadTask
-from video_grouper.models import MatchInfo, DirectoryState
-from video_grouper.utils.config import YouTubeConfig
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class YoutubeUploadTask(BaseUploadTask):
         """Return the group directory path."""
         return self.group_dir
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         """
         Serialize the task for state persistence.
 
@@ -251,7 +251,7 @@ class YoutubeUploadTask(BaseUploadTask):
         config: YouTubeConfig,
         ntfy_service,
         storage_path: str,
-    ) -> tuple[Optional[str], Optional[str]]:
+    ) -> tuple[str | None, str | None]:
         """
         Get playlist names for processed and raw videos.
 
@@ -348,7 +348,7 @@ class YoutubeUploadTask(BaseUploadTask):
         return f"YoutubeUploadTask({os.path.basename(self.group_dir)})"
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "YoutubeUploadTask":
+    def from_dict(cls, data: dict[str, Any]) -> "YoutubeUploadTask":
         """
         Create a YoutubeUploadTask from serialized data.
 
@@ -363,7 +363,7 @@ class YoutubeUploadTask(BaseUploadTask):
         return cls(group_dir=group_dir)
 
     @classmethod
-    def deserialize(cls, data: Dict[str, object]) -> "YoutubeUploadTask":
+    def deserialize(cls, data: dict[str, object]) -> "YoutubeUploadTask":
         """
         Deserialize a YoutubeUploadTask from its serialized data.
 

--- a/video_grouper/task_processors/tasks/video/base_ffmpeg_task.py
+++ b/video_grouper/task_processors/tasks/video/base_ffmpeg_task.py
@@ -4,10 +4,9 @@ Base class for FFmpeg tasks.
 
 import logging
 from abc import abstractmethod
-from typing import Dict
 
-from ..base_task import BaseTask
 from ...queue_type import QueueType
+from ..base_task import BaseTask
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +28,7 @@ class BaseFfmpegTask(BaseTask):
         """Execute the FFmpeg task."""
         pass
 
-    def to_dict(self) -> Dict[str, object]:
+    def to_dict(self) -> dict[str, object]:
         """
         Convert task to dictionary format (alias for serialize for backward compatibility).
 

--- a/video_grouper/task_processors/tasks/video/combine_task.py
+++ b/video_grouper/task_processors/tasks/video/combine_task.py
@@ -2,18 +2,19 @@
 Combine task for combining multiple DAV files into a single MP4 video.
 """
 
-import os
 import logging
-from typing import List, Dict, Any
+import os
 from dataclasses import dataclass
+from typing import Any
 
-from .base_ffmpeg_task import BaseFfmpegTask
 from video_grouper.models import DirectoryState
 from video_grouper.utils.ffmpeg_utils import combine_videos
 from video_grouper.utils.paths import (
     get_combined_video_path,
     resolve_path,
 )
+
+from .base_ffmpeg_task import BaseFfmpegTask
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class CombineTask(BaseFfmpegTask):
         """Return the group directory path."""
         return self.group_dir
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         """
         Serialize the task for state persistence.
 
@@ -60,7 +61,7 @@ class CombineTask(BaseFfmpegTask):
     # Files produced by the pipeline itself that should not be combined
     EXCLUDE_PREFIXES = ("combined",)
 
-    def get_dav_files(self) -> List[str]:
+    def get_dav_files(self) -> list[str]:
         """
         Get the list of video files to combine from the group directory.
 
@@ -156,7 +157,7 @@ class CombineTask(BaseFfmpegTask):
         return f"CombineTask({os.path.basename(self.group_dir)})"
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "CombineTask":
+    def from_dict(cls, data: dict[str, Any]) -> "CombineTask":
         """
         Create a CombineTask from serialized data.
 
@@ -169,7 +170,7 @@ class CombineTask(BaseFfmpegTask):
         return cls(group_dir=data["group_dir"])
 
     @classmethod
-    def deserialize(cls, data: Dict[str, object]) -> "CombineTask":
+    def deserialize(cls, data: dict[str, object]) -> "CombineTask":
         """
         Deserialize a CombineTask from its serialized data.
 

--- a/video_grouper/task_processors/tasks/video/trim_task.py
+++ b/video_grouper/task_processors/tasks/video/trim_task.py
@@ -2,15 +2,16 @@
 Trim task for trimming combined videos based on match information.
 """
 
-import os
 import logging
-from typing import Dict, Any, Optional
+import os
 from dataclasses import dataclass, field
+from typing import Any
 
-from .base_ffmpeg_task import BaseFfmpegTask
 from video_grouper.models import DirectoryState
 from video_grouper.utils.ffmpeg_utils import trim_video
 from video_grouper.utils.paths import get_combined_video_path, get_trimmed_video_path
+
+from .base_ffmpeg_task import BaseFfmpegTask
 
 logger = logging.getLogger(__name__)
 
@@ -25,9 +26,7 @@ class TrimTask(BaseFfmpegTask):
 
     group_dir: str
     start_time: str  # Format: "HH:MM:SS"
-    end_time: Optional[str] = field(
-        default=None
-    )  # Format: "HH:MM:SS", None = no end trim
+    end_time: str | None = field(default=None)  # Format: "HH:MM:SS", None = no end trim
 
     @property
     def task_type(self) -> str:
@@ -88,7 +87,7 @@ class TrimTask(BaseFfmpegTask):
         """Return the group directory path."""
         return self.group_dir
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         """
         Serialize the task for state persistence.
 
@@ -122,7 +121,7 @@ class TrimTask(BaseFfmpegTask):
         return f"TrimTask({os.path.basename(self.group_dir)}, {self.start_time}-{end})"
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "TrimTask":
+    def from_dict(cls, data: dict[str, Any]) -> "TrimTask":
         """
         Create a TrimTask from serialized data.
 
@@ -141,7 +140,7 @@ class TrimTask(BaseFfmpegTask):
         )
 
     @classmethod
-    def deserialize(cls, data: Dict[str, object]) -> "TrimTask":
+    def deserialize(cls, data: dict[str, object]) -> "TrimTask":
         """
         Deserialize a TrimTask from its serialized data.
 

--- a/video_grouper/task_processors/ttt_job_processor.py
+++ b/video_grouper/task_processors/ttt_job_processor.py
@@ -4,10 +4,9 @@ import asyncio
 import logging
 import os
 import platform
-from typing import Optional
 
-from .base_polling_processor import PollingProcessor
 from ..utils.config import Config
+from .base_polling_processor import PollingProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +40,8 @@ class TTTJobProcessor(PollingProcessor):
         self.video_processor = video_processor
         self.upload_processor = upload_processor
         self._processing_jobs: set[str] = set()
-        self._service_id: Optional[str] = None
-        self._heartbeat_task: Optional[asyncio.Task] = None
+        self._service_id: str | None = None
+        self._heartbeat_task: asyncio.Task | None = None
 
     async def start(self) -> None:
         """Start the processor and register service with TTT."""
@@ -219,7 +218,7 @@ class TTTJobProcessor(PollingProcessor):
         except Exception as e:
             logger.error("TTT_JOBS: Failed to report failure for %s: %s", job_id, e)
 
-    async def _resolve_or_create_group(self, job: dict, config: dict) -> Optional[str]:
+    async def _resolve_or_create_group(self, job: dict, config: dict) -> str | None:
         """Resolve or create the recording group directory for this job."""
         recording_dir = config.get("recording_group_dir")
         if recording_dir:
@@ -234,7 +233,7 @@ class TTTJobProcessor(PollingProcessor):
 
     async def _wait_for_combined(
         self, group_dir: str, timeout: int = 3600
-    ) -> Optional[str]:
+    ) -> str | None:
         """Wait for combined.mp4 to appear in the group directory."""
         from ..utils.paths import get_combined_video_path
 
@@ -254,8 +253,8 @@ class TTTJobProcessor(PollingProcessor):
         group_dir: str,
         combined_path: str,
         trim_start: str,
-        trim_end: Optional[str],
-    ) -> Optional[str]:
+        trim_end: str | None,
+    ) -> str | None:
         """Trim the combined video using FFmpeg."""
         from ..utils.ffmpeg_utils import trim_video
 
@@ -265,7 +264,7 @@ class TTTJobProcessor(PollingProcessor):
 
     async def _upload_video(
         self, group_dir: str, video_path: str, config: dict
-    ) -> Optional[str]:
+    ) -> str | None:
         """Upload video to YouTube via the upload processor."""
         if not self.upload_processor or not self.config.youtube.enabled:
             logger.info("TTT_JOBS: YouTube uploads not enabled, skipping")

--- a/video_grouper/task_processors/upload_processor.py
+++ b/video_grouper/task_processors/upload_processor.py
@@ -1,10 +1,11 @@
 import logging
-from typing import Any, Optional
+from typing import Any
+
+from video_grouper.utils.config import Config
 
 from .base_queue_processor import QueueProcessor
-from .tasks.upload import BaseUploadTask
 from .queue_type import QueueType
-from video_grouper.utils.config import Config
+from .tasks.upload import BaseUploadTask
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ class UploadProcessor(QueueProcessor):
         self,
         storage_path: str,
         config: Config,
-        ntfy_service: Optional[Any] = None,
+        ntfy_service: Any | None = None,
     ):
         """Initialize the upload processor.
 
@@ -77,8 +78,8 @@ class UploadProcessor(QueueProcessor):
 
             # Validate YouTube token (non-interactive, no browser)
             from video_grouper.utils.youtube_upload import (
-                get_youtube_paths,
                 ensure_valid_token,
+                get_youtube_paths,
             )
 
             credentials_file, token_file = get_youtube_paths(self.storage_path)

--- a/video_grouper/task_processors/upload_recovery_processor.py
+++ b/video_grouper/task_processors/upload_recovery_processor.py
@@ -18,9 +18,10 @@ import logging
 import os
 from pathlib import Path
 
+from video_grouper.utils.config import Config
+
 from .base_polling_processor import PollingProcessor
 from .upload_processor import UploadProcessor
-from video_grouper.utils.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class UploadRecoveryProcessor(PollingProcessor):
             if not state_file.exists():
                 continue
             try:
-                with open(state_file, "r") as f:
+                with open(state_file) as f:
                     status = json.load(f).get("status")
             except (json.JSONDecodeError, OSError) as e:
                 logger.error(

--- a/video_grouper/task_processors/video_processor.py
+++ b/video_grouper/task_processors/video_processor.py
@@ -1,14 +1,15 @@
 import asyncio
 import logging
 import os
-from typing import Any, Optional
+from typing import Any
 
 from video_grouper.task_processors.upload_processor import UploadProcessor
 from video_grouper.utils.config import Config
 from video_grouper.utils.paths import get_combined_video_path, get_match_info_path
+
 from .base_queue_processor import QueueProcessor
-from .tasks.video import BaseFfmpegTask
 from .queue_type import QueueType
+from .tasks.video import BaseFfmpegTask
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +25,8 @@ class VideoProcessor(QueueProcessor):
         storage_path: str,
         config: Config,
         upload_processor: UploadProcessor,
-        match_info_service: Optional[Any] = None,
-        ntfy_processor: Optional[Any] = None,
+        match_info_service: Any | None = None,
+        ntfy_processor: Any | None = None,
     ):
         super().__init__(storage_path, config)
         self.upload_processor = upload_processor

--- a/video_grouper/tray/autocam_automation.py
+++ b/video_grouper/tray/autocam_automation.py
@@ -1,15 +1,15 @@
-import time
+import datetime
 import logging
 import os
 import subprocess
-import win32gui
-import psutil
-from pywinauto import Desktop
-import datetime
-from typing import Optional
+import time
 
-from video_grouper.utils.config import AutocamConfig
+import psutil
+import win32gui
+from pywinauto import Desktop
+
 from video_grouper.models.directory_state import DirectoryState
+from video_grouper.utils.config import AutocamConfig
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ _AUTOCAM_WINDOW_PREFIX = "Once Sport Autocam"
 _AUTOCAM_PROCESS_NAME = "GUI.exe"
 
 
-def _find_autocam_hwnd() -> Optional[int]:
+def _find_autocam_hwnd() -> int | None:
     """Return the hwnd of an Once Sport Autocam window, or None.
 
     Uses win32gui.EnumWindows (fast, non-blocking) instead of
@@ -40,7 +40,7 @@ def _find_autocam_hwnd() -> Optional[int]:
 
 
 def _find_autocam_gui_pids(
-    since_epoch: Optional[float] = None,
+    since_epoch: float | None = None,
 ) -> list[int]:
     """Return PIDs of running GUI.exe processes (case-insensitive).
 
@@ -290,9 +290,9 @@ def _set_file_via_browse_dialog(
 
 def _wait_for_completion_and_cleanup(
     main_window,
-    state: Optional[DirectoryState],
-    output_path: Optional[str] = None,
-    tracked_pids: Optional[list[int]] = None,
+    state: DirectoryState | None,
+    output_path: str | None = None,
+    tracked_pids: list[int] | None = None,
 ) -> bool:
     """Poll AutoCam's Notification text until processing finishes, then clean up.
 
@@ -425,7 +425,7 @@ def _execute_autocam_gui_automation(
     executable_path: str,
     input_path: str,
     output_path: str,
-    group_dir: Optional[str] = None,
+    group_dir: str | None = None,
 ) -> bool:
     """
     Execute the autocam GUI automation process for Once Sport Autocam 3.x.
@@ -773,7 +773,7 @@ def run_autocam_on_file(
     autocam_config: AutocamConfig,
     input_path: str,
     output_path: str,
-    group_dir: Optional[str] = None,
+    group_dir: str | None = None,
 ) -> bool:
     """
     Automates the Once Autocam GUI to process a video file.

--- a/video_grouper/tray/main.py
+++ b/video_grouper/tray/main.py
@@ -1,29 +1,9 @@
-import sys
-import os
-import time
-import atexit
 import asyncio
+import atexit
+import os
+import sys
 import threading
-from pathlib import Path
-from PyQt6.QtWidgets import QApplication, QSystemTrayIcon, QMenu
-from PyQt6.QtCore import (
-    QRunnable,
-    QThreadPool,
-    QObject,
-    pyqtSignal as Signal,
-    pyqtSlot as Slot,
-)
-from PyQt6.QtGui import QIcon, QAction
-import win32serviceutil
-
-from video_grouper.tray.autocam_automation import run_autocam_on_file
-from video_grouper.update.update_manager import check_and_update
-from video_grouper.version import get_version, get_full_version
-from video_grouper.utils.youtube_upload import authenticate_youtube
-from video_grouper.utils.paths import get_shared_data_path
-from video_grouper.utils.config import load_config, Config
-from video_grouper.task_processors import BallTrackingProcessor
-from video_grouper.task_processors.register_tasks import register_tray_tasks
+import time
 
 # NOTE: ``register_providers`` is imported lazily inside the autocam_gui
 # branch of __init__. Importing it eagerly here would pull in the
@@ -31,9 +11,32 @@ from video_grouper.task_processors.register_tasks import register_tray_tasks
 # never needs — it only runs autocam_gui ball-tracking. Doing it lazy
 # keeps the tray bootable on machines without GPU drivers.
 import webbrowser
-from typing import Optional
+from pathlib import Path
 
-from video_grouper.utils.logger import setup_logging, get_logger
+import win32serviceutil
+from PyQt6.QtCore import (
+    QObject,
+    QRunnable,
+    QThreadPool,
+)
+from PyQt6.QtCore import (
+    pyqtSignal as Signal,
+)
+from PyQt6.QtCore import (
+    pyqtSlot as Slot,
+)
+from PyQt6.QtGui import QAction, QIcon
+from PyQt6.QtWidgets import QApplication, QMenu, QSystemTrayIcon
+
+from video_grouper.task_processors import BallTrackingProcessor
+from video_grouper.task_processors.register_tasks import register_tray_tasks
+from video_grouper.tray.autocam_automation import run_autocam_on_file
+from video_grouper.update.update_manager import check_and_update
+from video_grouper.utils.config import Config, load_config
+from video_grouper.utils.logger import get_logger, setup_logging
+from video_grouper.utils.paths import get_shared_data_path
+from video_grouper.utils.youtube_upload import authenticate_youtube
+from video_grouper.version import get_full_version, get_version
 
 
 def _bootstrap_log_dir() -> Path:
@@ -242,7 +245,7 @@ class SystemTrayIcon(QSystemTrayIcon):
         else:
             self.config_path = get_shared_data_path() / "config.ini"
 
-        self.config: Optional[Config] = None
+        self.config: Config | None = None
         if self.config_path.exists():
             self.config = load_config(self.config_path)
             # Switch logging from the bootstrap LOCALAPPDATA path to
@@ -471,8 +474,9 @@ class SystemTrayIcon(QSystemTrayIcon):
     def toggle_recording(self):
         """Toggle camera recording on/off via the Reolink API."""
         import asyncio
-        from video_grouper.utils.config import load_config
+
         from video_grouper.cameras.reolink import ReolinkCamera
+        from video_grouper.utils.config import load_config
 
         try:
             config = load_config(self.config_path)

--- a/video_grouper/tray/tray_entry.py
+++ b/video_grouper/tray/tray_entry.py
@@ -1,6 +1,7 @@
 """Entry point for PyInstaller-built tray executable."""
 
 import asyncio
+
 from video_grouper.task_processors.register_tasks import register_tray_tasks
 from video_grouper.tray.main import main
 

--- a/video_grouper/update/update_manager.py
+++ b/video_grouper/update/update_manager.py
@@ -1,14 +1,14 @@
-import os
-import sys
-import subprocess
 import json
-import httpx
 import logging
-import tempfile
+import os
 import shutil
-from typing import Tuple, Optional, TypedDict
+import subprocess
+import sys
+import tempfile
+from typing import TypedDict
 
-from packaging.version import Version, InvalidVersion
+import httpx
+from packaging.version import InvalidVersion, Version
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class UpdateManager:
             300.0, connect=10.0
         )  # 300s read timeout, 10s connect
 
-    async def check_for_updates(self) -> Tuple[bool, Optional[VersionInfo]]:
+    async def check_for_updates(self) -> tuple[bool, VersionInfo | None]:
         """
         Check GitHub Releases for a newer version.
         Returns a tuple of (has_update, version_info).
@@ -95,7 +95,7 @@ class UpdateManager:
                     return False, None
                 except httpx.RequestError as e:
                     logger.error(f"Network error checking for updates: {e}")
-                    raise NetworkError(f"Failed to connect to GitHub API: {e}")
+                    raise NetworkError(f"Failed to connect to GitHub API: {e}") from e
                 except json.JSONDecodeError as e:
                     logger.error(f"Invalid JSON from GitHub API: {e}")
                     return False, None
@@ -103,7 +103,7 @@ class UpdateManager:
         except Exception as e:
             if not isinstance(e, UpdateError):
                 logger.error(f"Unexpected error checking for updates: {e}")
-                raise UpdateCheckError(f"Failed to check for updates: {e}")
+                raise UpdateCheckError(f"Failed to check for updates: {e}") from e
             raise
 
         # Parse version from tag
@@ -174,14 +174,14 @@ class UpdateManager:
                     return False
                 except httpx.RequestError as e:
                     logger.error(f"Network error downloading file: {e}")
-                    raise NetworkError(f"Failed to download file: {e}")
+                    raise NetworkError(f"Failed to download file: {e}") from e
 
             return True
 
         except Exception as e:
             if not isinstance(e, UpdateError):
                 logger.error(f"Unexpected error downloading file: {e}")
-                raise UpdateDownloadError(f"Failed to download file: {e}")
+                raise UpdateDownloadError(f"Failed to download file: {e}") from e
             raise
 
     async def download_update(self, version_info: VersionInfo) -> bool:
@@ -229,7 +229,7 @@ class UpdateManager:
                 win32serviceutil.StopService(self.service_name)
             except Exception as e:
                 logger.error(f"Error stopping service: {e}")
-                raise UpdateInstallError(f"Failed to stop service: {e}")
+                raise UpdateInstallError(f"Failed to stop service: {e}") from e
 
             # Kill the tray process so its exe can be overwritten
             try:
@@ -266,7 +266,7 @@ class UpdateManager:
             except Exception as e:
                 logger.error(f"Error starting service: {e}")
                 self._restore_backups(backup_files)
-                raise UpdateInstallError(f"Failed to start service: {e}")
+                raise UpdateInstallError(f"Failed to start service: {e}") from e
 
             # Clean up
             self._cleanup_backups(backup_files)

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import configparser
 from pathlib import Path
-from typing import Dict, Optional, List
 
 from pydantic import BaseModel, Field, RootModel, field_validator
 
 from video_grouper.ball_tracking.config import BallTrackingConfig
-
 
 # Monkey-patch ConfigParser to allow attribute-style access to sections used by tests
 if not hasattr(configparser.ConfigParser, "__getattr__"):
@@ -23,7 +21,7 @@ if not hasattr(configparser.ConfigParser, "__getattr__"):
     def _section_setattr(self, name, value):
         # Allow setting attributes on sections directly
         section = name.upper()
-        if not isinstance(value, (str, int, float, bool)):
+        if not isinstance(value, str | int | float | bool):
             # Fallback to normal behaviour for internal attributes
             return object.__setattr__(self, name, value)
         if not self.has_section(section) and section != "DEFAULT":
@@ -77,7 +75,7 @@ class ProcessingConfig(BaseModel):
     trim_end_enabled: bool = False
     ffmpeg_timeout_seconds: int = 1800
     seam_realign_enabled: bool = False
-    seam_realign_profile_path: Optional[str] = None
+    seam_realign_profile_path: str | None = None
 
 
 class LoggingConfig(BaseModel):
@@ -91,30 +89,30 @@ class AppConfig(BaseModel):
     check_interval_seconds: int = 60
     timezone: str = "America/New_York"
     github_repo: str = "mblakley/soccer-cam"
-    storage_path: Optional[str] = None
+    storage_path: str | None = None
     max_lookback_hours: int = 48
     max_files_per_poll: int = 50
-    recording_end_date: Optional[str] = None
+    recording_end_date: str | None = None
 
 
 class TeamSnapTeamConfig(BaseModel):
     enabled: bool = False
-    team_id: Optional[str] = None
+    team_id: str | None = None
     team_name: str
 
 
 class TeamSnapConfig(BaseModel):
     enabled: bool = False
-    client_id: Optional[str] = None
-    client_secret: Optional[str] = None
-    access_token: Optional[str] = None
-    refresh_token: Optional[str] = None
+    client_id: str | None = None
+    client_secret: str | None = None
+    access_token: str | None = None
+    refresh_token: str | None = None
     teams: list[TeamSnapTeamConfig] = Field(default_factory=list)
 
     # Legacy single-team fields (kept optional for backward compatibility)
-    team_id: Optional[str] = None
-    team_name: Optional[str] = None
-    my_team_name: Optional[str] = None
+    team_id: str | None = None
+    team_name: str | None = None
+    my_team_name: str | None = None
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -131,8 +129,8 @@ class TeamSnapConfig(BaseModel):
 
 
 class PlayMetricsTeamConfig(BaseModel):
-    team_id: Optional[str] = None
-    team_name: Optional[str] = None
+    team_id: str | None = None
+    team_name: str | None = None
     enabled: bool = True
 
 
@@ -148,14 +146,14 @@ class PlayMetricsConfig(BaseModel):
     """
 
     enabled: bool = False
-    username: Optional[str] = None
-    password: Optional[str] = None
+    username: str | None = None
+    password: str | None = None
 
     # Legacy single-team fields (kept optional for backward compatibility)
-    team_id: Optional[str] = None
-    team_name: Optional[str] = None
+    team_id: str | None = None
+    team_name: str | None = None
 
-    teams: List[PlayMetricsTeamConfig] = Field(default_factory=list)
+    teams: list[PlayMetricsTeamConfig] = Field(default_factory=list)
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -173,7 +171,7 @@ class PlayMetricsConfig(BaseModel):
 class NtfyConfig(BaseModel):
     enabled: bool = False
     server_url: str = "https://ntfy.sh"
-    topic: Optional[str] = None
+    topic: str | None = None
     response_service: bool = False
     auto_respond: bool = False
     unplug_notification: bool = True
@@ -181,12 +179,12 @@ class NtfyConfig(BaseModel):
 
 class AutocamConfig(BaseModel):
     enabled: bool = True
-    executable: Optional[str] = None
+    executable: str | None = None
 
 
 class CloudSyncConfig(BaseModel):
     enabled: bool = False
-    provider: Optional[str] = None
+    provider: str | None = None
 
 
 class NodeConfig(BaseModel):
@@ -305,8 +303,8 @@ class YouTubePlaylistConfig(BaseModel):
     privacy_status: str
 
 
-class YouTubePlaylistMapConfig(RootModel[Dict[str, str]]):
-    def get(self, team_name: str) -> Optional[str]:
+class YouTubePlaylistMapConfig(RootModel[dict[str, str]]):
+    def get(self, team_name: str) -> str | None:
         # First try exact match
         if team_name in self.root:
             return self.root[team_name]
@@ -328,14 +326,14 @@ class YouTubeConfig(BaseModel):
     # video id without calling the Google API. Must NOT be enabled in
     # production — reels will reference non-existent YouTube videos.
     skip_upload: bool = False
-    processed_playlist: Optional[YouTubePlaylistConfig] = None
-    raw_playlist: Optional[YouTubePlaylistConfig] = None
-    playlist_map: Optional[YouTubePlaylistMapConfig] = None
+    processed_playlist: YouTubePlaylistConfig | None = None
+    raw_playlist: YouTubePlaylistConfig | None = None
+    playlist_map: YouTubePlaylistMapConfig | None = None
 
     model_config = {"validate_by_name": True}
 
     @property
-    def playlist_map_dict(self) -> Dict[str, str]:
+    def playlist_map_dict(self) -> dict[str, str]:
         return self.playlist_map.root if self.playlist_map else {}
 
 

--- a/video_grouper/utils/ffmpeg_utils.py
+++ b/video_grouper/utils/ffmpeg_utils.py
@@ -1,8 +1,7 @@
-import os
 import asyncio
 import logging
+import os
 import shutil
-from typing import Optional
 
 
 # ``av`` is loaded lazily via the proxy below. The tray PyInstaller
@@ -45,14 +44,14 @@ _EXT_TO_AV_FORMAT = {
 }
 
 
-def _av_format_for(path: str) -> Optional[str]:
+def _av_format_for(path: str) -> str | None:
     return _EXT_TO_AV_FORMAT.get(os.path.splitext(path)[1].lower())
 
 
 def av_open_read(
     path: str,
     *,
-    format: Optional[str] = None,
+    format: str | None = None,
     timeout: float = AV_IO_TIMEOUT,
     **kwargs,
 ):
@@ -131,7 +130,7 @@ async def verify_ffmpeg_install() -> bool:
         return False
 
 
-def _get_video_duration_sync(file_path: str) -> Optional[float]:
+def _get_video_duration_sync(file_path: str) -> float | None:
     """Synchronous implementation: get video duration via av.open metadata."""
     with av_open_read(file_path) as container:
         if container.duration is not None:
@@ -143,7 +142,7 @@ def _get_video_duration_sync(file_path: str) -> Optional[float]:
     return None
 
 
-async def get_video_duration(file_path: str) -> Optional[float]:
+async def get_video_duration(file_path: str) -> float | None:
     """Get the duration of a video file using PyAV."""
     try:
         return await asyncio.to_thread(_get_video_duration_sync, file_path)
@@ -245,7 +244,7 @@ def _remux_dav_to_mp4_sync(file_path: str, output_path: str) -> str:
     return output_path
 
 
-async def async_convert_file(file_path: str) -> Optional[str]:
+async def async_convert_file(file_path: str) -> str | None:
     """Converts a video file to MP4 format using PyAV.
 
     Video stream is copied (no re-encoding), audio is re-encoded to AAC 192k.
@@ -269,7 +268,7 @@ async def async_convert_file(file_path: str) -> Optional[str]:
             f"Successfully converted {os.path.basename(file_path)} to {os.path.basename(output_path)}"
         )
         return output_path
-    except asyncio.TimeoutError:
+    except TimeoutError:
         logger.error(
             f"Conversion timed out for {os.path.basename(file_path)} after {FFMPEG_TIMEOUT}s"
         )
@@ -303,7 +302,7 @@ def _create_screenshot_sync(
     video_path: str,
     output_path: str,
     time_offset: str,
-    max_dim: Optional[int] = None,
+    max_dim: int | None = None,
     quality: int = 95,
 ) -> bool:
     """Synchronous implementation: extract a single frame as JPEG.
@@ -378,7 +377,7 @@ async def create_screenshot(
     video_path: str,
     output_path: str,
     time_offset: str = "00:00:01",
-    max_dim: Optional[int] = None,
+    max_dim: int | None = None,
     quality: int = 95,
 ) -> bool:
     """Creates a screenshot from a video file.
@@ -411,7 +410,7 @@ async def create_screenshot(
 
 
 def _trim_video_sync(
-    input_path: str, output_path: str, start_offset: str, duration: Optional[str]
+    input_path: str, output_path: str, start_offset: str, duration: str | None
 ) -> bool:
     """Synchronous implementation: trim video with stream copy."""
     # Parse start offset
@@ -503,7 +502,7 @@ def _trim_video_sync(
 
 
 async def trim_video(
-    input_path: str, output_path: str, start_offset: str, duration: Optional[str] = None
+    input_path: str, output_path: str, start_offset: str, duration: str | None = None
 ) -> bool:
     """Trims a video file using stream copy via PyAV.
 
@@ -526,7 +525,7 @@ async def trim_video(
         else:
             _cleanup_temp(temp_output)
         return result
-    except asyncio.TimeoutError:
+    except TimeoutError:
         logger.error(f"Trim timed out after {FFMPEG_TIMEOUT}s")
         _cleanup_temp(temp_output)
         return False
@@ -693,7 +692,7 @@ async def combine_videos(
         else:
             _cleanup_temp(temp_output)
         return result
-    except asyncio.TimeoutError:
+    except TimeoutError:
         logger.error(f"Combine timed out after {timeout}s")
         _cleanup_temp(temp_output)
         return False

--- a/video_grouper/utils/game_selection.py
+++ b/video_grouper/utils/game_selection.py
@@ -16,22 +16,22 @@ game for a given recording timespan. The algorithm:
 
 import logging
 from datetime import datetime, timedelta
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 # Type alias: each candidate is (game_object, game_start_utc, game_end_utc)
-GameCandidate = Tuple[Any, datetime, datetime]
+GameCandidate = tuple[Any, datetime, datetime]
 
 MAX_PROXIMITY = timedelta(hours=2)
 
 
 def select_best_game(
-    candidates: List[GameCandidate],
+    candidates: list[GameCandidate],
     recording_start: datetime,
     recording_end: datetime,
     game_label_fn=None,
-) -> Optional[Any]:
+) -> Any | None:
     """
     Select the best game for a recording from a list of candidates.
 
@@ -113,7 +113,7 @@ def select_best_game(
     best_distance = float("inf")
 
     # First pass: games whose midpoint is within the recording window
-    for game, g_start, g_end, g_mid in nearby:
+    for game, _g_start, _g_end, g_mid in nearby:
         if recording_start <= g_mid <= recording_end:
             dist = abs((g_mid - recording_mid).total_seconds())
             if dist < best_distance:
@@ -122,7 +122,7 @@ def select_best_game(
 
     # Fallback: closest midpoint overall
     if best_game is None:
-        for game, g_start, g_end, g_mid in nearby:
+        for game, _g_start, _g_end, g_mid in nearby:
             dist = abs((g_mid - recording_mid).total_seconds())
             if dist < best_distance:
                 best_distance = dist

--- a/video_grouper/utils/locking.py
+++ b/video_grouper/utils/locking.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import time
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class FileLock:
                     logger.error(f"Timeout acquiring lock on {self.lock_file_path}")
                     raise TimeoutError(
                         f"Could not acquire lock on {self.lock_file_path}"
-                    )
+                    ) from None
                 time.sleep(self.delay)
             except Exception as e:
                 logger.error(

--- a/video_grouper/utils/logger.py
+++ b/video_grouper/utils/logger.py
@@ -1,15 +1,16 @@
 import logging
 import logging.handlers
 from pathlib import Path
-from typing import Optional
-from .paths import get_shared_data_path
+
 from video_grouper.utils.paths import resolve_path
+
+from .paths import get_shared_data_path
 
 
 def setup_logging(
     level: str = "INFO",
-    log_dir: Optional[Path] = None,
-    log_file: Optional[Path] = None,
+    log_dir: Path | None = None,
+    log_file: Path | None = None,
     app_name: str = "video_grouper",
     backup_count: int = 30,
 ) -> None:

--- a/video_grouper/utils/paths.py
+++ b/video_grouper/utils/paths.py
@@ -1,7 +1,7 @@
-from pathlib import Path
 import os
 import sys
 from datetime import datetime
+from pathlib import Path
 
 
 def _is_pyinstaller() -> bool:

--- a/video_grouper/utils/resumable_upload.py
+++ b/video_grouper/utils/resumable_upload.py
@@ -11,7 +11,6 @@ transient 5xx.
 import asyncio
 import logging
 import os
-from typing import Optional
 
 import httpx
 
@@ -32,7 +31,7 @@ async def upload_to_resumable_url(
     mime_type: str,
     *,
     chunk_size: int = CHUNK_SIZE,
-) -> Optional[str]:
+) -> str | None:
     """Upload a file to an existing resumable session URL.
 
     Returns the final destination URL (Drive webViewLink / YouTube URL) from

--- a/video_grouper/utils/stitch_remap.py
+++ b/video_grouper/utils/stitch_remap.py
@@ -20,7 +20,6 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 
@@ -42,7 +41,7 @@ class StitchProfile:
     dx_anchors: list[tuple[int, int]]
 
     @classmethod
-    def from_dict(cls, d: dict) -> "StitchProfile":
+    def from_dict(cls, d: dict) -> StitchProfile:
         anchors = [(int(a[0]), int(a[1])) for a in d["dx_anchors"]]
         return cls(
             source_width=int(d["source_width"]),
@@ -60,7 +59,7 @@ class StitchProfile:
         }
 
 
-def load_profile(path: str | Path) -> Optional[StitchProfile]:
+def load_profile(path: str | Path) -> StitchProfile | None:
     """Return the parsed profile, or None if the file doesn't exist or is invalid."""
     p = Path(path)
     if not p.exists():

--- a/video_grouper/utils/time_utils.py
+++ b/video_grouper/utils/time_utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 import pytz
 
 

--- a/video_grouper/utils/youtube_upload.py
+++ b/video_grouper/utils/youtube_upload.py
@@ -1,18 +1,20 @@
-import os
-import logging
+import configparser
 import json
+import logging
+import os
 import time
 import uuid
+from collections.abc import Callable
 from datetime import datetime
-from typing import Optional, List, Tuple
+
 import google.oauth2.credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
+from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
-from googleapiclient.http import MediaFileUpload
 from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaFileUpload
+
 from video_grouper.models import MatchInfo
-import configparser
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +92,7 @@ def make_youtube_flow(credentials_file: str, redirect_uri: str) -> InstalledAppF
     return flow
 
 
-def get_youtube_paths(storage_path: str) -> Tuple[str, str]:
+def get_youtube_paths(storage_path: str) -> tuple[str, str]:
     """Get the paths for YouTube credentials and token files.
 
     Args:
@@ -108,7 +110,7 @@ def get_youtube_paths(storage_path: str) -> Tuple[str, str]:
     return credentials_file, token_file
 
 
-def ensure_valid_token(credentials_file: str, token_file: str) -> Tuple[bool, str]:
+def ensure_valid_token(credentials_file: str, token_file: str) -> tuple[bool, str]:
     """Check if YouTube token is valid, refreshing if needed. No interactive auth.
 
     This is used by the main pipeline (service) which runs headless.
@@ -132,7 +134,7 @@ def ensure_valid_token(credentials_file: str, token_file: str) -> Tuple[bool, st
         )
 
     try:
-        with open(token_file, "r") as f:
+        with open(token_file) as f:
             creds_data = json.load(f)
             creds = google.oauth2.credentials.Credentials.from_authorized_user_info(
                 creds_data, SCOPES
@@ -163,7 +165,7 @@ def ensure_valid_token(credentials_file: str, token_file: str) -> Tuple[bool, st
     )
 
 
-def authenticate_youtube(credentials_file: str, token_file: str) -> Tuple[bool, str]:
+def authenticate_youtube(credentials_file: str, token_file: str) -> tuple[bool, str]:
     """Authenticate with YouTube API.
 
     Args:
@@ -183,7 +185,7 @@ def authenticate_youtube(credentials_file: str, token_file: str) -> Tuple[bool, 
         # Check if token file exists
         if os.path.exists(token_file):
             try:
-                with open(token_file, "r") as token:
+                with open(token_file) as token:
                     creds_data = json.load(token)
                     creds = (
                         google.oauth2.credentials.Credentials.from_authorized_user_info(
@@ -295,7 +297,7 @@ def authenticate_youtube(credentials_file: str, token_file: str) -> Tuple[bool, 
         return False, f"Authentication error: {str(e)}"
 
 
-def authenticate_youtube_embedded(token_file: str) -> Tuple[bool, str]:
+def authenticate_youtube_embedded(token_file: str) -> tuple[bool, str]:
     """Authenticate with YouTube using the embedded OAuth client.
 
     No client_secret.json file is needed -- the OAuth client config is
@@ -313,7 +315,7 @@ def authenticate_youtube_embedded(token_file: str) -> Tuple[bool, str]:
         # Check if token file exists and is valid
         if os.path.exists(token_file):
             try:
-                with open(token_file, "r") as f:
+                with open(token_file) as f:
                     creds_data = json.load(f)
                     creds = (
                         google.oauth2.credentials.Credentials.from_authorized_user_info(
@@ -396,7 +398,7 @@ class YouTubeUploader:
         success, _ = authenticate_youtube(self.credentials_file, self.token_file)
         if success:
             creds = None
-            with open(self.token_file, "r") as token:
+            with open(self.token_file) as token:
                 creds_data = json.load(token)
                 creds = google.oauth2.credentials.Credentials.from_authorized_user_info(
                     creds_data, SCOPES
@@ -410,11 +412,11 @@ class YouTubeUploader:
         video_path: str,
         title: str,
         description: str,
-        tags: Optional[List[str]] = None,
+        tags: list[str] | None = None,
         privacy_status: str = "unlisted",
-        playlist_id: Optional[str] = None,
-        on_progress: Optional[callable] = None,
-    ) -> Optional[str]:
+        playlist_id: str | None = None,
+        on_progress: Callable[[int], None] | None = None,
+    ) -> str | None:
         """Upload a video to YouTube.
 
         Args:
@@ -570,7 +572,7 @@ class YouTubeUploader:
             logger.error(f"Error uploading video {video_path}: {e}")
             return None
 
-    def find_playlist_by_name(self, name: str) -> Optional[str]:
+    def find_playlist_by_name(self, name: str) -> str | None:
         """Find a playlist by name.
 
         Args:
@@ -611,7 +613,7 @@ class YouTubeUploader:
 
     def create_playlist(
         self, name: str, description: str = "", privacy_status: str = "unlisted"
-    ) -> Optional[str]:
+    ) -> str | None:
         """Create a new playlist.
 
         Args:
@@ -647,7 +649,7 @@ class YouTubeUploader:
 
     def get_or_create_playlist(
         self, name: str, description: str = "", privacy_status: str = "unlisted"
-    ) -> Optional[str]:
+    ) -> str | None:
         """Get an existing playlist by name or create a new one.
 
         Args:
@@ -735,7 +737,7 @@ def format_video_title(match_info, file_path: str, group_dir: str) -> str:
 
 def get_playlist_name_from_mapping(
     team_name: str, config: configparser.ConfigParser
-) -> Optional[str]:
+) -> str | None:
     """
     Get the base playlist name for a team from the config mapping.
 
@@ -757,8 +759,8 @@ def upload_group_videos(
     group_dir: str,
     credentials_file: str,
     token_file: str,
-    processed_playlist_name: Optional[str] = None,
-    raw_playlist_name: Optional[str] = None,
+    processed_playlist_name: str | None = None,
+    raw_playlist_name: str | None = None,
     privacy_status: str = "private",
 ) -> bool:
     """

--- a/video_grouper/video_grouper_app.py
+++ b/video_grouper/video_grouper_app.py
@@ -1,26 +1,25 @@
-import os
 import asyncio
+import os
 import platform
 from pathlib import Path
-from typing import Optional
 
+from video_grouper.api_integrations.command_executor import CommandExecutor
 from video_grouper.api_integrations.ntfy_response import create_ntfy_response_service
 from video_grouper.api_integrations.ttt_reporter import TTTReporter
-from video_grouper.api_integrations.command_executor import CommandExecutor
-from video_grouper.utils.config import Config
-from video_grouper.utils.error_tracker import ErrorTracker
-from video_grouper.utils.logger import setup_logging_from_config, get_logger
 from video_grouper.task_processors import (
-    StateAuditor,
     CameraPoller,
-    DownloadProcessor,
-    VideoProcessor,
-    UploadProcessor,
-    NtfyProcessor,
-    ClipProcessor,
     ClipDiscoveryProcessor,
+    ClipProcessor,
+    DownloadProcessor,
+    NtfyProcessor,
+    StateAuditor,
+    UploadProcessor,
+    VideoProcessor,
 )
 from video_grouper.task_processors.register_tasks import register_service_tasks
+from video_grouper.utils.config import Config
+from video_grouper.utils.error_tracker import ErrorTracker
+from video_grouper.utils.logger import get_logger, setup_logging_from_config
 
 # Configure logging will be done after config is loaded
 logger = get_logger(__name__)
@@ -32,7 +31,7 @@ class VideoGrouperApp:
     Each task processor is self-contained and manages its own queue and state.
     """
 
-    def __init__(self, config: Config, camera=None, config_path: Optional[Path] = None):
+    def __init__(self, config: Config, camera=None, config_path: Path | None = None):
         """
         Initialize the VideoGrouperApp with task processors.
 
@@ -69,7 +68,7 @@ class VideoGrouperApp:
         setup_logging_from_config(config)
 
         # Stash for the auth server's config editor (Phase 1).
-        self.config_path: Optional[Path] = config_path
+        self.config_path: Path | None = config_path
 
         # Initialize mock services if environment variables are set
         try:
@@ -115,11 +114,11 @@ class VideoGrouperApp:
         if bt.enabled and bt.provider == "homegrown":
             # Side-effect import: registers the BallTrackingProvider implementations.
             import video_grouper.ball_tracking.register_providers  # noqa: F401
-            from video_grouper.task_processors.ball_tracking_processor import (
-                BallTrackingProcessor,
-            )
             from video_grouper.task_processors.ball_tracking_discovery_processor import (
                 BallTrackingDiscoveryProcessor,
+            )
+            from video_grouper.task_processors.ball_tracking_processor import (
+                BallTrackingProcessor,
             )
 
             self.ball_tracking_processor = BallTrackingProcessor(
@@ -217,14 +216,14 @@ class VideoGrouperApp:
 
         self.ntfy_processor = None
         if self.config.ntfy.enabled:
-            from video_grouper.task_processors.services.ntfy_service import NtfyService
             from video_grouper.task_processors.services.match_info_service import (
                 MatchInfoService,
             )
             from video_grouper.task_processors.services.mock_services import (
-                create_teamsnap_service,
                 create_playmetrics_service,
+                create_teamsnap_service,
             )
+            from video_grouper.task_processors.services.ntfy_service import NtfyService
 
             # Create services first
             teamsnap_service = create_teamsnap_service(self.config.teamsnap)
@@ -284,10 +283,10 @@ class VideoGrouperApp:
         self.highlight_reel_processor = None
         if self.config.ttt.enabled:
             try:
+                from video_grouper.api_integrations.ttt_api import TTTApiClient
                 from video_grouper.task_processors.clip_request_processor import (
                     ClipRequestProcessor,
                 )
-                from video_grouper.api_integrations.ttt_api import TTTApiClient
                 from video_grouper.utils.google_drive_upload import GoogleDriveUploader
 
                 ttt_client = TTTApiClient(
@@ -637,7 +636,6 @@ class VideoGrouperApp:
         # Ensure built-in camera modules are imported (triggers registration)
         import video_grouper.cameras.dahua  # noqa: F401
         import video_grouper.cameras.reolink  # noqa: F401
-
         from video_grouper.cameras import create_camera
 
         logger.info(
@@ -706,8 +704,9 @@ class VideoGrouperApp:
         auth_task = None
         if self.config.ttt.auth_server_enabled:
             try:
-                from video_grouper.web.auth_server import create_app
                 import uvicorn
+
+                from video_grouper.web.auth_server import create_app
 
                 def _auth_status_provider() -> dict:
                     # get_queue_sizes() reports -1 for processors that aren't
@@ -883,7 +882,7 @@ class VideoGrouperApp:
             self._shutdown_event.set()
             return
 
-    async def _wait_for_config_stable(self, last_mtime: float) -> Optional[float]:
+    async def _wait_for_config_stable(self, last_mtime: float) -> float | None:
         """Sleep until the config has been stable for the coalesce window.
 
         Returns the new last_mtime, or None if cancelled. If more
@@ -908,7 +907,7 @@ class VideoGrouperApp:
                 continue
             return last_mtime
 
-    async def _wait_for_download_idle(self, last_mtime: float) -> Optional[float]:
+    async def _wait_for_download_idle(self, last_mtime: float) -> float | None:
         """Defer restart while any download is in-flight.
 
         Returns the (possibly updated) last_mtime, or None if

--- a/video_grouper/web/auth_server.py
+++ b/video_grouper/web/auth_server.py
@@ -30,9 +30,10 @@ import json
 import logging
 import re
 import time
-from datetime import datetime, timezone
+from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any
 from urllib.parse import urlencode
 
 from fastapi import Body, FastAPI, Form, HTTPException, Request, Response, UploadFile
@@ -64,9 +65,9 @@ _TTT_DEFAULT_API_BASE_URL = "https://team-tech-tools.vercel.app"
 
 try:
     from video_grouper.utils._ttt_config import (
-        TTT_SUPABASE_URL,
         TTT_ANON_KEY,
         TTT_API_BASE_URL,
+        TTT_SUPABASE_URL,
     )
 except ImportError:
     TTT_SUPABASE_URL = _TTT_DEFAULT_SUPABASE_URL
@@ -378,13 +379,13 @@ def _read_youtube_status(token_file: Path) -> dict:
     if not data.get("refresh_token"):
         return empty
     expiry_iso = data.get("expiry")
-    expires_at: Optional[int] = None
+    expires_at: int | None = None
     if expiry_iso:
         try:
             # google-auth writes naive ISO timestamps in UTC.
             expires_at = int(
                 datetime.fromisoformat(expiry_iso.replace("Z", "+00:00"))
-                .replace(tzinfo=timezone.utc if expiry_iso.endswith("Z") else None)
+                .replace(tzinfo=UTC if expiry_iso.endswith("Z") else None)
                 .timestamp()
             )
         except (ValueError, TypeError):
@@ -426,8 +427,8 @@ def _read_status(token_file: Path) -> dict:
     if not access_token or not expires_at:
         return empty
 
-    user_id: Optional[str] = None
-    email: Optional[str] = None
+    user_id: str | None = None
+    email: str | None = None
     try:
         payload = _decode_jwt_payload(access_token)
         user_id = payload.get("sub")
@@ -472,12 +473,10 @@ def _scan_games(storage_path: Path) -> list[dict]:
     return games
 
 
-def _fmt_ts(ts: Optional[int]) -> str:
+def _fmt_ts(ts: int | None) -> str:
     if not ts:
         return "—"
-    return datetime.fromtimestamp(int(ts), tz=timezone.utc).strftime(
-        "%Y-%m-%d %H:%M:%S UTC"
-    )
+    return datetime.fromtimestamp(int(ts), tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
 def _render_auth_flags_banner(storage: Path) -> str:
@@ -583,8 +582,8 @@ def _render_tray_section(storage: Path) -> str:
             '<p class="warn"><span class="status-dot bad"></span>Could not '
             f"read tray log: {html.escape(str(exc))}</p>"
         )
-    mtime = datetime.fromtimestamp(log_path.stat().st_mtime, tz=timezone.utc)
-    age_seconds = (datetime.now(tz=timezone.utc) - mtime).total_seconds()
+    mtime = datetime.fromtimestamp(log_path.stat().st_mtime, tz=UTC)
+    age_seconds = (datetime.now(tz=UTC) - mtime).total_seconds()
     if age_seconds < 120:
         dot = "on"
         age_label = f"active &mdash; last entry {int(age_seconds)}s ago"
@@ -703,7 +702,7 @@ def _render_auth_section(token_file: Path, providers: tuple[str, ...]) -> str:
     return prefix + oauth_block + password_form + magic_form
 
 
-def _render_queues_section(status: Optional[dict]) -> str:
+def _render_queues_section(status: dict | None) -> str:
     queue_sizes = (status or {}).get("queue_sizes")
     if not queue_sizes:
         return '<p class="muted">No live pipeline status available.</p>'
@@ -714,7 +713,7 @@ def _render_queues_section(status: Optional[dict]) -> str:
     return "<table><tr><th>Processor</th><th>Queue size</th></tr>" + rows + "</table>"
 
 
-def _render_cameras_section(status: Optional[dict]) -> str:
+def _render_cameras_section(status: dict | None) -> str:
     cameras = (status or {}).get("cameras") or []
     if not cameras:
         return '<p class="muted">No cameras configured.</p>'
@@ -767,9 +766,9 @@ def _render_games_section(games: list[dict]) -> str:
 def create_app(
     ttt_config: TTTConfig,
     storage_path: str,
-    status_provider: Optional[Callable[[], dict[str, Any]]] = None,
+    status_provider: Callable[[], dict[str, Any]] | None = None,
     providers: tuple[str, ...] = _DEFAULT_PROVIDERS,
-    config_path: Optional[Path] = None,
+    config_path: Path | None = None,
     node_role: str = "standalone",
 ) -> FastAPI:
     """Build the FastAPI app for the headless auth server.
@@ -1108,9 +1107,9 @@ def create_app(
 
     @app.get("/auth/youtube/callback", response_class=HTMLResponse)
     def youtube_callback(
-        code: Optional[str] = None,
-        state: Optional[str] = None,
-        error: Optional[str] = None,
+        code: str | None = None,
+        state: str | None = None,
+        error: str | None = None,
     ) -> Response:
         """Receive Google's OAuth redirect, persist the user's token."""
         if error:
@@ -1176,7 +1175,9 @@ def create_app(
                 token_file.unlink()
             except OSError as exc:
                 logger.warning("Failed to delete tokens.json: %s", exc)
-                raise HTTPException(status_code=500, detail="Could not delete tokens")
+                raise HTTPException(
+                    status_code=500, detail="Could not delete tokens"
+                ) from exc
         client._access_token = None
         client._refresh_token_value = None
         client._expires_at = None

--- a/video_grouper/web/auth_status.py
+++ b/video_grouper/web/auth_status.py
@@ -21,9 +21,8 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ def write_auth_needed(storage_path: str | Path, provider: str, last_error: str) 
     """Mark that ``provider`` needs interactive re-auth."""
     payload = {
         "provider": provider,
-        "since": datetime.now(timezone.utc).isoformat(),
+        "since": datetime.now(UTC).isoformat(),
         "last_error": last_error,
     }
     path = _flag_path(storage_path, provider)
@@ -48,7 +47,7 @@ def write_auth_needed(storage_path: str | Path, provider: str, last_error: str) 
         logger.warning("AUTH_STATUS: failed to write %s auth flag: %s", provider, exc)
 
 
-def read_auth_needed(storage_path: str | Path, provider: str) -> Optional[dict]:
+def read_auth_needed(storage_path: str | Path, provider: str) -> dict | None:
     """Return the flag payload if present, else None."""
     path = _flag_path(storage_path, provider)
     if not path.exists():

--- a/video_grouper/web/setup/router.py
+++ b/video_grouper/web/setup/router.py
@@ -8,7 +8,6 @@ import logging
 import os
 import string
 from pathlib import Path
-from typing import Optional
 
 from fastapi import APIRouter, Form, HTTPException, Query, Request, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -523,7 +522,7 @@ def build_router(config_path: Path) -> APIRouter:
         return resp
 
     @router.get("/storage/browse", response_class=HTMLResponse)
-    def storage_browse(at: Optional[str] = Query(None)) -> HTMLResponse:
+    def storage_browse(at: str | None = Query(None)) -> HTMLResponse:
         """Render a directory listing fragment for the in-page browse modal.
 
         ``at`` is the directory to list. Empty/missing → top level
@@ -837,7 +836,7 @@ def build_router(config_path: Path) -> APIRouter:
             raise HTTPException(
                 status_code=400,
                 detail=f"Uploaded file is not valid JSON: {exc}",
-            )
+            ) from exc
         # Google's Desktop OAuth client_secret.json wraps everything
         # under a top-level "installed" key with client_id/client_secret.
         installed = data.get("installed") or data.get("web") or {}
@@ -915,7 +914,7 @@ def build_router(config_path: Path) -> APIRouter:
             raise HTTPException(
                 status_code=500,
                 detail=f"Could not write {config_path}: {exc}",
-            )
+            ) from exc
 
         discard(token)
         # Land on /config so the user can immediately tweak integrations.
@@ -966,5 +965,5 @@ def _build_config(state) -> Config:
 # Optional helper used by the dashboard to detect "no config yet" and
 # redirect to the wizard. Kept here so the auth_server doesn't grow a
 # new responsibility.
-def needs_setup(config_path: Optional[Path]) -> bool:
+def needs_setup(config_path: Path | None) -> bool:
     return config_path is None or not config_path.exists()

--- a/video_grouper/web/setup/state.py
+++ b/video_grouper/web/setup/state.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import logging
 import secrets
 from dataclasses import dataclass
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +34,7 @@ class WizardState:
 _states: dict[str, WizardState] = {}
 
 
-def get_or_create(token: Optional[str]) -> tuple[str, WizardState]:
+def get_or_create(token: str | None) -> tuple[str, WizardState]:
     """Return ``(token, state)``. Mints a new token when none is supplied."""
     if token and token in _states:
         return token, _states[token]
@@ -44,13 +43,13 @@ def get_or_create(token: Optional[str]) -> tuple[str, WizardState]:
     return new_token, _states[new_token]
 
 
-def get(token: Optional[str]) -> Optional[WizardState]:
+def get(token: str | None) -> WizardState | None:
     if not token:
         return None
     return _states.get(token)
 
 
-def discard(token: Optional[str]) -> None:
+def discard(token: str | None) -> None:
     if token and token in _states:
         del _states[token]
 

--- a/video_grouper/web/worker_api.py
+++ b/video_grouper/web/worker_api.py
@@ -17,9 +17,8 @@ import json
 import logging
 import secrets
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -36,7 +35,7 @@ logger = logging.getLogger(__name__)
 class RegisterRequest(BaseModel):
     node_id: str  # client-chosen stable id (e.g. hostname)
     capabilities: list[str] = []
-    version: Optional[str] = None
+    version: str | None = None
 
 
 class RegisterResponse(BaseModel):
@@ -129,7 +128,7 @@ def build_router(storage_path: str | Path) -> APIRouter:
             "token": token,
             "capabilities": req.capabilities,
             "version": req.version,
-            "registered_at": datetime.now(timezone.utc).isoformat(),
+            "registered_at": datetime.now(UTC).isoformat(),
             "last_heartbeat": time.time(),
         }
         _save_registry(storage_path, registry)

--- a/video_grouper/worker/__main__.py
+++ b/video_grouper/worker/__main__.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import httpx
 
 from video_grouper.utils.config import load_config
-from video_grouper.utils.logger import setup_logging_from_config, get_logger
+from video_grouper.utils.logger import get_logger, setup_logging_from_config
 from video_grouper.utils.paths import get_shared_data_path
 
 logger = get_logger(__name__)
@@ -101,7 +101,7 @@ async def _heartbeat_loop(
         try:
             await asyncio.wait_for(stop.wait(), timeout=interval)
             return  # stop_event was set
-        except asyncio.TimeoutError:
+        except TimeoutError:
             try:
                 await client.post(f"{master_url}/api/work/{task_id}/heartbeat")
             except httpx.HTTPError as exc:


### PR DESCRIPTION
## Summary

- **Widen ruff** with bugbear (B), isort (I), comprehensions (C4), and pyupgrade (UP). Fixed ~1045 auto-rewrites plus a handful of real bugs surfaced by the new rules (`Optional[callable]` evaluating eagerly in PEP604, `lstrip("D:/")` stripping a character set instead of a prefix, missing `from exc` in re-raises that were dropping exception chains).
- **Install mypy** with a curated `[tool.mypy]` config. Third-party ML/CV/Windows/PyQt6/google libs get precise named `[[overrides]]` (no blanket top-level `ignore_missing_imports`). 52 currently-noisy `video_grouper.*` modules are listed by name with `ignore_errors = true` and a header comment flagging them as follow-up — so new code in already-clean modules is gated now while the existing 283-error backlog is reclaimed incrementally.
- **Add lint CI** (`.github/workflows/lint.yml`) running ruff check + ruff format + mypy on every PR to `main`, using `uv sync --frozen` to mirror local. Extended `.pre-commit-config.yaml` with the matching mypy hook.

## Real bugs fixed (not workarounds)

- `video_grouper/utils/youtube_upload.py`: `on_progress: Optional[callable]` (the builtin, not a type) → after UP007 became `callable | None` which crashed at import. Fixed to `Callable[[int], None] | None`.
- `video_grouper/update/update_manager.py`, `utils/locking.py`, `web/auth_server.py`, `web/setup/router.py`, `training/data_prep/manifest_dataset.py`: missing `from exc` on re-raises — original tracebacks were being lost.
- `training/pipeline/machine_manager.py`: `remote_path.lstrip("D:/").lstrip("D:\\\\")` was stripping a character SET, not a prefix; any path starting with D/:/\/forward-slash got mangled. Switched to `removeprefix`.
- `video_grouper/__main__.py`: untyped `tasks = []` global → `list[asyncio.Task[None]]`.

## Deferred (intentionally out of scope)

- The 175 bare `dict` usages in `api_integrations/` flagged in the audit. Separate cleanup PR.
- 283 pre-existing type errors across 52 modules (mostly Optional/None threaded through constructor sentinels, missing collection init annotations, TypedDict drift). Listed by name in `pyproject.toml` so each one is a clearly-scoped follow-up.
- `tools/apply_correction.py` and `tools/seam_sweep.py` audit findings — those files are untracked one-offs not in the repo tree, so ruff never saw them. `tools/` is excluded from mypy and not lint-gated either.

## Test plan

- [x] `uv run --with ruff ruff check .` → clean
- [x] `uv run --with ruff ruff format --check .` → clean
- [x] `uv run mypy video_grouper/` → 0 errors across 151 source files
- [x] `uv run pytest tests/ -m "not integration and not e2e and not gui" --ignore=tests/test_tray.py --ignore=tests/test_autocam_automation.py --ignore=tests/test_autocam_resume.py` → 1018 passed, 1 skipped
- [x] `pre-commit run --all-files` → all hooks pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)