### PR TITLE
fix(autocam): validate output via PyAV moov + duration + bps, not size alone

### DIFF
--- a/tests/test_autocam_output_validation.py
+++ b/tests/test_autocam_output_validation.py
@@ -1,0 +1,168 @@
+"""Regression tests for the AutoCam output validator.
+
+These tests intentionally use **real** filesystem operations and **real**
+PyAV. The repository's `tests/conftest.py` defines autouse fixtures that
+mock both (`mock_file_system` pins `os.path.getsize` to 1 MB; `mock_ffmpeg`
+intercepts `av.open`). Those mocks are the exact reason tonight's
+regression slipped through unit tests: every existing AutoCam test was
+asking a MagicMock whether the output was real, not the actual file.
+
+We override both fixtures at module scope below so this file gets real
+filesystem and real PyAV. Don't drop the overrides -- if they go away
+the validator tests become tautologies again.
+"""
+
+from pathlib import Path
+
+import av
+import pytest
+
+from video_grouper.tray.autocam_automation import _validate_autocam_output
+
+
+@pytest.fixture(autouse=True)
+def mock_file_system():
+    """Override conftest autouse mock; validator needs real os.path I/O."""
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def mock_ffmpeg():
+    """Override conftest autouse mock; validator needs real av.open."""
+    yield None
+
+
+def _write_test_mp4(
+    path: Path, duration_s: float, width: int = 320, height: int = 240
+) -> None:
+    """Write a real H264 MP4 of ~`duration_s` seconds using PyAV.
+
+    Solid-color frames keep the file tiny (KB-scale) regardless of
+    duration, which lets the duration-based tests run a synthetic
+    "1 hour" video without producing a 1-hour-sized file on disk.
+    """
+    fps = 10
+    with av.open(str(path), mode="w") as container:
+        stream = container.add_stream("h264", rate=fps)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        n_frames = max(1, int(duration_s * fps))
+        for _ in range(n_frames):
+            frame = av.VideoFrame(width=width, height=height, format="yuv420p")
+            for plane in frame.planes:
+                plane.update(bytes(plane.buffer_size))
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode(None):
+            container.mux(packet)
+
+
+def _write_header_only_mp4(path: Path, target_bytes: int = 15 * 1024 * 1024) -> None:
+    """Write the exact failure mode from the 2026-06-01 game: a valid
+    ftyp box followed by zero-padded bytes, no moov atom, no streams.
+
+    PyAV fails to open this with "Invalid data found when processing input".
+    The header bytes are copied from the first 32 bytes of the corrupt
+    output that AutoCam left behind tonight.
+    """
+    header = bytes.fromhex(
+        "00000020"  # box size = 32
+        "66747970"  # box type = 'ftyp'
+        "69736f6d"  # major brand = 'isom'
+        "00000200"  # minor version
+        "69736f6d"  # compatible brand 1 = 'isom'
+        "69736f32"  # compatible brand 2 = 'iso2'
+        "61766331"  # compatible brand 3 = 'avc1'
+        "6d703431"  # compatible brand 4 = 'mp41'
+    )
+    chunk = b"\x00" * (1024 * 1024)
+    with open(path, "wb") as f:
+        f.write(header)
+        remaining = target_bytes - len(header)
+        while remaining > 0:
+            n = min(remaining, len(chunk))
+            f.write(chunk[:n])
+            remaining -= n
+
+
+class TestValidateAutocamOutput:
+    """Each case below corresponds to a real-world failure mode the old
+    size-only check would have passed."""
+
+    def test_missing_file_is_rejected(self, tmp_path):
+        ok, reason = _validate_autocam_output(str(tmp_path / "nope.mp4"))
+        assert ok is False
+        assert "does not exist" in reason
+
+    def test_sub_threshold_file_is_rejected(self, tmp_path):
+        out = tmp_path / "tiny.mp4"
+        out.write_bytes(b"\x00" * (1024 * 1024))  # 1 MB
+        ok, reason = _validate_autocam_output(str(out))
+        assert ok is False
+        assert "floor" in reason
+
+    def test_header_only_mp4_is_rejected(self, tmp_path):
+        """The 2026-06-01 regression: ftyp present, moov missing, file
+        passes the 10 MB absolute size floor but PyAV cannot decode."""
+        out = tmp_path / "header_only.mp4"
+        _write_header_only_mp4(out)
+        import os
+
+        assert os.path.getsize(out) >= 15 * 1024 * 1024, (
+            "test fixture produced wrong size; conftest fs mock may still be active"
+        )
+        ok, reason = _validate_autocam_output(str(out))
+        assert ok is False
+        assert "moov" in reason.lower() or "pyav" in reason.lower()
+
+    def test_valid_mp4_without_input_is_accepted(self, tmp_path):
+        """No input_path supplied (resume path): pass on size + moov +
+        non-zero duration only."""
+        out = tmp_path / "real.mp4"
+        _write_test_mp4(out, duration_s=120)
+        # Solid-color H264 compresses to ~KB; bypass the 10 MB absolute floor.
+        ok, reason = _validate_autocam_output(str(out), min_bytes=1024)
+        assert ok is True, f"expected pass, got: {reason}"
+
+    def test_duration_parity_below_threshold_is_rejected(self, tmp_path):
+        """Output duration < 95% of input = AutoCam exited mid-pass."""
+        input_mp4 = tmp_path / "input.mp4"
+        output_mp4 = tmp_path / "output.mp4"
+        _write_test_mp4(input_mp4, duration_s=120)
+        _write_test_mp4(output_mp4, duration_s=60)  # 50% parity
+        ok, reason = _validate_autocam_output(
+            str(output_mp4), input_path=str(input_mp4), min_bytes=1024
+        )
+        assert ok is False
+        assert "parity" in reason.lower() or "duration" in reason.lower()
+
+    def test_duration_parity_at_threshold_is_accepted(self, tmp_path):
+        """Verifies only the parity check; the bps floor is disabled here
+        because solid-color H264 compresses below 0.5 Mbps regardless of
+        duration. A real soccer game won't have this problem."""
+        input_mp4 = tmp_path / "input.mp4"
+        output_mp4 = tmp_path / "output.mp4"
+        _write_test_mp4(input_mp4, duration_s=10)
+        _write_test_mp4(output_mp4, duration_s=10)
+        ok, reason = _validate_autocam_output(
+            str(output_mp4),
+            input_path=str(input_mp4),
+            min_bytes=1024,
+            min_bps=0,  # disable bps floor; this case isolates the parity check
+        )
+        assert ok is True, f"expected pass, got: {reason}"
+
+    def test_implausibly_small_for_input_duration_is_rejected(self, tmp_path):
+        """1h input + 1h output that's only KB-large fails the 0.5 Mbps
+        floor. Catches a hypothetical regression where the output runs
+        full-duration but encodes nothing useful (e.g. constant black)."""
+        input_mp4 = tmp_path / "input.mp4"
+        output_mp4 = tmp_path / "output.mp4"
+        _write_test_mp4(output_mp4, duration_s=3600)
+        _write_test_mp4(input_mp4, duration_s=3600)
+        ok, reason = _validate_autocam_output(
+            str(output_mp4), input_path=str(input_mp4), min_bytes=1024
+        )
+        assert ok is False
+        assert "implausibly" in reason.lower() or "mbps" in reason.lower()

--- a/tests/test_autocam_output_validation.py
+++ b/tests/test_autocam_output_validation.py
@@ -1,4 +1,5 @@
-"""Regression tests for the AutoCam output validator.
+"""Regression tests for the AutoCam output validator + the resume-race
+guard around it.
 
 These tests intentionally use **real** filesystem operations and **real**
 PyAV. The repository's `tests/conftest.py` defines autouse fixtures that
@@ -13,11 +14,15 @@ the validator tests become tautologies again.
 """
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import av
 import pytest
 
-from video_grouper.tray.autocam_automation import _validate_autocam_output
+from video_grouper.tray.autocam_automation import (
+    _autocam_still_writing,
+    _validate_autocam_output,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -166,3 +171,97 @@ class TestValidateAutocamOutput:
         )
         assert ok is False
         assert "implausibly" in reason.lower() or "mbps" in reason.lower()
+
+
+class TestAutocamStillWriting:
+    """Resume-race guard: when a previous tray run is still rendering
+    this output, the short-circuit must NOT validate-and-delete the
+    file. Otherwise it pulls the rug out from under the in-flight
+    AutoCam process.
+
+    The mid-write file has the ftyp box but no moov atom yet (AutoCam
+    only finalizes moov at clean exit), so the validator correctly
+    classifies it as broken -- but the file is going to be valid in a
+    few minutes when AutoCam wraps up. ``_autocam_still_writing``
+    short-circuits the short-circuit.
+    """
+
+    def test_returns_false_when_state_is_none(self, tmp_path):
+        assert _autocam_still_writing(None, str(tmp_path / "in.mp4")) is False
+
+    def test_returns_false_when_no_marker(self):
+        state = MagicMock()
+        state.get_autocam_run.return_value = None
+        assert _autocam_still_writing(state, "/x/in.mp4") is False
+
+    def test_returns_false_when_marker_is_for_different_input(self):
+        """Different render in flight -- shouldn't influence this one's
+        short-circuit decision."""
+        state = MagicMock()
+        state.get_autocam_run.return_value = {
+            "input_path": "/x/other-game.mp4",
+            "gui_pids": [12345],
+        }
+        # Even with live PIDs, mismatched input means it's not "this" render.
+        with patch(
+            "video_grouper.tray.autocam_automation._live_autocam_pids",
+            return_value=[12345],
+        ):
+            assert _autocam_still_writing(state, "/x/in.mp4") is False
+
+    def test_returns_false_when_pids_are_stale(self):
+        """Marker exists for this input but all GUI.exe PIDs have died.
+        Safe to delete pre-existing partial output and relaunch."""
+        state = MagicMock()
+        state.get_autocam_run.return_value = {
+            "input_path": "/x/in.mp4",
+            "gui_pids": [12345],
+        }
+        with patch(
+            "video_grouper.tray.autocam_automation._live_autocam_pids",
+            return_value=[],
+        ):
+            assert _autocam_still_writing(state, "/x/in.mp4") is False
+
+    def test_returns_true_when_marker_matches_and_pids_alive(self):
+        """The exact scenario the reviewer flagged: tray restarted while
+        AutoCam keeps running, output file is mid-write. Validator would
+        reject the partial; we must NOT delete it."""
+        state = MagicMock()
+        state.get_autocam_run.return_value = {
+            "input_path": "/x/in.mp4",
+            "gui_pids": [12345, 67890],
+        }
+        with patch(
+            "video_grouper.tray.autocam_automation._live_autocam_pids",
+            return_value=[12345],
+        ):
+            assert _autocam_still_writing(state, "/x/in.mp4") is True
+
+    def test_short_circuit_skips_delete_when_autocam_still_writing(self, tmp_path):
+        """Integration smoke: a partial output + live autocam = file
+        survives the short-circuit. End-to-end through
+        ``_execute_autocam_gui_automation`` is too involved for a unit
+        test (Desktop / win32gui), so we drive the relevant branch via
+        the helper that guards the delete."""
+        partial = tmp_path / "out.mp4"
+        # Header-only -- validator would reject if asked.
+        partial.write_bytes(
+            bytes.fromhex(
+                "000000206674797069736f6d0000020069736f6d69736f32617663316d703431"
+            )
+            + b"\x00" * 100
+        )
+        state = MagicMock()
+        state.get_autocam_run.return_value = {
+            "input_path": str(tmp_path / "in.mp4"),
+            "gui_pids": [4242],
+        }
+        with patch(
+            "video_grouper.tray.autocam_automation._live_autocam_pids",
+            return_value=[4242],
+        ):
+            assert _autocam_still_writing(state, str(tmp_path / "in.mp4")) is True
+        # File still exists -- the short-circuit would have skipped the
+        # validate-and-delete branch.
+        assert partial.exists()

--- a/video_grouper/tray/autocam_automation.py
+++ b/video_grouper/tray/autocam_automation.py
@@ -31,6 +31,108 @@ _NO_WINDOW = 0x08000000
 _SHUTDOWN_MARKERS = ("framereader_close", "finished processing")
 
 
+# Output-validation thresholds. AutoCam 3.x hardcodes ~8 Mbps output, so
+# a healthy completed render is roughly input_duration_seconds * 1 MB/s.
+# The size floor here is deliberately one order of magnitude looser than
+# that (0.5 Mbps average) so it only flags clear failures and never
+# blocks a legit run because of an unexpectedly low-bitrate output.
+_MIN_OUTPUT_BYTES_ABSOLUTE = 10 * 1024 * 1024  # 10 MB
+_MIN_OUTPUT_BPS = 500_000  # 0.5 Mbps, far below the 8 Mbps target
+# Output duration must reach this fraction of input duration; below
+# means AutoCam exited mid-pass.
+_MIN_DURATION_PARITY = 0.95
+
+
+def _validate_autocam_output(
+    output_path: str,
+    input_path: str | None = None,
+    min_bytes: int = _MIN_OUTPUT_BYTES_ABSOLUTE,
+    min_bps: int = _MIN_OUTPUT_BPS,
+    min_duration_parity: float = _MIN_DURATION_PARITY,
+) -> tuple[bool, str]:
+    """Validate an AutoCam output is a real processed video, not a partial.
+
+    Catches three failure modes the fixed-byte-floor check missed
+    (regression observed 2026-06-01: a 15.5 MB header-only MP4 passed
+    the 10 MB floor and was marked ball_tracking_complete):
+
+    1. Header-only MP4 -- ftyp written, moov atom never finalized. PyAV
+       fails to open these with "Invalid data found when processing input".
+    2. Truncated output -- output duration is materially shorter than
+       input. We require >= 95% parity when an input file is supplied.
+    3. Implausibly low bitrate -- output below 0.5 Mbps averaged across
+       the input's duration. Once Sport AutoCam targets ~8 Mbps, so
+       anything under 0.5 Mbps is a partial render.
+
+    Returns (ok, reason). On a False result the caller should treat the
+    file as a crashed partial and delete it before retry.
+    """
+    # Local import keeps PyAV out of the tray boot path; the validator
+    # is only ever called from inside the AutoCam poll loop.
+    import av
+
+    if not os.path.isfile(output_path):
+        return False, f"output file does not exist: {output_path}"
+    try:
+        size = os.path.getsize(output_path)
+    except OSError as e:
+        return False, f"could not stat output: {e}"
+    if size < min_bytes:
+        return (
+            False,
+            f"output {size / 1024 / 1024:.1f} MB below "
+            f"{min_bytes / 1024 / 1024:.0f} MB absolute floor",
+        )
+
+    # PyAV moov-atom probe: the most direct catch for the 2026-06-01
+    # failure mode. A header-only MP4 has the ftyp box but no moov, so
+    # av.open() raises (av.error.InvalidDataError on PyAV >= 11) before
+    # we can read any stream info. Catch broadly: any PyAV failure to
+    # open the file means the output isn't usable.
+    try:
+        with av.open(output_path) as out_container:
+            if not out_container.streams.video:
+                return False, "output has no video stream"
+            out_duration_us = out_container.duration or 0
+    except Exception as e:
+        return False, f"PyAV cannot decode output (likely no moov atom): {e}"
+
+    out_duration_s = out_duration_us / 1_000_000 if out_duration_us else 0
+    if out_duration_s <= 0:
+        return False, "output reports zero or unknown duration"
+
+    # Compare against input when we have it (the resume-existing short-
+    # circuit doesn't always; that path falls back to moov+size only).
+    if input_path and os.path.isfile(input_path):
+        try:
+            with av.open(input_path) as in_container:
+                in_duration_us = in_container.duration or 0
+        except Exception:
+            in_duration_us = 0
+        in_duration_s = in_duration_us / 1_000_000 if in_duration_us else 0
+        if in_duration_s > 0:
+            ratio = out_duration_s / in_duration_s
+            if ratio < min_duration_parity:
+                return (
+                    False,
+                    f"output duration {out_duration_s:.0f}s is only "
+                    f"{ratio * 100:.0f}% of input {in_duration_s:.0f}s "
+                    f"(min parity {min_duration_parity * 100:.0f}%)",
+                )
+            if min_bps > 0:
+                min_bytes_for_duration = int(in_duration_s * min_bps / 8)
+                if size < min_bytes_for_duration:
+                    return (
+                        False,
+                        f"output {size / 1024 / 1024:.1f} MB implausibly small "
+                        f"for {in_duration_s:.0f}s input "
+                        f"(minimum {min_bytes_for_duration / 1024 / 1024:.0f} MB "
+                        f"at {min_bps / 1_000_000:.1f} Mbps)",
+                    )
+
+    return True, (f"OK: {size / 1024 / 1024:.1f} MB, {out_duration_s:.0f}s")
+
+
 def _taskkill_autocam_tree() -> None:
     """Kill GUI.exe AND autocam.exe. AutoCam 3.0.7 spawns autocam.exe
     as a child of GUI.exe; killing only GUI.exe leaves autocam.exe
@@ -448,6 +550,7 @@ def _wait_for_completion_and_cleanup(
     state: DirectoryState | None,
     output_path: str | None = None,
     tracked_pids: list[int] | None = None,
+    input_path: str | None = None,
 ) -> bool:
     """Poll AutoCam's Notification text until processing finishes, then clean up.
 
@@ -475,10 +578,6 @@ def _wait_for_completion_and_cleanup(
     timeout_seconds = 60 * 60 * 24  # 24 hours
     startup_timeout_seconds = 300  # 5 minutes to start processing
     poll_interval = 30  # 30 seconds
-    # Min size below which we treat the output file as a partial-write
-    # rather than a real success. Anything smaller than this means
-    # AutoCam exited before producing a usable processed video.
-    output_min_bytes = 10 * 1024 * 1024  # 10 MB
     found = False
     processing_started = False
 
@@ -508,22 +607,34 @@ def _wait_for_completion_and_cleanup(
                     and output_path
                     and any(m in notification_text for m in _SHUTDOWN_MARKERS)
                 ):
-                    out_size = 0
-                    if os.path.isfile(output_path):
-                        try:
-                            out_size = os.path.getsize(output_path)
-                        except OSError:
-                            out_size = 0
-                    if out_size >= output_min_bytes:
+                    ok, reason = _validate_autocam_output(
+                        output_path, input_path=input_path
+                    )
+                    if ok:
                         found = True
                         logger.info(
                             "AutoCam shutdown marker observed "
-                            "(notification=%r, output=%.1f MB); "
+                            "(notification=%r, validation=%s); "
                             "treating as success and breaking out.",
                             raw_notification,
-                            out_size / 1024 / 1024,
+                            reason,
                         )
                         break
+                    logger.error(
+                        "AutoCam shutdown marker observed but output "
+                        "failed validation (%s); treating as failure.",
+                        reason,
+                    )
+                    if os.path.isfile(output_path):
+                        try:
+                            os.remove(output_path)
+                        except OSError as rm_err:
+                            logger.warning(
+                                "Could not remove invalid output %s: %s",
+                                output_path,
+                                rm_err,
+                            )
+                    break
 
                 if "finished processing" in notification_text:
                     found = True
@@ -548,35 +659,30 @@ def _wait_for_completion_and_cleanup(
                 logger.warning(f"Error while checking for success message: {e}")
 
             # Exit-detection fallback: if AutoCam's GUI processes have
-            # all exited, infer success/failure from the output file
-            # size. >= 10 MB at GUI exit = real run; below = crashed
-            # partial, delete so next attempt re-runs from scratch.
-            #
-            # Size-only is safe here because mid-pass wedges (which can
-            # leave a multi-hundred-MB partial that looks like a real
-            # video) are eliminated by locking download_protocol to a
-            # single transport per session -- mixed-protocol GOP
-            # boundaries were the only known wedge trigger.
+            # all exited, decide success/failure from the output file's
+            # actual contents -- not just byte count. Size-only let a
+            # 15.5 MB header-only MP4 (no moov atom) pass through on
+            # 2026-06-01; full validation catches that, truncated
+            # outputs, and implausibly low bitrates.
             live_pids = _live_autocam_pids(tracked_pids) if tracked_pids else None
             if tracked_pids and not live_pids:
                 if output_path and os.path.isfile(output_path):
-                    try:
-                        size = os.path.getsize(output_path)
-                    except OSError:
-                        size = 0
-                    if size >= output_min_bytes:
+                    ok, reason = _validate_autocam_output(
+                        output_path, input_path=input_path
+                    )
+                    if ok:
                         found = True
                         logger.info(
-                            "AutoCam GUI exited with output at %.1f MB; "
+                            "AutoCam GUI exited with validated output (%s); "
                             "treating as success.",
-                            size / 1024 / 1024,
+                            reason,
                         )
                         break
                     logger.error(
-                        "AutoCam GUI exited with sub-threshold output at "
-                        "%d bytes -- treating as crash. Deleting so next "
+                        "AutoCam GUI exited but output failed validation "
+                        "(%s); treating as crash. Deleting so next "
                         "attempt re-runs.",
-                        size,
+                        reason,
                     )
                     try:
                         os.remove(output_path)
@@ -668,39 +774,47 @@ def _execute_autocam_gui_automation(
 
     state = DirectoryState(group_dir) if group_dir else None
 
-    # Already-done short-circuit: if the output mp4 exists at non-trivial
-    # size, AutoCam already produced it. Re-running would waste 1-2 hours
-    # of GPU work on output we already have. Most common trigger: the
-    # tray crashed after AutoCam finished but before the success was
-    # recorded; the in_progress task was restored from disk on the next
-    # tray boot and would otherwise relaunch GUI.exe from scratch.
+    # Already-done short-circuit: if the output mp4 already passes the
+    # same validator the poll loop uses, AutoCam previously produced a
+    # real result; re-running would waste 1-2 hours of GPU work on
+    # output we already have. Most common trigger: the tray crashed
+    # after AutoCam finished but before the success was recorded; the
+    # in_progress task was restored from disk on the next tray boot and
+    # would otherwise relaunch GUI.exe from scratch.
     #
-    # Size-only check is safe because every failure path inside the
-    # poll loop deletes its partial output before breaking, so a >= 10
-    # MB file on disk is always a real completed run.
+    # Validation here is identical to the poll-loop exit check so a
+    # broken pre-existing output (e.g. a header-only MP4 left over from
+    # a previous bug) is detected and deleted rather than skipped.
     if os.path.isfile(abs_output_path):
+        ok, reason = _validate_autocam_output(
+            abs_output_path, input_path=abs_input_path
+        )
         try:
             existing_size = os.path.getsize(abs_output_path)
         except OSError:
             existing_size = 0
-        if existing_size >= 10 * 1024 * 1024:
+        if ok:
             logger.info(
-                "AutoCam output already exists at %s (%.1f MB); skipping re-run.",
+                "AutoCam output already validated at %s (%s); skipping re-run.",
                 abs_output_path,
-                existing_size / 1024 / 1024,
+                reason,
             )
             if state is not None:
                 state.clear_autocam_run()
             return True
-        # Sub-10MB output is junk from a previous failed Save-dialog
-        # interaction; delete it before relaunching so the overwrite-
-        # confirm overlay (which the dialog automation can't drive)
-        # never appears.
+        # Pre-existing file failed validation -- could be junk from a
+        # previous failed Save-dialog interaction, a header-only MP4
+        # from an aborted render, or any other partial. Delete before
+        # relaunching so the overwrite-confirm overlay (which the
+        # dialog automation can't drive) never appears.
+        logger.info(
+            "Pre-existing output failed validation (%s); deleting before relaunch.",
+            reason,
+        )
         try:
             os.remove(abs_output_path)
             logger.info(
-                "Removed sub-threshold pre-existing output at %s (%.1f MB) "
-                "before relaunch",
+                "Removed invalid pre-existing output at %s (%.1f MB) before relaunch",
                 abs_output_path,
                 existing_size / 1024 / 1024,
             )
@@ -749,6 +863,7 @@ def _execute_autocam_gui_automation(
                         state,
                         output_path=existing.get("output_path", abs_output_path),
                         tracked_pids=live,
+                        input_path=existing.get("input_path", abs_input_path),
                     )
             else:
                 logger.info(
@@ -981,6 +1096,7 @@ def _execute_autocam_gui_automation(
             state,
             output_path=abs_output_path,
             tracked_pids=list({launcher.pid, window_pid}),
+            input_path=abs_input_path,
         )
 
     except Exception as e:

--- a/video_grouper/tray/autocam_automation.py
+++ b/video_grouper/tray/autocam_automation.py
@@ -133,6 +133,35 @@ def _validate_autocam_output(
     return True, (f"OK: {size / 1024 / 1024:.1f} MB, {out_duration_s:.0f}s")
 
 
+def _autocam_still_writing(state: DirectoryState | None, input_path: str) -> bool:
+    """True if a previous tray run is still actively rendering this output.
+
+    Reads ``state.get_autocam_run()`` and checks whether any recorded
+    GUI.exe PID for the same ``input_path`` is still alive. Guard for
+    the validate-and-delete short-circuit at function entry: a mid-write
+    output has the ftyp box but no moov atom yet, so the validator will
+    correctly reject it -- but deleting that file out from under a live
+    AutoCam would corrupt the in-flight render. When this returns True
+    the caller must skip validation and fall through to the resume
+    reattach path.
+
+    Returns False when:
+      - state is None (no group_dir tracking enabled)
+      - no autocam_run marker exists
+      - marker exists but input_path doesn't match (different render)
+      - marker exists for this input but no PIDs are alive (stale)
+    """
+    if state is None:
+        return False
+    existing = state.get_autocam_run()
+    if not existing:
+        return False
+    if existing.get("input_path") != input_path:
+        return False
+    live = _live_autocam_pids(existing.get("gui_pids", []))
+    return bool(live)
+
+
 def _taskkill_autocam_tree() -> None:
     """Kill GUI.exe AND autocam.exe. AutoCam 3.0.7 spawns autocam.exe
     as a child of GUI.exe; killing only GUI.exe leaves autocam.exe
@@ -785,7 +814,15 @@ def _execute_autocam_gui_automation(
     # Validation here is identical to the poll-loop exit check so a
     # broken pre-existing output (e.g. a header-only MP4 left over from
     # a previous bug) is detected and deleted rather than skipped.
-    if os.path.isfile(abs_output_path):
+    #
+    # SAFETY: if a previous tray run is still writing this output
+    # (resume-marker has live AutoCam PIDs), DON'T validate-and-delete --
+    # the file is mid-write and has no moov atom yet, but deleting it
+    # would corrupt the in-flight render. Skip the short-circuit and
+    # let the resume-marker reattach path below take over.
+    if os.path.isfile(abs_output_path) and not _autocam_still_writing(
+        state, abs_input_path
+    ):
         ok, reason = _validate_autocam_output(
             abs_output_path, input_path=abs_input_path
         )
@@ -802,11 +839,12 @@ def _execute_autocam_gui_automation(
             if state is not None:
                 state.clear_autocam_run()
             return True
-        # Pre-existing file failed validation -- could be junk from a
-        # previous failed Save-dialog interaction, a header-only MP4
-        # from an aborted render, or any other partial. Delete before
-        # relaunching so the overwrite-confirm overlay (which the
-        # dialog automation can't drive) never appears.
+        # Pre-existing file failed validation AND no live AutoCam PIDs --
+        # safe to delete before relaunch. Could be junk from a previous
+        # failed Save-dialog interaction, a header-only MP4 from an
+        # aborted render, or any other partial. Removing it avoids the
+        # overwrite-confirm overlay (which the dialog automation can't
+        # drive).
         logger.info(
             "Pre-existing output failed validation (%s); deleting before relaunch.",
             reason,


### PR DESCRIPTION
## Summary

The 10 MB size-only success check (introduced in `d14769a` when the completion sentinel was ripped out for PR #62) let a header-only MP4 through on tonight's run: AutoCam wrote a 15.5 MB file with a valid `ftyp` box but no `moov` atom, unplayable, and the pipeline still marked the group `ball_tracking_complete` and uploaded the panoramic raw instead. ffprobe confirmed `moov atom not found`.

Replace size-only with `_validate_autocam_output()` at all three trust points — shutdown-marker fast path, GUI-exit fallback, and the already-done short-circuit — covering:

1. **Absolute size floor (10 MB)** — unchanged, cheap reject for empty files.
2. **PyAV moov-atom probe** — `av.open()` raises `InvalidDataError` when the moov atom is missing, the exact failure tonight.
3. **Duration parity vs input** — output duration must be ≥ 95% of input. Catches mid-pass exits.
4. **Bitrate floor vs input duration** — output size must reach 0.5 Mbps averaged over input duration. AutoCam targets 8 Mbps, so under 0.5 is a partial render.

## Why the existing tests missed this

`tests/conftest.py` defines autouse fixtures that mock `os.path.getsize` (pinned to 1 MB) and `av.open` (mock container with fixed 100s duration). Every existing AutoCam test runs against those mocks — the size check was effectively asking a MagicMock whether the output was real, not the actual file.

`tests/test_autocam_output_validation.py` overrides both autouse fixtures at module scope (same pattern as `tests/integration/test_camera_emulator.py`) and exercises the validator against real PyAV-generated MP4s in `tmp_path`. The header-only fixture uses the exact byte sequence observed on tonight's corrupt file.

## Ground-truth confirmation

Ran the validator against the actual files on DESKTOP-5L867J8 where tonight's run landed:

| File | Result |
|---|---|
| broken AutoCam output (15.5 MB) | ❌ rejected — `PyAV cannot decode output (likely no moov atom): Invalid data found when processing input` |
| `*-raw.mp4` (13.8 GB, 5641s) | ✅ accepted |
| `combined.mp4` (14.65 GB, 5701s) | ✅ accepted |
| raw vs raw (100% parity) | ✅ accepted |

## Test plan

- [x] `pytest tests/test_autocam_output_validation.py` — 7 new tests pass (real PyAV + real fs)
- [x] `pytest tests/test_autocam_automation.py tests/test_autocam_resume.py` — all 39 existing tests pass (still mock fs/PyAV, validator passes through them harmlessly)
- [x] `ruff check`/`format`/`mypy` clean
- [x] Pre-commit hooks pass
- [x] Validator behavior confirmed end-to-end against the actual tonight's-game files on the production box

## Deploy

Once installed, the next AutoCam run will fail loudly on any header-only or truncated output (delete the partial + mark the task failed) instead of falsely advancing state. Already-uploaded YouTube videos from prior false-positive runs are not affected; only the local state machine changes behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)