### PR TITLE
feat(state_auditor): run as polling loop, not one-shot startup scan

### DIFF
--- a/tests/test_state_auditor_enhanced.py
+++ b/tests/test_state_auditor_enhanced.py
@@ -2,6 +2,7 @@
 Tests for the enhanced StateAuditor with service integrations.
 """
 
+import asyncio
 import tempfile
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -613,48 +614,67 @@ class TestStateAuditorPipelineToggle:
         mock_upload_processor.add_work.assert_not_called()
 
 
-class TestStateAuditorStartupOnly:
-    """Tests that StateAuditor is startup-only (not continuous polling)."""
+class TestStateAuditorPolling:
+    """Tests that StateAuditor runs as a continuous polling loop so
+    that mid-session changes (e.g. manual edits to match_info.ini)
+    get picked up without a service restart."""
 
     @patch("video_grouper.task_processors.services.teamsnap_service.TeamSnapAPI")
     @patch("video_grouper.task_processors.services.playmetrics_service.PlayMetricsAPI")
     @patch("video_grouper.task_processors.services.ntfy_service.NtfyAPI")
     @pytest.mark.asyncio
-    async def test_start_runs_discover_work_once(
+    async def test_start_creates_polling_loop(
         self, mock_ntfy, mock_playmetrics, mock_teamsnap, mock_config, tmp_path
     ):
-        """start() should call discover_work() once and return."""
+        """start() should create a background polling task that calls
+        discover_work() on the poll_interval."""
         mock_teamsnap.return_value.enabled = True
         mock_playmetrics.return_value.enabled = True
         mock_playmetrics.return_value.login.return_value = True
         mock_ntfy.return_value.enabled = True
 
         auditor = StateAuditor(str(tmp_path), mock_config, Mock(), Mock())
+        auditor.match_info_service.shutdown = AsyncMock()
 
         with patch.object(auditor, "discover_work", new_callable=AsyncMock) as mock_dw:
             await auditor.start()
-            mock_dw.assert_called_once()
+            # Give the task one tick to run discover_work() the first time.
+            await asyncio.sleep(0.05)
+            assert auditor._processor_task is not None
+            assert mock_dw.call_count >= 1
+            await auditor.stop()
 
     @patch("video_grouper.task_processors.services.teamsnap_service.TeamSnapAPI")
     @patch("video_grouper.task_processors.services.playmetrics_service.PlayMetricsAPI")
     @patch("video_grouper.task_processors.services.ntfy_service.NtfyAPI")
     @pytest.mark.asyncio
-    async def test_start_does_not_create_polling_loop(
+    async def test_polling_loop_calls_discover_work_repeatedly(
         self, mock_ntfy, mock_playmetrics, mock_teamsnap, mock_config, tmp_path
     ):
-        """start() should NOT create a persistent _processor_task (no polling loop)."""
+        """Regression guard for the 2026-06-01 West Seneca incident:
+        a manually-edited match_info.ini needed a service restart
+        because the auditor ran only at startup. With polling, the
+        next loop iteration picks the change up automatically."""
         mock_teamsnap.return_value.enabled = True
         mock_playmetrics.return_value.enabled = True
         mock_playmetrics.return_value.login.return_value = True
         mock_ntfy.return_value.enabled = True
 
-        auditor = StateAuditor(str(tmp_path), mock_config, Mock(), Mock())
+        # Short poll interval so the test doesn't have to wait.
+        auditor = StateAuditor(
+            str(tmp_path), mock_config, Mock(), Mock(), poll_interval=1
+        )
+        auditor.match_info_service.shutdown = AsyncMock()
 
-        with patch.object(auditor, "discover_work", new_callable=AsyncMock):
+        with patch.object(auditor, "discover_work", new_callable=AsyncMock) as mock_dw:
             await auditor.start()
-
-        # _processor_task should remain None (no background loop created)
-        assert auditor._processor_task is None
+            await asyncio.sleep(1.2)
+            await auditor.stop()
+            # At least 2 calls: initial + one polled iteration.
+            assert mock_dw.call_count >= 2, (
+                f"expected polling loop to call discover_work repeatedly, "
+                f"got {mock_dw.call_count} calls"
+            )
 
     @patch("video_grouper.task_processors.services.teamsnap_service.TeamSnapAPI")
     @patch("video_grouper.task_processors.services.playmetrics_service.PlayMetricsAPI")

--- a/tests/test_state_auditor_enhanced.py
+++ b/tests/test_state_auditor_enhanced.py
@@ -623,6 +623,76 @@ class TestStateAuditorPolling:
     @patch("video_grouper.task_processors.services.playmetrics_service.PlayMetricsAPI")
     @patch("video_grouper.task_processors.services.ntfy_service.NtfyAPI")
     @pytest.mark.asyncio
+    async def test_temp_cleanup_runs_only_on_first_pass(
+        self, mock_ntfy, mock_playmetrics, mock_teamsnap, mock_config, tmp_path
+    ):
+        """Regression guard: the *.partial*/*.tmp orphan sweep is
+        boot-only. A recurring sweep would delete the staging files
+        that active downloads / combines / trims are writing (POSIX:
+        the final os.replace then fails; Windows: sharing-violation
+        spam every poll)."""
+        mock_teamsnap.return_value.enabled = True
+        mock_playmetrics.return_value.enabled = True
+        mock_playmetrics.return_value.login.return_value = True
+        mock_ntfy.return_value.enabled = True
+
+        group_dir = tmp_path / "2026.06.12-10.00.00"
+        group_dir.mkdir()
+
+        auditor = StateAuditor(str(tmp_path), mock_config, Mock(), Mock())
+
+        with (
+            patch.object(auditor, "_cleanup_temp_files") as mock_tmp,
+            patch.object(
+                auditor, "_audit_directory", new_callable=AsyncMock
+            ) as mock_audit,
+        ):
+            await auditor.discover_work()  # boot pass: sweep runs
+            assert mock_tmp.call_count == 1
+            assert mock_audit.call_count == 1
+
+            await auditor.discover_work()  # poll pass: sweep must NOT run
+            assert mock_tmp.call_count == 1, (
+                "temp-file cleanup ran on a polling pass — it would race "
+                "in-flight download/combine/trim staging files"
+            )
+            assert mock_audit.call_count == 2  # the audit itself still polls
+
+    @patch("video_grouper.task_processors.services.teamsnap_service.TeamSnapAPI")
+    @patch("video_grouper.task_processors.services.playmetrics_service.PlayMetricsAPI")
+    @patch("video_grouper.task_processors.services.ntfy_service.NtfyAPI")
+    @pytest.mark.asyncio
+    async def test_partial_file_survives_polling_pass(
+        self, mock_ntfy, mock_playmetrics, mock_teamsnap, mock_config, tmp_path
+    ):
+        """End-to-end shape of the race: a .partial staging file created
+        AFTER boot (i.e. an in-flight download) must survive subsequent
+        discover_work() polls."""
+        mock_teamsnap.return_value.enabled = True
+        mock_playmetrics.return_value.enabled = True
+        mock_playmetrics.return_value.login.return_value = True
+        mock_ntfy.return_value.enabled = True
+
+        group_dir = tmp_path / "2026.06.12-10.00.00"
+        group_dir.mkdir()
+
+        auditor = StateAuditor(str(tmp_path), mock_config, Mock(), Mock())
+
+        with patch.object(auditor, "_audit_directory", new_callable=AsyncMock):
+            await auditor.discover_work()  # boot pass (nothing to sweep)
+
+            in_flight = group_dir / "0.10.03-0.20.07.mp4.partial"
+            in_flight.write_bytes(b"streaming download in progress")
+
+            await auditor.discover_work()  # polling pass
+            assert in_flight.exists(), (
+                "polling pass deleted an in-flight .partial staging file"
+            )
+
+    @patch("video_grouper.task_processors.services.teamsnap_service.TeamSnapAPI")
+    @patch("video_grouper.task_processors.services.playmetrics_service.PlayMetricsAPI")
+    @patch("video_grouper.task_processors.services.ntfy_service.NtfyAPI")
+    @pytest.mark.asyncio
     async def test_start_creates_polling_loop(
         self, mock_ntfy, mock_playmetrics, mock_teamsnap, mock_config, tmp_path
     ):

--- a/tests/test_video_grouper_app.py
+++ b/tests/test_video_grouper_app.py
@@ -183,22 +183,18 @@ class TestVideoGrouperAppRefactored:
         # Initialize should start all processors
         await app.initialize()
 
-        # All processors except StateAuditor (startup-only) should be running
+        # All processors run a polling/processing loop — including the
+        # StateAuditor, which polls so mid-session changes (e.g. a manual
+        # match_info.ini edit) get picked up without a restart.
         for processor in app.processors:
-            if processor is app.state_auditor:
-                # StateAuditor is startup-only: runs discover_work() once, no loop
-                assert processor._processor_task is None
-            else:
-                assert processor._processor_task is not None
-                assert not processor._processor_task.done()
+            assert processor._processor_task is not None
+            assert not processor._processor_task.done()
 
         # Shutdown should stop all processors
         await app.shutdown()
 
-        # All processors with tasks should be stopped
+        # All processors' tasks should be stopped
         for processor in app.processors:
-            if processor is app.state_auditor:
-                continue  # No task to check
             assert processor._processor_task.done()
 
     @pytest.mark.asyncio

--- a/video_grouper/task_processors/state_auditor.py
+++ b/video_grouper/task_processors/state_auditor.py
@@ -39,6 +39,11 @@ class StateAuditor(PollingProcessor):
     Now runs on a poll interval (default 60s). Safe to re-poll because
     every downstream ``add_work`` call dedupes on the task's item_key,
     so a still-in-progress task isn't re-enqueued.
+
+    Temp-file cleanup stays BOOT-ONLY (first successful pass): the
+    ``*.partial*`` / ``*.tmp`` suffixes it reaps are exactly what active
+    downloads, combines, trims and state saves stage to, so re-running
+    the sweep on every poll would race live writers.
     """
 
     def __init__(
@@ -77,6 +82,15 @@ class StateAuditor(PollingProcessor):
         # Initialize cleanup service
         self.cleanup_service = CleanupService(storage_path)
 
+        # Temp-file cleanup is BOOT-ONLY. Active operations stage to the
+        # same suffixes the cleanup reaps (downloads -> *.partial*,
+        # combine/trim -> *.tmp, state saves -> state.json.tmp), so a
+        # recurring sweep would race live writers: on POSIX an unlink of
+        # an open file makes the final os.replace fail; on Windows it
+        # spams sharing-violation warnings every poll. At boot nothing
+        # is in flight, so the orphan sweep is safe exactly once.
+        self._startup_cleanup_done = False
+
     @property
     def download_processor(self):
         """Backward compat: return the first download processor."""
@@ -92,12 +106,17 @@ class StateAuditor(PollingProcessor):
 
         try:
             # Get all directories in storage path
+            run_cleanup = not self._startup_cleanup_done
             items = os.listdir(self.storage_path)
             for item in items:
                 group_dir = os.path.join(self.storage_path, item)
                 if os.path.isdir(group_dir) and not item.startswith("."):
-                    self._cleanup_temp_files(group_dir)
+                    if run_cleanup:
+                        self._cleanup_temp_files(group_dir)
                     await self._audit_directory(group_dir)
+            # Only after a full pass — a failed listdir retries cleanup
+            # on the next poll instead of silently never sweeping.
+            self._startup_cleanup_done = True
 
         except Exception as e:
             logger.error(f"STATE_AUDITOR: Error during directory audit: {e}")
@@ -336,8 +355,11 @@ class StateAuditor(PollingProcessor):
                     f"STATE_AUDITOR: Found not_a_game status for {group_dir}, skipping further processing"
                 )
 
-            # Handle cleanup tasks
-            await self._handle_cleanup(group_dir)
+            # Handle cleanup tasks — boot-only, same reasoning as
+            # _cleanup_temp_files (CleanupService reaps *.tmp, which
+            # combine/trim and state saves actively stage to).
+            if not self._startup_cleanup_done:
+                await self._handle_cleanup(group_dir)
 
         except Exception as e:
             logger.error(f"STATE_AUDITOR: Error auditing directory {group_dir}: {e}")

--- a/video_grouper/task_processors/state_auditor.py
+++ b/video_grouper/task_processors/state_auditor.py
@@ -26,12 +26,19 @@ logger = logging.getLogger(__name__)
 
 class StateAuditor(PollingProcessor):
     """
-    Startup recovery scanner for the pipeline.
+    Recovery scanner for the pipeline.
 
-    On app start, scans the shared_data directory for state.json files and
-    re-queues any interrupted work (pending downloads, combined dirs awaiting
-    match info, etc.). Does NOT run as a continuous poller during normal
-    operation — event-driven transitions handle ongoing work.
+    Scans the shared_data directory for state.json files and re-queues
+    any work that needs to start or restart (pending downloads,
+    combined dirs awaiting match info, ball_tracking_complete dirs
+    awaiting upload, etc.). Originally a one-shot startup scan, but
+    that left a gap: when a user manually populates a match_info.ini
+    after startup (e.g. tournament-day fix), the auditor wouldn't see
+    it until the next service restart.
+
+    Now runs on a poll interval (default 60s). Safe to re-poll because
+    every downstream ``add_work`` call dedupes on the task's item_key,
+    so a still-in-progress task isn't re-enqueued.
     """
 
     def __init__(
@@ -69,16 +76,6 @@ class StateAuditor(PollingProcessor):
 
         # Initialize cleanup service
         self.cleanup_service = CleanupService(storage_path)
-
-    async def start(self) -> None:
-        """Run a one-time startup scan to recover interrupted work.
-
-        Unlike the base PollingProcessor.start(), this does NOT create a
-        persistent polling loop. It runs discover_work() once and returns.
-        """
-        logger.info("STATE_AUDITOR: Running startup recovery scan")
-        await self.discover_work()
-        logger.info("STATE_AUDITOR: Startup recovery scan complete")
 
     @property
     def download_processor(self):
@@ -420,5 +417,6 @@ class StateAuditor(PollingProcessor):
             logger.error(f"STATE_AUDITOR: Error during cleanup for {group_dir}: {e}")
 
     async def stop(self) -> None:
-        """Clean up services. No polling loop to stop."""
+        """Cancel the polling loop and clean up services."""
+        await super().stop()
         await self.match_info_service.shutdown()


### PR DESCRIPTION
## Summary
StateAuditor previously ran ``discover_work()`` exactly once on service start and then exited. Now it runs on the base ``PollingProcessor`` loop every 60s (configurable via ``poll_interval``).

- Remove the ``start()`` override so the inherited loop fires
- Update ``stop()`` to chain to ``super().stop()`` so the loop is actually cancelled
- Update tests to match (the old startup-only tests are inverted to verify polling-loop behavior)

## Why
The auditor handles state transitions that don't have a dedicated event-driven path — most notably, a directory that's at ``status=combined`` with a populated ``match_info.ini`` needs to be transitioned to a ``TrimTask``. The original design assumed all transitions either happen at startup or are event-driven from a specific trigger (NTFY response, API populate). But manual edits to ``match_info.ini`` after startup didn't trigger anything.

Hit live on 2026-06-01 with the West Seneca game: I'd written the match_info.ini by hand, but nothing picked it up until I restarted the service. With polling, the next loop iteration sees the populated file and queues the TrimTask.

## Why polling is safe (no duplicate work)
Every downstream ``add_work()`` dedups on the task's ``item_key`` (verified at ``base_queue_processor.py:85``). If the auditor calls ``add_work(TrimTask(group_dir))`` while a TrimTask for that group_dir is already queued or in flight, the second call is a no-op.

## Test plan
- [x] Lint + mypy clean
- [x] ``uv run pytest tests/test_state_auditor_enhanced.py`` — 11 passing
- [x] ``uv run pytest tests/test_state_auditor_enhanced.py tests/test_camera_poller.py tests/test_autocam_automation.py`` — 77 passing
- [x] New tests: ``test_start_creates_polling_loop`` + ``test_polling_loop_calls_discover_work_repeatedly`` (regression guard for the West Seneca incident)
- [ ] After merge + deploy, manually edit a match_info.ini on the server and confirm a TrimTask gets queued within ~60s without restarting the service.