### PR TITLE
fix(tray): pre-delete partial AutoCam output and detect stale-notification hangs

### DIFF
--- a/tests/test_autocam_automation.py
+++ b/tests/test_autocam_automation.py
@@ -1,5 +1,6 @@
 """Tests for the autocam automation function."""
 
+import datetime
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -442,6 +443,7 @@ class TestExecuteAutocamGuiAutomationOutputPrecheck:
             ) as mock_popen,
             patch("video_grouper.tray.autocam_automation.Desktop"),
             patch("video_grouper.tray.autocam_automation.time.sleep"),
+            patch("video_grouper.tray.autocam_automation.os.remove"),
             patch(
                 "video_grouper.tray.autocam_automation._find_autocam_hwnd",
                 return_value=None,
@@ -454,3 +456,225 @@ class TestExecuteAutocamGuiAutomationOutputPrecheck:
             except Exception:
                 pass  # downstream pywinauto interactions will fail; that's ok
         mock_popen.assert_called()
+
+    def test_pre_deletes_partial_output(self, tmp_path, mock_file_system):
+        """A sub-threshold partial output gets os.remove'd before any
+        AutoCam launch. Leaving it would trigger the Windows Save
+        dialog's "Confirm Save As" overwrite-confirm overlay, which
+        the dialog automation can't drive; AutoCam then errors
+        "No output file selected" the instant Start Processing fires.
+        """
+        mock_file_system["getsize"].return_value = 5 * 1024 * 1024  # 5 MB < 10 MB
+        input_path = tmp_path / "input.mp4"
+        input_path.touch()
+        output_path = tmp_path / "output.mp4"
+        output_path.touch()
+        with (
+            patch(
+                "video_grouper.tray.autocam_automation.subprocess.Popen"
+            ) as mock_popen,
+            patch("video_grouper.tray.autocam_automation.Desktop"),
+            patch("video_grouper.tray.autocam_automation.time.sleep"),
+            patch("video_grouper.tray.autocam_automation.os.remove") as mock_remove,
+            patch(
+                "video_grouper.tray.autocam_automation._find_autocam_hwnd",
+                return_value=None,
+            ),
+        ):
+            try:
+                _execute_autocam_gui_automation(
+                    "C:/fake/GUI.exe", str(input_path), str(output_path)
+                )
+            except Exception:
+                pass  # downstream pywinauto will fail; we only care that
+                # the precheck ran the remove + reached Popen
+        mock_remove.assert_called_once()
+        assert mock_remove.call_args.args[0].endswith("output.mp4")
+        # And we still launched AutoCam afterwards.
+        mock_popen.assert_called()
+
+    def test_partial_output_remove_oserror_does_not_abort_run(
+        self, tmp_path, mock_file_system
+    ):
+        """If os.remove fails (file locked, permissions, etc.), log a
+        warning and proceed with the launch anyway -- a doomed retry
+        attempt is still better than skipping the queue entry."""
+        mock_file_system["getsize"].return_value = 5 * 1024 * 1024  # 5 MB
+        input_path = tmp_path / "input.mp4"
+        input_path.touch()
+        output_path = tmp_path / "output.mp4"
+        output_path.touch()
+        with (
+            patch(
+                "video_grouper.tray.autocam_automation.subprocess.Popen"
+            ) as mock_popen,
+            patch("video_grouper.tray.autocam_automation.Desktop"),
+            patch("video_grouper.tray.autocam_automation.time.sleep"),
+            patch(
+                "video_grouper.tray.autocam_automation.os.remove",
+                side_effect=PermissionError("locked"),
+            ) as mock_remove,
+            patch(
+                "video_grouper.tray.autocam_automation._find_autocam_hwnd",
+                return_value=None,
+            ),
+        ):
+            try:
+                _execute_autocam_gui_automation(
+                    "C:/fake/GUI.exe", str(input_path), str(output_path)
+                )
+            except Exception:
+                pass
+        mock_remove.assert_called_once()
+        mock_popen.assert_called()
+
+
+class TestWaitForCompletionStaleNotification:
+    """Test the stale-notification hang detector.
+
+    Background: AutoCam can wedge mid-pass with the GUI alive but no
+    frames advancing. The notification text stays byte-identical for
+    hours. Observed 2026-05-30 on a 90-min input that froze at 65.4%
+    and pinned the queue for 8+ hours before manual intervention.
+    """
+
+    def _make_notification(self, texts):
+        """Build a (main_window, advance) pair. Each call to advance()
+        moves the notification to the next text in ``texts``; the test
+        controls how many times to advance per simulated poll."""
+        idx = [0]
+
+        def text_for_call():
+            i = min(idx[0], len(texts) - 1)
+            return texts[i]
+
+        def advance():
+            idx[0] += 1
+
+        notification = MagicMock()
+        notification.window_text.side_effect = lambda: text_for_call()
+        mw = MagicMock()
+        mw.child_window.return_value = notification
+        return mw, advance
+
+    def _run_with_simulated_clock(
+        self,
+        mw,
+        advance,
+        *,
+        poll_count,
+        seconds_per_poll=30,
+        tracked_pids=(12345,),
+        live_pids=(12345,),
+    ):
+        """Drive _wait_for_completion_and_cleanup through ``poll_count``
+        polls with a synthetic clock. Advances the notification index
+        once per poll (so the test fixture's text list models what
+        AutoCam shows on each call)."""
+        import video_grouper.tray.autocam_automation as mod
+
+        start = datetime.datetime(2026, 5, 30, 21, 30, 0)
+        clock = [start]
+
+        def fake_now():
+            return clock[0]
+
+        def fake_sleep(_seconds):
+            clock[0] = clock[0] + datetime.timedelta(seconds=seconds_per_poll)
+            advance()
+
+        polls_done = [0]
+        real_sleep = mod.time.sleep
+
+        def counted_sleep(seconds):
+            polls_done[0] += 1
+            fake_sleep(seconds)
+            if polls_done[0] >= poll_count:
+                # Stop the loop by advancing the clock past 24h ceiling.
+                clock[0] = start + datetime.timedelta(days=2)
+            real_sleep(0)
+
+        with (
+            patch.object(mod.datetime, "datetime", wraps=datetime.datetime) as fake_dt,
+            patch(
+                "video_grouper.tray.autocam_automation._live_autocam_pids",
+                return_value=list(live_pids),
+            ),
+            patch(
+                "video_grouper.tray.autocam_automation.time.sleep",
+                side_effect=counted_sleep,
+            ),
+            patch("video_grouper.tray.autocam_automation.subprocess.run"),
+        ):
+            fake_dt.now = MagicMock(side_effect=fake_now)
+            return _wait_for_completion_and_cleanup(
+                mw,
+                state=None,
+                output_path=None,
+                tracked_pids=list(tracked_pids),
+            )
+
+    def test_stuck_notification_triggers_hang_break(self):
+        """Notification stays identical for >10 min while PIDs alive →
+        loop bails with found=False so the queue retry can kick in."""
+        # Frame timing fluctuates for the first 3 polls, then sticks at
+        # exactly "68 [ms]" for the remaining 25 polls (12.5 simulated
+        # min). The fixture's last entry is repeated past end-of-list.
+        texts = [
+            "* average time per frame: 102 [ms]",
+            "* average time per frame: 77 [ms]",
+            "* average time per frame: 69 [ms]",
+            "* average time per frame: 68 [ms]",  # repeated forever past here
+        ]
+        mw, advance = self._make_notification(texts)
+        result = self._run_with_simulated_clock(mw, advance, poll_count=30)
+        assert result is False
+
+    def test_changing_notification_keeps_loop_running(self):
+        """Notification value changes every poll → never stale, loop
+        runs to its synthetic timeout (which simulates the 24h ceiling
+        firing without a hang detect)."""
+        # 50 unique values guarantee no stale streak inside poll_count.
+        texts = [f"* average time per frame: {i} [ms]" for i in range(50)]
+        mw, advance = self._make_notification(texts)
+        result = self._run_with_simulated_clock(mw, advance, poll_count=30)
+        # No hang detected; the loop exits via the synthetic 24h-ceiling
+        # path with found=False (no success notification arrived in the
+        # window either, which is expected since these texts contain
+        # "processed" but not "finished processing").
+        assert result is False
+
+    def test_stuck_under_threshold_does_not_trigger(self):
+        """Notification stuck for 9 simulated min (< STALE_NOTIFICATION_SECONDS
+        of 10 min) must NOT trigger the hang detect. Verifies the
+        threshold isn't off by one poll interval."""
+        # 3 polls of fluctuation + 17 polls stuck @ 30 s each = 8.5 min stuck.
+        texts = [
+            "* average time per frame: 102 [ms]",
+            "* average time per frame: 77 [ms]",
+            "* average time per frame: 69 [ms]",
+            "* average time per frame: 68 [ms]",
+        ]
+        mw, advance = self._make_notification(texts)
+        # Only 20 polls -- 17 stuck @ 30s = 510s, below 600s threshold.
+        result = self._run_with_simulated_clock(mw, advance, poll_count=20)
+        # Loop fell out via the synthetic 24h ceiling, NOT via the
+        # stale-notification break. The distinction is observable
+        # through logs; here we just verify the function didn't return
+        # early with the stale-notification path being hit.
+        assert result is False
+
+    def test_stuck_notification_with_dead_pids_uses_exit_branch(self):
+        """If the GUI processes have already exited, the existing
+        process-exit branch wins -- we should NOT also trigger the
+        stale-notification branch. The exit branch produces a more
+        specific failure log."""
+        texts = ["* average time per frame: 68 [ms]"]
+        mw, advance = self._make_notification(texts)
+        # live_pids=[] means _live_autocam_pids returns empty.
+        result = self._run_with_simulated_clock(
+            mw, advance, poll_count=30, live_pids=()
+        )
+        # Returns False via the exit-detection branch (no output_path,
+        # so the "exited without producing output" path).
+        assert result is False

--- a/tests/test_autocam_resume.py
+++ b/tests/test_autocam_resume.py
@@ -86,35 +86,17 @@ class TestSetClearAutocamRun:
         assert DirectoryState(group_dir).get_youtube_playlist_name() == "Heat 2012s"
 
 
-def _pid_filter_from_cmd(cmd: list[str]) -> int | None:
-    """Pull the integer PID out of a `tasklist /FI 'PID eq N' ...` cmd."""
-    for i, arg in enumerate(cmd):
-        if arg == "/FI" and i + 1 < len(cmd) and cmd[i + 1].startswith("PID eq "):
-            try:
-                return int(cmd[i + 1].split()[-1])
-            except ValueError:
-                return None
-    return None
-
-
 class TestLiveAutocamPids:
     def test_returns_only_alive_gui_exe(self):
-        # PID 1 -> alive GUI.exe, PID 2 -> alive notepad.exe (filter excludes),
-        # PID 99 -> not running. tasklist applies both PID and IMAGENAME filters
-        # in a single call: a non-empty body means the row matched both.
-        def fake_run_console(cmd, timeout=10.0):
-            pid = _pid_filter_from_cmd(cmd)
-            if pid == 1:
-                return '"GUI.exe","1","Console","1","12,345 K"\n'
-            # PID 2's IMAGENAME doesn't match -> tasklist returns its
-            # "no tasks running" banner on stdout in some Win versions;
-            # either way _parse_tasklist_csv_pids returns []. PID 99
-            # doesn't exist: same outcome.
-            return ""
-
+        # _live_autocam_pids makes a single tasklist call filtered on
+        # IMAGENAME=GUI.exe (no PID filter), then intersects the result
+        # against candidate_pids. PID 1 is in the tasklist output;
+        # PIDs 2 and 99 are not (either wrong image name or not
+        # running) so they get filtered out.
+        tasklist_out = '"GUI.exe","1","Console","1","12,345 K"\n'
         with patch(
             "video_grouper.tray.autocam_automation._run_console",
-            side_effect=fake_run_console,
+            return_value=tasklist_out,
         ):
             assert _live_autocam_pids([1, 2, 99]) == [1]
 

--- a/video_grouper/tray/autocam_automation.py
+++ b/video_grouper/tray/autocam_automation.py
@@ -22,6 +22,13 @@ _AUTOCAM_PROCESS_NAME = "GUI.exe"
 # a GUI app and these run on a 30s discovery loop.
 _NO_WINDOW = 0x08000000
 
+# Seconds the AutoCam notification text may stay byte-identical before
+# we declare the run wedged and bail. Under healthy processing the
+# notification fluctuates every 30s poll ("* average time per frame: NN
+# [ms]"); once wedged it sits unchanged for hours. 10 min gives plenty
+# of margin if AutoCam ever briefly stabilizes on the same integer.
+STALE_NOTIFICATION_SECONDS = 600
+
 
 def _find_autocam_hwnd() -> int | None:
     """Return the hwnd of an Once Sport Autocam window, or None.
@@ -459,6 +466,11 @@ def _wait_for_completion_and_cleanup(
     output_min_bytes = 10 * 1024 * 1024  # 10 MB
     found = False
     processing_started = False
+    # Track when the notification text last changed for stale-hang
+    # detection. Under healthy processing the text fluctuates every
+    # poll; once wedged it sits identical for hours.
+    last_notification_text: str | None = None
+    last_notification_changed_at = start_time
 
     try:
         while (datetime.datetime.now() - start_time).total_seconds() < timeout_seconds:
@@ -466,34 +478,28 @@ def _wait_for_completion_and_cleanup(
                 notification = main_window.child_window(
                     auto_id="Notification", control_type="Text"
                 )
-                notification_text = notification.window_text().lower()
+                raw_notification = notification.window_text()
+                notification_text = raw_notification.lower()
+                logger.info("Autocam status: %r", raw_notification)
+
+                if notification_text != last_notification_text:
+                    last_notification_text = notification_text
+                    last_notification_changed_at = datetime.datetime.now()
 
                 if "finished processing" in notification_text:
                     found = True
-                    logger.info(
-                        f"Detected success message: '{notification.window_text()}'"
-                    )
+                    logger.info("Detected success message: %r", raw_notification)
                     break
                 elif "error" in notification_text:
-                    logger.error(
-                        f"Autocam reported an error: '{notification.window_text()}'"
-                    )
+                    logger.error("Autocam reported an error: %r", raw_notification)
                     break
                 elif (
                     "processing" in notification_text
                     or "processed" in notification_text
                 ):
-                    # Autocam reports "% of video processed" during active processing.
-                    # Both "processing" and "processed" indicate the job is underway.
                     if not processing_started:
                         processing_started = True
-                        logger.info(
-                            f"Processing started: '{notification.window_text()}'"
-                        )
-                    else:
-                        logger.debug(f"Autocam status: '{notification.window_text()}'")
-                else:
-                    logger.debug(f"Autocam status: '{notification.window_text()}'")
+                        logger.info("Processing started: %r", raw_notification)
             except Exception as e:
                 logger.warning(f"Error while checking for success message: {e}")
 
@@ -502,7 +508,8 @@ def _wait_for_completion_and_cleanup(
             # rather than waiting for a notification string that may
             # never come (some AutoCam builds end with a C-level
             # cleanup message instead of a user-facing success).
-            if tracked_pids and not _live_autocam_pids(tracked_pids):
+            live_pids = _live_autocam_pids(tracked_pids) if tracked_pids else None
+            if tracked_pids and not live_pids:
                 if output_path and os.path.isfile(output_path):
                     try:
                         size = os.path.getsize(output_path)
@@ -526,6 +533,28 @@ def _wait_for_completion_and_cleanup(
                     f"output at {output_path}; treating as failure."
                 )
                 break
+
+            # Stale-notification hang detect: AutoCam can wedge mid-pass
+            # with the GUI process alive but no frames advancing. The
+            # notification text stays byte-identical for hours while
+            # processing has effectively stopped. Bail so the queue
+            # retry can move on.
+            if (
+                processing_started
+                and last_notification_text is not None
+                and (tracked_pids is None or live_pids)
+            ):
+                stale_seconds = (
+                    datetime.datetime.now() - last_notification_changed_at
+                ).total_seconds()
+                if stale_seconds > STALE_NOTIFICATION_SECONDS:
+                    logger.error(
+                        "AutoCam notification unchanged for %.1f minutes "
+                        "(last text: %r); treating as hung.",
+                        stale_seconds / 60,
+                        last_notification_text,
+                    )
+                    break
 
             # If processing hasn't started within 5 minutes, bail out.
             # (Skip this guard on the resume path: an in-flight pass has
@@ -616,6 +645,25 @@ def _execute_autocam_gui_automation(
             if state is not None:
                 state.clear_autocam_run()
             return True
+        # Pre-delete partial output below the success threshold. Leaving
+        # a sub-threshold file in place triggers the Windows Save
+        # dialog's "Confirm Save As" overwrite-confirm overlay, which
+        # our automation can't drive -- AutoCam then reports "Output
+        # error: No output file selected" the instant Start Processing
+        # fires.
+        try:
+            os.remove(abs_output_path)
+            logger.info(
+                "Removed partial AutoCam output at %s (%.1f MB) before relaunch",
+                abs_output_path,
+                existing_size / 1024 / 1024,
+            )
+        except OSError as e:
+            logger.warning(
+                "Could not remove partial output %s: %s; continuing anyway",
+                abs_output_path,
+                e,
+            )
 
     desktop = Desktop(backend="uia")
 


### PR DESCRIPTION
## Summary

Two AutoCam-automation failures on 2026-05-30 (tournament day, server DESKTOP-5L867J8, AutoCam 3.0.7), verified against `D:\soccer-cam-storage\logs\video_grouper_tray.log.2026-05-30`:

- **WNY Flash `2026.05.30-12.09.22`**: an earlier pass crashed mid-processing at 7 MB. From then on, every retry hit `Autocam reported an error: 'Output error: No output file selected'` within ~4 s of clicking Start Processing. Root cause: the pre-existing partial output triggers Windows' `Confirm Save As` overwrite-confirm overlay over the file dialog, which our automation can't drive — the Save dialog never commits the typed path, AutoCam's output state stays empty, Start errors instantly.
- **Fairport `2026.05.30-15.56.39`**: ran cleanly for ~2.5 h, then the AutoCam GUI process wedged with the notification text frozen at `* average time per frame: 68 [ms]`. The poll loop sat for 8+ hours because no exit condition fired (GUI alive, no `finished processing`/`error` substrings, past 5-min startup, far short of the 24h ceiling).

## Changes

- **Fix A** (`_execute_autocam_gui_automation`): after the existing `>=10 MB` "already-done" short-circuit, `os.remove` any sub-threshold partial output before launching AutoCam, so the Save dialog never sees an existing file.
- **Fix C** (`_wait_for_completion_and_cleanup`): track when the notification text last changed (under healthy load the integer ms value fluctuates every 30 s poll). If `processing_started` is true, PIDs are alive, and the text has been byte-identical for `STALE_NOTIFICATION_SECONDS` (10 min default, module-level constant), break with `found=False` so `base_queue_processor` retries.
- **Fix D**: promote the per-poll notification text logging from DEBUG to INFO. This investigation was only diagnosable because DEBUG happened to be on.
- Drive-by: fix a pre-existing `test_returns_only_alive_gui_exe` that still modeled the per-PID tasklist call replaced in #55 by the single-call optimization.

Out of scope (rejected during planning): handling the overwrite-confirm overlay directly, and writing a `ball_tracking_failed` status on exhausted retries. Fix A removes the overlay's trigger; keeping the directory at `trimmed` lets discovery re-enqueue cleanly after the fix is in place.

## Test plan

- [x] `uv run pytest tests/test_autocam_automation.py tests/test_autocam_resume.py` (40 passed, including 3 new Fix A tests and 4 new Fix C tests)
- [x] `uv run --with ruff ruff check .` clean
- [x] `uv run mypy video_grouper/tray/` clean
- [ ] **Manual e2e**: server cleanup (kill wedged Fairport PIDs 442628/452724, delete the two stale partial outputs), redeploy tray, re-trigger ball-tracking for both stuck games via discovery, confirm WNY Flash succeeds first try and Fairport processes without re-hanging — or if it hangs, that the 10-min stale-notification timer fires and the queue retry kicks in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)