### PR TITLE
fix(ntfy): dedup ?since=24h topic replays with a consumed-message-id ledger

### DIFF
--- a/tests/test_ntfy_replay_dedup.py
+++ b/tests/test_ntfy_replay_dedup.py
@@ -1,0 +1,135 @@
+"""Tests for NTFY topic-replay dedup via the consumed-message-id ledger.
+
+The listener reconnects with ``?since=24h``, which redelivers every recent
+topic message with its stable server-assigned id. Without a ledger of what we
+already consumed, a replayed "Yes"/"No" tap can re-answer a freshly-queued
+question on its own — the regression these tests pin down (2026-06 incident
+where an earlier game's taps walked a new game's game-start question forward).
+
+The NTFY topic is the source of truth; the ledger only records what we used
+from it.
+"""
+
+import asyncio
+import json
+import tempfile
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from video_grouper.api_integrations.ntfy import NtfyAPI
+from video_grouper.task_processors.services.ntfy_service import (
+    NTFY_PROCESSED_LOG_RETENTION_SECONDS,
+    NtfyService,
+)
+from video_grouper.utils.config import NtfyConfig
+from video_grouper.utils.paths import get_ntfy_processed_log_path
+
+
+@pytest.fixture
+def config():
+    return NtfyConfig(enabled=True, topic="test-topic")
+
+
+@pytest.fixture
+def storage_path():
+    with tempfile.TemporaryDirectory() as tmp:
+        yield tmp
+
+
+def test_record_and_has_used_message(config, storage_path):
+    svc = NtfyService(config, storage_path)
+
+    assert not svc.has_used_message("abc")
+    svc.record_used_message("abc", event="message", message="Yes, game started")
+    assert svc.has_used_message("abc")
+    assert not svc.has_used_message("other-id")
+
+    # A falsy id is never "used" and recording it is a no-op.
+    assert not svc.has_used_message(None)
+    svc.record_used_message(None)
+
+    # Recording the same id twice does not duplicate the audit-log line.
+    svc.record_used_message("abc")
+    with open(get_ntfy_processed_log_path(storage_path)) as f:
+        lines = [line for line in f if line.strip()]
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["id"] == "abc"
+    assert entry["message"] == "Yes, game started"
+
+
+def test_used_messages_persist_across_restart(config, storage_path):
+    svc1 = NtfyService(config, storage_path)
+    svc1.record_used_message("persist-me", message="No, not yet at 05:00")
+
+    # A fresh service (e.g. after a service/tray restart) reloads the ledger,
+    # so the replay guard survives the restart that ``?since=24h`` exists for.
+    svc2 = NtfyService(config, storage_path)
+    assert svc2.has_used_message("persist-me")
+
+
+def test_stale_used_messages_pruned_on_load(config, storage_path):
+    log_path = get_ntfy_processed_log_path(storage_path)
+    stale_at = (
+        datetime.now() - timedelta(seconds=NTFY_PROCESSED_LOG_RETENTION_SECONDS + 3600)
+    ).isoformat()
+    fresh_at = datetime.now().isoformat()
+    with open(log_path, "w") as f:
+        f.write(json.dumps({"id": "stale", "recorded_at": stale_at}) + "\n")
+        f.write(json.dumps({"id": "recent", "recorded_at": fresh_at}) + "\n")
+
+    svc = NtfyService(config, storage_path)
+    assert not svc.has_used_message("stale")  # older than retention -> dropped
+    assert svc.has_used_message("recent")
+
+    # The file is rewritten compacted, so stale ids don't accumulate forever.
+    with open(log_path) as f:
+        ids = {json.loads(line)["id"] for line in f if line.strip()}
+    assert ids == {"recent"}
+
+
+@pytest.mark.asyncio
+async def test_process_response_skips_replayed_message_id(config, storage_path):
+    """A replayed message id is routed to the service exactly once."""
+    svc = NtfyService(config, storage_path)
+    svc.process_response = AsyncMock()
+    api = NtfyAPI(config, service_callback=svc)
+
+    tap = {
+        "id": "tap-1",
+        "event": "message",
+        "time": 1749370000,
+        "message": "Yes, game started at 10:00",
+    }
+
+    # First delivery: consumed and dispatched to the service.
+    await api._process_response(dict(tap))
+    # ?since=24h reconnect redelivers the SAME id -> must be dropped.
+    await api._process_response(dict(tap))
+    # Let the create_task'd dispatch from the first delivery run.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert svc.process_response.call_count == 1
+    assert svc.has_used_message("tap-1")
+
+
+@pytest.mark.asyncio
+async def test_distinct_message_ids_both_processed(config, storage_path):
+    """Two genuinely different taps (distinct ids) are both processed."""
+    svc = NtfyService(config, storage_path)
+    svc.process_response = AsyncMock()
+    api = NtfyAPI(config, service_callback=svc)
+
+    await api._process_response(
+        {"id": "a", "event": "message", "time": 1, "message": "No, not yet at 00:00"}
+    )
+    await api._process_response(
+        {"id": "b", "event": "message", "time": 2, "message": "No, not yet at 05:00"}
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert svc.process_response.call_count == 2

--- a/tests/test_ntfy_replay_dedup.py
+++ b/tests/test_ntfy_replay_dedup.py
@@ -6,8 +6,9 @@ already consumed, a replayed "Yes"/"No" tap can re-answer a freshly-queued
 question on its own — the regression these tests pin down (2026-06 incident
 where an earlier game's taps walked a new game's game-start question forward).
 
-The NTFY topic is the source of truth; the ledger only records what we used
-from it.
+The NTFY topic is the source of truth; the ledger only records what we actually
+used from it (record-on-use), so a dispatch that fails can still be retried by
+the next replay.
 """
 
 import asyncio
@@ -42,7 +43,7 @@ def test_record_and_has_used_message(config, storage_path):
     svc = NtfyService(config, storage_path)
 
     assert not svc.has_used_message("abc")
-    svc.record_used_message("abc", event="message", message="Yes, game started")
+    svc.record_used_message("abc", message="Yes, game started", decision="applied")
     assert svc.has_used_message("abc")
     assert not svc.has_used_message("other-id")
 
@@ -58,6 +59,14 @@ def test_record_and_has_used_message(config, storage_path):
     entry = json.loads(lines[0])
     assert entry["id"] == "abc"
     assert entry["message"] == "Yes, game started"
+
+
+def test_record_truncates_long_message(config, storage_path):
+    svc = NtfyService(config, storage_path)
+    svc.record_used_message("long", message="x" * 500)
+    with open(get_ntfy_processed_log_path(storage_path)) as f:
+        entry = json.loads(f.readline())
+    assert len(entry["message"]) == 200
 
 
 def test_used_messages_persist_across_restart(config, storage_path):
@@ -90,11 +99,33 @@ def test_stale_used_messages_pruned_on_load(config, storage_path):
     assert ids == {"recent"}
 
 
+def test_missing_or_malformed_recorded_at_is_kept(config, storage_path):
+    """An entry whose recorded_at is absent/unparseable is kept (can't prove
+    it's stale); a genuinely old one is still dropped. Also: a torn JSON line
+    is skipped without losing the rest of the log."""
+    log_path = get_ntfy_processed_log_path(storage_path)
+    stale_at = (
+        datetime.now() - timedelta(seconds=NTFY_PROCESSED_LOG_RETENTION_SECONDS + 3600)
+    ).isoformat()
+    with open(log_path, "w") as f:
+        f.write(json.dumps({"id": "no-ts"}) + "\n")  # missing recorded_at
+        f.write(json.dumps({"id": "bad-ts", "recorded_at": "not-a-date"}) + "\n")
+        f.write("{torn json line\n")  # corrupt — must be skipped, not fatal
+        f.write(json.dumps({"id": "stale", "recorded_at": stale_at}) + "\n")
+
+    svc = NtfyService(config, storage_path)
+    assert svc.has_used_message("no-ts")
+    assert svc.has_used_message("bad-ts")
+    assert not svc.has_used_message("stale")
+
+
 @pytest.mark.asyncio
 async def test_process_response_skips_replayed_message_id(config, storage_path):
-    """A replayed message id is routed to the service exactly once."""
+    """A replayed message id is routed to the service exactly once (record-on-use)."""
     svc = NtfyService(config, storage_path)
-    svc.process_response = AsyncMock()
+    # Spy on the REAL process_response so it still records on consume.
+    real = svc.process_response
+    svc.process_response = AsyncMock(side_effect=real)
     api = NtfyAPI(config, service_callback=svc)
 
     tap = {
@@ -104,16 +135,79 @@ async def test_process_response_skips_replayed_message_id(config, storage_path):
         "message": "Yes, game started at 10:00",
     }
 
-    # First delivery: consumed and dispatched to the service.
+    # First delivery: dispatched, consumed (buffered — no task waiting), recorded.
     await api._process_response(dict(tap))
-    # ?since=24h reconnect redelivers the SAME id -> must be dropped.
-    await api._process_response(dict(tap))
-    # Let the create_task'd dispatch from the first delivery run.
     await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    # ?since=24h reconnect redelivers the SAME id -> skipped at ingest.
+    await api._process_response(dict(tap))
     await asyncio.sleep(0)
 
     assert svc.process_response.call_count == 1
     assert svc.has_used_message("tap-1")
+    # The replay never reached the buffer either (skipped before dispatch).
+    assert len(svc._unmatched_responses) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_dispatch_is_not_recorded(config, storage_path):
+    """If consuming the response fails, the id is NOT recorded — so the next
+    ?since=24h replay can retry it. This is the whole point of record-on-use
+    over record-on-ingest."""
+    svc = NtfyService(config, storage_path)
+    svc.process_response = AsyncMock(side_effect=RuntimeError("boom"))
+    api = NtfyAPI(config, service_callback=svc)
+
+    await api._process_response(
+        {
+            "id": "boom-1",
+            "event": "message",
+            "time": 1,
+            "message": "Yes, game started at 00:00",
+        }
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert not svc.has_used_message("boom-1")
+
+
+@pytest.mark.asyncio
+async def test_echoed_notification_not_recorded(config, storage_path):
+    """Our own echoed notification (carries title/actions/tags) is never
+    consumed, so its id must not enter the ledger."""
+    svc = NtfyService(config, storage_path)
+    svc.process_response = AsyncMock()
+    api = NtfyAPI(config, service_callback=svc)
+
+    await api._process_response(
+        {
+            "id": "echo-1",
+            "event": "message",
+            "time": 1,
+            "message": "Does the game start at 00:00?",
+            "title": "Game Start Time",
+            "actions": [{"action": "http", "label": "Yes"}],
+        }
+    )
+    await asyncio.sleep(0)
+
+    assert not svc.has_used_message("echo-1")
+    assert svc.process_response.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_keepalive_event_not_recorded(config, storage_path):
+    """Keepalive heartbeats carry an id but are never consumed."""
+    svc = NtfyService(config, storage_path)
+    svc.process_response = AsyncMock()
+    api = NtfyAPI(config, service_callback=svc)
+
+    await api._process_response({"id": "ka-1", "event": "keepalive", "time": 1})
+    await asyncio.sleep(0)
+
+    assert not svc.has_used_message("ka-1")
+    assert svc.process_response.call_count == 0
 
 
 @pytest.mark.asyncio

--- a/video_grouper/api_integrations/ntfy.py
+++ b/video_grouper/api_integrations/ntfy.py
@@ -102,6 +102,9 @@ class NtfyAPI:
         self.listener_task = None
         self.session_id = str(uuid.uuid4())[:8]  # Create a unique session ID
         self.service_callback = service_callback
+        # Id of the topic message currently being dispatched, threaded to the
+        # consume path so the service records it on use (see _process_response).
+        self._pending_topic_msg_id = None
 
         # Track sent messages and their responses
         self.pending_messages = {}  # message_id -> future
@@ -306,28 +309,16 @@ class NtfyAPI:
                 )
                 return
 
-            # Record response-bearing messages as consumed. Skip keepalive/open
-            # heartbeats and our own echoed notifications (title/actions/tags/
-            # attachment) — we never act on those, so they shouldn't enter the
-            # audit log. This is what lets the skip above work across restarts.
-            is_echoed_notification = event_type == "message" and any(
-                key in response_data
-                for key in ("actions", "attachment", "title", "tags")
-            )
-            if (
-                ntfy_msg_id
-                and cb is not None
-                and hasattr(cb, "record_used_message")
-                and event_type in ("message", "action", "click", "response")
-                and not is_echoed_notification
-            ):
-                cb.record_used_message(
-                    ntfy_msg_id,
-                    server_time=server_time,
-                    event=event_type,
-                    message=message,
-                    decision="consumed",
-                )
+            # Thread this message's id to the consume path so the service
+            # records it only once it actually USES the response (record-on-use;
+            # see NtfyService.process_response). Recording at consume rather than
+            # here at ingest means a dispatch that fails still gets retried by
+            # the next ?since=24h replay, and the audit log reflects what was
+            # used rather than merely received. Reset every call — the listener
+            # processes one message at a time, so a non-dispatching event
+            # (echoed notification / keepalive) can't leak a stale id onto the
+            # next dispatch.
+            self._pending_topic_msg_id = ntfy_msg_id
 
             # For message events (regular messages)
             if event_type == "message":
@@ -477,6 +468,23 @@ class NtfyAPI:
         except Exception as e:
             logger.error(f"Error processing NTFY response: {e}", exc_info=True)
 
+    def _record_consumed(self, topic_msg_id, response, server_time, decision):
+        """Record a consumed topic message id on the service ledger (guarded).
+
+        No-op when there's no id (synthetic/internal responses) or the callback
+        doesn't expose the ledger (e.g. a bare mock). This is the API-side
+        consume point for the legacy pending-future paths; the service records
+        its own consume points (task match / buffer) in process_response.
+        """
+        cb = self.service_callback
+        if topic_msg_id and cb is not None and hasattr(cb, "record_used_message"):
+            cb.record_used_message(
+                topic_msg_id,
+                server_time=server_time,
+                message=str(response)[:200],
+                decision=decision,
+            )
+
     def _handle_response(self, response: str, server_time: float | None = None):
         """Handle a response to a message.
 
@@ -487,6 +495,7 @@ class NtfyAPI:
                 it can reject stale replays. None for synthetic/internal
                 responses or the legacy pending-future path.
         """
+        topic_msg_id = getattr(self, "_pending_topic_msg_id", None)
         # First, try to handle as a pending message (for legacy compatibility)
         if self.pending_messages:
             # Find the most recent message
@@ -501,6 +510,7 @@ class NtfyAPI:
                 future.set_result(response)
 
                 self._cleanup_pending_message(most_recent_id)
+                self._record_consumed(topic_msg_id, response, server_time, "future")
 
                 logger.info(
                     f"Processed response for message {most_recent_id}: {response}"
@@ -517,7 +527,7 @@ class NtfyAPI:
             # Use asyncio.create_task to avoid blocking
             asyncio.create_task(
                 self.service_callback.process_response(
-                    response, server_time=server_time
+                    response, server_time=server_time, topic_msg_id=topic_msg_id
                 )
             )
         else:
@@ -540,6 +550,12 @@ class NtfyAPI:
                 future.set_result(response_data)
 
                 self._cleanup_pending_message(message_id)
+                self._record_consumed(
+                    getattr(self, "_pending_topic_msg_id", None),
+                    response,
+                    None,
+                    "future",
+                )
 
                 logger.info(
                     f"Processed specific response for message {message_id}: {response}"

--- a/video_grouper/api_integrations/ntfy.py
+++ b/video_grouper/api_integrations/ntfy.py
@@ -286,6 +286,49 @@ class NtfyAPI:
             # reconnect. Absent for synthetic/internal events → None.
             server_time = response_data.get("time")
 
+            # The NTFY topic is the source of truth; ?since=24h redelivers every
+            # recent message on listener reconnect with its stable server id.
+            # Guard against re-applying a tap we already consumed (e.g. an
+            # earlier game's "Yes" walking a fresh question forward) by skipping
+            # ids already in the service's ledger. A missing callback or a
+            # ledger hiccup must never block live processing.
+            ntfy_msg_id = response_data.get("id")
+            cb = self.service_callback
+            if (
+                ntfy_msg_id
+                and cb is not None
+                and hasattr(cb, "has_used_message")
+                and cb.has_used_message(ntfy_msg_id)
+            ):
+                logger.debug(
+                    f"NTFY: skipping already-consumed message id={ntfy_msg_id} "
+                    "(?since=24h replay)"
+                )
+                return
+
+            # Record response-bearing messages as consumed. Skip keepalive/open
+            # heartbeats and our own echoed notifications (title/actions/tags/
+            # attachment) — we never act on those, so they shouldn't enter the
+            # audit log. This is what lets the skip above work across restarts.
+            is_echoed_notification = event_type == "message" and any(
+                key in response_data
+                for key in ("actions", "attachment", "title", "tags")
+            )
+            if (
+                ntfy_msg_id
+                and cb is not None
+                and hasattr(cb, "record_used_message")
+                and event_type in ("message", "action", "click", "response")
+                and not is_echoed_notification
+            ):
+                cb.record_used_message(
+                    ntfy_msg_id,
+                    server_time=server_time,
+                    event=event_type,
+                    message=message,
+                    decision="consumed",
+                )
+
             # For message events (regular messages)
             if event_type == "message":
                 # Check for responses to our questions (case insensitive)

--- a/video_grouper/task_processors/services/ntfy_service.py
+++ b/video_grouper/task_processors/services/ntfy_service.py
@@ -12,6 +12,7 @@ from typing import Any
 from video_grouper.api_integrations.ntfy import NtfyAPI
 from video_grouper.utils.config import NtfyConfig
 
+from ...utils.locking import FileLock
 from ...utils.paths import (
     get_ntfy_processed_log_path,
     get_ntfy_service_state_path,
@@ -206,36 +207,46 @@ class NtfyService:
         replay) and rewrites the file compacted so it stays bounded. A
         corrupt or unreadable log must never block startup — on any error we
         keep whatever ids parsed so far and carry on.
+
+        The read-then-compacting-rewrite is taken under FileLock so a
+        concurrent appender (e.g. a second tray agent) can't be clobbered by
+        the truncate. NOTE: the in-memory id set is per-process, so this guards
+        the file's integrity, not cross-process dedup — two live listeners each
+        consume a given tap once. See record_used_message.
         """
         if not os.path.exists(self._processed_log_file):
             return
         cutoff = datetime.now().timestamp() - NTFY_PROCESSED_LOG_RETENTION_SECONDS
         kept_lines: list[str] = []
         try:
-            with open(self._processed_log_file, encoding="utf-8") as f:
-                for raw in f:
-                    line = raw.strip()
-                    if not line:
-                        continue
-                    try:
-                        entry = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue  # skip a torn line, don't lose the rest
-                    recorded_at = entry.get("recorded_at")
-                    if recorded_at:
+            with FileLock(self._processed_log_file):
+                with open(self._processed_log_file, encoding="utf-8") as f:
+                    for raw in f:
+                        line = raw.strip()
+                        if not line:
+                            continue
                         try:
-                            if datetime.fromisoformat(recorded_at).timestamp() < cutoff:
-                                continue  # stale, prune
-                        except ValueError:
-                            pass
-                    mid = entry.get("id")
-                    if mid:
-                        self._used_message_ids.add(mid)
-                        kept_lines.append(line)
-            # Rewrite compacted so pruned/stale entries don't accumulate.
-            with open(self._processed_log_file, "w", encoding="utf-8") as f:
-                if kept_lines:
-                    f.write("\n".join(kept_lines) + "\n")
+                            entry = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue  # skip a torn line, don't lose the rest
+                        recorded_at = entry.get("recorded_at")
+                        if recorded_at:
+                            try:
+                                if (
+                                    datetime.fromisoformat(recorded_at).timestamp()
+                                    < cutoff
+                                ):
+                                    continue  # stale, prune
+                            except ValueError:
+                                pass
+                        mid = entry.get("id")
+                        if mid:
+                            self._used_message_ids.add(mid)
+                            kept_lines.append(line)
+                # Rewrite compacted so pruned/stale entries don't accumulate.
+                with open(self._processed_log_file, "w", encoding="utf-8") as f:
+                    if kept_lines:
+                        f.write("\n".join(kept_lines) + "\n")
             logger.debug(
                 f"NTFY: loaded {len(self._used_message_ids)} consumed message ids"
             )
@@ -255,7 +266,6 @@ class NtfyService:
         message_id: str | None,
         *,
         server_time: float | None = None,
-        event: str | None = None,
         message: str | None = None,
         decision: str | None = None,
     ) -> None:
@@ -265,6 +275,13 @@ class NtfyService:
         server-assigned id. Idempotent: a no-op if the id was already
         recorded. A failed write is logged but never raised — the listener
         must keep processing even if the ledger can't be persisted.
+
+        The append is taken under FileLock so it can't interleave with another
+        process's compacting rewrite (see _load_used_messages). This protects
+        the file, NOT cross-process dedup: the id set is per-process and only
+        loaded at init, so two live listeners on the same topic each consume a
+        given tap once — concurrent dual-consumers are out of scope here (the
+        single-instance tray lock is what prevents that).
         """
         if not message_id or message_id in self._used_message_ids:
             return
@@ -272,14 +289,14 @@ class NtfyService:
         entry = {
             "id": message_id,
             "ntfy_time": server_time,
-            "event": event,
             "message": (message or "")[:200],
             "decision": decision,
             "recorded_at": datetime.now().isoformat(),
         }
         try:
-            with open(self._processed_log_file, "a", encoding="utf-8") as f:
-                f.write(json.dumps(entry) + "\n")
+            with FileLock(self._processed_log_file):
+                with open(self._processed_log_file, "a", encoding="utf-8") as f:
+                    f.write(json.dumps(entry) + "\n")
         except Exception as e:
             logger.warning(f"NTFY: failed to append processed-message log: {e}")
 
@@ -625,7 +642,10 @@ class NtfyService:
         self._response_handlers.pop(key, None)
 
     async def process_response(
-        self, response: str, server_time: float | None = None
+        self,
+        response: str,
+        server_time: float | None = None,
+        topic_msg_id: str | None = None,
     ) -> None:
         """
         Process a response from NTFY and route it to the appropriate pending task.
@@ -639,8 +659,23 @@ class NtfyService:
                 seconds), when available. Used to reject stale replays when the
                 response has to be buffered. None for synthetic/internal
                 responses (e.g. the mock API or registered response handlers).
+            topic_msg_id: The NTFY topic message id this response came from,
+                when available. Recorded to the consumed-id ledger at the point
+                the response is actually used (matched/handled/buffered) so the
+                ?since=24h replay never re-applies it. None for synthetic calls.
         """
         logger.info(f"Processing NTFY response: {response}")
+
+        def _record_consumed(decision: str) -> None:
+            # Record-on-use: only called once we've actually consumed the
+            # response, so a dispatch that throws before this is left
+            # un-recorded and the next replay can retry it.
+            self.record_used_message(
+                topic_msg_id,
+                server_time=server_time,
+                message=str(response)[:200],
+                decision=decision,
+            )
 
         # Check generic response handlers first (e.g. home recording deletion)
         response_lower = response.lower()
@@ -649,6 +684,7 @@ class NtfyService:
                 logger.info(f"Matched response handler: {key}")
                 try:
                     await handler(response)
+                    _record_consumed("handler")
                 except Exception as e:
                     logger.error(f"Error in response handler '{key}': {e}")
                 return
@@ -668,6 +704,7 @@ class NtfyService:
                     await self._process_task_response(
                         self._last_notified_group_dir, task_type, metadata, response
                     )
+                    _record_consumed("applied")
                     return
 
         # Fall back to iterating all pending tasks (sorted by sent_at descending)
@@ -689,6 +726,7 @@ class NtfyService:
                 await self._process_task_response(
                     group_dir, task_type, metadata, response
                 )
+                _record_consumed("applied")
                 return
         # No task currently waiting for this response. Buffer it — a task
         # registration may be moments away (state_auditor and the response
@@ -700,6 +738,7 @@ class NtfyService:
 
         self._prune_unmatched_buffer()
         self._unmatched_responses.append((time.monotonic(), server_time, response))
+        _record_consumed("buffered")
         logger.warning(
             f"No matching task found for response: {response} "
             f"(buffered {len(self._unmatched_responses)} unmatched responses, "

--- a/video_grouper/task_processors/services/ntfy_service.py
+++ b/video_grouper/task_processors/services/ntfy_service.py
@@ -12,7 +12,10 @@ from typing import Any
 from video_grouper.api_integrations.ntfy import NtfyAPI
 from video_grouper.utils.config import NtfyConfig
 
-from ...utils.paths import get_ntfy_service_state_path
+from ...utils.paths import (
+    get_ntfy_processed_log_path,
+    get_ntfy_service_state_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +37,13 @@ BUFFER_FRESHNESS_WINDOW_SECONDS = 60
 # entry must have been received within this many seconds (monotonic) of the
 # task registering. We never replay an older entry on this weak signal.
 BUFFER_RACE_WINDOW_SECONDS = 10
+
+# How long to remember consumed NTFY message ids. The ntfy.sh free tier
+# retains topic messages ~12-24h, so the ?since=24h replay can only ever
+# resurface an id younger than that; anything older can never replay and is
+# pruned from the ledger on load to keep it bounded. 48h gives comfortable
+# headroom over the replay window.
+NTFY_PROCESSED_LOG_RETENTION_SECONDS = 48 * 3600
 
 
 class NtfyService:
@@ -61,6 +71,16 @@ class NtfyService:
         self._pending_tasks: dict[str, dict[str, Any]] = {}
         self._processed_dirs: set[str] = set()
         self._state_file = get_ntfy_service_state_path(storage_path)
+
+        # Authoritative replay guard: the set of NTFY message ids we have
+        # already consumed. The ?since=24h replay on listener reconnect
+        # redelivers every recent message with its stable server-assigned id;
+        # ids in this set are skipped at ingest so a tap can never be applied
+        # twice (e.g. an earlier game's "Yes" walking a new game's question).
+        # Backed by an append-only JSONL audit log so it survives restarts.
+        # The topic is the source of truth; this records what we used from it.
+        self._processed_log_file = get_ntfy_processed_log_path(storage_path)
+        self._used_message_ids: set[str] = set()
 
         # Buffer for responses that arrived before any task was registered
         # to receive them. The recurring race: state_auditor queues a new
@@ -101,6 +121,7 @@ class NtfyService:
 
         self._initialize_api()
         self._load_state()
+        self._load_used_messages()
 
     def _initialize_api(self) -> None:
         """Initialize NTFY API."""
@@ -177,6 +198,90 @@ class NtfyService:
                 json.dump(state, f, indent=2)
         except Exception as e:
             logger.error(f"Error saving NTFY unified state: {e}")
+
+    def _load_used_messages(self) -> None:
+        """Load consumed NTFY message ids from the audit log.
+
+        Drops entries older than the retention window (they can no longer
+        replay) and rewrites the file compacted so it stays bounded. A
+        corrupt or unreadable log must never block startup — on any error we
+        keep whatever ids parsed so far and carry on.
+        """
+        if not os.path.exists(self._processed_log_file):
+            return
+        cutoff = datetime.now().timestamp() - NTFY_PROCESSED_LOG_RETENTION_SECONDS
+        kept_lines: list[str] = []
+        try:
+            with open(self._processed_log_file, encoding="utf-8") as f:
+                for raw in f:
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue  # skip a torn line, don't lose the rest
+                    recorded_at = entry.get("recorded_at")
+                    if recorded_at:
+                        try:
+                            if datetime.fromisoformat(recorded_at).timestamp() < cutoff:
+                                continue  # stale, prune
+                        except ValueError:
+                            pass
+                    mid = entry.get("id")
+                    if mid:
+                        self._used_message_ids.add(mid)
+                        kept_lines.append(line)
+            # Rewrite compacted so pruned/stale entries don't accumulate.
+            with open(self._processed_log_file, "w", encoding="utf-8") as f:
+                if kept_lines:
+                    f.write("\n".join(kept_lines) + "\n")
+            logger.debug(
+                f"NTFY: loaded {len(self._used_message_ids)} consumed message ids"
+            )
+        except Exception as e:
+            logger.error(f"Error loading NTFY processed-message log: {e}")
+
+    def has_used_message(self, message_id: str | None) -> bool:
+        """Return True if we have already consumed this NTFY message id.
+
+        Used by the listener to drop ?since=24h replays of a tap we already
+        acted on, so a stale response can never re-answer a live question.
+        """
+        return bool(message_id) and message_id in self._used_message_ids
+
+    def record_used_message(
+        self,
+        message_id: str | None,
+        *,
+        server_time: float | None = None,
+        event: str | None = None,
+        message: str | None = None,
+        decision: str | None = None,
+    ) -> None:
+        """Record that we consumed (used) an NTFY topic message.
+
+        Appends one line to the audit log keyed on the message's
+        server-assigned id. Idempotent: a no-op if the id was already
+        recorded. A failed write is logged but never raised — the listener
+        must keep processing even if the ledger can't be persisted.
+        """
+        if not message_id or message_id in self._used_message_ids:
+            return
+        self._used_message_ids.add(message_id)
+        entry = {
+            "id": message_id,
+            "ntfy_time": server_time,
+            "event": event,
+            "message": (message or "")[:200],
+            "decision": decision,
+            "recorded_at": datetime.now().isoformat(),
+        }
+        try:
+            with open(self._processed_log_file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(entry) + "\n")
+        except Exception as e:
+            logger.warning(f"NTFY: failed to append processed-message log: {e}")
 
     def is_waiting_for_input(self, group_dir: str) -> bool:
         """Check if we're waiting for user input for a specific directory."""

--- a/video_grouper/utils/paths.py
+++ b/video_grouper/utils/paths.py
@@ -169,6 +169,24 @@ def get_ntfy_service_state_path(storage_path: str) -> str:
     return os.path.join(storage_path, "ntfy_service_state.json")
 
 
+def get_ntfy_processed_log_path(storage_path: str) -> str:
+    """Get the path to the NTFY processed-message audit log.
+
+    Append-only JSONL recording every NTFY topic message we have consumed,
+    keyed by the message's server-assigned id. The NTFY topic is the source
+    of truth; this log is our record of what we actually used from it, so the
+    ``?since=24h`` replay on listener reconnect never re-applies a tap we have
+    already acted on. Also doubles as a human-readable audit trail.
+
+    Args:
+        storage_path: The storage path
+
+    Returns:
+        Path to the ntfy_processed.jsonl file
+    """
+    return os.path.join(storage_path, "ntfy_processed.jsonl")
+
+
 def get_home_cleanup_state_path(storage_path: str) -> str:
     """Get the path to the home recording cleanup state file.
 


### PR DESCRIPTION
## Problem
The NTFY listener subscribes with `?since=24h`, so on every reconnect (service/tray restart, config-watch bounce, recovery window) the server **redelivers** every recent topic message with its stable server-assigned `id`. The only guard was the `_unmatched_responses` freshness heuristic — but a freshly-queued question *is* `waiting_for_input`, so a replayed "Yes"/"No" from an earlier game could walk a new game's game-start question forward on its own (the user never tapped).

## Fix
Authoritative, id-based dedup. The NTFY topic stays the source of truth; `NtfyService` keeps a ledger of message ids it has actually **consumed**, persisted to an append-only `ntfy_processed.jsonl` audit log:
- `_process_response` skips any id already in the ledger at ingest.
- **Record-on-use:** the id is recorded only when the response is actually used — matched to a task / handled / buffered (`process_response`), or a completed pending-future (API side) — *not* at ingest. So a dispatch that throws is left un-recorded and the next replay can retry it, and the audit `decision` reflects what happened (`applied`/`handler`/`buffered`/`future`). Keepalive/open heartbeats and our own echoed notifications are never recorded.
- Stale ids (older than 48h; the topic only retains ~12–24h) are pruned and the log compacted on load (torn lines skipped, not fatal).
- Ledger append + compacting rewrite are taken under `FileLock`.

## Scope / limitations
- This makes redelivery **idempotent within a process's lifetime** and **complements** the buffer (which still covers the genuine pre-registration race) — it does not replace it.
- It does **not** dedup across two concurrently-live listeners: the in-memory id set is per-process (loaded at init), so two tray agents on the same topic each consume a live tap once. `FileLock` protects the file's integrity, not cross-process dedup — preventing concurrent dual-consumers remains the tray's single-instance lock's job.

## Files
- `video_grouper/api_integrations/ntfy.py` — ingest skip + id threading to the consume path
- `video_grouper/task_processors/services/ntfy_service.py` — ledger (load / has / record-on-use / prune), FileLock
- `video_grouper/utils/paths.py` — `get_ntfy_processed_log_path`
- `tests/test_ntfy_replay_dedup.py` — new

## Test plan
- pre-commit: `ruff check` ✓, `ruff format` ✓, `mypy` ✓
- Full unit suite: **1193 passed**, 110 integration/e2e deselected
- Tests include: replay-skipped (and skipped *before* buffering), **failed-dispatch-is-not-recorded** (the record-on-use guarantee), echo/keepalive not recorded, cross-restart persistence, stale-pruning, malformed/torn ledger lines, truncation.

Reviewed by an independent opus pass; its findings (record-on-use over record-on-ingest, FileLock, dual-tray scope doc, test gaps) are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
