### PR TITLE
fix(autocam): replace PyAV moov probe with pure-Python box scan

### DIFF
--- a/tests/test_autocam_automation.py
+++ b/tests/test_autocam_automation.py
@@ -298,14 +298,12 @@ class TestWaitForCompletionExitDetection:
     def test_exit_with_real_output_returns_success(
         self, mock_main_window, mock_file_system
     ):
-        """GUI.exe PIDs exit + output file >= 10 MB → True. Size alone
-        is the success signal; every failure path inside the loop
-        deletes its partial before breaking, so a real-sized file at
-        exit time is always a completed run.
-
-        The autouse ``mock_file_system`` conftest fixture pins
-        ``os.path.getsize`` to 1 MB; we override it here so the size
-        check exercises the success branch.
+        """GUI.exe PIDs exit + output passes validation → True.
+        v0.4.12 validation = size floor + moov-atom presence. The test
+        fixture is an empty ``output.touch()`` file; we mock the moov
+        scan to True because this test's purpose is the exit-detection
+        branch behavior, not the validator internals (those have
+        dedicated tests in test_autocam_output_validation.py).
         """
         mock_file_system["getsize"].return_value = 11 * 1024 * 1024  # > 10 MB threshold
         with tempfile.TemporaryDirectory() as tmp:
@@ -315,6 +313,10 @@ class TestWaitForCompletionExitDetection:
                 patch(
                     "video_grouper.tray.autocam_automation._live_autocam_pids",
                     return_value=[],
+                ),
+                patch(
+                    "video_grouper.tray.autocam_automation._mp4_has_moov_atom",
+                    return_value=True,
                 ),
                 patch("video_grouper.tray.autocam_automation.time.sleep"),
                 patch(
@@ -390,6 +392,10 @@ class TestWaitForCompletionExitDetection:
                     "video_grouper.tray.autocam_automation._live_autocam_pids",
                     side_effect=lambda pids: next(live_results),
                 ),
+                patch(
+                    "video_grouper.tray.autocam_automation._mp4_has_moov_atom",
+                    return_value=True,
+                ),
                 patch("video_grouper.tray.autocam_automation.time.sleep"),
                 patch("video_grouper.tray.autocam_automation.subprocess.run"),
             ):
@@ -409,10 +415,11 @@ class TestExecuteAutocamGuiAutomationOutputPrecheck:
     tray crash would re-process a video we already have."""
 
     def test_skips_when_output_already_exists(self, tmp_path, mock_file_system):
-        """Output file present + large enough → return True immediately
-        without launching subprocess.Popen / Desktop / pywinauto. Size
-        alone is sufficient because every in-loop failure path deletes
-        its partial before breaking."""
+        """Output file present + passes validation → return True
+        immediately without launching subprocess.Popen / Desktop /
+        pywinauto. v0.4.12: validation = size floor + moov-atom
+        presence; mocked True here because the test fixture is an
+        empty ``touch()``ed file."""
         mock_file_system["getsize"].return_value = 50 * 1024 * 1024  # > 10 MB
         input_path = tmp_path / "input.mp4"
         input_path.touch()
@@ -423,6 +430,10 @@ class TestExecuteAutocamGuiAutomationOutputPrecheck:
                 "video_grouper.tray.autocam_automation.subprocess.Popen"
             ) as mock_popen,
             patch("video_grouper.tray.autocam_automation.Desktop") as mock_desktop,
+            patch(
+                "video_grouper.tray.autocam_automation._mp4_has_moov_atom",
+                return_value=True,
+            ),
         ):
             result = _execute_autocam_gui_automation(
                 "C:/fake/GUI.exe", str(input_path), str(output_path)
@@ -613,6 +624,13 @@ class TestShutdownMarkerFastPath:
             patch(
                 "video_grouper.tray.autocam_automation.os.path.getsize",
                 return_value=3_800_000_000,  # 3.8 GB
+            ),
+            # v0.4.12: validator also requires moov atom; mock True since
+            # this test's purpose is the fast-path timing, not the
+            # validator (covered in test_autocam_output_validation.py).
+            patch(
+                "video_grouper.tray.autocam_automation._mp4_has_moov_atom",
+                return_value=True,
             ),
         ):
             fake_dt.now = MagicMock(side_effect=lambda: clock[0])

--- a/tests/test_autocam_output_validation.py
+++ b/tests/test_autocam_output_validation.py
@@ -1,26 +1,35 @@
 """Regression tests for the AutoCam output validator + the resume-race
 guard around it.
 
-These tests intentionally use **real** filesystem operations and **real**
-PyAV. The repository's `tests/conftest.py` defines autouse fixtures that
-mock both (`mock_file_system` pins `os.path.getsize` to 1 MB; `mock_ffmpeg`
-intercepts `av.open`). Those mocks are the exact reason tonight's
-regression slipped through unit tests: every existing AutoCam test was
-asking a MagicMock whether the output was real, not the actual file.
+These tests use **real** filesystem operations. The repository's
+``tests/conftest.py`` defines autouse fixtures that mock the file
+system (``mock_file_system`` pins ``os.path.getsize`` to 1 MB) and
+``av.open`` (``mock_ffmpeg``). Those mocks are the exact reason
+tonight's regression slipped through unit tests: every existing
+AutoCam test was asking a MagicMock whether the output was real,
+not the actual file.
 
-We override both fixtures at module scope below so this file gets real
-filesystem and real PyAV. Don't drop the overrides -- if they go away
+We override both autouse fixtures at module scope below so this file
+gets real filesystem I/O. Don't drop the overrides -- if they go away
 the validator tests become tautologies again.
+
+v0.4.12: the validator is now pure-Python (no PyAV) because PyAV's
+``av.open`` is not reachable from the production tray binary -- the
+v0.4.11 release shipped with an ``AttributeError`` that the broad
+exception handler relabelled as "no moov atom", which accidentally did
+the right thing for the broken file but would have wrongly deleted a
+real output on completion. The new ``_mp4_has_moov_atom`` is a direct
+box-walk, no PyAV.
 """
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import av
 import pytest
 
 from video_grouper.tray.autocam_automation import (
     _autocam_still_writing,
+    _mp4_has_moov_atom,
     _validate_autocam_output,
 )
 
@@ -33,7 +42,8 @@ def mock_file_system():
 
 @pytest.fixture(autouse=True)
 def mock_ffmpeg():
-    """Override conftest autouse mock; validator needs real av.open."""
+    """Override conftest autouse mock; defensive even though validator
+    is now PyAV-free (tests-only PyAV usage in fixtures still wants real av)."""
     yield None
 
 
@@ -42,10 +52,12 @@ def _write_test_mp4(
 ) -> None:
     """Write a real H264 MP4 of ~`duration_s` seconds using PyAV.
 
-    Solid-color frames keep the file tiny (KB-scale) regardless of
-    duration, which lets the duration-based tests run a synthetic
-    "1 hour" video without producing a 1-hour-sized file on disk.
+    PyAV is a test-only dependency here (the production validator is
+    pure-Python). Solid-color frames keep the file tiny (KB-scale)
+    regardless of duration.
     """
+    import av
+
     fps = 10
     with av.open(str(path), mode="w") as container:
         stream = container.add_stream("h264", rate=fps)
@@ -67,9 +79,8 @@ def _write_header_only_mp4(path: Path, target_bytes: int = 15 * 1024 * 1024) -> 
     """Write the exact failure mode from the 2026-06-01 game: a valid
     ftyp box followed by zero-padded bytes, no moov atom, no streams.
 
-    PyAV fails to open this with "Invalid data found when processing input".
-    The header bytes are copied from the first 32 bytes of the corrupt
-    output that AutoCam left behind tonight.
+    The header bytes match the first 32 bytes of the corrupt output
+    AutoCam produced tonight (verified hex-identical).
     """
     header = bytes.fromhex(
         "00000020"  # box size = 32
@@ -91,9 +102,69 @@ def _write_header_only_mp4(path: Path, target_bytes: int = 15 * 1024 * 1024) -> 
             remaining -= n
 
 
+class TestMp4HasMoovAtom:
+    """The moov-presence scanner is pure-Python (no PyAV); we test it
+    standalone since it's the load-bearing reject in
+    ``_validate_autocam_output``."""
+
+    def test_missing_file_returns_false(self, tmp_path):
+        assert _mp4_has_moov_atom(str(tmp_path / "nope.mp4")) is False
+
+    def test_header_only_mp4_returns_false(self, tmp_path):
+        """The 2026-06-01 failure mode: ftyp present, no moov."""
+        out = tmp_path / "header_only.mp4"
+        _write_header_only_mp4(out, target_bytes=1024)
+        assert _mp4_has_moov_atom(str(out)) is False
+
+    def test_valid_mp4_returns_true(self, tmp_path):
+        out = tmp_path / "real.mp4"
+        _write_test_mp4(out, duration_s=2)
+        assert _mp4_has_moov_atom(str(out)) is True
+
+    def test_truncated_after_ftyp_returns_false(self, tmp_path):
+        """Box header says 100 MB but file ends after 8 bytes -- malformed
+        but should not crash; just return False."""
+        out = tmp_path / "trunc.mp4"
+        # ftyp header claiming the box is 100 MB, then EOF.
+        out.write_bytes(bytes.fromhex("06400000667479700000000000000000"))
+        assert _mp4_has_moov_atom(str(out)) is False
+
+    def test_zero_size_box_returns_false(self, tmp_path):
+        """A box with size=0 means 'extends to EOF' -- if it's not moov,
+        no further boxes can appear."""
+        out = tmp_path / "zero.mp4"
+        # ftyp box (32 bytes), then a box with size=0 of type 'mdat'.
+        ftyp = bytes.fromhex(
+            "000000206674797069736f6d0000020069736f6d69736f32617663316d703431"
+        )
+        mdat_eof = bytes.fromhex("000000006d646174") + b"\x00" * 1024
+        out.write_bytes(ftyp + mdat_eof)
+        assert _mp4_has_moov_atom(str(out)) is False
+
+    def test_large_size_box_with_moov_returns_true(self, tmp_path):
+        """size==1 means 'real size in next 8 bytes' (64-bit large box).
+        Construct a small fake one followed by a moov to verify the
+        large-size box is skipped correctly."""
+        out = tmp_path / "large.mp4"
+        # ftyp (32 bytes)
+        ftyp = bytes.fromhex(
+            "000000206674797069736f6d0000020069736f6d69736f32617663316d703431"
+        )
+        # Large box: size=1, type=skip, then 8 bytes of large_size = 24, then 8 bytes of payload.
+        # Total box length = 24 bytes (header 8 + ext-size 8 + payload 8).
+        large = (
+            bytes.fromhex("00000001")  # size flag
+            + b"skip"  # box type
+            + (24).to_bytes(8, "big")  # large size
+            + b"\x00" * 8  # payload
+        )
+        moov = bytes.fromhex("00000010") + b"moov" + b"\x00" * 8
+        out.write_bytes(ftyp + large + moov)
+        assert _mp4_has_moov_atom(str(out)) is True
+
+
 class TestValidateAutocamOutput:
-    """Each case below corresponds to a real-world failure mode the old
-    size-only check would have passed."""
+    """End-to-end validator tests against real files."""
 
     def test_missing_file_is_rejected(self, tmp_path):
         ok, reason = _validate_autocam_output(str(tmp_path / "nope.mp4"))
@@ -121,56 +192,47 @@ class TestValidateAutocamOutput:
         assert ok is False
         assert "moov" in reason.lower() or "pyav" in reason.lower()
 
-    def test_valid_mp4_without_input_is_accepted(self, tmp_path):
-        """No input_path supplied (resume path): pass on size + moov +
-        non-zero duration only."""
+    def test_valid_mp4_is_accepted(self, tmp_path):
         out = tmp_path / "real.mp4"
-        _write_test_mp4(out, duration_s=120)
+        _write_test_mp4(out, duration_s=2)
         # Solid-color H264 compresses to ~KB; bypass the 10 MB absolute floor.
         ok, reason = _validate_autocam_output(str(out), min_bytes=1024)
         assert ok is True, f"expected pass, got: {reason}"
 
-    def test_duration_parity_below_threshold_is_rejected(self, tmp_path):
-        """Output duration < 95% of input = AutoCam exited mid-pass."""
-        input_mp4 = tmp_path / "input.mp4"
-        output_mp4 = tmp_path / "output.mp4"
-        _write_test_mp4(input_mp4, duration_s=120)
-        _write_test_mp4(output_mp4, duration_s=60)  # 50% parity
+    def test_input_path_arg_is_accepted_but_unused(self, tmp_path):
+        """Forward-compat: callers (the 3 trust points in
+        _wait_for_completion_and_cleanup + the short-circuit) still pass
+        input_path. v0.4.12 ignores it because the PyAV-based duration
+        parity check is unreachable from the tray binary; the arg stays
+        in the signature so future v0.4.13 can re-add the check when
+        PyAV is properly bundled in the tray."""
+        out = tmp_path / "real.mp4"
+        inp = tmp_path / "input.mp4"
+        _write_test_mp4(out, duration_s=2)
+        _write_test_mp4(inp, duration_s=2)
         ok, reason = _validate_autocam_output(
-            str(output_mp4), input_path=str(input_mp4), min_bytes=1024
-        )
-        assert ok is False
-        assert "parity" in reason.lower() or "duration" in reason.lower()
-
-    def test_duration_parity_at_threshold_is_accepted(self, tmp_path):
-        """Verifies only the parity check; the bps floor is disabled here
-        because solid-color H264 compresses below 0.5 Mbps regardless of
-        duration. A real soccer game won't have this problem."""
-        input_mp4 = tmp_path / "input.mp4"
-        output_mp4 = tmp_path / "output.mp4"
-        _write_test_mp4(input_mp4, duration_s=10)
-        _write_test_mp4(output_mp4, duration_s=10)
-        ok, reason = _validate_autocam_output(
-            str(output_mp4),
-            input_path=str(input_mp4),
-            min_bytes=1024,
-            min_bps=0,  # disable bps floor; this case isolates the parity check
+            str(out), input_path=str(inp), min_bytes=1024
         )
         assert ok is True, f"expected pass, got: {reason}"
 
-    def test_implausibly_small_for_input_duration_is_rejected(self, tmp_path):
-        """1h input + 1h output that's only KB-large fails the 0.5 Mbps
-        floor. Catches a hypothetical regression where the output runs
-        full-duration but encodes nothing useful (e.g. constant black)."""
-        input_mp4 = tmp_path / "input.mp4"
-        output_mp4 = tmp_path / "output.mp4"
-        _write_test_mp4(output_mp4, duration_s=3600)
-        _write_test_mp4(input_mp4, duration_s=3600)
-        ok, reason = _validate_autocam_output(
-            str(output_mp4), input_path=str(input_mp4), min_bytes=1024
-        )
+    def test_validator_runs_without_pyav_in_path(self, tmp_path, monkeypatch):
+        """Regression for the v0.4.11 production failure: the tray
+        PyInstaller binary doesn't bundle PyAV, so any code path that
+        does ``import av; av.open(...)`` hits AttributeError at runtime.
+        v0.4.12 must work even if PyAV is wholly absent.
+
+        Simulate that by deleting the av module from sys.modules before
+        the validator runs. The validator should still produce the
+        correct verdict on the header-only file.
+        """
+        import sys
+
+        monkeypatch.setitem(sys.modules, "av", None)  # importing av raises now
+        broken = tmp_path / "header_only.mp4"
+        _write_header_only_mp4(broken, target_bytes=15 * 1024 * 1024)
+        ok, reason = _validate_autocam_output(str(broken))
         assert ok is False
-        assert "implausibly" in reason.lower() or "mbps" in reason.lower()
+        assert "moov" in reason.lower()
 
 
 class TestAutocamStillWriting:

--- a/video_grouper/tray/autocam_automation.py
+++ b/video_grouper/tray/autocam_automation.py
@@ -31,45 +31,91 @@ _NO_WINDOW = 0x08000000
 _SHUTDOWN_MARKERS = ("framereader_close", "finished processing")
 
 
-# Output-validation thresholds. AutoCam 3.x hardcodes ~8 Mbps output, so
+# Output-validation thresholds. AutoCam 3.x hardcodes ~8 Mbps output;
 # a healthy completed render is roughly input_duration_seconds * 1 MB/s.
-# The size floor here is deliberately one order of magnitude looser than
-# that (0.5 Mbps average) so it only flags clear failures and never
-# blocks a legit run because of an unexpectedly low-bitrate output.
+# The 10 MB absolute floor is a backstop for empty/header-only output;
+# the moov-atom presence check (below) is the load-bearing reject for
+# the 2026-06-01 failure mode.
 _MIN_OUTPUT_BYTES_ABSOLUTE = 10 * 1024 * 1024  # 10 MB
-_MIN_OUTPUT_BPS = 500_000  # 0.5 Mbps, far below the 8 Mbps target
-# Output duration must reach this fraction of input duration; below
-# means AutoCam exited mid-pass.
-_MIN_DURATION_PARITY = 0.95
+
+
+def _mp4_has_moov_atom(path: str) -> bool:
+    """Walk top-level MP4 boxes looking for the 'moov' atom.
+
+    A clean AutoCam exit writes ftyp + ... + moov + mdat (or with
+    movflags=faststart, ftyp + moov + mdat). A mid-write or truncated
+    output has the ftyp box but no moov -- the same shape as the 15.5 MB
+    file produced 2026-06-01 that v0.4.10 wrongly marked
+    ball_tracking_complete.
+
+    Pure-Python so the tray binary doesn't need PyAV bundled (v0.4.11
+    shipped with PyAV in the validator but av.open isn't reachable from
+    the tray PyInstaller bundle -- AttributeError on av.open at runtime
+    fed the broad exception handler and produced the right verdict for
+    the wrong reason).
+
+    Returns False on any I/O error or malformed box header.
+    """
+    try:
+        with open(path, "rb") as f:
+            while True:
+                header = f.read(8)
+                if len(header) < 8:
+                    return False
+                size = int.from_bytes(header[:4], "big")
+                box_type = header[4:8]
+                if box_type == b"moov":
+                    return True
+                if size == 1:
+                    # 'largesize' extension box: real size is the next 8 bytes.
+                    ext = f.read(8)
+                    if len(ext) < 8:
+                        return False
+                    size = int.from_bytes(ext, "big")
+                    skip = size - 16
+                elif size == 0:
+                    # Box extends to EOF -- no further boxes, so no moov.
+                    return False
+                else:
+                    skip = size - 8
+                if skip < 0:
+                    return False
+                f.seek(skip, 1)
+    except OSError:
+        return False
 
 
 def _validate_autocam_output(
     output_path: str,
     input_path: str | None = None,
     min_bytes: int = _MIN_OUTPUT_BYTES_ABSOLUTE,
-    min_bps: int = _MIN_OUTPUT_BPS,
-    min_duration_parity: float = _MIN_DURATION_PARITY,
 ) -> tuple[bool, str]:
     """Validate an AutoCam output is a real processed video, not a partial.
 
-    Catches three failure modes the fixed-byte-floor check missed
-    (regression observed 2026-06-01: a 15.5 MB header-only MP4 passed
-    the 10 MB floor and was marked ball_tracking_complete):
+    Two checks, in order:
 
-    1. Header-only MP4 -- ftyp written, moov atom never finalized. PyAV
-       fails to open these with "Invalid data found when processing input".
-    2. Truncated output -- output duration is materially shorter than
-       input. We require >= 95% parity when an input file is supplied.
-    3. Implausibly low bitrate -- output below 0.5 Mbps averaged across
-       the input's duration. Once Sport AutoCam targets ~8 Mbps, so
-       anything under 0.5 Mbps is a partial render.
+    1. Absolute size floor (default 10 MB). Cheap reject for empty or
+       barely-started files; primarily a backstop in case the moov scan
+       returns spuriously True on a tiny well-formed test fixture.
+    2. moov-atom presence via :func:`_mp4_has_moov_atom`. AutoCam writes
+       the moov atom only at clean exit, so its absence means the file
+       is a partial -- the exact 2026-06-01 failure mode where a 15.5 MB
+       header-only MP4 passed the size-only check and got marked
+       ball_tracking_complete.
 
-    Returns (ok, reason). On a False result the caller should treat the
-    file as a crashed partial and delete it before retry.
+    Returns (ok, reason). On a False result the caller deletes the file
+    as a crashed partial before retry.
+
+    Note (v0.4.12): the PyAV-based duration parity / bitrate floor that
+    v0.4.11 attempted was unreachable in the production tray binary
+    (PyAV's av.open isn't exposed there). For v0.4.12 we rely on the
+    pure-Python moov scan, which catches the actual observed failure
+    mode. The duration-parity defense returns when the tray binary
+    properly bundles PyAV.
+
+    ``input_path`` is accepted for forward compatibility but unused.
     """
-    # Local import keeps PyAV out of the tray boot path; the validator
-    # is only ever called from inside the AutoCam poll loop.
-    import av
+    del input_path  # kept in signature for caller compatibility
 
     if not os.path.isfile(output_path):
         return False, f"output file does not exist: {output_path}"
@@ -84,53 +130,14 @@ def _validate_autocam_output(
             f"{min_bytes / 1024 / 1024:.0f} MB absolute floor",
         )
 
-    # PyAV moov-atom probe: the most direct catch for the 2026-06-01
-    # failure mode. A header-only MP4 has the ftyp box but no moov, so
-    # av.open() raises (av.error.InvalidDataError on PyAV >= 11) before
-    # we can read any stream info. Catch broadly: any PyAV failure to
-    # open the file means the output isn't usable.
-    try:
-        with av.open(output_path) as out_container:
-            if not out_container.streams.video:
-                return False, "output has no video stream"
-            out_duration_us = out_container.duration or 0
-    except Exception as e:
-        return False, f"PyAV cannot decode output (likely no moov atom): {e}"
+    if not _mp4_has_moov_atom(output_path):
+        return (
+            False,
+            f"output {size / 1024 / 1024:.1f} MB has no moov atom "
+            f"(AutoCam exited before finalizing the MP4 container)",
+        )
 
-    out_duration_s = out_duration_us / 1_000_000 if out_duration_us else 0
-    if out_duration_s <= 0:
-        return False, "output reports zero or unknown duration"
-
-    # Compare against input when we have it (the resume-existing short-
-    # circuit doesn't always; that path falls back to moov+size only).
-    if input_path and os.path.isfile(input_path):
-        try:
-            with av.open(input_path) as in_container:
-                in_duration_us = in_container.duration or 0
-        except Exception:
-            in_duration_us = 0
-        in_duration_s = in_duration_us / 1_000_000 if in_duration_us else 0
-        if in_duration_s > 0:
-            ratio = out_duration_s / in_duration_s
-            if ratio < min_duration_parity:
-                return (
-                    False,
-                    f"output duration {out_duration_s:.0f}s is only "
-                    f"{ratio * 100:.0f}% of input {in_duration_s:.0f}s "
-                    f"(min parity {min_duration_parity * 100:.0f}%)",
-                )
-            if min_bps > 0:
-                min_bytes_for_duration = int(in_duration_s * min_bps / 8)
-                if size < min_bytes_for_duration:
-                    return (
-                        False,
-                        f"output {size / 1024 / 1024:.1f} MB implausibly small "
-                        f"for {in_duration_s:.0f}s input "
-                        f"(minimum {min_bytes_for_duration / 1024 / 1024:.0f} MB "
-                        f"at {min_bps / 1_000_000:.1f} Mbps)",
-                    )
-
-    return True, (f"OK: {size / 1024 / 1024:.1f} MB, {out_duration_s:.0f}s")
+    return True, f"OK: {size / 1024 / 1024:.1f} MB, moov atom present"
 
 
 def _autocam_still_writing(state: DirectoryState | None, input_path: str) -> bool:


### PR DESCRIPTION
## Summary

v0.4.11 hotfix. The validator's ``import av; av.open(...)`` works in dev (system PyAV installed) but raises ``AttributeError: module 'av' has no attribute 'open'`` from the production tray PyInstaller bundle. The broad ``except Exception`` in v0.4.11 relabelled that as "no moov atom" — which happened to delete the existing broken file for the right outcome but the wrong reason. Worse, the SAME AttributeError would fire on a real ``av.open(good_output)`` call when AutoCam completes, rejecting the GOOD output and silently retrying forever.

**Confirmed live on DESKTOP-5L867J8 after v0.4.11 install** — tray log read:
```
Pre-existing output failed validation (PyAV cannot decode output
(likely no moov atom): module 'av' has no attribute 'open');
deleting before relaunch
```

## Fix

Replace the PyAV probe with `_mp4_has_moov_atom` — a pure-Python ISO base-media-file-format box walker. Reads the file 8 bytes at a time, walks top-level boxes, returns True at the first 'moov' it finds, False on EOF / malformed header. No PyAV import.

The duration-parity and bps-floor checks from v0.4.11 are dropped — they also depended on PyAV. The moov-presence check catches the actual 2026-06-01 failure mode (ftyp+mdat-only mid-write exit). Duration/bps defenses return when the tray binary properly bundles PyAV (follow-up).

## Why v0.4.11's tests missed this

They ran under dev Python with system PyAV. The production tray binary is a separate PyInstaller bundle without PyAV runtime. Only an integration test against the installed binary would have caught the import discrepancy.

New regression test `test_validator_runs_without_pyav_in_path` sets `sys.modules['av'] = None` to simulate production absence and asserts the validator still rejects the header-only file. Six new box-walker tests cover edge cases (truncated header, size=0 box, large 64-bit size box).

## Test plan

- [x] `pytest tests/test_autocam_output_validation.py` — 18 tests pass (6 moov-scan + 6 validator including PyAV-absent simulation + 6 resume-race)
- [x] `pytest tests/test_autocam_automation.py tests/test_autocam_resume.py` — 39 existing tests pass (4 updated to mock `_mp4_has_moov_atom`)
- [x] `ruff check`/`format`/`mypy` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)