### PR TITLE
Wire field-outline model into homegrown detect + render

### DIFF
--- a/tests/test_pipeline_presets.py
+++ b/tests/test_pipeline_presets.py
@@ -83,32 +83,35 @@ def test_preset_round_trips_through_save_load(tmp_path, name):
         assert {k: str(v) for k, v in o.config.items()} == b.config
 
 
-def test_homegrown_preset_has_expected_four_steps_in_order():
+def test_homegrown_preset_has_expected_five_steps_in_order():
     pc = apply_preset("homegrown")
     ordered = pc.ordered_steps()
     assert [s.type for s in ordered] == [
         "stitch_correct",
+        "field_detect",
         "detect",
         "track",
         "render",
     ]
     assert [s.step_id for s in ordered] == [
         "stitch_correct",
+        "field_detect",
         "detect",
         "track",
         "render",
     ]
 
 
-def test_homegrown_detect_leaves_model_source_unset():
-    """The detect step must NOT seed a model source — the user supplies a
+@pytest.mark.parametrize("step_id", ["detect", "field_detect"])
+def test_homegrown_model_steps_leave_model_source_unset(step_id):
+    """Model-running steps must NOT seed a model source — the user supplies a
     model_key (TTT login) or model_path (local .onnx)."""
     pc = apply_preset("homegrown")
-    detect_cfg = pc.step_specs["detect"].config
-    assert "model_key" not in detect_cfg
-    assert "model_path" not in detect_cfg
+    cfg = pc.step_specs[step_id].config
+    assert "model_key" not in cfg
+    assert "model_path" not in cfg
     # but inference tunables are seeded
-    assert "detect_confidence" in detect_cfg
+    assert len(cfg) > 0
 
 
 def test_autocam_preset_is_single_autocam_step():

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -16,7 +16,7 @@ from video_grouper.pipeline.steps.detect import DetectStep
 from video_grouper.pipeline.steps.stitch_correct import StitchCorrectStep
 from video_grouper.pipeline.steps.track import TrackStep
 
-BUILTINS = {"autocam", "stitch_correct", "detect", "track", "render"}
+BUILTINS = {"autocam", "stitch_correct", "field_detect", "detect", "track", "render"}
 
 
 def _ctx(tmp_path):

--- a/tests/test_pipeline_steps_field_detect.py
+++ b/tests/test_pipeline_steps_field_detect.py
@@ -1,0 +1,196 @@
+"""Unit tests for the field_detect pipeline step."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# Importing register_steps registers all built-ins as a side effect.
+import video_grouper.pipeline.register_steps  # noqa: F401
+from video_grouper.pipeline import create_step, get_step_meta
+from video_grouper.pipeline.base import StepContext
+from video_grouper.pipeline.manifest import PipelineManifest
+from video_grouper.pipeline.steps.field_detect import (
+    FieldDetectStep,
+    _sample_times,
+)
+
+
+def _ctx(tmp_path):
+    return StepContext(group_dir=tmp_path, team_name=None, storage_path=tmp_path)
+
+
+def _manifest(tmp_path):
+    return PipelineManifest.load_or_init(
+        tmp_path, str(tmp_path / "game.mp4"), str(tmp_path / "out.mp4")
+    )
+
+
+def test_field_detect_registered_with_expected_metadata():
+    meta = get_step_meta("field_detect")
+    assert meta.runtime == "service"
+    assert meta.resources == ("gpu",)
+    assert meta.requires == ("onnxruntime", "cv2", "av")
+
+
+def test_create_field_detect_step_validates_config():
+    step = create_step(
+        "field_detect", {"model_path": "f.onnx", "field_sample_frames": 3}
+    )
+    assert isinstance(step, FieldDetectStep)
+    assert step.config.model_path == "f.onnx"
+    assert step.config.field_sample_frames == 3
+    assert step.config.model_key is None
+    assert step.config.field_score_threshold == 0.5  # default
+    assert step.config.field_min_keypoints == 6  # default
+
+
+def test_sample_times_spread_across_middle():
+    times = _sample_times(100.0, 5)
+    assert len(times) == 5
+    assert times[0] == pytest.approx(10.0)  # 10% in
+    assert times[-1] == pytest.approx(90.0)  # 90% in
+    assert times == sorted(times)
+
+
+def test_sample_times_degenerate_durations():
+    # Unknown / zero duration falls back to a single midpoint sample.
+    assert _sample_times(0.0, 5) == [0.0]
+    assert _sample_times(60.0, 1) == [30.0]
+
+
+@pytest.mark.asyncio
+async def test_field_detect_full_frame_without_model(tmp_path, monkeypatch):
+    """No model_key/model_path: the step still produces a polygon — the
+    neutral full-frame rectangle (downstream steps require the artifact)."""
+    monkeypatch.setattr(
+        "video_grouper.pipeline.steps.field_detect._video_dims",
+        lambda path: (5120, 1440),
+    )
+    manifest = _manifest(tmp_path)
+    step = create_step("field_detect", {})
+    ok = await step.run(manifest, _ctx(tmp_path))
+    assert ok is True
+
+    polygon_path = tmp_path / "field_polygon.json"
+    assert manifest.get("field_polygon_path") == str(polygon_path)
+    payload = json.loads(polygon_path.read_text(encoding="utf-8"))
+    assert payload["source"] == "full_frame"
+    assert payload["polygon"] == [
+        [0.0, 0.0],
+        [5120.0, 0.0],
+        [5120.0, 1440.0],
+        [0.0, 1440.0],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_field_detect_writes_polygon_and_manifest(tmp_path, monkeypatch):
+    """With a model configured and a polygon found, the step writes
+    field_polygon.json and records field_polygon_path — the artifact key the
+    track and render steps read."""
+    captured = {}
+    polygon = [[float(i * 100), float(100 + (i % 5))] for i in range(10)]
+
+    def fake_create_session(model_path, use_gpu=False):
+        captured["model_path"] = str(model_path)
+        captured["use_gpu"] = use_gpu
+        return object()
+
+    def fake_detect_polygon(
+        video_path, session, score_threshold, min_keypoints, sample_frames
+    ):
+        captured["video_path"] = video_path
+        captured["score_threshold"] = score_threshold
+        captured["min_keypoints"] = min_keypoints
+        captured["sample_frames"] = sample_frames
+        return polygon, 0.91
+
+    monkeypatch.setattr(
+        "video_grouper.pipeline.steps.field_detect.create_field_session",
+        fake_create_session,
+    )
+    monkeypatch.setattr(
+        "video_grouper.pipeline.steps.field_detect._detect_field_polygon",
+        fake_detect_polygon,
+    )
+
+    manifest = _manifest(tmp_path)
+    step = create_step(
+        "field_detect",
+        {"model_path": "f.onnx", "device": "cpu", "field_sample_frames": 3},
+    )
+    ok = await step.run(manifest, _ctx(tmp_path))
+    assert ok is True
+
+    polygon_path = tmp_path / "field_polygon.json"
+    assert manifest.get("field_polygon_path") == str(polygon_path)
+    payload = json.loads(polygon_path.read_text(encoding="utf-8"))
+    assert payload["polygon"] == polygon
+    assert payload["mean_score"] == 0.91
+    assert payload["source"] == "model_path"
+    # config threaded through
+    assert captured["use_gpu"] is False
+    assert captured["sample_frames"] == 3
+    # The render/track loaders read payload["polygon"] — same shape they parse.
+    assert len(payload["polygon"]) == 10
+
+
+@pytest.mark.asyncio
+async def test_field_detect_no_polygon_found_falls_back_to_full_frame(
+    tmp_path, monkeypatch
+):
+    """A configured model that finds no usable polygon must not fail the
+    pipeline — the step falls back to the neutral full-frame polygon."""
+    monkeypatch.setattr(
+        "video_grouper.pipeline.steps.field_detect.create_field_session",
+        lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        "video_grouper.pipeline.steps.field_detect._detect_field_polygon",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "video_grouper.pipeline.steps.field_detect._video_dims",
+        lambda path: (1920, 1080),
+    )
+
+    manifest = _manifest(tmp_path)
+    step = create_step("field_detect", {"model_path": "f.onnx"})
+    ok = await step.run(manifest, _ctx(tmp_path))
+    assert ok is True
+
+    payload = json.loads((tmp_path / "field_polygon.json").read_text(encoding="utf-8"))
+    assert payload["source"] == "full_frame"
+    assert payload["mean_score"] == 0.0
+    assert len(payload["polygon"]) == 4
+
+
+def test_render_defaults_to_full_frame_polygon():
+    """Render's polygon requirement: absent a real polygon it synthesizes the
+    full-frame rectangle (one geometry code path either way)."""
+    import numpy as np
+
+    from video_grouper.pipeline.steps.render import _polygon_or_full_frame
+
+    full = _polygon_or_full_frame(None, 5120, 1440)
+    assert full.dtype == np.float32
+    assert full.tolist() == [
+        [0.0, 0.0],
+        [5120.0, 0.0],
+        [5120.0, 1440.0],
+        [0.0, 1440.0],
+    ]
+    # A real polygon passes through untouched.
+    real = np.array([[1, 2], [3, 4], [5, 6], [7, 8]], dtype=np.float32)
+    assert _polygon_or_full_frame(real, 5120, 1440) is real
+
+
+@pytest.mark.asyncio
+async def test_field_detect_model_key_requires_ttt_config(tmp_path):
+    """model_key without TTT config must raise (same contract as detect)."""
+    manifest = _manifest(tmp_path)
+    step = create_step("field_detect", {"model_key": "some-key"})
+    with pytest.raises(RuntimeError, match="TTT integration is disabled"):
+        await step.run(manifest, _ctx(tmp_path))  # ctx has ttt_config=None

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -4,6 +4,20 @@ Append-only. Never delete entries — if a decision is reversed, add a new entry
 
 ---
 
+## 2026-06-12: Field-outline wired into the plugin pipeline as a `field_detect` step
+
+**Context:** The distilled field-outline model (EXP-008) needed to actually drive homegrown ball tracking + rendering. The pipeline's track and render steps already consume a `field_polygon_path` manifest artifact (location filtering, mount-tilt/leveling derivation, off-field rejection, pan bounds) — but nothing produced it automatically.
+
+**Decisions:**
+- **New `field_detect` pipeline step** (`video_grouper/pipeline/steps/field_detect.py`), inserted `stitch_correct → field_detect → detect → track → render` in the homegrown preset. Runs the field-outline model on a few sampled frames and keeps the **highest-confidence** polygon (the field is static per fixed camera, so one polygon serves the game). Writes `field_polygon.json` and records `field_polygon_path` in the manifest.
+- **The polygon is a required artifact with a neutral default, not an optional one.** With no model configured (or no usable polygon found) the step writes the **full-frame rectangle** (`source: "full_frame"`), and render synthesizes the same default if the manifest has no polygon at all. The full frame is the neutral element of the geometry: centred base pitch, full vertical extent, full pan range, derived mount tilt ≈ 0, and the off-field filter keeps every in-frame detection — one code path whether or not a real field was found.
+- **Same two-source loading as the ball model**: `model_key` (TTT-licensed — ships as a **free** TTT-provided model) or `model_path` (local plaintext, dev/community). The shared license-acquisition path moved to `pipeline/steps/licensed_model.py`, used by both `detect` and `field_detect`. No model binary or seeded model identifier in the OSS repo, per policy.
+- **No detect-side filtering and no render-side framing logic in this step** — the earlier provider-era draft filtered detections in detect and recentred the crop in render; both are superseded by the pipeline's existing design (track's re-sweepable `track_field_margin` filter, render's polygon-derived geometry). The step only *produces* the polygon.
+
+**Trade-off:** One model load + a few-frame inference per game (cheap, once per game). The full-frame default changes render's no-model behaviour from the hand-tuned config fallbacks (`render_view_pitch_deg`, `render_mount_tilt_deg`, `render_field_half_pitch_deg`) to polygon-derived neutral values — intentional: the polygon is the single source of framing truth.
+
+---
+
 ## 2026-06-11: Field-boundary student model via teacher distillation
 
 **Context:** The 10-point field-boundary polygon (used to mask off-field ball detections and to drive the broadcast camera) comes from a third-party "teacher" ONNX model we want to retire. We own the footage, so we can distill it: run the teacher over our Reolink games to auto-label, then train an in-house student. Built as standalone tools (`training/field_outline/` + `training/cli/{generate,train,eval,export}_field_outline.py`), not yet wired into the pipeline task system.

--- a/video_grouper/config.ini.dist
+++ b/video_grouper/config.ini.dist
@@ -92,7 +92,7 @@ privacy_status = private
 enabled = false
 
 # Ordered step ids (the homegrown ball-tracking pipeline). Reorder / remove freely.
-steps = stitch, detect, track, render
+steps = stitch, field_detect, detect, track, render
 
 # Opt in to loading unsigned community plugins from <storage>/plugins/community/
 # (they run in-process with full privileges — only enable code you trust).
@@ -106,6 +106,19 @@ ram_heavy_concurrency = 1
 type = stitch_correct
 # Optional per-camera stitch calibration profile; passes through unchanged when unset.
 # stitch_profile_path =
+
+[PIPELINE.field_detect]
+type = field_detect
+# Field-outline model — finds the playing-field boundary polygon once per game
+# so the track step can drop off-field ball detections and the render step can
+# level + frame the virtual camera to the field. With no model configured the
+# step writes the neutral full-frame polygon instead. Model source — pick ONE:
+#   model_key  : a TTT-provided model (requires a free TTT account)
+#   model_path : a community / bring-your-own local model (no TTT account)
+# model_key = field_outline
+# model_path = /path/to/model.onnx
+# field_sample_frames = 7    ; frames sampled to pick the best polygon
+# field_min_keypoints = 6    ; confident keypoints a frame needs to qualify
 
 [PIPELINE.detect]
 type = detect

--- a/video_grouper/pipeline/presets.py
+++ b/video_grouper/pipeline/presets.py
@@ -42,16 +42,29 @@ PRESETS: dict[str, list[_PresetStep]] = {
     # ball per frame, link detections into a smoothed trajectory, then render a
     # broadcast-style virtual-camera crop following the ball.
     #
-    # NOTE: the detect step deliberately carries NO model source (model_key /
-    # model_path). The user supplies it after picking this preset — TTT login
-    # resolves a model_key, or a local model_path points at a .onnx. See the
-    # module docstring.
+    # NOTE: the detect and field_detect steps deliberately carry NO model
+    # source (model_key / model_path). The user supplies it after picking this
+    # preset — TTT login resolves a model_key, or a local model_path points at
+    # a .onnx. See the module docstring.
     "homegrown": [
         (
             "stitch_correct",
             "stitch_correct",
             # Opt-in seam calibration; user points this at their profile.
             {"stitch_profile_path": ""},
+        ),
+        (
+            "field_detect",
+            "field_detect",
+            # Model source intentionally omitted (same policy as detect). With
+            # no model configured the step still produces a polygon — the
+            # neutral full-frame rectangle — so track/render always have one.
+            {
+                "device": "cuda:0",
+                "field_score_threshold": 0.5,
+                "field_min_keypoints": 6,
+                "field_sample_frames": 7,
+            },
         ),
         (
             "detect",

--- a/video_grouper/pipeline/register_steps.py
+++ b/video_grouper/pipeline/register_steps.py
@@ -34,6 +34,13 @@ except Exception as e:  # noqa: BLE001
     )
 
 try:
+    from video_grouper.pipeline.steps import field_detect  # noqa: F401
+except Exception as e:  # noqa: BLE001
+    logger.debug(
+        "pipeline: step field_detect unavailable (%s: %s)", type(e).__name__, e
+    )
+
+try:
     from video_grouper.pipeline.steps import detect  # noqa: F401
 except Exception as e:  # noqa: BLE001
     logger.debug("pipeline: step detect unavailable (%s: %s)", type(e).__name__, e)

--- a/video_grouper/pipeline/steps/detect.py
+++ b/video_grouper/pipeline/steps/detect.py
@@ -33,6 +33,7 @@ from video_grouper.inference.ball_detector import create_session, detect_video
 from video_grouper.pipeline import register_step
 from video_grouper.pipeline.base import PipelineStep, StepContext
 from video_grouper.pipeline.manifest import PipelineManifest
+from video_grouper.pipeline.steps.licensed_model import build_secure_loader_session
 
 logger = logging.getLogger(__name__)
 
@@ -88,49 +89,6 @@ def _run_detection_from_path(
     )
 
 
-def _build_secure_loader_session(
-    model_key: str,
-    channel: str | None,
-    pipeline_version: str | None,
-    ctx: StepContext,
-) -> Any:
-    """Acquire a license + decrypted ONNX session from TTT.
-
-    Constructs a TTTApiClient from ``ctx.ttt_config`` and runs the SecureLoader
-    against it. Returns the loaded ``InferenceSession``.
-    """
-    from video_grouper.api_integrations.ttt_api import TTTApiClient
-    from video_grouper.ball_tracking.secure_loader import SecureLoader
-
-    if not ctx.ttt_config:
-        raise RuntimeError(
-            "detect: model_key is set but TTT integration is disabled "
-            "(set [TTT] enabled = true and configure credentials, or fall back "
-            "to model_path for a community / bring-your-own model)"
-        )
-
-    cfg = ctx.ttt_config
-    client = TTTApiClient(
-        supabase_url=cfg.get("supabase_url", ""),
-        anon_key=cfg.get("anon_key", ""),
-        api_base_url=cfg.get("api_base_url", ""),
-        storage_path=str(ctx.storage_path),
-    )
-    public_keys = cfg.get("plugin_signing_public_keys") or []
-    loader = SecureLoader(client, public_keys, state_storage_path=str(ctx.storage_path))
-    loaded = loader.acquire(
-        model_key, channel=channel, pipeline_version=pipeline_version
-    )
-    logger.info(
-        "detect: licensed %s v%s (%s, provider=%s)",
-        loaded.model_key,
-        loaded.version,
-        loaded.tier,
-        loaded.provider,
-    )
-    return loaded.session
-
-
 class DetectStep(PipelineStep[DetectStepConfig]):
     name = "detect"
     config_model = DetectStepConfig
@@ -151,7 +109,8 @@ class DetectStep(PipelineStep[DetectStepConfig]):
         # filters, so they can be re-swept without re-running this expensive step.
         if cfg.model_key:
             session = await asyncio.to_thread(
-                _build_secure_loader_session,
+                build_secure_loader_session,
+                self.name,
                 cfg.model_key,
                 cfg.detect_channel,
                 cfg.detect_pipeline_version,

--- a/video_grouper/pipeline/steps/field_detect.py
+++ b/video_grouper/pipeline/steps/field_detect.py
@@ -1,0 +1,229 @@
+"""Field-detect step — find the playing-field boundary polygon once per game.
+
+Runs the in-house field-outline model (10-point boundary polygon) on a few
+sampled frames and keeps the highest-confidence polygon. The field is static
+for a fixed camera, so one polygon serves the whole game. Writes
+``field_polygon.json`` next to the input video and records
+``field_polygon_path`` in the manifest, where the downstream steps already
+look for it:
+
+- **track** drops off-field ball detections (``track_field_margin``);
+- **render** derives mount tilt / leveling roll from the polygon's world-up,
+  rejects off-field detections, and bounds the pan to the field's lateral
+  extent.
+
+Model source mirrors the ``detect`` step (the freemium boundary lives at TTT,
+not here): ``model_key`` licenses a TTT-provided model (free tier), or
+``model_path`` loads a local plaintext ``.onnx``.
+
+The polygon artifact is **always produced**: with no model configured, or no
+usable polygon found, the step writes the neutral full-frame rectangle
+(``source: "full_frame"``). Downstream steps require the polygon and treat the
+full frame as "the field is everywhere" — full pan range, centred framing, and
+a filter that keeps every in-frame detection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic import BaseModel
+
+# Top-level import: pulls in onnxruntime/cv2. In a bundle without the inference
+# stack importing this module fails and register_steps' try/except omits the
+# step — the intended behaviour (same as detect).
+from video_grouper.inference.field_detector import (
+    build_field_polygon,
+    create_field_session,
+    detect_field_keypoints,
+)
+from video_grouper.pipeline import register_step
+from video_grouper.pipeline.base import PipelineStep, StepContext
+from video_grouper.pipeline.manifest import PipelineManifest
+from video_grouper.pipeline.steps.licensed_model import build_secure_loader_session
+
+logger = logging.getLogger(__name__)
+
+
+class FieldDetectStepConfig(BaseModel):
+    # Pick exactly one source (or neither — the step then passes through):
+    #   model_key:  ask TTT for a license + encrypted artifact (free tier)
+    #   model_path: load a plaintext .onnx from disk (community / bring-your-own)
+    model_key: str | None = None
+    model_path: str | None = None
+    field_detect_channel: str | None = None  # canary / beta / stable
+    field_detect_pipeline_version: str | None = None
+    device: str = "cuda:0"
+    # Per-keypoint score floor; points below it don't count toward the polygon.
+    field_score_threshold: float = 0.5
+    # A frame needs at least this many confident keypoints to be a candidate.
+    field_min_keypoints: int = 6
+    # Frames sampled across the middle 80% of the video; best polygon wins.
+    field_sample_frames: int = 7
+
+
+def _video_dims(video_path: str) -> tuple[int, int]:
+    """Return ``(width, height)`` of the video's first stream."""
+    import av
+
+    with av.open(video_path) as container:
+        stream = container.streams.video[0]
+        return stream.width, stream.height
+
+
+def _sample_times(duration: float, n: int) -> list[float]:
+    """N timestamps spread across the middle 80% of the video."""
+    if duration <= 0 or n <= 1:
+        return [max(duration, 0.0) / 2.0]
+    lo, hi = 0.1 * duration, 0.9 * duration
+    return [lo + (hi - lo) * i / (n - 1) for i in range(n)]
+
+
+def _detect_field_polygon(
+    video_path: str,
+    session: Any,
+    score_threshold: float,
+    min_keypoints: int,
+    sample_frames: int,
+) -> tuple[list[list[float]], float] | None:
+    """Sample frames, run the field model, return the best (polygon, mean_score).
+
+    "Best" = the candidate with the highest mean keypoint score that has
+    enough keypoints and builds a valid polygon. Returns ``None`` if no
+    frame yields a usable polygon.
+    """
+    import av
+
+    best: tuple[list[list[float]], float] | None = None
+    container = av.open(video_path)
+    try:
+        stream = container.streams.video[0]
+        stream.thread_type = "AUTO"
+        if stream.duration is not None and stream.time_base is not None:
+            duration = float(stream.duration * stream.time_base)
+        elif container.duration is not None:
+            duration = container.duration / av.time_base
+        else:
+            duration = 0.0
+
+        for t in _sample_times(duration, sample_frames):
+            try:
+                if stream.time_base:
+                    container.seek(
+                        int(t / stream.time_base), stream=stream, backward=True
+                    )
+                frame = next(container.decode(stream), None)
+            except Exception as e:  # corrupt packet at this offset — skip
+                logger.debug("field_detect: seek/decode failed at %.0fs: %s", t, e)
+                continue
+            if frame is None:
+                continue
+
+            frame_bgr = frame.to_ndarray(format="bgr24")
+            kpts = detect_field_keypoints(frame_bgr, session, score_threshold)
+            detected = [kp for kp in kpts if kp[0] is not None]
+            if len(detected) < min_keypoints:
+                continue
+            polygon = build_field_polygon(kpts)
+            if polygon is None:
+                continue
+            mean_score = sum(kp[2] for kp in detected) / len(detected)
+            if best is None or mean_score > best[1]:
+                best = ([[float(x), float(y)] for x, y in polygon], mean_score)
+    finally:
+        container.close()
+    return best
+
+
+class FieldDetectStep(PipelineStep[FieldDetectStepConfig]):
+    name = "field_detect"
+    config_model = FieldDetectStepConfig
+    consumes = ("input_path",)
+    produces = ("field_polygon_path",)
+    runtime = "service"
+    requires = ("onnxruntime", "cv2", "av")
+    resources = ("gpu",)
+
+    async def run(self, manifest: PipelineManifest, ctx: StepContext) -> bool:
+        cfg = self.config
+        in_path = Path(cast(str, manifest.get("input_path")))
+
+        result = None
+        source = "full_frame"
+        if cfg.model_key:
+            session = await asyncio.to_thread(
+                build_secure_loader_session,
+                self.name,
+                cfg.model_key,
+                cfg.field_detect_channel,
+                cfg.field_detect_pipeline_version,
+                ctx,
+            )
+            source = "model_key"
+        elif cfg.model_path:
+            use_gpu = cfg.device.startswith(("cuda", "gpu"))
+            session = await asyncio.to_thread(
+                create_field_session, Path(cfg.model_path), use_gpu
+            )
+            source = "model_path"
+        else:
+            session = None
+            logger.info(
+                "field_detect: no model_key/model_path configured; using the "
+                "full-frame polygon"
+            )
+
+        if session is not None:
+            result = await asyncio.to_thread(
+                _detect_field_polygon,
+                str(in_path),
+                session,
+                cfg.field_score_threshold,
+                cfg.field_min_keypoints,
+                cfg.field_sample_frames,
+            )
+            if result is None:
+                source = "full_frame"
+                logger.warning(
+                    "field_detect: no valid field polygon detected; falling "
+                    "back to the full-frame polygon"
+                )
+
+        if result is None:
+            # Neutral default: the field IS the frame. Downstream filters keep
+            # everything; render frames to the full extent.
+            src_w, src_h = await asyncio.to_thread(_video_dims, str(in_path))
+            polygon = [
+                [0.0, 0.0],
+                [float(src_w), 0.0],
+                [float(src_w), float(src_h)],
+                [0.0, float(src_h)],
+            ]
+            mean_score = 0.0
+        else:
+            polygon, mean_score = result
+
+        polygon_path = in_path.with_name("field_polygon.json")
+        payload = {
+            "polygon": polygon,
+            "source": source,
+            "mean_score": round(mean_score, 4),
+        }
+        with open(polygon_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        logger.info(
+            "field_detect: %d-point polygon (source=%s, mean_score=%.2f) -> %s",
+            len(polygon),
+            source,
+            mean_score,
+            polygon_path,
+        )
+        manifest.put("field_polygon_path", str(polygon_path))
+        return True
+
+
+register_step(FieldDetectStep.name, FieldDetectStep, FieldDetectStepConfig)

--- a/video_grouper/pipeline/steps/licensed_model.py
+++ b/video_grouper/pipeline/steps/licensed_model.py
@@ -1,0 +1,67 @@
+"""Shared helper for steps that run a TTT-licensed model.
+
+Any step whose config carries a ``model_key`` acquires its model the same
+way: build a :class:`TTTApiClient` from the step context's ``ttt_config``,
+run the :class:`SecureLoader` against it, and use the decrypted in-memory
+session. This module holds that one path so each step doesn't re-implement
+it (``detect`` and ``field_detect`` today).
+
+Import is cheap — TTT client and loader are imported lazily inside the
+function, so pulling this in doesn't drag the network stack into bundles
+that never license a model.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from video_grouper.pipeline.base import StepContext
+
+logger = logging.getLogger(__name__)
+
+
+def build_secure_loader_session(
+    step_name: str,
+    model_key: str,
+    channel: str | None,
+    pipeline_version: str | None,
+    ctx: StepContext,
+) -> Any:
+    """Acquire a license + decrypted ONNX session from TTT.
+
+    Constructs a TTTApiClient from ``ctx.ttt_config`` and runs the SecureLoader
+    against it. Returns the loaded ``InferenceSession``. ``step_name`` only
+    scopes the log/error messages.
+    """
+    from video_grouper.api_integrations.ttt_api import TTTApiClient
+    from video_grouper.ball_tracking.secure_loader import SecureLoader
+
+    if not ctx.ttt_config:
+        raise RuntimeError(
+            f"{step_name}: model_key is set but TTT integration is disabled "
+            "(set [TTT] enabled = true and configure credentials, or fall back "
+            "to model_path for a community / bring-your-own model)"
+        )
+
+    cfg = ctx.ttt_config
+    client = TTTApiClient(
+        supabase_url=cfg.get("supabase_url", ""),
+        anon_key=cfg.get("anon_key", ""),
+        api_base_url=cfg.get("api_base_url", ""),
+        storage_path=str(ctx.storage_path),
+    )
+    public_keys = cfg.get("plugin_signing_public_keys") or []
+    loader = SecureLoader(client, public_keys, state_storage_path=str(ctx.storage_path))
+    loaded = loader.acquire(
+        model_key, channel=channel, pipeline_version=pipeline_version
+    )
+    logger.info(
+        "%s: licensed %s v%s (%s, provider=%s)",
+        step_name,
+        loaded.model_key,
+        loaded.version,
+        loaded.tier,
+        loaded.provider,
+    )
+    return loaded.session

--- a/video_grouper/pipeline/steps/render.py
+++ b/video_grouper/pipeline/steps/render.py
@@ -825,6 +825,28 @@ def _load_field(polygon_path: str | None):
     return polygon, homography
 
 
+def _polygon_or_full_frame(polygon, src_w: int, src_h: int):
+    """The render geometry requires a polygon; absent one, the field IS the frame.
+
+    A full-frame rectangle is the neutral default: centred base pitch, full
+    vertical extent, full lateral pan range, derived mount tilt ≈ 0 (its
+    world-up is straight up), and the off-field rejection keeps everything —
+    one code path whether or not an upstream field_detect found a real field.
+    """
+    if polygon is not None and len(polygon) > 0:
+        return polygon
+    import numpy as np
+
+    logger.info(
+        "render: no field polygon supplied; defaulting to the full %dx%d frame",
+        src_w,
+        src_h,
+    )
+    return np.array(
+        [[0.0, 0.0], [src_w, 0.0], [src_w, src_h], [0.0, src_h]], dtype=np.float32
+    )
+
+
 def _parse_bitrate(bitrate: str) -> int:
     s = bitrate.strip().lower()
     if s.endswith("m"):
@@ -917,6 +939,7 @@ def _render_video(
         src_w = in_video.width
         src_h = in_video.height
 
+        polygon = _polygon_or_full_frame(polygon, src_w, src_h)
         geom = _resolve_geometry(src_w, src_h, cfg, polygon)
         yaw_min, yaw_max = field_lateral_yaw_extent(polygon, src_w, geom.src_hfov_deg)
         yaw_min -= cfg.render_yaw_padding_deg
@@ -1075,6 +1098,7 @@ class RenderFrameConsumer(FrameConsumer[RenderConsumerConfig]):
         with open(manifest.get(cfg.trajectory_key), encoding="utf-8") as f:
             self._entries = compute_entries(json.load(f), self._mode.velocity_ema)
         polygon, self._homography = _load_field(manifest.get("field_polygon_path"))
+        polygon = _polygon_or_full_frame(polygon, source.width, source.height)
         self._geom = _resolve_geometry(source.width, source.height, cfg, polygon)
         from video_grouper.inference.field_geometry import field_lateral_yaw_extent
 

--- a/video_grouper/pipeline/steps/track.py
+++ b/video_grouper/pipeline/steps/track.py
@@ -29,7 +29,9 @@ class TrackStepConfig(BaseModel):
     # Tunable filters on the RAW detections (detect saves all candidates above its low floor):
     #   confidence threshold + field-polygon location filter. Applied here, cheaply, so they can be
     #   re-swept without re-running detection. The off-field reject (timestamp/spectators/scoreboard)
-    #   needs a field_polygon_path in the manifest; absent ⇒ confidence filter only.
+    #   needs a field_polygon_path in the manifest; absent, the field defaults to the FULL FRAME
+    #   (field_detect writes that fallback polygon itself) — every in-frame detection is kept,
+    #   which is exactly the confidence-filter-only behaviour.
     track_conf_threshold: float = 0.45
     track_field_margin: float = 50.0
     track_kalman_gate: float = 200.0


### PR DESCRIPTION
## Summary

Wires the in-house **field-outline** model (PR #81) into the homegrown ball-tracking + rendering pipeline. Stacked on `feat/field-outline-distillation` — review/merge #81 first.

**Ported onto the plugin pipeline**: the original draft targeted the legacy `ball_tracking/providers/` system, which Phase 5b deleted from main. The pipeline's `track` and `render` steps already consume a `field_polygon_path` manifest artifact (location filter, mount-tilt/leveling derivation, off-field rejection, pan bounds) — this PR adds the step that produces it.

## Changes

- **New `field_detect` pipeline step** (`video_grouper/pipeline/steps/field_detect.py`) — samples a few frames across the middle 80% of the game, runs the field-outline model, keeps the highest-confidence 10-point polygon, writes `field_polygon.json`, records `field_polygon_path`. Preset order: `stitch_correct → field_detect → detect → track → render`.
- **The polygon is a required artifact with a neutral default.** No model configured (or no usable polygon found) ⇒ the step writes the **full-frame rectangle** (`source: "full_frame"`); `render` synthesizes the same default if the manifest carries no polygon at all. Full frame = centred base pitch, full vertical extent, full pan range, derived mount tilt ≈ 0, keep-everything filter — one geometry code path always.
- **Shared TTT license acquisition** extracted to `pipeline/steps/licensed_model.py`, used by `detect` and `field_detect`. Model sources mirror detect: `model_key` (TTT free tier) or `model_path` (local). No model identifier seeded in preset or `config.ini.dist`, per OSS policy.
- **Dropped from the original draft:** detect-side soft filtering (superseded by track's re-sweepable `track_field_margin` filter) and render-side vertical recentring (superseded by render's polygon-derived geometry).

## Testing

- 9 new unit tests (`tests/test_pipeline_steps_field_detect.py`): registration/metadata, config validation, frame sampling, full-frame fallback (no model + model-found-nothing), polygon write + manifest recording, TTT-config guard, render's full-frame default.
- Preset tests updated to the 5-step order; model-source-unset policy test now parametrized over detect + field_detect.
- Full unit suite: 1281 passed. ruff + mypy clean.
- Full homegrown e2e (ball+field → rendered video) pending a ball model.

## Model distribution

No model binary in the OSS repo (per policy). Production uses `model_key` (free TTT-provided); dev uses a local `model_path`. Versioned artifact: `F:/training_checkpoints/field_outline/field_outline_v1.onnx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)