### PR TITLE
fix(reolink): sticky HTTP - never fall to Baichuan after any HTTP success

### DIFF
--- a/tests/test_reolink_download.py
+++ b/tests/test_reolink_download.py
@@ -10,6 +10,7 @@ import pytest
 from video_grouper.cameras.reolink_download import (
     _HTTP_PATH_SUPPORTED,
     _HTTP_PROBE_RETRIES,
+    _HTTP_STICKY_MAX_RETRIES,
     ANNEX_B_START_CODE,
     HEADER_MAGIC,
     HOST_CH_ID,
@@ -29,6 +30,7 @@ from video_grouper.cameras.reolink_download import (
     _aes_decrypt,
     _aes_encrypt,
     _decrypt_baichuan,
+    _download_and_mux_async,
     _download_via_http_async,
     _encrypt_baichuan,
     _has_start_codes,
@@ -961,3 +963,157 @@ class TestDownloadViaHttp:
             r = await _download_via_http_async(HOST, 80, SDA_FILE, str(out))
         assert r is False
         assert not out.exists()  # never published on size mismatch
+
+
+class TestStickyHttpRetry:
+    """Sticky-HTTP: once any file has downloaded via HTTP this session,
+    transient failures must retry HTTP rather than fall back to Baichuan.
+    Baichuan is reserved for cameras where HTTP has never worked."""
+
+    @pytest.mark.asyncio
+    async def test_confirmed_host_retries_http_on_transient_failure(self, tmp_path):
+        """Confirmed host + 1st HTTP attempt False + 2nd attempt True → succeed via HTTP, never touch Baichuan."""
+        _HTTP_PATH_SUPPORTED[HOST] = True
+        calls = []
+
+        async def fake_http(host, http_port, file_path, output, on_progress=None):
+            calls.append(file_path)
+            return True if len(calls) >= 2 else False
+
+        with (
+            patch(
+                "video_grouper.cameras.reolink_download._download_via_http_async",
+                side_effect=fake_http,
+            ),
+            patch(
+                "video_grouper.cameras.reolink_download.BaichuanStreamClient"
+            ) as MockBaichuan,
+            _no_sleep(),
+        ):
+            result = await _download_and_mux_async(
+                host=HOST,
+                port=9000,
+                username="x",
+                password="y",
+                file_path=SDA_FILE,
+                output_mp4=str(tmp_path / "o.mp4"),
+                http_port=80,
+            )
+
+        assert result is True
+        assert len(calls) == 2  # initial + 1 sticky retry
+        MockBaichuan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_confirmed_host_exhausts_retries_never_uses_baichuan(self, tmp_path):
+        """Confirmed host + all HTTP attempts fail → return False, never Baichuan."""
+        _HTTP_PATH_SUPPORTED[HOST] = True
+        calls = []
+
+        async def fake_http(host, http_port, file_path, output, on_progress=None):
+            calls.append(file_path)
+            return False
+
+        with (
+            patch(
+                "video_grouper.cameras.reolink_download._download_via_http_async",
+                side_effect=fake_http,
+            ),
+            patch(
+                "video_grouper.cameras.reolink_download.BaichuanStreamClient"
+            ) as MockBaichuan,
+            _no_sleep(),
+        ):
+            result = await _download_and_mux_async(
+                host=HOST,
+                port=9000,
+                username="x",
+                password="y",
+                file_path=SDA_FILE,
+                output_mp4=str(tmp_path / "o.mp4"),
+                http_port=80,
+            )
+
+        assert result is False
+        assert len(calls) == 1 + _HTTP_STICKY_MAX_RETRIES
+        MockBaichuan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unconfirmed_host_still_falls_to_baichuan(self, tmp_path):
+        """First file ever / unconfirmed host + HTTP fails → original Baichuan fallback (no sticky retry)."""
+        # _HTTP_PATH_SUPPORTED clear via autouse fixture
+        calls = []
+
+        async def fake_http(host, http_port, file_path, output, on_progress=None):
+            calls.append(file_path)
+            return None  # unconfirmed probe miss
+
+        with (
+            patch(
+                "video_grouper.cameras.reolink_download._download_via_http_async",
+                side_effect=fake_http,
+            ),
+            patch(
+                "video_grouper.cameras.reolink_download.BaichuanStreamClient"
+            ) as MockBaichuan,
+        ):
+            instance = MockBaichuan.return_value
+            instance.connect = AsyncMock(side_effect=ConnectionRefusedError("refused"))
+            instance.close = AsyncMock()
+
+            result = await _download_and_mux_async(
+                host=HOST,
+                port=9000,
+                username="x",
+                password="y",
+                file_path=SDA_FILE,
+                output_mp4=str(tmp_path / "o.mp4"),
+                http_port=80,
+            )
+
+        # HTTP tried once (no sticky retries), then fell to Baichuan
+        # which we mocked to fail -> overall False, but Baichuan WAS
+        # attempted (the point of this test).
+        assert result is False
+        assert len(calls) == 1
+        MockBaichuan.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_confirmed_host_but_ineligible_path_uses_baichuan(self, tmp_path):
+        """Confirmed host + file outside /mnt/sda/ → HTTP not applicable, Baichuan still used."""
+        _HTTP_PATH_SUPPORTED[HOST] = True
+        # File path not under CAMERA_RECORD_PREFIX
+        non_sda_path = "/some/other/path/x.mp4"
+        calls = []
+
+        async def fake_http(host, http_port, file_path, output, on_progress=None):
+            calls.append(file_path)
+            return None  # http_async itself returns None for non-prefix paths
+
+        with (
+            patch(
+                "video_grouper.cameras.reolink_download._download_via_http_async",
+                side_effect=fake_http,
+            ),
+            patch(
+                "video_grouper.cameras.reolink_download.BaichuanStreamClient"
+            ) as MockBaichuan,
+        ):
+            instance = MockBaichuan.return_value
+            instance.connect = AsyncMock(side_effect=ConnectionRefusedError("refused"))
+            instance.close = AsyncMock()
+
+            result = await _download_and_mux_async(
+                host=HOST,
+                port=9000,
+                username="x",
+                password="y",
+                file_path=non_sda_path,
+                output_mp4=str(tmp_path / "o.mp4"),
+                http_port=80,
+            )
+
+        # Sticky logic skipped because path is ineligible; falls to Baichuan.
+        assert len(calls) == 1
+        MockBaichuan.assert_called_once()
+        assert result is False  # because mocked Baichuan also fails

--- a/video_grouper/cameras/reolink_download.py
+++ b/video_grouper/cameras/reolink_download.py
@@ -1072,6 +1072,16 @@ _HTTP_PATH_SUPPORTED: dict[str, bool] = {}
 _HTTP_PROBE_RETRIES = 5
 _HTTP_PROBE_BACKOFF = (0.5, 1.5, 4.0, 10.0, 15.0)
 
+# Sticky-HTTP retry tuning. Once ANY file has downloaded successfully
+# via HTTP this session, transient failures on later files must retry
+# HTTP rather than fall to Baichuan -- Baichuan is reserved for cameras
+# where HTTP has never worked. 5 retries x cumulative ~105s of backoff
+# is generous enough to ride through any short blip the camera throws
+# at us; beyond that we surface failure to the queue layer which will
+# retry the whole download task later.
+_HTTP_STICKY_MAX_RETRIES = 5
+_HTTP_STICKY_BACKOFF = (1.0, 4.0, 10.0, 30.0, 60.0)
+
 
 class _ProbeResult(enum.Enum):
     """Outcome of probing the HTTP fast path for a single file."""
@@ -1248,6 +1258,12 @@ async def _download_via_http_async(
                 os.replace(tmp, output_mp4)
                 elapsed = time.monotonic() - t0
                 mbps = (written * 8) / elapsed / 1e6 if elapsed > 0 else 0
+                # Streaming success is the strongest possible signal that
+                # HTTP works for this host — set the session sticky flag
+                # here too, not just on probe OK, so the sticky-retry
+                # policy below kicks in for the next file even on a
+                # camera where the first file skipped the probe path.
+                _HTTP_PATH_SUPPORTED[host] = True
                 logger.info(
                     f"HTTP download complete: {written / 1024 / 1024:.1f}MB "
                     f"in {elapsed:.1f}s ({mbps:.1f} Mbps)"
@@ -1298,6 +1314,39 @@ async def _download_and_mux_async(
     )
     if http_result is True:
         return True
+
+    # Sticky-HTTP: once ANY file on this host has downloaded via HTTP this
+    # session, transient failures must retry HTTP rather than fall to
+    # Baichuan. Baichuan is reserved for cameras where HTTP has never
+    # worked. Falling to Baichuan post-confirmation would have us
+    # downloading at ~1.8 MB/s when ~10 MB/s is available, just because
+    # one probe blip nudged us off the fast path.
+    #
+    # Only applies to files under CAMERA_RECORD_PREFIX: HTTP fast path
+    # is only valid for /mnt/sda/ paths; non-record paths must use
+    # Baichuan regardless.
+    if _HTTP_PATH_SUPPORTED.get(host) is True and file_path.startswith(
+        CAMERA_RECORD_PREFIX
+    ):
+        for attempt in range(_HTTP_STICKY_MAX_RETRIES):
+            await asyncio.sleep(_HTTP_STICKY_BACKOFF[attempt])
+            logger.info(
+                f"{host}: HTTP confirmed for session; sticky retry "
+                f"{attempt + 1}/{_HTTP_STICKY_MAX_RETRIES} "
+                f"({os.path.basename(file_path)}) -- not falling to Baichuan"
+            )
+            http_result = await _download_via_http_async(
+                host, http_port, file_path, output_mp4, on_progress
+            )
+            if http_result is True:
+                return True
+        logger.error(
+            f"{host}: HTTP confirmed for session but all "
+            f"{_HTTP_STICKY_MAX_RETRIES} sticky retries failed for "
+            f"{os.path.basename(file_path)}; surfacing failure to queue"
+        )
+        return False
+
     if http_result is False:
         logger.warning(
             "HTTP fast path attempted but failed mid-stream; falling back to Baichuan"


### PR DESCRIPTION
## Summary

The v0.4.5 fix biases toward HTTP and recovers from per-file 404s, but it still falls back to Baichuan on transient HTTP failures (probe inconclusive, mid-stream errors, connection blips) even after multiple files have already succeeded via HTTP. Today's debugging showed file 6 of 14 in a session taking ~10 min on Baichuan after files 1-5 ran ~1 min each on HTTP, just because one probe got a 503.

Per Mark's design: **HTTP is enabled in config → all downloads use HTTP for the session. Only fall back to Baichuan if NO file has downloaded via HTTP this session.**

## Changes

- \`_HTTP_STICKY_MAX_RETRIES = 5\` with \`_HTTP_STICKY_BACKOFF = (1, 4, 10, 30, 60)\` — cumulative ~105 s, well past any transient nginx blip.
- \`_download_and_mux_async\`: when \`_HTTP_PATH_SUPPORTED[host] is True\` AND the file is HTTP-eligible (under \`/mnt/sda/\`), retry HTTP up to 5 times on transient failure. On exhaustion, surface \`False\` so the upstream queue retries the whole task later. Baichuan is still used when host has never confirmed HTTP this session.
- \`_download_via_http_async\`: also set \`_HTTP_PATH_SUPPORTED[host] = True\` on completed streaming download (in addition to probe OK). A finished file is the strongest signal HTTP works.

## Test plan

- [x] \`uv run pytest tests/test_reolink_download.py\` — 69 passed (65 prior + 4 new TestStickyHttpRetry)
- [x] \`uv run --with ruff ruff check . && ruff format --check .\` clean
- [x] \`uv run mypy video_grouper/cameras/reolink_download.py\` clean
- [ ] **Manual e2e**: on next camera reconnect with files queued, verify any transient HTTP failure mid-session retries HTTP rather than falling to Baichuan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)