### PR TITLE
feat(camera_poller): per-poll diagnostic summary + HWM-stall warning

### DIFF
--- a/tests/test_camera_poller.py
+++ b/tests/test_camera_poller.py
@@ -1,5 +1,6 @@
 """Tests for the CameraPoller processor."""
 
+import logging
 import os
 import tempfile
 from datetime import datetime
@@ -338,6 +339,79 @@ class TestCameraPoller:
 
         # File should not be queued again
         mock_download_processor.add_work.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_poll_summary_logs_when_all_files_are_runts(
+        self, temp_storage, mock_config, mock_camera, caplog
+    ):
+        """When the camera returns only runts (isolated short recordings),
+        no file advances the HWM. The poll-summary log must report
+        all-files-filtered AND a warning must fire so future stalls are
+        debuggable. Regression guard for the 2026-05-30 tournament
+        incident where the HWM stuck at a runt's end_time."""
+        mock_camera.get_file_list.return_value = [
+            {
+                "path": "/runt1.dav",
+                "startTime": "2026-05-28 09:33:28",
+                "endTime": "2026-05-28 09:33:32",  # 4s, alone -> runt
+            }
+        ]
+        mock_download_processor = Mock()
+        mock_download_processor.add_work = AsyncMock()
+        poller = CameraPoller(
+            temp_storage, mock_config, mock_camera, mock_download_processor
+        )
+
+        with caplog.at_level(
+            logging.INFO, logger="video_grouper.task_processors.camera_poller"
+        ):
+            await poller._sync_files_from_camera()
+
+        # Summary line must reflect the 1 runt + 0 of everything else.
+        assert any(
+            "poll summary -- 1 files seen" in r.message
+            and "runt=1" in r.message
+            and "new=0" in r.message
+            for r in caplog.records
+        ), f"missing or wrong poll summary, got: {[r.message for r in caplog.records]}"
+        # Warning must fire to flag the HWM-stall risk.
+        assert any(
+            "HWM not advanced" in r.message and r.levelname == "WARNING"
+            for r in caplog.records
+        ), "expected HWM-not-advanced warning for all-runts case"
+
+    @pytest.mark.asyncio
+    async def test_poll_summary_logs_normal_new_file(
+        self, temp_storage, mock_config, mock_camera, caplog
+    ):
+        """A normal poll with one new file must emit a summary showing
+        new=1 and an HWM-advanced INFO line citing the file."""
+        mock_camera.get_file_list.return_value = [
+            {
+                "path": "/normal.dav",
+                "startTime": "2026-05-28 14:00:00",
+                "endTime": "2026-05-28 14:30:00",
+            }
+        ]
+        mock_download_processor = Mock()
+        mock_download_processor.add_work = AsyncMock()
+        poller = CameraPoller(
+            temp_storage, mock_config, mock_camera, mock_download_processor
+        )
+
+        with caplog.at_level(
+            logging.INFO, logger="video_grouper.task_processors.camera_poller"
+        ):
+            await poller._sync_files_from_camera()
+
+        assert any(
+            "poll summary -- 1 files seen" in r.message and "new=1" in r.message
+            for r in caplog.records
+        )
+        assert any(
+            "HWM advanced to" in r.message and "normal.dav" in r.message
+            for r in caplog.records
+        ), "expected HWM-advanced INFO line citing the new file"
 
     def test_find_group_directory_new_group(self, temp_storage):
         """Test finding group directory when creating a new group."""

--- a/video_grouper/task_processors/camera_poller.py
+++ b/video_grouper/task_processors/camera_poller.py
@@ -302,6 +302,19 @@ class CameraPoller(PollingProcessor):
         runt_paths = _identify_runt_recordings(files, existing_dirs)
 
         latest_end_time = None
+        latest_end_time_file = None
+        # Per-poll diagnostics so HWM stalls can be root-caused after the
+        # fact: classify every file the camera returned and emit a single
+        # summary line at end of poll. Without this, an HWM-stuck
+        # incident (5/30 runt stuck at 19:44:06 for 14+ hours, 2026-05-30
+        # tournament day) requires DEBUG logs to reconstruct.
+        counts = {
+            "new_added": 0,
+            "already_known": 0,
+            "runt": 0,
+            "home_connected": 0,
+            "unparseable": 0,
+        }
 
         # Get connected timeframes for filtering
         connected_timeframes = self.camera.get_connected_timeframes()
@@ -329,6 +342,7 @@ class CameraPoller(PollingProcessor):
                 # Isolated runt (handled before parsing end time, which may
                 # be unparseable for an aborted recording).
                 if file_info["path"] in runt_paths:
+                    counts["runt"] += 1
                     continue
 
                 file_start_time, file_end_time = _parse_recording_times(file_info)
@@ -336,6 +350,7 @@ class CameraPoller(PollingProcessor):
                     logger.warning(
                         f"CAMERA_POLLER: unparseable start time for {filename}; skipping"
                     )
+                    counts["unparseable"] += 1
                     continue
                 if file_end_time is None or file_end_time <= file_start_time:
                     # Aborted/unparseable end on a KEPT (contiguous) file — fall
@@ -371,12 +386,14 @@ class CameraPoller(PollingProcessor):
                             break
 
                 if should_skip:
+                    counts["home_connected"] += 1
                     files_to_delete.append(file_info["path"])
                     continue
 
                 # Track high-water mark from non-skipped files only
                 if latest_end_time is None or file_end_time > latest_end_time:
                     latest_end_time = file_end_time
+                    latest_end_time_file = filename
 
                 group_dir = find_group_directory(
                     file_start_time, self.storage_path, existing_dirs
@@ -388,10 +405,16 @@ class CameraPoller(PollingProcessor):
 
                 dir_state = DirectoryState(group_dir)
                 if dir_state.is_file_in_state(local_path):
-                    logger.debug(
-                        f"CAMERA_POLLER: File {filename} is already known. Skipping."
+                    counts["already_known"] += 1
+                    logger.info(
+                        "CAMERA_POLLER: File %s (end=%s) already known; "
+                        "HWM advanced past it, no re-download.",
+                        filename,
+                        file_end_time,
                     )
                     continue
+
+                counts["new_added"] += 1
 
                 # Store camera identity in metadata for downstream use
                 file_info["camera_name"] = self.camera.name
@@ -448,10 +471,39 @@ class CameraPoller(PollingProcessor):
                         f"CAMERA_POLLER: TTT registration failed for {os.path.basename(group_dir)}: {e}"
                     )
 
+        total_seen = sum(counts.values())
+        logger.info(
+            "CAMERA_POLLER: poll summary -- %d files seen "
+            "(new=%d already_known=%d runt=%d home_connected=%d unparseable=%d)",
+            total_seen,
+            counts["new_added"],
+            counts["already_known"],
+            counts["runt"],
+            counts["home_connected"],
+            counts["unparseable"],
+        )
+
         if latest_end_time:
             await self._update_latest_processed_time(latest_end_time)
             logger.info(
-                f"CAMERA_POLLER: File sync complete. New high-water mark set to: {latest_end_time}"
+                "CAMERA_POLLER: HWM advanced to %s (by file %s)",
+                latest_end_time,
+                latest_end_time_file,
+            )
+        elif total_seen > 0:
+            # Files were returned but none advanced the HWM -- all were
+            # runts, home-connected, or unparseable. The HWM stays where
+            # it is, so the next poll re-queries the same window. If
+            # this repeats for many consecutive polls, the camera has
+            # effectively stalled on a class of files the poller won't
+            # process; manual recovery (delete the offending dir + bump
+            # HWM) may be needed.
+            logger.warning(
+                "CAMERA_POLLER: %d files seen but HWM not advanced "
+                "(all filtered out by runt/home-connected/unparseable). "
+                "HWM remains at previous value; next poll will re-query "
+                "the same window.",
+                total_seen,
             )
 
     async def _get_latest_processed_time(self) -> datetime | None:


### PR DESCRIPTION
## Summary
Pure observability — no behavior change. Classify every file the camera returns per poll into one of five categories (``new`` / ``already_known`` / ``runt`` / ``home_connected`` / ``unparseable``) and emit a single summary line per poll showing the counts. When files were returned but none advanced the HWM, log a WARNING — that's the signature of an HWM stall.

Also promotes the per-file ``already known`` log from DEBUG to INFO so the next stall can be diagnosed from normal logs.

## Why
The 2026-05-30 tournament-day stall stuck the HWM at a runt's end_time for 14+ hours and required manually editing ``camera_state.json`` to recover. The existing logs didn't make the root cause obvious — the stall could have been caused by an offline camera, all-runt returns, all-home-connected returns, or a code bug. With this change, the next occurrence will show exactly which class of file the poller is rejecting and whether the HWM is moving.

I considered shipping a speculative behavior fix (delay HWM advance to after ``is_file_in_state``), but on close reading the code looked correct as-is for normal scenarios. Adding diagnostics first lets us catch the next stall in the act rather than ship a fix that may not address the actual root cause.

## Test plan
- [x] Lint + mypy clean
- [x] ``uv run pytest tests/test_camera_poller.py`` — 42 passing (40 existing + 2 new)
  - ``test_poll_summary_logs_when_all_files_are_runts`` — regression guard for the tournament stall
  - ``test_poll_summary_logs_normal_new_file`` — verifies the HWM-advance INFO line
- [ ] After merge + deploy, watch a few normal polls in the server log; confirm the summary line appears once per poll.