### PR TITLE
fix(tray): replace psutil with tasklist/wmic in autocam_automation

### DIFF
--- a/tests/test_autocam_resume.py
+++ b/tests/test_autocam_resume.py
@@ -1,10 +1,11 @@
 """Tests for the AutoCam resume-on-restart path.
 
 The full ``_execute_autocam_gui_automation`` runs pywinauto + win32gui +
-psutil against a live desktop, so we exercise it indirectly: directly
-test the tiny helpers (``_live_autocam_pids``, the resume-marker
-read/write on DirectoryState), and assert the documented behavior of
-the wider function via patches on its dependencies.
+subprocess (tasklist/wmic) against a live desktop, so we exercise it
+indirectly: directly test the tiny helpers (``_live_autocam_pids``,
+``_find_autocam_gui_pids``, the resume-marker read/write on
+DirectoryState), and assert the documented behavior of the wider
+function via patches on its dependencies.
 """
 
 from __future__ import annotations
@@ -19,7 +20,9 @@ import pytest
 from video_grouper.models.directory_state import DirectoryState
 from video_grouper.tray.autocam_automation import (
     _execute_autocam_gui_automation,
+    _find_autocam_gui_pids,
     _live_autocam_pids,
+    _parse_wmi_datetime,
 )
 
 
@@ -83,34 +86,121 @@ class TestSetClearAutocamRun:
         assert DirectoryState(group_dir).get_youtube_playlist_name() == "Heat 2012s"
 
 
+def _pid_filter_from_cmd(cmd: list[str]) -> int | None:
+    """Pull the integer PID out of a `tasklist /FI 'PID eq N' ...` cmd."""
+    for i, arg in enumerate(cmd):
+        if arg == "/FI" and i + 1 < len(cmd) and cmd[i + 1].startswith("PID eq "):
+            try:
+                return int(cmd[i + 1].split()[-1])
+            except ValueError:
+                return None
+    return None
+
+
 class TestLiveAutocamPids:
     def test_returns_only_alive_gui_exe(self):
-        # Build two psutil.Process mocks: one alive GUI.exe, one alive Notepad.exe,
-        # and one dead PID (NoSuchProcess).
-        alive_gui = MagicMock()
-        alive_gui.is_running.return_value = True
-        alive_gui.name.return_value = "GUI.exe"
-        alive_other = MagicMock()
-        alive_other.is_running.return_value = True
-        alive_other.name.return_value = "notepad.exe"
-
-        import psutil as real_psutil
-
-        def fake_process(pid):
+        # PID 1 -> alive GUI.exe, PID 2 -> alive notepad.exe (filter excludes),
+        # PID 99 -> not running. tasklist applies both PID and IMAGENAME filters
+        # in a single call: a non-empty body means the row matched both.
+        def fake_run_console(cmd, timeout=10.0):
+            pid = _pid_filter_from_cmd(cmd)
             if pid == 1:
-                return alive_gui
-            if pid == 2:
-                return alive_other
-            raise real_psutil.NoSuchProcess(pid)
+                return '"GUI.exe","1","Console","1","12,345 K"\n'
+            # PID 2's IMAGENAME doesn't match -> tasklist returns its
+            # "no tasks running" banner on stdout in some Win versions;
+            # either way _parse_tasklist_csv_pids returns []. PID 99
+            # doesn't exist: same outcome.
+            return ""
 
         with patch(
-            "video_grouper.tray.autocam_automation.psutil.Process",
-            side_effect=fake_process,
+            "video_grouper.tray.autocam_automation._run_console",
+            side_effect=fake_run_console,
         ):
             assert _live_autocam_pids([1, 2, 99]) == [1]
 
     def test_empty_input_returns_empty(self):
         assert _live_autocam_pids([]) == []
+
+
+class TestFindAutocamGuiPids:
+    def test_no_filter_returns_tasklist_pids(self):
+        tasklist_out = (
+            '"GUI.exe","1234","Console","1","12,345 K"\n'
+            '"GUI.exe","5678","Console","1","11,000 K"\n'
+        )
+        with patch(
+            "video_grouper.tray.autocam_automation._run_console",
+            return_value=tasklist_out,
+        ):
+            assert sorted(_find_autocam_gui_pids()) == [1234, 5678]
+
+    def test_since_epoch_filters_out_old_pids(self):
+        # tasklist reports both PIDs; wmic dates them on opposite sides
+        # of the cutoff. The filter drops the older one.
+        import datetime as _dt
+
+        cutoff = _dt.datetime(2026, 3, 1, tzinfo=_dt.UTC).timestamp()
+        tasklist_out = (
+            '"GUI.exe","1234","Console","1","12,345 K"\n'
+            '"GUI.exe","5678","Console","1","11,000 K"\n'
+        )
+
+        def fake_run_console(cmd, timeout=10.0):
+            if cmd[0] == "tasklist":
+                return tasklist_out
+            assert cmd[0] == "wmic"
+            pid = -1
+            for arg in cmd:
+                if arg.startswith("ProcessId="):
+                    pid = int(arg.split("=", 1)[1])
+                    break
+            if pid == 1234:  # 2026-01-01 -- before cutoff
+                return "Node,CreationDate\nDESKTOP,20260101000000.000000+000\n"
+            if pid == 5678:  # 2026-06-01 -- after cutoff
+                return "Node,CreationDate\nDESKTOP,20260601000000.000000+000\n"
+            return ""
+
+        with patch(
+            "video_grouper.tray.autocam_automation._run_console",
+            side_effect=fake_run_console,
+        ):
+            assert _find_autocam_gui_pids(since_epoch=cutoff) == [5678]
+
+    def test_wmic_unavailable_falls_open(self):
+        # wmic returning '' (timeout/missing) should keep the PID
+        # rather than drop it -- a false positive is recoverable;
+        # a false negative would skip the resume reattach.
+        tasklist_out = '"GUI.exe","1234","Console","1","12,345 K"\n'
+
+        def fake_run_console(cmd, timeout=10.0):
+            if cmd[0] == "tasklist":
+                return tasklist_out
+            return ""  # wmic unavailable
+
+        with patch(
+            "video_grouper.tray.autocam_automation._run_console",
+            side_effect=fake_run_console,
+        ):
+            assert _find_autocam_gui_pids(since_epoch=1.0) == [1234]
+
+
+class TestParseWmiDatetime:
+    def test_round_trips_utc_offset(self):
+        # 2026-05-29 18:27:08.123456 UTC-5h
+        epoch = _parse_wmi_datetime("20260529182708.123456-300")
+        assert epoch is not None
+        # 18:27:08 in UTC-5 == 23:27:08 UTC
+        import datetime as _dt
+
+        expected = _dt.datetime(
+            2026, 5, 29, 23, 27, 8, 123456, tzinfo=_dt.UTC
+        ).timestamp()
+        assert epoch == pytest.approx(expected, abs=1e-3)
+
+    def test_malformed_returns_none(self):
+        assert _parse_wmi_datetime("") is None
+        assert _parse_wmi_datetime("garbage") is None
+        assert _parse_wmi_datetime("20260529182708.xxxxxx-300") is None
 
 
 class TestResumeBranch:

--- a/video_grouper/task_processors/ball_tracking_discovery_processor.py
+++ b/video_grouper/task_processors/ball_tracking_discovery_processor.py
@@ -176,7 +176,7 @@ class BallTrackingDiscoveryProcessor(PollingProcessor):
         # If the group already reached "complete", no upload needed
         state_file = group_dir / "state.json"
         try:
-            with open(state_file, "r") as f:
+            with open(state_file) as f:
                 state_data = json.load(f)
             if state_data.get("status") == "complete":
                 return

--- a/video_grouper/tray/autocam_automation.py
+++ b/video_grouper/tray/autocam_automation.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import time
 
-import psutil
 import win32gui
 from pywinauto import Desktop
 
@@ -18,6 +17,10 @@ logger = logging.getLogger(__name__)
 # this as a module constant lets the resume + fresh-launch paths agree.
 _AUTOCAM_WINDOW_PREFIX = "Once Sport Autocam"
 _AUTOCAM_PROCESS_NAME = "GUI.exe"
+
+# Suppress the console flash on every tasklist/wmic poll -- the tray is
+# a GUI app and these run on a 30s discovery loop.
+_NO_WINDOW = 0x08000000
 
 
 def _find_autocam_hwnd() -> int | None:
@@ -39,6 +42,121 @@ def _find_autocam_hwnd() -> int | None:
     return found[0] if found else None
 
 
+def _run_console(cmd: list[str], timeout: float = 10.0) -> str:
+    """Run a Windows console helper (tasklist/wmic), return stdout, or ''
+    on timeout / OSError. Swallow-and-log matches the posture of the
+    callers, which treat absent data as 'no match' rather than fatal.
+    """
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+            creationflags=_NO_WINDOW,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.debug("console helper %s failed: %s", cmd[0], e)
+        return ""
+    return result.stdout or ""
+
+
+def _parse_tasklist_csv_pids(stdout: str) -> list[int]:
+    """Parse `tasklist /FO CSV /NH` output and return PIDs (column 2).
+
+    Returns an empty list if tasklist's "no tasks running" banner is
+    present (some Windows versions route that to stdout instead of
+    stderr) or any other unparseable content appears.
+    """
+    pids: list[int] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = [p.strip('"') for p in line.split('","')]
+        if len(parts) < 2:
+            continue
+        try:
+            pids.append(int(parts[1]))
+        except ValueError:
+            continue
+    return pids
+
+
+def _parse_wmi_datetime(s: str) -> float | None:
+    """Parse a WMI CIM_DATETIME field to Unix epoch seconds.
+
+    Format: ``yyyymmddHHMMSS.ffffff±UUU`` (UUU = minutes east of UTC).
+    Example: ``20260529182708.123456-300`` is 2026-05-29 18:27:08.123456
+    in UTC-5h. Returns None on any parse failure.
+    """
+    s = s.strip()
+    if len(s) < 25:
+        return None
+    try:
+        year = int(s[0:4])
+        month = int(s[4:6])
+        day = int(s[6:8])
+        hour = int(s[8:10])
+        minute = int(s[10:12])
+        second = int(s[12:14])
+        micro = int(s[15:21])
+        sign = s[21]
+        tz_minutes = int(s[22:25])
+        if sign == "-":
+            tz_minutes = -tz_minutes
+        dt = datetime.datetime(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            micro,
+            tzinfo=datetime.timezone(datetime.timedelta(minutes=tz_minutes)),
+        )
+        return dt.timestamp()
+    except (ValueError, IndexError):
+        return None
+
+
+def _wmi_creation_time(pid: int) -> float | None:
+    """Return Unix-epoch creation time for ``pid`` via wmic, or None.
+
+    `wmic` is deprecated on newer Windows but still ships on Win10/11.
+    None means we couldn't determine it; callers treat that as
+    'no filter' (fail-open) -- a false positive is harmless because
+    every downstream consumer revalidates via _live_autocam_pids.
+    """
+    out = _run_console(
+        [
+            "wmic",
+            "process",
+            "where",
+            f"ProcessId={pid}",
+            "get",
+            "CreationDate",
+            "/FORMAT:CSV",
+        ]
+    )
+    for line in out.splitlines():
+        line = line.strip()
+        if (
+            not line
+            or line.lower().startswith("node")
+            or "creationdate" in line.lower()
+        ):
+            continue
+        parts = line.split(",")
+        if len(parts) < 2:
+            continue
+        epoch = _parse_wmi_datetime(parts[-1])
+        if epoch is not None:
+            return epoch
+    return None
+
+
 def _find_autocam_gui_pids(
     since_epoch: float | None = None,
 ) -> list[int]:
@@ -49,46 +167,64 @@ def _find_autocam_gui_pids(
     Both PIDs go into the resume marker; reattach validates that at
     least one is still alive.
 
+    Uses `tasklist` (+ `wmic` for the optional since_epoch filter)
+    rather than psutil: psutil's PyInstaller bundle is unreliable in
+    this tray's onedir build (v0.4.x bundles raised AttributeError on
+    psutil.process_iter even with the metrics extra synced). Subprocess
+    over stdlib is what every other process-enum site in the repo uses.
+
     Args:
-        since_epoch: If provided, only return processes whose create_time
-            is at-or-after this Unix timestamp (seconds). Used by the
-            launch path to avoid grabbing PIDs of unrelated GUI.exe
+        since_epoch: If provided, only return processes whose creation
+            time is at-or-after this Unix timestamp (seconds). Used by
+            the launch path to avoid grabbing PIDs of unrelated GUI.exe
             instances that were already running.
     """
-    pids: list[int] = []
-    for proc in psutil.process_iter(["pid", "name", "create_time"]):
-        try:
-            name = (proc.info.get("name") or "").lower()
-            if name != _AUTOCAM_PROCESS_NAME.lower():
-                continue
-            if (
-                since_epoch is not None
-                and proc.info.get("create_time", 0) < since_epoch
-            ):
-                continue
-            pids.append(proc.info["pid"])
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            continue
-    return pids
+    pids = _parse_tasklist_csv_pids(
+        _run_console(
+            [
+                "tasklist",
+                "/FI",
+                f"IMAGENAME eq {_AUTOCAM_PROCESS_NAME}",
+                "/FO",
+                "CSV",
+                "/NH",
+            ]
+        )
+    )
+    if since_epoch is None:
+        return pids
+    filtered: list[int] = []
+    for pid in pids:
+        created = _wmi_creation_time(pid)
+        if created is None or created >= since_epoch:
+            filtered.append(pid)
+    return filtered
 
 
 def _live_autocam_pids(candidate_pids: list[int]) -> list[int]:
     """Filter ``candidate_pids`` to those that are alive AND named GUI.exe.
 
-    A bare ``pid_exists`` check would accept a PID that's been recycled
-    by an unrelated process; the name guard prevents that.
+    A bare existence check would accept a PID that's been recycled by
+    an unrelated process; the name guard prevents that. Each candidate
+    becomes a single `tasklist` call with both filters applied -- a
+    non-empty result row means alive-and-correctly-named.
     """
     live: list[int] = []
     for pid in candidate_pids:
-        try:
-            proc = psutil.Process(pid)
-            if (
-                proc.is_running()
-                and proc.name().lower() == _AUTOCAM_PROCESS_NAME.lower()
-            ):
-                live.append(pid)
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            continue
+        out = _run_console(
+            [
+                "tasklist",
+                "/FI",
+                f"PID eq {pid}",
+                "/FI",
+                f"IMAGENAME eq {_AUTOCAM_PROCESS_NAME}",
+                "/FO",
+                "CSV",
+                "/NH",
+            ]
+        )
+        if _parse_tasklist_csv_pids(out):
+            live.append(pid)
     return live
 
 

--- a/video_grouper/tray/main.py
+++ b/video_grouper/tray/main.py
@@ -539,6 +539,7 @@ class SystemTrayIcon(QSystemTrayIcon):
 
         import json
         from pathlib import Path
+
         from video_grouper.task_processors.tasks.upload import YoutubeUploadTask
 
         storage = Path(self.config.storage.path)
@@ -550,7 +551,7 @@ class SystemTrayIcon(QSystemTrayIcon):
             if not state_file.exists():
                 continue
             try:
-                with open(state_file, "r") as f:
+                with open(state_file) as f:
                     status = json.load(f).get("status")
             except (json.JSONDecodeError, OSError):
                 continue

--- a/video_grouper/version.py
+++ b/video_grouper/version.py
@@ -3,7 +3,7 @@ Version information for VideoGrouper.
 This file is automatically updated during the build process.
 """
 
-VERSION = "0.3.5"
+VERSION = "0.4.2"
 BUILD_NUMBER = "0"  # 0 for releases, commit count for dev builds
 
 # Full version string including build number


### PR DESCRIPTION
## Summary
- Drop `import psutil` from `video_grouper/tray/autocam_automation.py` and rewrite `_find_autocam_gui_pids` / `_live_autocam_pids` over `subprocess` + `tasklist` (+ `wmic` for the `since_epoch` filter). Public signatures unchanged, four call sites untouched.
- Bumps `version.py` to 0.4.2.

## Why
v0.4.x bundles crash every 30s in `BallTrackingDiscoveryProcessor` with:
```
module 'psutil' has no attribute 'process_iter'
```
This is `AttributeError`, not `ModuleNotFoundError` — `import psutil` succeeds but the bundled module is missing `process_iter`. ae6ecd0 added `--extra metrics` so psutil was at least present during PyInstaller Analysis, but v0.4.1 still ships a broken bundle. The exact MERGE-pass defect would take significant time to root-cause locally.

v0.3.5 worked because `autocam_automation.py` had no psutil at all. The crash-resume feature in 5088148 added PID tracking and pulled psutil in. The resume feature is worth keeping; the psutil dependency is not. Rewrites use the same `subprocess`+`tasklist`+`wmic` pattern that `tests/e2e/kill_test_processes.py` already uses (and that the rest of `autocam_automation.py` already uses for `taskkill`).

`video_grouper/utils/system_metrics.py` still uses psutil but already guards `import psutil` with try/except, so the service degrades gracefully — out of scope here.

## Test plan
- [x] `uv run ruff check video_grouper/tray/autocam_automation.py tests/test_autocam_resume.py` — passes
- [x] `uv run mypy video_grouper/tray/autocam_automation.py` — passes
- [x] `uv run pytest tests/test_autocam_resume.py -v` — 15/15 pass (added `TestFindAutocamGuiPids`, `TestParseWmiDatetime`)
- [x] Broader sweep: `uv run pytest tests/ -k "tray or autocam or system_metrics" --ignore=tests/e2e` — 57 pass, 1 skipped
- [x] Source-mode smoke: helpers import cleanly and return `[]` when no GUI.exe is running
- [ ] **Built-bundle verification (post-merge)**: install the tagged `v0.4.2` release, kick the paused `2026.05.28-18.27.08` group; expect the discovery processor to proceed past `autocam_gui` instead of the AttributeError loop. Kill the tray mid-AutoCam and restart to confirm the resume reattach still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)