### PR TITLE
fix(service): set CWD to config.storage.path, not config dir

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -19,7 +19,7 @@ sys.modules["win32event"] = mock_win32event
 sys.modules["servicemanager"] = mock_servicemanager
 sys.modules["win32service"] = mock_win32service
 
-from video_grouper.service.main import VideoGrouperService
+from video_grouper.service.main import VideoGrouperService, _resolve_storage_cwd
 
 
 class TestVideoGrouperService:
@@ -50,3 +50,30 @@ class TestVideoGrouperService:
         mock_servicemanager.LogMsg.assert_called()
         assert service.running is True
         service.main.assert_called_once()
+
+
+class TestResolveStorageCwd:
+    """Service CWD must follow [STORAGE] path, not config-file location.
+
+    Regression: when these diverged (config under %ProgramData%, storage on
+    a separate drive), DirectoryState's bare-basename fallback and any
+    relative ``.lock`` write landed under %ProgramData% and every lock
+    acquire raised FileNotFoundError on a path that didn't exist.
+    """
+
+    def test_returns_configured_storage_path(self):
+        config = MagicMock()
+        config.storage.path = r"D:\soccer-cam-storage"
+        result = _resolve_storage_cwd(config)
+        assert result == Path(r"D:\soccer-cam-storage")
+
+    def test_is_independent_of_config_file_location(self, tmp_path):
+        """Helper takes only config -- there's no way to accidentally
+        derive CWD from the config file's parent directory."""
+        config = MagicMock()
+        config.storage.path = str(tmp_path / "storage_root")
+        result = _resolve_storage_cwd(config)
+        assert result == Path(tmp_path / "storage_root")
+        # The helper itself must not require the path to exist; that's
+        # the caller's job via mkdir(parents=True, exist_ok=True).
+        assert not result.exists()

--- a/video_grouper/service/main.py
+++ b/video_grouper/service/main.py
@@ -4,12 +4,32 @@ import asyncio
 import logging
 import os
 import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 import servicemanager
 import win32event
 import win32service
 import win32serviceutil
 import win32timezone  # noqa: F401 - required for pyinstaller
+
+if TYPE_CHECKING:
+    from video_grouper.utils.config import Config
+
+
+def _resolve_storage_cwd(config: "Config") -> Path:
+    """Return the directory the service should chdir into.
+
+    Must be the configured ``[STORAGE] path`` rather than the
+    config-file's parent. The two are usually different: config.ini
+    lives under ``%ProgramData%\\VideoGrouper`` (for write-access
+    reasons), but the user's storage tree is typically on a separate
+    drive. If CWD points at the config dir, then DirectoryState's
+    bare-basename fallback and any ``.lock`` file written via a
+    relative path land under ``%ProgramData%`` instead of the storage
+    drive, producing ``FileNotFoundError`` on every lock acquire.
+    """
+    return Path(config.storage.path)
 
 
 class VideoGrouperService(win32serviceutil.ServiceFramework):
@@ -45,8 +65,6 @@ class VideoGrouperService(win32serviceutil.ServiceFramework):
         self.main()
 
     def main(self):
-        from pathlib import Path
-
         from video_grouper.utils.config import load_config
         from video_grouper.utils.locking import FileLock
         from video_grouper.utils.logger import setup_logging
@@ -101,10 +119,14 @@ class VideoGrouperService(win32serviceutil.ServiceFramework):
             logger.error(f"Failed to load config: {e}")
             return
 
-        # Set CWD to storage path so relative paths resolve correctly.
-        # Windows services default to C:\WINDOWS\system32 which breaks
-        # state.json lock files, video paths, and everything else.
-        storage_dir = config_path.parent
+        # Set CWD to configured storage path so relative paths resolve
+        # correctly. Windows services default to C:\WINDOWS\system32 which
+        # breaks state.json lock files, video paths, and everything else.
+        # NOTE: must use config.storage.path, not config_path.parent --
+        # the config typically lives under %ProgramData%\VideoGrouper but
+        # the storage tree is usually on a separate drive.
+        storage_dir = _resolve_storage_cwd(config)
+        storage_dir.mkdir(parents=True, exist_ok=True)
         os.chdir(storage_dir)
         logger.info(f"Set working directory to {storage_dir}")
 


### PR DESCRIPTION
## Summary

Service was doing `os.chdir(config_path.parent)` which resolves to `%ProgramData%\VideoGrouper\` -- not the user's configured storage path. When config.ini and storage live on different drives (the common case: config under ProgramData, storage on D:\), CWD-relative path resolution lands in the wrong tree.

## What broke

`DirectoryState("<bare-basename>")` (single-arg call, common across the codebase) derives its storage root from `os.path.abspath(directory_path)`, which is CWD-relative. With CWD on the config dir instead of storage, every `.lock` write via `FileLock` ends up at `C:\ProgramData\VideoGrouper\<group>\state.json.lock` -- a path that doesn't exist, so the acquire raises `FileNotFoundError`.

Observed live tonight at multiple stage transitions (combine/trim/upload completion) with storage path = `D:\soccer-cam-storage`:

```
ERROR | video_grouper.utils.locking:acquire:65 - Unexpected error acquiring
lock on C:\ProgramData\VideoGrouper\2026.06.01-18.25.38\state.json.lock:
[Errno 2] No such file or directory
```

The state writes themselves still succeed (they pass an absolute path), so the bug was silent except for log noise -- but any code path that races on the lock loses, and `state_auditor` / cross-process coordination silently degrades.

## Fix

Extract `_resolve_storage_cwd(config)` and use it. The helper takes only `config` -- the bug literally cannot be re-introduced via `config_path.parent` because that argument is no longer reachable.

## Test plan

- [x] `pytest tests/test_service.py` -- 5 passed (3 existing + 2 new regression tests)
- [x] `ruff check` + `ruff format` clean on touched files
- [x] `mypy video_grouper/service/main.py` clean
- [x] Pre-commit hooks pass

## Deploy

Next service restart on any existing install picks up the fix automatically -- no migration needed, no config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)