### PR TITLE
fix(upload): run sync YouTube upload via asyncio.to_thread

### DIFF
--- a/tests/test_upload_off_thread.py
+++ b/tests/test_upload_off_thread.py
@@ -1,0 +1,170 @@
+"""Regression tests: YouTube uploads must not block the event loop.
+
+Memory entry [sync_upload_blocks_tray]: ``upload_video`` is synchronous
+(googleapiclient resumable upload). When called via plain ``await`` from
+an ``async def`` it runs on the shared event loop, blocking it for the
+upload duration (60-90 min for a full-field match). That starves the
+auth server's uvicorn loop and the tray's status poller, which then
+times out every 60s with ``update status poll unexpected error: timed
+out`` -- observed live during the 2026-06-01 game.
+
+These tests use a synchronous ``time.sleep`` inside the mocked uploader
+and a concurrent heartbeat coroutine. If the production code awaits the
+sync upload directly, the heartbeat is starved and tick count stays at
+zero. If the upload is wrapped in ``asyncio.to_thread``, the event loop
+keeps running and the heartbeat advances normally.
+"""
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_file_system():
+    """Override conftest mock so we can place real files in tmp_path."""
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def mock_ffmpeg():
+    """Override conftest mock; these tests don't touch PyAV."""
+    yield None
+
+
+# Tunables. Block long enough that heartbeat skew is unambiguous, but
+# not so long that CI feels it.
+_BLOCK_SECONDS = 0.4
+_HEARTBEAT_INTERVAL_S = 0.05
+# Allow a few ticks slack for scheduler jitter and the thread spin-up cost.
+_HEARTBEAT_MIN_TICKS = int(_BLOCK_SECONDS / _HEARTBEAT_INTERVAL_S) - 2
+
+
+async def _run_heartbeat_while(coro):
+    """Run `coro` to completion while ticking a counter on the event loop.
+
+    Returns (coro_result, tick_count). A blocked event loop yields zero
+    ticks during the call; a properly-offloaded sync workload yields
+    roughly BLOCK_SECONDS / HEARTBEAT_INTERVAL_S ticks.
+    """
+    ticks = 0
+    stop = asyncio.Event()
+
+    async def beat():
+        nonlocal ticks
+        while not stop.is_set():
+            ticks += 1
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=_HEARTBEAT_INTERVAL_S)
+            except TimeoutError:
+                pass
+
+    hb = asyncio.create_task(beat())
+    try:
+        result = await coro
+    finally:
+        stop.set()
+        await hb
+    return result, ticks
+
+
+class TestClipProcessorUploadOffThread:
+    """``ClipProcessor._upload_to_youtube`` wraps the sync uploader call
+    in ``asyncio.to_thread`` so the event loop stays responsive during
+    long uploads."""
+
+    @pytest.mark.asyncio
+    async def test_upload_releases_event_loop(self, tmp_path):
+        from video_grouper.task_processors.clip_processor import ClipProcessor
+
+        def blocking_upload(*args, **kwargs):
+            time.sleep(_BLOCK_SECONDS)
+            return "fake_video_id"
+
+        config = MagicMock()
+        config.youtube.privacy_status = "unlisted"
+
+        uploader = MagicMock()
+        uploader.upload_video = blocking_upload
+
+        # Build a minimal ClipProcessor without running __init__ -- we
+        # only need youtube_uploader and config for _upload_to_youtube.
+        processor = ClipProcessor.__new__(ClipProcessor)
+        processor.youtube_uploader = uploader
+        processor.config = config
+
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"x" * 1024)
+
+        result, ticks = await _run_heartbeat_while(
+            processor._upload_to_youtube(str(video), "title", "desc")
+        )
+        assert result == "fake_video_id"
+        assert ticks >= _HEARTBEAT_MIN_TICKS, (
+            f"event loop appears to be blocked during the upload: only "
+            f"{ticks} heartbeat ticks during a {_BLOCK_SECONDS:.1f}s sleep "
+            f"(expected at least {_HEARTBEAT_MIN_TICKS}). Did you remove "
+            f"the asyncio.to_thread wrap?"
+        )
+
+
+class TestYoutubeUploadTaskOffThread:
+    """The full ``YoutubeUploadTask.execute`` end-to-end path has too many
+    side effects (OAuth, match-info loading, playlist coordination) to
+    drive in a unit test without a brittle mock stack. The clip-processor
+    case above is the behavioral regression test for the
+    ``asyncio.to_thread`` pattern; here we add a static guard against
+    the same wrap being reverted in ``youtube_upload_task``."""
+
+    def test_upload_calls_routed_through_to_thread(self):
+        """Static guard: if a refactor reverts the ``asyncio.to_thread``
+        wrap around ``uploader.upload_video`` or ``get_or_create_playlist``,
+        this test fails with a clear message.
+        """
+        import inspect
+        import re
+
+        from video_grouper.task_processors.tasks.upload import youtube_upload_task
+
+        src = inspect.getsource(youtube_upload_task)
+
+        # Direct call: `uploader.upload_video(...)`. Should be zero --
+        # the only references should be `uploader.upload_video,` (as a
+        # reference passed to asyncio.to_thread, no parens).
+        direct_upload_calls = re.findall(r"uploader\.upload_video\s*\(", src)
+        assert len(direct_upload_calls) == 0, (
+            f"uploader.upload_video is called directly {len(direct_upload_calls)} "
+            f"time(s); it must be wrapped in `await asyncio.to_thread(...)` "
+            f"so the resumable upload doesn't block the shared event loop."
+        )
+
+        # Direct call: `uploader.get_or_create_playlist(...)`. Same rule.
+        direct_playlist_calls = re.findall(
+            r"uploader\.get_or_create_playlist\s*\(", src
+        )
+        assert len(direct_playlist_calls) == 0, (
+            f"uploader.get_or_create_playlist is called directly "
+            f"{len(direct_playlist_calls)} time(s); must be wrapped in "
+            f"`await asyncio.to_thread(...)` -- it issues blocking HTTP."
+        )
+
+        # Reference passed to to_thread: `asyncio.to_thread(...,\n  uploader.upload_video,`.
+        # Soccer-cam uploads processed + raw, so we expect exactly 2.
+        to_thread_uploads = re.findall(
+            r"asyncio\.to_thread\s*\(\s*uploader\.upload_video\s*,", src
+        )
+        assert len(to_thread_uploads) == 2, (
+            f"Expected exactly 2 `asyncio.to_thread(uploader.upload_video, ...)` "
+            f"call sites (processed + raw uploads), found {len(to_thread_uploads)}."
+        )
+
+        # Reference passed to to_thread for playlist creation.
+        to_thread_playlists = re.findall(
+            r"asyncio\.to_thread\s*\(\s*uploader\.get_or_create_playlist\s*,", src
+        )
+        assert len(to_thread_playlists) == 2, (
+            f"Expected exactly 2 `asyncio.to_thread(uploader.get_or_create_playlist, ...)` "
+            f"call sites (one per upload variant), found {len(to_thread_playlists)}."
+        )

--- a/video_grouper/task_processors/clip_processor.py
+++ b/video_grouper/task_processors/clip_processor.py
@@ -5,6 +5,7 @@ Handles ClipExtractionTask (FFmpeg trim) and HighlightCompilationTask (FFmpeg co
 then uploads results to YouTube and updates the API.
 """
 
+import asyncio
 import logging
 import os
 
@@ -115,7 +116,11 @@ class ClipProcessor(QueueProcessor):
             return None
 
         try:
-            video_id = self.youtube_uploader.upload_video(
+            # googleapiclient is sync; without asyncio.to_thread the upload
+            # blocks the event loop shared by the auth server, tray status
+            # poller, and other queue processors.
+            video_id = await asyncio.to_thread(
+                self.youtube_uploader.upload_video,
                 video_path,
                 title=title,
                 description=description,

--- a/video_grouper/task_processors/tasks/upload/youtube_upload_task.py
+++ b/video_grouper/task_processors/tasks/upload/youtube_upload_task.py
@@ -2,6 +2,7 @@
 YouTube upload task for uploading videos to YouTube.
 """
 
+import asyncio
 import logging
 import os
 from dataclasses import dataclass
@@ -154,6 +155,12 @@ class YoutubeUploadTask(BaseUploadTask):
                 )
                 return False
 
+            # googleapiclient is sync; without asyncio.to_thread the
+            # 60-90 minute resumable upload would block this event loop,
+            # which the auth server, tray status poller, and other queue
+            # processors share. Symptoms observed live tonight:
+            # "update status poll unexpected error: timed out" every
+            # 60s in the tray log throughout the upload window.
             # Upload processed (trimmed) video
             if processed_video_path and os.path.exists(processed_video_path):
                 logger.info(f"Uploading processed video: {processed_video_path}")
@@ -162,11 +169,14 @@ class YoutubeUploadTask(BaseUploadTask):
                 playlist_id = None
 
                 if processed_playlist_name:
-                    playlist_id = uploader.get_or_create_playlist(
-                        processed_playlist_name, description
+                    playlist_id = await asyncio.to_thread(
+                        uploader.get_or_create_playlist,
+                        processed_playlist_name,
+                        description,
                     )
 
-                video_id = uploader.upload_video(
+                video_id = await asyncio.to_thread(
+                    uploader.upload_video,
                     processed_video_path,
                     title,
                     description,
@@ -188,11 +198,14 @@ class YoutubeUploadTask(BaseUploadTask):
                 playlist_id = None
 
                 if raw_playlist_name:
-                    playlist_id = uploader.get_or_create_playlist(
-                        raw_playlist_name, description
+                    playlist_id = await asyncio.to_thread(
+                        uploader.get_or_create_playlist,
+                        raw_playlist_name,
+                        description,
                     )
 
-                video_id = uploader.upload_video(
+                video_id = await asyncio.to_thread(
+                    uploader.upload_video,
                     raw_video_path,
                     title,
                     description,


### PR DESCRIPTION
## Summary

`YoutubeUploadTask.execute()` and `ClipProcessor._upload_to_youtube()` both called `uploader.upload_video(...)` directly inside `async def`. googleapiclient is synchronous — each `await`-less call pinned the shared event loop for the upload window (70 minutes for tonight's 14 GB raw).

Symptom observed live throughout tonight's upload:
```
WARNING | __main__:run:128 - update status poll unexpected error: timed out
```
The tray status poller (10s timeout against `/api/update/status` on the auth server) couldn't complete a single request while the upload held the loop, so the warning fired every 60s for the duration. The auth server, ball-tracking discovery, and other queue processors share that loop and were starved alongside.

Matches the existing memory entry `[sync_upload_blocks_tray]` — known issue, now actually fixed.

## Fix

Wrap both call sites in `await asyncio.to_thread(...)`. Same wrap applied to `get_or_create_playlist`, which also issues blocking HTTP from googleapiclient.

## Why the existing tests didn't catch this

No test exercised an upload while another coroutine needed the loop. Mocks of `upload_video` returned instantly, so any "is the loop free" check would have trivially passed. The bug only shows under a real upload (or a sync sleep that mimics one).

The new `tests/test_upload_off_thread.py` adds:

1. **Behavioral regression test** for `ClipProcessor._upload_to_youtube`: mocks `upload_video` to `time.sleep(0.4)` and runs a heartbeat coroutine in parallel that ticks every 50ms. If the production code awaits the sync call directly, the heartbeat stalls at zero ticks. With `asyncio.to_thread` it ticks ~6+ times. The test asserts a minimum tick count and fails with a clear message if the wrap is reverted.

2. **Static guard** for `YoutubeUploadTask` (which has too many side effects for an end-to-end behavioral test): regex-scans the module source for direct `uploader.upload_video(` / `get_or_create_playlist(` calls and asserts they're all routed through `asyncio.to_thread`. Catches accidental reverts.

## Test plan

- [x] `pytest tests/test_upload_off_thread.py` — 2 new tests pass
- [x] `pytest tests/test_upload_processor.py tests/test_clip_tasks.py` — 25 existing tests still pass
- [x] `ruff check`/`format`/`mypy` clean
- [x] Pre-commit hooks pass

## Deploy

Next service restart picks up the fix. The tray timeouts and any other event-loop-starvation symptoms during YT uploads go away on the next upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)