### PR TITLE
fix(ntfy): match buffered responses by group_dir + freshness, not task_type alone

### DIFF
--- a/tests/test_ntfy_processor.py
+++ b/tests/test_ntfy_processor.py
@@ -237,11 +237,12 @@ class TestNtfyProcessor:
             match_info_service=mock_match_info_service,
         )
 
-        # Initialize the queue
+        # Initialize the queue. Keys are stable (task_type:group_dir) — see
+        # NtfyProcessor.get_item_key.
         processor._queue = Mock()
         processor._queued_items = {
-            "game_start_time:/test/path:123",
-            "team_info:/test/path:456",
+            "game_start_time:/test/path",
+            "team_info:/test/path",
         }
 
         # Mock save_state to avoid file operations
@@ -251,13 +252,40 @@ class TestNtfyProcessor:
             )
 
             # Should remove the task from _queued_items
-            assert "game_start_time:/test/path:123" not in processor._queued_items
+            assert "game_start_time:/test/path" not in processor._queued_items
             assert (
-                "team_info:/test/path:456" in processor._queued_items
+                "team_info:/test/path" in processor._queued_items
             )  # Other task should remain
 
             # Should save state
             mock_save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_enqueue_is_deduped(
+        self, mock_config, mock_ntfy_service, mock_match_info_service, storage_path
+    ):
+        """Two equivalent game_start_time tasks for the same dir must dedup to a
+        single queued item (stable get_item_key), so a startup race that
+        enqueues the same question twice yields one notification, not two."""
+        processor = NtfyProcessor(
+            storage_path=storage_path,
+            config=mock_config,
+            ntfy_service=mock_ntfy_service,
+            match_info_service=mock_match_info_service,
+        )
+
+        def make_task():
+            task = Mock()
+            task.get_task_type.return_value = "game_start_time"
+            task.group_dir = "/test/dir"
+            return task
+
+        await processor.add_work(make_task())
+        await processor.add_work(make_task())
+
+        # Distinct instances, same stable key → only one enqueued.
+        assert processor._queued_items == {"game_start_time:/test/dir"}
+        assert processor._queue.qsize() == 1
 
 
 class TestNtfyProcessorBlocking:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2,8 +2,10 @@
 Tests for the new service classes in task_processors/services.
 """
 
+import asyncio
 import os
 import tempfile
+import time
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -487,3 +489,143 @@ class TestCleanupService:
             assert mock_remove.call_count == 2
             mock_remove.assert_any_call(str(group_dir / "temp1.tmp"))
             mock_remove.assert_any_call(str(group_dir / "temp2.temp"))
+
+
+class TestNtfyBufferedResponseFreshness:
+    """Buffered NTFY responses must only replay against a freshly-registered
+    task when they plausibly answer THAT task (i.e. are fresh relative to its
+    registration time). A stale tap from a previous game — replayed by the
+    listener's ?since=24h reconnect on restart — must never auto-answer a new
+    game's question. See ntfy_service._try_buffered_responses_for.
+    """
+
+    @pytest.fixture
+    def ntfy_config(self):
+        return NtfyConfig(
+            enabled=True, server_url="http://localhost:8080", topic="test-topic"
+        )
+
+    @pytest.fixture
+    def storage_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield tmpdir
+
+    @staticmethod
+    def _make_service(ntfy_config, storage_path):
+        """Build an enabled NtfyService with a mocked API (no network)."""
+        with patch(
+            "video_grouper.task_processors.services.ntfy_service.NtfyAPI"
+        ) as mock_api_class:
+            mock_api = Mock()
+            mock_api.enabled = True
+            mock_api_class.return_value = mock_api
+            return NtfyService(ntfy_config, storage_path)
+
+    @pytest.mark.asyncio
+    async def test_stale_buffered_response_not_replayed(
+        self, ntfy_config, storage_path
+    ):
+        """The bug: a game_start_time response tapped hours ago must NOT replay
+        against a newly-registered game_start_time task for a different game."""
+        service = self._make_service(ntfy_config, storage_path)
+
+        with patch.object(
+            service, "_process_task_response", new_callable=AsyncMock
+        ) as mock_process:
+            # Matches the game_start_time TYPE, but tapped two hours ago — long
+            # before the task below registers.
+            stale_server_time = datetime.now().timestamp() - 7200
+            await service.process_response(
+                "Yes, game started at 05:00", server_time=stale_server_time
+            )
+            assert len(service._unmatched_responses) == 1
+
+            # Register a game_start_time task for a DIFFERENT game; this
+            # auto-schedules a replay attempt against the buffer.
+            service.mark_waiting_for_input(
+                "/storage/game_B", "game_start_time", {"time_offset": "00:00"}
+            )
+            await asyncio.sleep(0.05)  # let the scheduled attempt run
+
+            mock_process.assert_not_called()
+            # Entry stays buffered to age out via TTL, not consumed.
+            assert len(service._unmatched_responses) == 1
+            assert service.is_waiting_for_input("/storage/game_B")
+
+    @pytest.mark.asyncio
+    async def test_fresh_buffered_response_is_replayed(self, ntfy_config, storage_path):
+        """A response tapped around the time the task registers IS replayed —
+        the legitimate sub-second race the buffer exists to fix."""
+        service = self._make_service(ntfy_config, storage_path)
+
+        with patch.object(
+            service, "_process_task_response", new_callable=AsyncMock
+        ) as mock_process:
+            fresh_server_time = datetime.now().timestamp()
+            await service.process_response(
+                "Yes, game started at 00:00", server_time=fresh_server_time
+            )
+            assert len(service._unmatched_responses) == 1
+
+            service.mark_waiting_for_input(
+                "/storage/game_A", "game_start_time", {"time_offset": "00:00"}
+            )
+            await asyncio.sleep(0.05)
+
+            mock_process.assert_awaited_once()
+            args = mock_process.await_args.args
+            assert args[0] == "/storage/game_A"
+            assert args[1] == "game_start_time"
+            assert args[3] == "Yes, game started at 00:00"
+            # Consumed from the buffer.
+            assert len(service._unmatched_responses) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_server_time_old_entry_not_replayed(
+        self, ntfy_config, storage_path
+    ):
+        """Without a server timestamp, only an in-flight race (very recent
+        monotonic receive) may replay; an older entry must not."""
+        service = self._make_service(ntfy_config, storage_path)
+
+        with patch.object(
+            service, "_process_task_response", new_callable=AsyncMock
+        ) as mock_process:
+            # Register first (buffer empty → no auto-schedule), then inject an
+            # entry received 100s ago with no server time.
+            service.mark_waiting_for_input(
+                "/storage/game_A", "game_start_time", {"time_offset": "00:00"}
+            )
+            service._unmatched_responses.append(
+                (time.monotonic() - 100, None, "Yes, game started at 00:00")
+            )
+
+            result = await service._try_buffered_responses_for("/storage/game_A")
+
+            assert result is False
+            mock_process.assert_not_called()
+            assert len(service._unmatched_responses) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_server_time_inflight_race_is_replayed(
+        self, ntfy_config, storage_path
+    ):
+        """Without a server timestamp, a just-received entry (the genuine race)
+        still replays so the original buffer fix keeps working."""
+        service = self._make_service(ntfy_config, storage_path)
+
+        with patch.object(
+            service, "_process_task_response", new_callable=AsyncMock
+        ) as mock_process:
+            service.mark_waiting_for_input(
+                "/storage/game_A", "game_start_time", {"time_offset": "00:00"}
+            )
+            service._unmatched_responses.append(
+                (time.monotonic(), None, "Yes, game started at 00:00")
+            )
+
+            result = await service._try_buffered_responses_for("/storage/game_A")
+
+            assert result is True
+            mock_process.assert_awaited_once()
+            assert len(service._unmatched_responses) == 0

--- a/video_grouper/api_integrations/ntfy.py
+++ b/video_grouper/api_integrations/ntfy.py
@@ -280,6 +280,11 @@ class NtfyAPI:
             # Extract event type and message
             event_type = response_data.get("event")
             message = response_data.get("message", "")
+            # NTFY stamps every message with the server-side receive time
+            # (epoch seconds). Thread it through so the service can tell a
+            # fresh user tap from a stale one replayed by ?since=24h on
+            # reconnect. Absent for synthetic/internal events → None.
+            server_time = response_data.get("time")
 
             # For message events (regular messages)
             if event_type == "message":
@@ -331,18 +336,18 @@ class NtfyAPI:
                     ]
                 ):
                     logger.info(f"Detected YES response: '{message}'")
-                    self._handle_response(message)
+                    self._handle_response(message, server_time=server_time)
                 elif any(
                     keyword in lower_message
                     for keyword in ["no", "not yet", "continue"]
                 ):
                     logger.info(f"Detected NO response: '{message}'")
-                    self._handle_response(message)
+                    self._handle_response(message, server_time=server_time)
                 elif message.strip():
                     # Route any non-empty text to the service callback
                     # (e.g. team name, opponent name, location replies)
                     logger.info(f"Routing free-text response: '{message}'")
-                    self._handle_response(message)
+                    self._handle_response(message, server_time=server_time)
 
             # For action events (button clicks)
             elif event_type in ["action", "click", "response"]:
@@ -375,7 +380,9 @@ class NtfyAPI:
                     if message_id:
                         self._handle_specific_response(message_id, input_text)
                     else:
-                        self._handle_response({"response": input_text})
+                        self._handle_response(
+                            {"response": input_text}, server_time=server_time
+                        )
                     return
 
                 # Check for game started/ended responses in any field
@@ -391,14 +398,14 @@ class NtfyAPI:
                     ]
                 ):
                     logger.info(f"Detected YES in action event: {response_data}")
-                    self._handle_response("Yes")
+                    self._handle_response("Yes", server_time=server_time)
                 elif any(
                     keyword in str(value).lower()
                     for value in response_data.values()
                     for keyword in ["no", "not yet", "continue"]
                 ):
                     logger.info(f"Detected NO in action event: {response_data}")
-                    self._handle_response("No")
+                    self._handle_response("No", server_time=server_time)
 
             elif event_type == "keepalive":
                 logger.debug(f"Received keepalive event: {response_data}")
@@ -422,13 +429,21 @@ class NtfyAPI:
                     logger.info(
                         f"Found potential response in unhandled event: {response_data}"
                     )
-                    self._handle_response(str(response_data))
+                    self._handle_response(str(response_data), server_time=server_time)
 
         except Exception as e:
             logger.error(f"Error processing NTFY response: {e}", exc_info=True)
 
-    def _handle_response(self, response: str):
-        """Handle a response to a message."""
+    def _handle_response(self, response: str, server_time: float | None = None):
+        """Handle a response to a message.
+
+        Args:
+            response: The user's response text (or a dict for structured input).
+            server_time: NTFY server receive time (epoch seconds) for this
+                message, when available. Forwarded to the service callback so
+                it can reject stale replays. None for synthetic/internal
+                responses or the legacy pending-future path.
+        """
         # First, try to handle as a pending message (for legacy compatibility)
         if self.pending_messages:
             # Find the most recent message
@@ -457,7 +472,11 @@ class NtfyAPI:
         if self.service_callback:
             logger.info(f"Routing response to service callback: {response}")
             # Use asyncio.create_task to avoid blocking
-            asyncio.create_task(self.service_callback.process_response(response))
+            asyncio.create_task(
+                self.service_callback.process_response(
+                    response, server_time=server_time
+                )
+            )
         else:
             logger.warning(
                 f"Received response but no pending messages and no service callback: {response}"

--- a/video_grouper/task_processors/ntfy_processor.py
+++ b/video_grouper/task_processors/ntfy_processor.py
@@ -141,8 +141,17 @@ class NtfyProcessor(QueueProcessor):
             raise RuntimeError(f"Failed to send NTFY notification for {item}")
 
     def get_item_key(self, item: BaseNtfyTask) -> str:
-        """Get unique key for a BaseNtfyTask."""
-        return f"{item.get_task_type()}:{item.group_dir}:{hash(item)}"
+        """Get a stable dedup key for a BaseNtfyTask.
+
+        Keyed on task_type + group_dir only — NOT hash(item). A per-instance
+        hash made two equivalent enqueues (e.g. a fresh game_start_time task
+        queued twice by racing startup-recovery and state-auditor passes)
+        look distinct, so both ran and the user got two identical phone
+        notifications for one game. There is never more than one in-flight
+        question of a given type for a given directory: the iterative
+        game-start / team-info follow-ups are executed inline, not re-queued.
+        """
+        return f"{item.get_task_type()}:{item.group_dir}"
 
     async def _process_pending_requests_on_startup(self) -> None:
         """Process any pending NTFY requests on startup."""
@@ -471,15 +480,10 @@ class NtfyProcessor(QueueProcessor):
             group_dir: Directory associated with the task
             task_type: Type of task that was completed
         """
-        # Find the task in the queue by matching task_type and group_dir
-        # We need to find the exact key that includes the hash
-        item_key_to_remove = None
-        for item_key in list(self._queued_items):
-            if item_key.startswith(f"{task_type}:{group_dir}:"):
-                item_key_to_remove = item_key
-                break
-
-        if item_key_to_remove:
+        # Item keys are stable (task_type:group_dir, see get_item_key), so
+        # rebuild the key directly rather than scanning.
+        item_key_to_remove = f"{task_type}:{group_dir}"
+        if item_key_to_remove in self._queued_items:
             # Remove from _queued_items set
             self._queued_items.discard(item_key_to_remove)
             logger.info(

--- a/video_grouper/task_processors/services/ntfy_service.py
+++ b/video_grouper/task_processors/services/ntfy_service.py
@@ -16,6 +16,25 @@ from ...utils.paths import get_ntfy_service_state_path
 
 logger = logging.getLogger(__name__)
 
+# A buffered response carries no group_dir of its own, so we use freshness
+# relative to task registration as an identity proxy: a response only replays
+# against a newly-registered task if it plausibly arrived AS an answer to that
+# task. This stops a stale tap from an earlier game (replayed by the listener's
+# ?since=24h reconnect) from auto-answering a different game's question.
+#
+# When we have the NTFY server timestamp (the normal phone-tap path), the tap
+# must have happened no earlier than this many seconds before the task was
+# registered. 60s comfortably covers the genuine sub-second race (the tap
+# arrives microseconds before mark_waiting_for_input finishes) while rejecting
+# taps that are minutes/hours old.
+BUFFER_FRESHNESS_WINDOW_SECONDS = 60
+
+# Fallback when a buffered response has no usable server timestamp
+# (synthetic/internal responses): only an in-flight race qualifies, so the
+# entry must have been received within this many seconds (monotonic) of the
+# task registering. We never replay an older entry on this weak signal.
+BUFFER_RACE_WINDOW_SECONDS = 10
+
 
 class NtfyService:
     """
@@ -51,9 +70,14 @@ class NtfyService:
         # finds no matching task and drops the response — and then the
         # task registers and the user's phone shows the SAME question
         # again, even though they already answered.
-        # Buffer entries are (received_at, response_text). When a new task
-        # registers we replay the buffer against it; entries older than
-        # the TTL get pruned on every check so the buffer doesn't grow.
+        # Buffer entries are (received_monotonic, server_time, response_text)
+        # where server_time is the NTFY server receive time (epoch seconds,
+        # or None if unavailable). When a new task registers we replay the
+        # buffer against it, but ONLY for entries that are fresh relative to
+        # the task's registration time (see _try_buffered_responses_for) — a
+        # stale tap from a previous game must never auto-answer a new one.
+        # Entries older than the TTL get pruned on every check so the buffer
+        # doesn't grow.
         from collections import deque
 
         self._unmatched_responses: deque = deque(maxlen=64)
@@ -495,7 +519,9 @@ class NtfyService:
         """Remove a previously registered response handler."""
         self._response_handlers.pop(key, None)
 
-    async def process_response(self, response: str) -> None:
+    async def process_response(
+        self, response: str, server_time: float | None = None
+    ) -> None:
         """
         Process a response from NTFY and route it to the appropriate pending task.
 
@@ -504,6 +530,10 @@ class NtfyService:
 
         Args:
             response: The user's response message
+            server_time: NTFY server receive time for this response (epoch
+                seconds), when available. Used to reject stale replays when the
+                response has to be buffered. None for synthetic/internal
+                responses (e.g. the mock API or registered response handlers).
         """
         logger.info(f"Processing NTFY response: {response}")
 
@@ -564,7 +594,7 @@ class NtfyService:
         import time
 
         self._prune_unmatched_buffer()
-        self._unmatched_responses.append((time.monotonic(), response))
+        self._unmatched_responses.append((time.monotonic(), server_time, response))
         logger.warning(
             f"No matching task found for response: {response} "
             f"(buffered {len(self._unmatched_responses)} unmatched responses, "
@@ -580,11 +610,48 @@ class NtfyService:
         while self._unmatched_responses and self._unmatched_responses[0][0] < cutoff:
             self._unmatched_responses.popleft()
 
+    @staticmethod
+    def _is_buffered_response_fresh(
+        server_time: float | None,
+        received_monotonic: float,
+        now_monotonic: float,
+        task_sent_at_epoch: float | None,
+    ) -> bool:
+        """Decide whether a buffered response is fresh enough to answer a task.
+
+        A response carries no group_dir, so we use freshness relative to the
+        task's registration time as an identity proxy. A response replays only
+        if it plausibly arrived AS an answer to the just-registered task:
+
+        - With an NTFY server timestamp (the normal phone-tap path), the tap
+          must have happened no earlier than BUFFER_FRESHNESS_WINDOW_SECONDS
+          before the task was registered. This rejects a tap replayed from a
+          previous game by ?since=24h on restart, while still accepting the
+          genuine sub-second race (the tap arrives microseconds before
+          mark_waiting_for_input finishes). If the task's sent_at can't be
+          parsed, fall back to the monotonic recency check below.
+        - Without a usable server timestamp (synthetic/internal responses),
+          only the genuine just-happened race qualifies: the entry must have
+          been received within BUFFER_RACE_WINDOW_SECONDS (monotonic). We never
+          replay an older entry on this weak signal.
+        """
+        if server_time is not None and task_sent_at_epoch is not None:
+            return server_time >= task_sent_at_epoch - BUFFER_FRESHNESS_WINDOW_SECONDS
+        return (now_monotonic - received_monotonic) <= BUFFER_RACE_WINDOW_SECONDS
+
     async def _try_buffered_responses_for(self, group_dir: str) -> bool:
         """Replay buffered unmatched responses against a freshly-registered task.
 
+        A buffered response is only replayed when it both matches the task type
+        AND is fresh relative to the task's registration time (see
+        _is_buffered_response_fresh). This prevents a stale answer from a
+        previous game — replayed by the listener's ?since=24h reconnect — from
+        auto-answering a newly-registered question for a different game.
+
         Returns True if a buffered response matched and was processed.
         """
+        import time
+
         self._prune_unmatched_buffer()
         if not self._unmatched_responses:
             return False
@@ -594,23 +661,47 @@ class NtfyService:
         task_type = task_data.get("task_type")
         metadata = task_data.get("task_metadata", {})
 
+        # Parse the task's registration time (epoch seconds) for the freshness
+        # check. Always written as ISO format by mark_waiting_for_input.
+        task_sent_at_epoch = None
+        sent_at_raw = task_data.get("sent_at")
+        if sent_at_raw:
+            try:
+                task_sent_at_epoch = datetime.fromisoformat(sent_at_raw).timestamp()
+            except (ValueError, TypeError):
+                task_sent_at_epoch = None
+
+        now_monotonic = time.monotonic()
+
         # Iterate a snapshot so we can mutate the deque safely.
         snapshot = list(self._unmatched_responses)
-        for received_at, response in snapshot:
-            if self._response_matches_task(group_dir, task_type, metadata, response):
+        for received_at, server_time, response in snapshot:
+            if not self._response_matches_task(
+                group_dir, task_type, metadata, response
+            ):
+                continue
+            if not self._is_buffered_response_fresh(
+                server_time, received_at, now_monotonic, task_sent_at_epoch
+            ):
                 logger.info(
-                    f"NTFY: Replaying buffered response '{response}' against "
-                    f"newly-registered task {task_type} for {group_dir}"
+                    f"NTFY: NOT replaying stale buffered response '{response}' "
+                    f"against task {task_type} for {group_dir} "
+                    f"(server_time={server_time}, task sent_at={sent_at_raw}) — "
+                    f"it predates this question, so it belongs to another game; "
+                    f"leaving it buffered to age out."
                 )
-                # Remove from buffer first so we don't loop on it.
-                try:
-                    self._unmatched_responses.remove((received_at, response))
-                except ValueError:
-                    pass
-                await self._process_task_response(
-                    group_dir, task_type, metadata, response
-                )
-                return True
+                continue
+            logger.info(
+                f"NTFY: Replaying buffered response '{response}' against "
+                f"newly-registered task {task_type} for {group_dir}"
+            )
+            # Remove from buffer first so we don't loop on it.
+            try:
+                self._unmatched_responses.remove((received_at, server_time, response))
+            except ValueError:
+                pass
+            await self._process_task_response(group_dir, task_type, metadata, response)
+            return True
         return False
 
     def _response_matches_task(


### PR DESCRIPTION
## Problem

On a service restart, soccer-cam auto-answered a brand-new game's "game start" question with a **stale response from a different, earlier game** — without the user tapping anything. Observed 2026-05-31 in production:

```
17:39:21 | NTFY: Marked …2026.05.31-14.40.51 as waiting for input (task_type: game_start_time)
17:39:23 | NTFY: Marked …2026.05.31-14.40.51 as waiting for input (task_type: game_start_time)   ← duplicate
17:39:23 | _try_buffered_responses_for:601 - NTFY: Replaying buffered response
          'Yes, game started at 05:00' against newly-registered task game_start_time for …14.40.51
```

Two defects:

1. **(Primary) Stale buffered response applied to the wrong game.** The unmatched-response buffer replayed an old answer against any newly-registered task as long as the response text matched the task *type*. The NTFY listener re-subscribes with `?since=24h` on restart and replays up to a day of cached ntfy.sh messages, so a `Yes, game started at 05:00` tap from an earlier game matched a new game's `game_start_time` task and auto-answered it with a stale start time.
2. **(Secondary) Duplicate notification.** `get_item_key` keyed on `hash(item)`, so two equivalent `game_start_time` enqueues from racing startup-recovery + state-auditor passes looked distinct and both fired → two identical phone notifications for one game.

## Fix

A buffered response carries **no group_dir**, so freshness relative to the task's registration time is used as an identity proxy — a response only replays if it plausibly arrived *as the answer to that task*:

- **Thread the NTFY server `time`** (epoch seconds = when the user actually tapped) from `_process_response` → `_handle_response` → `process_response`. It was previously discarded.
- Buffer entries become `(received_monotonic, server_time, response)`.
- `_try_buffered_responses_for` gates each candidate on freshness:
  - **With** a server timestamp (normal phone tap): replay only if the tap is no older than `BUFFER_FRESHNESS_WINDOW_SECONDS` (60s) before the task's `sent_at`. A tap from hours ago is rejected; the genuine sub-second registration race still passes.
  - **Without** a server timestamp (synthetic/internal responses): only the genuine in-flight race (`<= BUFFER_RACE_WINDOW_SECONDS`, 10s monotonic) qualifies.
  - Stale entries stay buffered and age out via the existing TTL.
- **Dedup:** `get_item_key` now keys on `task_type:group_dir` (stable), since there is only ever one in-flight question of a type per dir — the iterative game-start/team-info follow-ups execute inline, not via re-queue. `remove_completed_task_from_queue` rebuilds that stable key directly instead of prefix-scanning.

### Conditions under which a buffered response can now replay
Only when `_response_matches_task` is true **AND** the response's NTFY server `time` is `>= task.sent_at - 60s` (or, lacking a server time, the entry is `<= 10s` old by monotonic clock). A response tapped earlier — for any game — is rejected.

## Scope

The `?since=24h` replay and the buffer mechanism are **intentionally kept** — buffered replay is what lets a phone answer land while the service is briefly down. Only the match criteria are tightened. ntfy.sh's own message caching is out of scope (it's ntfy's design).

**Known follow-up (not in this PR):** the *direct* match path in `process_response` (most-recent-group + all-pending fallback) shares the same type-only matching but is the in-session live path, not the restart-replay path that caused this bug. Worth hardening separately if it ever surfaces.

## Tests
- `tests/test_services.py::TestNtfyBufferedResponseFreshness`: stale ≠ replay (the bug), fresh = replay (preserves the legit fix), no-server-time old entry not replayed, no-server-time in-flight race still replays.
- `tests/test_ntfy_processor.py`: duplicate-enqueue dedups to one queued item; updated `remove_completed_task_from_queue` test to the stable key.

## Verification
- `uv run pytest tests/test_services.py tests/test_ntfy_processor.py` — 37 passed
- `uv run pytest -m "not integration and not e2e"` — 1153 passed, 1 skipped
- `uv run pytest tests/integration/test_ntfy_integration.py` — 9 passed
- `ruff check` / `ruff format --check` clean; `mypy ntfy_service.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)