### PR TITLE
fix: ball tracking retry reliability — cap failures, detect stale progress

### DIFF
--- a/tests/test_ball_tracking_processor.py
+++ b/tests/test_ball_tracking_processor.py
@@ -70,14 +70,19 @@ class TestProcessItem:
         assert state["status"] == "ball_tracking_complete"
 
     @pytest.mark.asyncio
-    async def test_failure_does_not_update_state(self, processor, group_dir):
+    async def test_failure_raises_and_records_failure_count(
+        self, processor, group_dir
+    ):
         task = _make_task(group_dir)
         task.execute = AsyncMock(return_value=False)
 
-        await processor.process_item(task)
+        with pytest.raises(RuntimeError, match="Ball tracking task returned False"):
+            await processor.process_item(task)
 
         state = json.loads((group_dir / "state.json").read_text())
         assert state["status"] == "trimmed"  # unchanged
+        assert state["ball_tracking_failures"] == 1
+        assert "last_ball_tracking_failure" in state
 
     @pytest.mark.asyncio
     async def test_success_queues_youtube_upload_when_enabled(
@@ -135,7 +140,8 @@ class TestProcessItemPrecheck:
 
 
 class TestGetItemKey:
-    def test_keys_differ_per_provider(self, processor, group_dir):
+    def test_keys_same_for_same_group_different_provider(self, processor, group_dir):
+        """One group = one ball tracking task, regardless of provider."""
         a = _make_task(group_dir)
         b = BallTrackingTask(
             group_dir=group_dir,
@@ -144,7 +150,7 @@ class TestGetItemKey:
             provider_name="homegrown",
             provider_config={},
         )
-        assert processor.get_item_key(a) != processor.get_item_key(b)
+        assert processor.get_item_key(a) == processor.get_item_key(b)
 
     def test_keys_equal_for_identical_tasks(self, processor, group_dir):
         a = _make_task(group_dir)

--- a/video_grouper/task_processors/ball_tracking_discovery_processor.py
+++ b/video_grouper/task_processors/ball_tracking_discovery_processor.py
@@ -63,7 +63,17 @@ class BallTrackingDiscoveryProcessor(PollingProcessor):
                 continue
 
             if status == "trimmed":
-                await self._enqueue_for(group_dir)
+                failures = state_data.get("ball_tracking_failures", 0)
+                if failures >= 5:
+                    logger.debug(
+                        "BALL_TRACKING_DISCOVERY: skipping %s — %d failures "
+                        "recorded (max 5). Clear ball_tracking_failures in "
+                        "state.json to retry.",
+                        group_dir.name,
+                        failures,
+                    )
+                else:
+                    await self._enqueue_for(group_dir)
             elif status == "ball_tracking_complete":
                 await self._recover_upload(group_dir)
 

--- a/video_grouper/task_processors/ball_tracking_processor.py
+++ b/video_grouper/task_processors/ball_tracking_processor.py
@@ -10,6 +10,7 @@ Replaces the old ``AutocamProcessor``.
 from __future__ import annotations
 
 import asyncio
+import datetime
 import json
 import logging
 from pathlib import Path
@@ -73,12 +74,43 @@ class BallTrackingProcessor(QueueProcessor):
                 logger.info("BALL_TRACKING: task completed: %s", item)
                 await self._handle_successful_completion(item)
             else:
-                logger.error("BALL_TRACKING: task failed: %s", item)
+                self._record_failure(item)
+                raise RuntimeError(f"Ball tracking task returned False: {item}")
+        except RuntimeError:
+            raise  # Let base class retry logic handle it
         except Exception as e:
+            self._record_failure(item)
             logger.error("BALL_TRACKING: error processing task %s: %s", item, e)
+            raise
 
     def get_item_key(self, item: BallTrackingTaskBase) -> str:
-        return f"{item.task_type}:{item.get_item_path()}:{hash(item)}"
+        return f"{item.task_type}:{item.group_dir}"
+
+    def _record_failure(self, item: BallTrackingTaskBase) -> None:
+        """Increment ball_tracking_failures in state.json for durable failure tracking."""
+        state_file = item.group_dir / "state.json"
+        try:
+            with open(state_file) as f:
+                state_data = json.load(f)
+            state_data["ball_tracking_failures"] = (
+                state_data.get("ball_tracking_failures", 0) + 1
+            )
+            state_data["last_ball_tracking_failure"] = (
+                datetime.datetime.utcnow().isoformat() + "Z"
+            )
+            with open(state_file, "w") as f:
+                json.dump(state_data, f, indent=4)
+            logger.info(
+                "BALL_TRACKING: recorded failure #%d for %s",
+                state_data["ball_tracking_failures"],
+                item.group_dir.name,
+            )
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error(
+                "BALL_TRACKING: could not record failure for %s: %s",
+                item.group_dir.name,
+                e,
+            )
 
     async def _handle_successful_completion(self, item: BallTrackingTaskBase) -> None:
         group_dir = item.group_dir

--- a/video_grouper/tray/autocam_automation.py
+++ b/video_grouper/tray/autocam_automation.py
@@ -613,9 +613,12 @@ def _wait_for_completion_and_cleanup(
     start_time = datetime.datetime.now()
     timeout_seconds = 60 * 60 * 24  # 24 hours
     startup_timeout_seconds = 300  # 5 minutes to start processing
+    stale_progress_timeout = 600  # 10 minutes without progress change → hung
     poll_interval = 30  # 30 seconds
     found = False
     processing_started = False
+    last_notification_text = None
+    last_progress_change_time = datetime.datetime.now()
 
     try:
         while (datetime.datetime.now() - start_time).total_seconds() < timeout_seconds:
@@ -693,6 +696,34 @@ def _wait_for_completion_and_cleanup(
                         logger.info("Processing started: %r", raw_notification)
             except Exception as e:
                 logger.warning(f"Error while checking for success message: {e}")
+
+            # Stale progress detection: if the notification text hasn't
+            # changed for stale_progress_timeout seconds after processing
+            # started, AutoCam is hung. Kill it and treat as failure.
+            # Guard: notification_text may be unbound if the try block
+            # above raised before assigning it.
+            current_text = locals().get("notification_text")
+            if current_text is not None:
+                if processing_started and last_notification_text is not None:
+                    if current_text != last_notification_text:
+                        last_progress_change_time = datetime.datetime.now()
+                    stale_seconds = (
+                        datetime.datetime.now() - last_progress_change_time
+                    ).total_seconds()
+                    if stale_seconds > stale_progress_timeout:
+                        logger.error(
+                            "AutoCam progress stale for %.0f minutes "
+                            "(last status: %r); treating as hung.",
+                            stale_seconds / 60,
+                            current_text,
+                        )
+                        if output_path and os.path.isfile(output_path):
+                            try:
+                                os.remove(output_path)
+                            except OSError:
+                                pass
+                        break
+                last_notification_text = current_text
 
             # Exit-detection fallback: if AutoCam's GUI processes have
             # all exited, decide success/failure from the output file's


### PR DESCRIPTION
## Summary
- **process_item raises on failure** — base class retry logic (max 3) now handles ball tracking failures instead of silently swallowing them
- **Durable failure tracking** — `ball_tracking_failures` counter in state.json, incremented on each failure
- **Discovery failure cap** — groups with 5+ failures are skipped (clear counter to retry)
- **Stable item key** — `task_type:group_dir` instead of including `hash(item)`, ensuring one task per group
- **Stale progress detection** — kills AutoCam if notification text unchanged for 10 minutes after processing starts

## Context
In production (6/4 Irondequoit game), AutoCam crashed 6+ times overnight producing partial MP4s. The system retried forever because `process_item()` returned normally on failure, the base class treated it as success, and the discovery processor re-enqueued every 30s.

## Test plan
- [x] 1183 unit tests pass (0 failures)
- [x] Local PyInstaller build installed and verified through full pipeline
- [x] Irondequoit game: ball tracking completed, both YouTube uploads succeeded
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)