### PR TITLE
fix(tray): gate AutoCam success-detection on completion sentinel, not file size alone

### DIFF
--- a/tests/test_autocam_automation.py
+++ b/tests/test_autocam_automation.py
@@ -298,7 +298,8 @@ class TestWaitForCompletionExitDetection:
     def test_exit_with_real_output_returns_success(
         self, mock_main_window, mock_file_system
     ):
-        """GUI.exe PIDs exit + output file is large enough → True.
+        """GUI.exe PIDs exit + output file is large enough + completion
+        sentinel present → True.
 
         The autouse ``mock_file_system`` conftest fixture pins
         ``os.path.getsize`` to 1 MB; we override it here so the size
@@ -308,6 +309,10 @@ class TestWaitForCompletionExitDetection:
         with tempfile.TemporaryDirectory() as tmp:
             output = Path(tmp) / "out.mp4"
             output.touch()
+            # Sentinel signals AutoCam actually finished cleanly. Without
+            # it, the exit-detection branch treats the output as a
+            # crashed partial.
+            (Path(tmp) / "out.mp4.completed").touch()
             with (
                 patch(
                     "video_grouper.tray.autocam_automation._live_autocam_pids",
@@ -325,6 +330,34 @@ class TestWaitForCompletionExitDetection:
                     tracked_pids=[12345],
                 )
         assert result is True
+
+    def test_exit_with_output_but_no_sentinel_treats_as_crash_partial(
+        self, mock_main_window, mock_file_system
+    ):
+        """GUI.exe PIDs exit + large output + NO sentinel = crashed
+        mid-pass partial. Must delete output + return False so the next
+        attempt re-runs from scratch. This is the Spencerport gold 2
+        regression that v0.4.8 fixes."""
+        mock_file_system["getsize"].return_value = 657 * 1024 * 1024  # 657 MB partial
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "out.mp4"
+            output.write_bytes(b"\x00" * 1024)  # real file so os.remove succeeds
+            with (
+                patch(
+                    "video_grouper.tray.autocam_automation._live_autocam_pids",
+                    return_value=[],
+                ),
+                patch("video_grouper.tray.autocam_automation.time.sleep"),
+                patch("video_grouper.tray.autocam_automation.subprocess.run"),
+            ):
+                result = _wait_for_completion_and_cleanup(
+                    mock_main_window,
+                    state=None,
+                    output_path=str(output),
+                    tracked_pids=[12345],
+                )
+            assert result is False
+            assert not output.exists(), "crash partial must be deleted"
 
     def test_exit_with_partial_output_returns_failure(self, mock_main_window):
         """GUI.exe exits + output file is too small → False (treated as crash)."""
@@ -379,6 +412,8 @@ class TestWaitForCompletionExitDetection:
         with tempfile.TemporaryDirectory() as tmp:
             output = Path(tmp) / "out.mp4"
             output.touch()
+            # Sentinel needed for the success branch on the second poll.
+            (Path(tmp) / "out.mp4.completed").touch()
             # First poll: PID still alive (branch must NOT trigger).
             # Second poll: PID gone (branch fires + output present → success).
             live_results = iter([[12345], []])
@@ -405,14 +440,18 @@ class TestExecuteAutocamGuiAutomationOutputPrecheck:
     size — otherwise restoring an in_progress task from disk after a
     tray crash would re-process a video we already have."""
 
-    def test_skips_when_output_already_exists(self, tmp_path, mock_file_system):
-        """Output file present + large enough → return True immediately
-        without launching subprocess.Popen / Desktop / pywinauto."""
+    def test_skips_when_output_already_exists_with_sentinel(
+        self, tmp_path, mock_file_system
+    ):
+        """Output file present + large enough + completion sentinel
+        present → return True immediately without launching
+        subprocess.Popen / Desktop / pywinauto."""
         mock_file_system["getsize"].return_value = 50 * 1024 * 1024  # > 10 MB
         input_path = tmp_path / "input.mp4"
         input_path.touch()
         output_path = tmp_path / "output.mp4"
         output_path.touch()
+        (tmp_path / "output.mp4.completed").touch()
         with (
             patch(
                 "video_grouper.tray.autocam_automation.subprocess.Popen"
@@ -426,6 +465,45 @@ class TestExecuteAutocamGuiAutomationOutputPrecheck:
         # Crucially — no fresh AutoCam launch.
         mock_popen.assert_not_called()
         mock_desktop.assert_not_called()
+
+    def test_large_output_without_sentinel_is_deleted_and_relaunches(
+        self, tmp_path, mock_file_system
+    ):
+        """A 657MB partial without sentinel is the Spencerport gold 2
+        regression: AutoCam crashed at 22.7%, left a real-looking
+        partial. Without sentinel we must NOT short-circuit -- delete
+        the partial and run AutoCam fresh."""
+        mock_file_system["getsize"].return_value = 657 * 1024 * 1024
+        input_path = tmp_path / "input.mp4"
+        input_path.touch()
+        output_path = tmp_path / "output.mp4"
+        output_path.touch()
+        # No .completed sentinel.
+        with (
+            patch(
+                "video_grouper.tray.autocam_automation.subprocess.Popen"
+            ) as mock_popen,
+            patch("video_grouper.tray.autocam_automation.Desktop"),
+            patch("video_grouper.tray.autocam_automation.time.sleep"),
+            patch("video_grouper.tray.autocam_automation.os.remove") as mock_remove,
+            patch(
+                "video_grouper.tray.autocam_automation._find_autocam_hwnd",
+                return_value=None,
+            ),
+        ):
+            try:
+                _execute_autocam_gui_automation(
+                    "C:/fake/GUI.exe", str(input_path), str(output_path)
+                )
+            except Exception:
+                pass
+        # The 657 MB partial was deleted (NOT short-circuited as
+        # success) and Popen was called (AutoCam relaunched).
+        mock_remove.assert_called()
+        assert any(
+            call.args[0].endswith("output.mp4") for call in mock_remove.call_args_list
+        ), f"partial mp4 should be deleted, got: {mock_remove.call_args_list}"
+        mock_popen.assert_called()
 
     def test_does_not_skip_when_output_too_small(self, tmp_path, mock_file_system):
         """Output exists but is below the 10 MB threshold → don't
@@ -488,8 +566,10 @@ class TestExecuteAutocamGuiAutomationOutputPrecheck:
             except Exception:
                 pass  # downstream pywinauto will fail; we only care that
                 # the precheck ran the remove + reached Popen
-        mock_remove.assert_called_once()
-        assert mock_remove.call_args.args[0].endswith("output.mp4")
+        # mp4 deleted; sentinel cleanup also called (defense against
+        # stale-sentinel-without-mp4 state). Both touch os.remove.
+        removed = [c.args[0] for c in mock_remove.call_args_list]
+        assert any(p.endswith("output.mp4") for p in removed), removed
         # And we still launched AutoCam afterwards.
         mock_popen.assert_called()
 
@@ -525,7 +605,9 @@ class TestExecuteAutocamGuiAutomationOutputPrecheck:
                 )
             except Exception:
                 pass
-        mock_remove.assert_called_once()
+        # remove was attempted (and swallowed the PermissionError),
+        # and we continued to launch AutoCam.
+        mock_remove.assert_called()
         mock_popen.assert_called()
 
 
@@ -756,9 +838,11 @@ class TestWaitForCompletionStaleNotification:
             output_size=2 * 1024 * 1024,  # 2 MB << 10 MB
         )
         assert result is False
-        # Under the wedge-cleanup path the output gets deleted; that's
-        # fine here since 2 MB is junk.
-        assert removes == ["C:/fake/out.mp4", "C:/fake/out.mp4.jsonl"]
+        # Under the wedge-cleanup path the output gets deleted (and so
+        # does the JSONL + any sentinel) -- that's fine here since 2 MB
+        # is junk.
+        assert "C:/fake/out.mp4" in removes
+        assert "C:/fake/out.mp4.jsonl" in removes
 
     def test_wedge_with_partial_output_deletes_to_prevent_false_short_circuit(self):
         """The Fairport/Spencerport regression: AutoCam wedged at
@@ -807,3 +891,80 @@ class TestTaskkillAutocamTree:
         # operationally but the test pins it for clarity.
         image_names = [c.args[0][3] for c in mock_run.call_args_list]
         assert image_names == ["GUI.exe", "autocam.exe"]
+
+
+class TestCompletionSentinel:
+    """Tests for the completion sentinel helpers themselves."""
+
+    def test_mark_then_has_then_remove(self, tmp_path):
+        from video_grouper.tray.autocam_automation import (
+            _has_completion_sentinel,
+            _mark_output_completed,
+            _remove_completion_sentinel,
+        )
+
+        output = str(tmp_path / "out.mp4")
+        Path(output).touch()
+        assert not _has_completion_sentinel(output)
+        _mark_output_completed(output)
+        assert _has_completion_sentinel(output)
+        assert (tmp_path / "out.mp4.completed").exists()
+        # idempotent
+        _mark_output_completed(output)
+        assert _has_completion_sentinel(output)
+        _remove_completion_sentinel(output)
+        assert not _has_completion_sentinel(output)
+        # tolerant of missing
+        _remove_completion_sentinel(output)
+        assert not _has_completion_sentinel(output)
+
+    def test_mark_swallows_oserror(self, tmp_path):
+        """Sentinel write failing must NOT raise -- worst case the next
+        attempt will re-run AutoCam, which is the safe direction."""
+        from video_grouper.tray.autocam_automation import _mark_output_completed
+
+        # Path inside a nonexistent parent dir → OSError on open.
+        nonexistent = str(tmp_path / "nope" / "out.mp4")
+        # Should not raise
+        _mark_output_completed(nonexistent)
+
+
+class TestSuccessNotificationWritesSentinel:
+    """When AutoCam's 'finished processing' notification fires, we
+    must write the completion sentinel before returning so future
+    re-discoveries short-circuit correctly."""
+
+    def test_finished_processing_writes_sentinel(self):
+        import video_grouper.tray.autocam_automation as mod
+
+        notification = MagicMock()
+        notification.window_text.return_value = "finished processing"
+        mw = MagicMock()
+        mw.child_window.return_value = notification
+
+        mark_calls = []
+
+        def fake_mark(p):
+            mark_calls.append(p)
+
+        with (
+            patch.object(mod, "_mark_output_completed", side_effect=fake_mark),
+            patch("video_grouper.tray.autocam_automation.time.sleep"),
+            patch("video_grouper.tray.autocam_automation.subprocess.run"),
+            patch(
+                "video_grouper.tray.autocam_automation._live_autocam_pids",
+                return_value=[12345],
+            ),
+        ):
+            from video_grouper.tray.autocam_automation import (
+                _wait_for_completion_and_cleanup,
+            )
+
+            result = _wait_for_completion_and_cleanup(
+                mw,
+                state=None,
+                output_path="C:/fake/out.mp4",
+                tracked_pids=[12345],
+            )
+        assert result is True
+        assert mark_calls == ["C:/fake/out.mp4"]

--- a/video_grouper/tray/autocam_automation.py
+++ b/video_grouper/tray/autocam_automation.py
@@ -37,6 +37,62 @@ STALE_NOTIFICATION_SECONDS = 600
 # the output file is non-trivial size is the right move.
 _SHUTDOWN_MARKERS = ("framereader_close", "finished processing")
 
+# Sentinel file written next to the output mp4 when AutoCam actually
+# finished cleanly. File size alone is not a reliable "is this run
+# complete?" signal -- a crashed-mid-pass AutoCam leaves a partial
+# output that's plenty big (observed 2026-05-31: 657 MB partial at
+# 22.7% processed got marked complete via the exit-detection branch).
+# Three code paths consult this sentinel:
+#   1. The top-of-function short-circuit ("output already exists,
+#      skipping re-run")
+#   2. The exit-detection fallback in the poll loop ("PIDs dead +
+#      output exists = success")
+#   3. The Fix C shutdown-marker branch ("notification stuck on
+#      FrameReader_close + output exists = success")
+# Path 3 WRITES the sentinel on success. Path 1 and 2 require it
+# alongside the output. If the output exists without a sentinel, treat
+# it as a crash partial: delete + re-run.
+_COMPLETION_SENTINEL_SUFFIX = ".completed"
+
+
+def _completion_sentinel_path(output_path: str) -> str:
+    return output_path + _COMPLETION_SENTINEL_SUFFIX
+
+
+def _mark_output_completed(output_path: str) -> None:
+    """Write the completion sentinel next to a successful AutoCam output.
+
+    Idempotent. Logs a warning on OSError (e.g., disk full); the
+    failure mode is conservative -- a missing sentinel forces re-run
+    on the next discovery rather than uploading a possibly-truncated
+    video.
+    """
+    sentinel = _completion_sentinel_path(output_path)
+    try:
+        # Touch-style: open for append creates if missing, no truncation.
+        with open(sentinel, "a"):
+            pass
+    except OSError as e:
+        logger.warning(
+            "Could not write completion sentinel %s: %s "
+            "(output stays valid on disk; next attempt will re-run AutoCam)",
+            sentinel,
+            e,
+        )
+
+
+def _has_completion_sentinel(output_path: str) -> bool:
+    return os.path.isfile(_completion_sentinel_path(output_path))
+
+
+def _remove_completion_sentinel(output_path: str) -> None:
+    """Remove the sentinel; tolerated to fail (it just blocks the
+    short-circuit, which is the safe direction)."""
+    try:
+        os.remove(_completion_sentinel_path(output_path))
+    except OSError:
+        pass
+
 
 def _taskkill_autocam_tree() -> None:
     """Kill GUI.exe AND autocam.exe. AutoCam 3.0.7 spawns autocam.exe
@@ -513,6 +569,8 @@ def _wait_for_completion_and_cleanup(
                 if "finished processing" in notification_text:
                     found = True
                     logger.info("Detected success message: %r", raw_notification)
+                    if output_path:
+                        _mark_output_completed(output_path)
                     break
                 elif "error" in notification_text:
                     logger.error("Autocam reported an error: %r", raw_notification)
@@ -532,6 +590,16 @@ def _wait_for_completion_and_cleanup(
             # rather than waiting for a notification string that may
             # never come (some AutoCam builds end with a C-level
             # cleanup message instead of a user-facing success).
+            #
+            # CRITICAL: a non-trivial output file alone is NOT proof of
+            # completion. AutoCam writes the mp4 progressively, so a
+            # crash at e.g. 23% leaves a ~600 MB partial that looks
+            # like a real video by size alone (observed 2026-05-31:
+            # Spencerport gold 2 false-completed at 22.7% with 657 MB).
+            # We require the completion sentinel (written when AutoCam
+            # actually emits its "finished processing" notification).
+            # Output without sentinel = crashed partial. Delete it so
+            # the next attempt re-runs from scratch.
             live_pids = _live_autocam_pids(tracked_pids) if tracked_pids else None
             if tracked_pids and not live_pids:
                 if output_path and os.path.isfile(output_path):
@@ -539,18 +607,36 @@ def _wait_for_completion_and_cleanup(
                         size = os.path.getsize(output_path)
                     except OSError:
                         size = 0
-                    if size >= output_min_bytes:
+                    if size >= output_min_bytes and _has_completion_sentinel(
+                        output_path
+                    ):
                         found = True
                         logger.info(
-                            "AutoCam GUI exited and output exists "
-                            f"({size / 1024 / 1024:.1f} MB at {output_path}); "
-                            "treating as success."
+                            "AutoCam GUI exited and output exists with "
+                            f"completion sentinel ({size / 1024 / 1024:.1f} MB "
+                            f"at {output_path}); treating as success."
                         )
                         break
                     logger.error(
-                        "AutoCam GUI exited but output file is too small "
-                        f"({size} bytes at {output_path}); treating as failure."
+                        f"AutoCam GUI exited with output at {size} bytes "
+                        f"but no completion sentinel -- treating as crashed "
+                        f"partial. Deleting output so next attempt re-runs."
                     )
+                    try:
+                        os.remove(output_path)
+                    except OSError as e:
+                        logger.warning(
+                            "Could not remove crashed partial %s: %s",
+                            output_path,
+                            e,
+                        )
+                    jsonl = output_path + ".jsonl"
+                    if os.path.isfile(jsonl):
+                        try:
+                            os.remove(jsonl)
+                        except OSError:
+                            pass
+                    _remove_completion_sentinel(output_path)
                     break
                 logger.error(
                     "AutoCam GUI exited without producing the expected "
@@ -602,6 +688,12 @@ def _wait_for_completion_and_cleanup(
                             last_notification_text,
                             out_size / 1024 / 1024,
                         )
+                        # AutoCam emitted its shutdown signal, output is
+                        # complete -- write the sentinel so future
+                        # re-discoveries short-circuit cleanly instead
+                        # of re-running the whole AutoCam pass.
+                        if output_path:
+                            _mark_output_completed(output_path)
                         break
                     logger.error(
                         "AutoCam notification unchanged for %.1f minutes "
@@ -641,6 +733,8 @@ def _wait_for_completion_and_cleanup(
                             os.remove(jsonl_path)
                         except OSError:
                             pass
+                    if output_path:
+                        _remove_completion_sentinel(output_path)
                     break
 
             # If processing hasn't started within 5 minutes, bail out.
@@ -723,34 +817,45 @@ def _execute_autocam_gui_automation(
             existing_size = os.path.getsize(abs_output_path)
         except OSError:
             existing_size = 0
-        if existing_size >= 10 * 1024 * 1024:
+        if existing_size >= 10 * 1024 * 1024 and _has_completion_sentinel(
+            abs_output_path
+        ):
             logger.info(
-                "AutoCam output already exists at %s (%.1f MB); skipping re-run.",
+                "AutoCam output already exists at %s (%.1f MB) with completion "
+                "sentinel; skipping re-run.",
                 abs_output_path,
                 existing_size / 1024 / 1024,
             )
             if state is not None:
                 state.clear_autocam_run()
             return True
-        # Pre-delete partial output below the success threshold. Leaving
-        # a sub-threshold file in place triggers the Windows Save
-        # dialog's "Confirm Save As" overwrite-confirm overlay, which
-        # our automation can't drive -- AutoCam then reports "Output
-        # error: No output file selected" the instant Start Processing
-        # fires.
+        # No sentinel means either:
+        #   - sub-10MB junk from a Save-dialog overwrite-confirm dance, or
+        #   - >=10MB partial from a crashed/wedged previous AutoCam run.
+        # Either way the output is unsafe and must be deleted before
+        # relaunching -- a >=10MB partial would otherwise get false-
+        # certified as success by the exit-detection branch in the
+        # poll loop, and a sub-10MB junk file would trigger the
+        # "Confirm Save As" overlay that the dialog automation can't
+        # drive.
         try:
             os.remove(abs_output_path)
             logger.info(
-                "Removed partial AutoCam output at %s (%.1f MB) before relaunch",
+                "Removed pre-existing AutoCam output at %s (%.1f MB, no "
+                "completion sentinel) before relaunch",
                 abs_output_path,
                 existing_size / 1024 / 1024,
             )
         except OSError as e:
             logger.warning(
-                "Could not remove partial output %s: %s; continuing anyway",
+                "Could not remove pre-existing output %s: %s; continuing anyway",
                 abs_output_path,
                 e,
             )
+        # Also drop any stale sentinel if the output is gone (defense
+        # against a partial-leftover state where someone deleted the
+        # mp4 by hand but left the sentinel).
+        _remove_completion_sentinel(abs_output_path)
 
     desktop = Desktop(backend="uia")
 


### PR DESCRIPTION
## Summary

Three code paths in AutoCam automation all treat \`output mp4 file >= 10 MB\` as proof AutoCam finished successfully. AutoCam writes the mp4 **progressively**, so any crashed/killed run leaves a multi-hundred-MB partial that looks like a complete video by size alone. Today's run produced three false successes that almost got uploaded to YouTube as truncated videos:

| Game | False-success path | Partial size | Real % done |
|---|---|---|---|
| Fairport (reattach) | Short-circuit at function top | 715 MB | unknown crash |
| Spencerport gold 2 | Exit-detection fallback | 657 MB | 22.7% |
| WNY Flash (earlier) | Fix C v2 shutdown-marker | 4.4 GB | actually complete (lucky) |

Caught by manual rollback each time. Need a primary signal that's NOT file size.

## Fix

AutoCam doesn't write a "this is complete" signal itself, but soccer-cam can. After AutoCam's \`finished processing\` notification fires (the existing success branch in the poll loop), atomically write a sibling \`<output>.completed\` sentinel. All three trust-points require BOTH the output file at >= 10 MB AND the sentinel:

- **Short-circuit** at top of \`_execute_autocam_gui_automation\`: skips re-run only when output + sentinel both exist. Without sentinel, deletes the output (crashed partial) and runs AutoCam fresh.
- **Exit-detection fallback** in \`_wait_for_completion_and_cleanup\`: returns True only when output + sentinel both exist. Without sentinel, deletes the output (+ jsonl + any stale sentinel) and returns False so the queue retries.
- **Fix C v2 shutdown-marker branch**: writes the sentinel before returning True (this path is the canonical "we detected success" branch alongside the main one).

## Test plan

- [x] \`uv run pytest tests/test_autocam_automation.py tests/test_autocam_resume.py\` — 49 passed (44 prior + 5 new)
- [x] \`uv run --with ruff ruff check .\` + format clean
- [x] \`uv run mypy video_grouper/tray/\` clean
- [ ] **Manual e2e**: After this lands as v0.4.8 on the server, retry the 3 weekend games. None should hit the false-success path; if any AutoCam run crashes mid-pass, the next attempt will start fresh instead of inheriting a partial-as-complete.

## Backwards-compatibility note

Existing \`ball_tracking_complete\` games that were marked before this fix don't have sentinels. They won't get re-attempted by the discovery loop (which only re-enqueues \`trimmed\` directories), so this is benign for them. But if any of those games somehow gets re-enqueued (manual status revert, state corruption), they'd re-run AutoCam instead of short-circuiting -- the conservative direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)