### PR TITLE
feat(camera): download_protocol config (auto|http|baichuan)

### DIFF
--- a/tests/test_reolink_download.py
+++ b/tests/test_reolink_download.py
@@ -1117,3 +1117,162 @@ class TestStickyHttpRetry:
         assert len(calls) == 1
         MockBaichuan.assert_called_once()
         assert result is False  # because mocked Baichuan also fails
+
+
+class TestDownloadProtocolToggle:
+    """The ``download_protocol`` config selects http/baichuan/auto per
+    camera. Locking to one protocol avoids mixed-protocol GOP boundary
+    wedges in AutoCam (observed 2026-05-30 Fairport at 65.4%)."""
+
+    @pytest.mark.asyncio
+    async def test_protocol_baichuan_skips_http_probe_entirely(self, tmp_path):
+        """``download_protocol="baichuan"`` must skip the HTTP probe
+        and go straight to Baichuan, even when the host is in the
+        confirmed-HTTP cache."""
+        _HTTP_PATH_SUPPORTED[HOST] = True  # would normally force HTTP
+        http_calls = []
+
+        async def fake_http(*args, **kwargs):
+            http_calls.append(args)
+            return True
+
+        with (
+            patch(
+                "video_grouper.cameras.reolink_download._download_via_http_async",
+                side_effect=fake_http,
+            ),
+            patch(
+                "video_grouper.cameras.reolink_download.BaichuanStreamClient"
+            ) as MockBaichuan,
+        ):
+            instance = MockBaichuan.return_value
+            instance.connect = AsyncMock(side_effect=ConnectionRefusedError("refused"))
+            instance.close = AsyncMock()
+
+            await _download_and_mux_async(
+                host=HOST,
+                port=9000,
+                username="x",
+                password="y",
+                file_path=SDA_FILE,
+                output_mp4=str(tmp_path / "o.mp4"),
+                http_port=80,
+                download_protocol="baichuan",
+            )
+
+        assert http_calls == [], "HTTP probe must not be called when protocol=baichuan"
+        MockBaichuan.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_protocol_http_does_not_fall_to_baichuan_on_unconfirmed(
+        self, tmp_path
+    ):
+        """``download_protocol="http"`` + first-file probe miss must
+        return False rather than fall to Baichuan (which is what
+        ``auto`` would do here)."""
+        calls = []
+
+        async def fake_http(host, http_port, file_path, output, on_progress=None):
+            calls.append(file_path)
+            return None  # unconfirmed-and-probe-missed
+
+        with (
+            patch(
+                "video_grouper.cameras.reolink_download._download_via_http_async",
+                side_effect=fake_http,
+            ),
+            patch(
+                "video_grouper.cameras.reolink_download.BaichuanStreamClient"
+            ) as MockBaichuan,
+        ):
+            result = await _download_and_mux_async(
+                host=HOST,
+                port=9000,
+                username="x",
+                password="y",
+                file_path=SDA_FILE,
+                output_mp4=str(tmp_path / "o.mp4"),
+                http_port=80,
+                download_protocol="http",
+            )
+
+        assert result is False
+        assert len(calls) == 1
+        MockBaichuan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_protocol_http_does_not_fall_to_baichuan_on_midstream_fail(
+        self, tmp_path
+    ):
+        """``download_protocol="http"`` + HTTP-confirmed + sticky
+        retries exhausted must return False rather than fall to
+        Baichuan."""
+        _HTTP_PATH_SUPPORTED[HOST] = True
+        calls = []
+
+        async def fake_http(host, http_port, file_path, output, on_progress=None):
+            calls.append(file_path)
+            return False  # mid-stream failure every attempt
+
+        with (
+            patch(
+                "video_grouper.cameras.reolink_download._download_via_http_async",
+                side_effect=fake_http,
+            ),
+            patch(
+                "video_grouper.cameras.reolink_download.BaichuanStreamClient"
+            ) as MockBaichuan,
+            _no_sleep(),
+        ):
+            result = await _download_and_mux_async(
+                host=HOST,
+                port=9000,
+                username="x",
+                password="y",
+                file_path=SDA_FILE,
+                output_mp4=str(tmp_path / "o.mp4"),
+                http_port=80,
+                download_protocol="http",
+            )
+
+        assert result is False
+        assert len(calls) == 1 + _HTTP_STICKY_MAX_RETRIES
+        MockBaichuan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_protocol_auto_preserves_existing_behavior(self, tmp_path):
+        """``download_protocol="auto"`` (default) + first-file probe
+        miss falls back to Baichuan as before — proves the new toggle
+        doesn't regress the original ``auto`` behavior."""
+        calls = []
+
+        async def fake_http(host, http_port, file_path, output, on_progress=None):
+            calls.append(file_path)
+            return None
+
+        with (
+            patch(
+                "video_grouper.cameras.reolink_download._download_via_http_async",
+                side_effect=fake_http,
+            ),
+            patch(
+                "video_grouper.cameras.reolink_download.BaichuanStreamClient"
+            ) as MockBaichuan,
+        ):
+            instance = MockBaichuan.return_value
+            instance.connect = AsyncMock(side_effect=ConnectionRefusedError("refused"))
+            instance.close = AsyncMock()
+
+            await _download_and_mux_async(
+                host=HOST,
+                port=9000,
+                username="x",
+                password="y",
+                file_path=SDA_FILE,
+                output_mp4=str(tmp_path / "o.mp4"),
+                http_port=80,
+                download_protocol="auto",
+            )
+
+        assert len(calls) == 1
+        MockBaichuan.assert_called_once()

--- a/video_grouper/cameras/reolink.py
+++ b/video_grouper/cameras/reolink.py
@@ -537,6 +537,7 @@ class ReolinkCamera(Camera):
                 channel=self.channel,
                 on_progress=_progress,
                 http_port=self.config.http_port,
+                download_protocol=self.config.download_protocol,
             )
 
             if success:

--- a/video_grouper/cameras/reolink_download.py
+++ b/video_grouper/cameras/reolink_download.py
@@ -1030,6 +1030,7 @@ def _download_and_mux_sync(
     channel: int = 0,
     on_progress=None,
     http_port: int = 80,
+    download_protocol: str = "auto",
 ) -> bool:
     """Run download + mux in a dedicated event loop (called from a thread).
 
@@ -1050,6 +1051,7 @@ def _download_and_mux_sync(
                 channel,
                 on_progress,
                 http_port=http_port,
+                download_protocol=download_protocol,
             )
         )
     finally:
@@ -1296,61 +1298,77 @@ async def _download_and_mux_async(
     channel: int = 0,
     on_progress=None,
     http_port: int = 80,
+    download_protocol: str = "auto",
 ) -> bool:
-    """Download a recording. HTTP fast path first; Baichuan fallback.
+    """Download a recording per ``download_protocol``.
 
-    1. Try patched-firmware HTTP fast path (~80–90 Mbps, no remux).
-    2. If unavailable (404 / connection refused), fall back to Baichuan
-       on port 9000: stream BcMedia -> Annex-B -> remux to MP4 via ffmpeg.
-
-    Returns True on success.
+    "auto" (default): probe HTTP fast path, fall back to Baichuan on
+    unconfirmed/unsupported, sticky-retry HTTP once any file in the
+    session has succeeded.
+    "http": HTTP only. Never fall back to Baichuan; failures surface
+    to the queue. Use this when mixed-protocol downloads have
+    produced AutoCam wedges (observed 2026-05-30 Fairport) and one
+    fully-HTTP session is preferred to oscillating between protocols.
+    "baichuan": skip HTTP entirely and stream directly via Baichuan
+    on port 9000 (BcMedia -> Annex-B -> remux to MP4 via ffmpeg).
     """
-    # Try HTTP first. True = done over HTTP. None = HTTP not used for this
-    # file (unconfirmed-and-probe-missed / 404 / connection error) — fall
-    # back to Baichuan for this file; HTTP is re-probed on the next file.
-    # False = HTTP was serving but the transfer failed mid-stream.
-    http_result = await _download_via_http_async(
-        host, http_port, file_path, output_mp4, on_progress
-    )
-    if http_result is True:
-        return True
-
-    # Sticky-HTTP: once ANY file on this host has downloaded via HTTP this
-    # session, transient failures must retry HTTP rather than fall to
-    # Baichuan. Baichuan is reserved for cameras where HTTP has never
-    # worked. Falling to Baichuan post-confirmation would have us
-    # downloading at ~1.8 MB/s when ~10 MB/s is available, just because
-    # one probe blip nudged us off the fast path.
-    #
-    # Only applies to files under CAMERA_RECORD_PREFIX: HTTP fast path
-    # is only valid for /mnt/sda/ paths; non-record paths must use
-    # Baichuan regardless.
-    if _HTTP_PATH_SUPPORTED.get(host) is True and file_path.startswith(
-        CAMERA_RECORD_PREFIX
-    ):
-        for attempt in range(_HTTP_STICKY_MAX_RETRIES):
-            await asyncio.sleep(_HTTP_STICKY_BACKOFF[attempt])
-            logger.info(
-                f"{host}: HTTP confirmed for session; sticky retry "
-                f"{attempt + 1}/{_HTTP_STICKY_MAX_RETRIES} "
-                f"({os.path.basename(file_path)}) -- not falling to Baichuan"
-            )
-            http_result = await _download_via_http_async(
-                host, http_port, file_path, output_mp4, on_progress
-            )
-            if http_result is True:
-                return True
-        logger.error(
-            f"{host}: HTTP confirmed for session but all "
-            f"{_HTTP_STICKY_MAX_RETRIES} sticky retries failed for "
-            f"{os.path.basename(file_path)}; surfacing failure to queue"
+    if download_protocol == "baichuan":
+        logger.info(
+            "%s: download_protocol=baichuan; skipping HTTP fast path",
+            host,
         )
-        return False
-
-    if http_result is False:
-        logger.warning(
-            "HTTP fast path attempted but failed mid-stream; falling back to Baichuan"
+    else:
+        # Try HTTP first. True = done over HTTP. None = HTTP not used
+        # for this file (unconfirmed-and-probe-missed / 404 /
+        # connection error). False = HTTP was serving but the transfer
+        # failed mid-stream.
+        http_result = await _download_via_http_async(
+            host, http_port, file_path, output_mp4, on_progress
         )
+        if http_result is True:
+            return True
+
+        # Sticky-HTTP: once ANY file on this host has downloaded via
+        # HTTP this session, transient failures must retry HTTP rather
+        # than fall to Baichuan. Falling to Baichuan post-confirmation
+        # would drop us from ~10 MB/s to ~1.8 MB/s on a single blip.
+        # Only applies to files under CAMERA_RECORD_PREFIX.
+        if _HTTP_PATH_SUPPORTED.get(host) is True and file_path.startswith(
+            CAMERA_RECORD_PREFIX
+        ):
+            for attempt in range(_HTTP_STICKY_MAX_RETRIES):
+                await asyncio.sleep(_HTTP_STICKY_BACKOFF[attempt])
+                logger.info(
+                    f"{host}: HTTP confirmed for session; sticky retry "
+                    f"{attempt + 1}/{_HTTP_STICKY_MAX_RETRIES} "
+                    f"({os.path.basename(file_path)}) -- not falling to Baichuan"
+                )
+                http_result = await _download_via_http_async(
+                    host, http_port, file_path, output_mp4, on_progress
+                )
+                if http_result is True:
+                    return True
+            logger.error(
+                f"{host}: HTTP confirmed for session but all "
+                f"{_HTTP_STICKY_MAX_RETRIES} sticky retries failed for "
+                f"{os.path.basename(file_path)}; surfacing failure to queue"
+            )
+            return False
+
+        if download_protocol == "http":
+            logger.error(
+                "%s: download_protocol=http but HTTP unavailable for "
+                "%s (http_result=%r); not falling back to Baichuan",
+                host,
+                os.path.basename(file_path),
+                http_result,
+            )
+            return False
+
+        if http_result is False:
+            logger.warning(
+                "HTTP fast path attempted but failed mid-stream; falling back to Baichuan"
+            )
 
     # Baichuan delivers raw video + raw audio frames (no container);
     # we stage them as <name>.partial.video and <name>.partial.audio,
@@ -1427,11 +1445,13 @@ async def download_and_mux(
     channel: int = 0,
     on_progress=None,
     http_port: int = 80,
+    download_protocol: str = "auto",
 ) -> bool:
-    """Download a recording. HTTP fast path → Baichuan fallback → MP4 on disk.
+    """Download a recording per ``download_protocol`` and write MP4 to disk.
 
-    Runs in a dedicated thread with its own event loop to avoid contention
-    with the main service loop.
+    See ``_download_and_mux_async`` for protocol semantics. Runs in a
+    dedicated thread with its own event loop to avoid contention with
+    the main service loop.
     """
     return await asyncio.to_thread(
         _download_and_mux_sync,
@@ -1444,4 +1464,5 @@ async def download_and_mux(
         channel,
         on_progress,
         http_port,
+        download_protocol,
     )

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import configparser
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, Field, RootModel, field_validator
 
@@ -55,6 +56,14 @@ class CameraConfig(BaseModel):
     http_port: int = 80
     enabled: bool = True
     serial: str = ""
+    # Reolink download protocol selection. "auto" probes HTTP first and
+    # falls back to Baichuan; "http" requires patched-firmware HTTP and
+    # fails the download rather than falling back; "baichuan" skips the
+    # HTTP probe entirely. Mixed-protocol downloads in a single session
+    # have produced reproducible AutoCam wedges at the protocol-switch
+    # GOP boundary (observed 2026-05-30 Fairport), so locking to a
+    # single protocol per game is the safer default for tournament use.
+    download_protocol: Literal["auto", "http", "baichuan"] = "auto"
 
 
 class StorageConfig(BaseModel):


### PR DESCRIPTION
## Summary
Per-camera ``download_protocol`` selects how Reolink recordings are pulled:
- ``auto`` (default, current behavior) — HTTP probe, Baichuan fallback
- ``http`` — HTTP only; surfaces failure to the queue instead of falling back
- ``baichuan`` — skip HTTP probe entirely, BcMedia/Baichuan only

## Why
Mixed-protocol downloads in a single session produced reproducible AutoCam wedges at the GOP boundary where Baichuan-encoded files met HTTP-encoded files (observed 2026-05-30 Fairport: wedge at exactly 65.4% for hours; same input downloaded HTTP-only processed cleanly through the wedge point). Tournament operators who care about deterministic throughput now have a way to lock to one protocol per session.

Existing configs aren't touched — the default stays ``auto``.

## Test plan
- [x] Lint + mypy clean
- [x] ``uv run pytest tests/test_reolink_download.py tests/test_reolink_camera.py`` — 104 passing including 4 new ``TestDownloadProtocolToggle`` cases
- [x] New tests cover: protocol=baichuan skips HTTP probe; protocol=http with unconfirmed-probe returns False (no fallback); protocol=http with mid-stream fail exhausts sticky retries then False (no fallback); protocol=auto preserves existing fallback behavior
- [ ] Manual: set ``download_protocol = http`` on Mark's Reolink in soccer-cam config, verify next download session never touches Baichuan