### PR TITLE
Rename the detect pipeline step to ball_detect

### DIFF
--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -27,14 +27,14 @@ _PIPELINE_INI = """\
 [PIPELINE]
 enabled = true
 gpu_concurrency = 2
-steps = stitch, detect, track, render
+steps = stitch, ball_detect, track, render
 
 [PIPELINE.stitch]
 type = stitch_correct
 stitch_profile_path = /calib/flash.json
 
-[PIPELINE.detect]
-type = detect
+[PIPELINE.ball_detect]
+type = ball_detect
 model_path = /m/model.onnx
 detect_confidence = 0.5
 
@@ -61,8 +61,13 @@ def test_load_pipeline_section(tmp_path):
     assert pc.gpu_concurrency == 2
 
     ordered = pc.ordered_steps()
-    assert [s.step_id for s in ordered] == ["stitch", "detect", "track", "render"]
-    assert [s.type for s in ordered] == ["stitch_correct", "detect", "track", "render"]
+    assert [s.step_id for s in ordered] == ["stitch", "ball_detect", "track", "render"]
+    assert [s.type for s in ordered] == [
+        "stitch_correct",
+        "ball_detect",
+        "track",
+        "render",
+    ]
     assert ordered[0].config["stitch_profile_path"] == "/calib/flash.json"
     assert ordered[1].config["model_path"] == "/m/model.onnx"
     assert ordered[1].config["detect_confidence"] == "0.5"  # raw until create_step
@@ -76,7 +81,7 @@ def test_pipeline_round_trips(tmp_path):
 
     assert reloaded.pipeline.enabled is True
     assert reloaded.pipeline.gpu_concurrency == 2
-    assert reloaded.pipeline.steps == ["stitch", "detect", "track", "render"]
+    assert reloaded.pipeline.steps == ["stitch", "ball_detect", "track", "render"]
     orig = {s.step_id: (s.type, s.config) for s in cfg.pipeline.ordered_steps()}
     back = {s.step_id: (s.type, s.config) for s in reloaded.pipeline.ordered_steps()}
     assert orig == back
@@ -132,11 +137,11 @@ def test_migrate_homegrown_splits_fields_per_step():
             },
         }
     )
-    assert out["steps"] == ["stitch_correct", "detect", "track", "render"]
+    assert out["steps"] == ["stitch_correct", "ball_detect", "track", "render"]
     specs = out["step_specs"]
     assert specs["stitch_correct"]["config"] == {"stitch_profile_path": "/p.json"}
     # detect gets only detect fields, not track/render fields
-    assert specs["detect"]["config"] == {
+    assert specs["ball_detect"]["config"] == {
         "model_key": "video.ball",
         "detect_confidence": "0.45",
     }
@@ -145,7 +150,7 @@ def test_migrate_homegrown_splits_fields_per_step():
     pc = PipelineConfig.model_validate(out)
     assert [s.type for s in pc.ordered_steps()] == [
         "stitch_correct",
-        "detect",
+        "ball_detect",
         "track",
         "render",
     ]
@@ -160,10 +165,10 @@ def test_migrate_unknown_provider_returns_none():
 _MISSING_TYPE = """\
 [PIPELINE]
 enabled = true
-steps = detect, bad
+steps = ball_detect, bad
 
-[PIPELINE.detect]
-type = detect
+[PIPELINE.ball_detect]
+type = ball_detect
 model_path = /m.onnx
 
 [PIPELINE.bad]
@@ -175,7 +180,7 @@ def test_missing_type_section_skipped_not_fatal(tmp_path):
     # A [PIPELINE.<id>] without `type` must not brick the whole config load.
     cfg = load_config(_write(tmp_path, _REQUIRED_SECTIONS + _MISSING_TYPE))
     assert cfg.storage.path == "/data"  # rest of config still loaded
-    assert [s.step_id for s in cfg.pipeline.ordered_steps()] == ["detect"]
+    assert [s.step_id for s in cfg.pipeline.ordered_steps()] == ["ball_detect"]
 
 
 _PER_TEAM_AS_STEP = """\
@@ -197,17 +202,17 @@ def test_per_team_is_reserved_not_a_step(tmp_path):
 _UNDEFINED_STEP = """\
 [PIPELINE]
 enabled = true
-steps = detect, ghost
+steps = ball_detect, ghost
 
-[PIPELINE.detect]
-type = detect
+[PIPELINE.ball_detect]
+type = ball_detect
 model_path = /m.onnx
 """
 
 
 def test_undefined_step_id_skipped(tmp_path):
     cfg = load_config(_write(tmp_path, _REQUIRED_SECTIONS + _UNDEFINED_STEP))
-    assert [s.step_id for s in cfg.pipeline.ordered_steps()] == ["detect"]
+    assert [s.step_id for s in cfg.pipeline.ordered_steps()] == ["ball_detect"]
 
 
 _EMPTY_STEP_CONFIG = """\
@@ -270,7 +275,7 @@ def test_explicit_pipeline_wins_over_legacy_ball_tracking(tmp_path):
     assert not hasattr(reloaded, "ball_tracking")
     assert [s.type for s in reloaded.pipeline.ordered_steps()] == [
         "stitch_correct",
-        "detect",
+        "ball_detect",
         "track",
         "render",
     ]
@@ -302,14 +307,14 @@ def test_load_migrates_ball_tracking_when_no_pipeline_section(tmp_path):
     ordered = pc.ordered_steps()
     assert [s.type for s in ordered] == [
         "stitch_correct",
-        "detect",
+        "ball_detect",
         "track",
         "render",
     ]
     # per-step fields split correctly through migration.
     by_id = {s.step_id: s for s in ordered}
     assert by_id["stitch_correct"].config["stitch_profile_path"] == "/calib/flash.json"
-    assert by_id["detect"].config["detect_confidence"] == "0.45"
+    assert by_id["ball_detect"].config["detect_confidence"] == "0.45"
     # The legacy [BALL_TRACKING] section is no longer a Config field — it is
     # consumed by migration and dropped before model_validate.
     assert not hasattr(cfg, "ball_tracking")
@@ -343,7 +348,7 @@ def test_load_does_not_migrate_when_pipeline_section_present(tmp_path):
     # PIPELINE steps come from the explicit [PIPELINE.*] sections, in that order.
     assert [s.step_id for s in cfg.pipeline.ordered_steps()] == [
         "stitch",
-        "detect",
+        "ball_detect",
         "track",
         "render",
     ]

--- a/tests/test_pipeline_manifest.py
+++ b/tests/test_pipeline_manifest.py
@@ -14,7 +14,7 @@ def test_load_or_init_fresh(tmp_path):
     assert m.get("output_path") == "out.mp4"
     assert m.output_path == "out.mp4"
     assert m.data["steps"] == []
-    assert m.status_of("detect") is None
+    assert m.status_of("ball_detect") is None
 
 
 def test_put_and_save_roundtrip(tmp_path):
@@ -34,23 +34,25 @@ def test_put_and_save_roundtrip(tmp_path):
 
 def test_mark_running_then_complete_persists(tmp_path):
     m = PipelineManifest.load_or_init(tmp_path, "in.mp4", "out.mp4")
-    m.mark_running("detect", "detect", "fp1", "service")
-    assert m.status_of("detect") == "running"
-    m.mark_complete("detect", {"detections_path": "/abs/det.json"})
+    m.mark_running("ball_detect", "ball_detect", "fp1", "service")
+    assert m.status_of("ball_detect") == "running"
+    m.mark_complete("ball_detect", {"detections_path": "/abs/det.json"})
 
     reloaded = PipelineManifest.load_or_init(tmp_path, "in.mp4", "out.mp4")
-    assert reloaded.status_of("detect") == "complete"
+    assert reloaded.status_of("ball_detect") == "complete"
     assert reloaded.get("detections_path") == "/abs/det.json"
-    assert reloaded.produced_paths("detect") == {"detections_path": "/abs/det.json"}
+    assert reloaded.produced_paths("ball_detect") == {
+        "detections_path": "/abs/det.json"
+    }
 
 
 def test_is_complete_requires_matching_fingerprint(tmp_path):
     m = PipelineManifest.load_or_init(tmp_path, "in.mp4", "out.mp4")
-    m.mark_running("detect", "detect", "fp1", "service")
-    m.mark_complete("detect", {})
-    assert m.is_complete("detect", "fp1") is True
+    m.mark_running("ball_detect", "ball_detect", "fp1", "service")
+    m.mark_complete("ball_detect", {})
+    assert m.is_complete("ball_detect", "fp1") is True
     # config changed -> different fingerprint -> must re-run
-    assert m.is_complete("detect", "fp2") is False
+    assert m.is_complete("ball_detect", "fp2") is False
     # unknown step is never complete
     assert m.is_complete("track", "fp1") is False
 

--- a/tests/test_pipeline_presets.py
+++ b/tests/test_pipeline_presets.py
@@ -89,20 +89,20 @@ def test_homegrown_preset_has_expected_five_steps_in_order():
     assert [s.type for s in ordered] == [
         "stitch_correct",
         "field_detect",
-        "detect",
+        "ball_detect",
         "track",
         "render",
     ]
     assert [s.step_id for s in ordered] == [
         "stitch_correct",
         "field_detect",
-        "detect",
+        "ball_detect",
         "track",
         "render",
     ]
 
 
-@pytest.mark.parametrize("step_id", ["detect", "field_detect"])
+@pytest.mark.parametrize("step_id", ["ball_detect", "field_detect"])
 def test_homegrown_model_steps_leave_model_source_unset(step_id):
     """Model-running steps must NOT seed a model source — the user supplies a
     model_key (TTT login) or model_path (local .onnx)."""

--- a/tests/test_pipeline_processor.py
+++ b/tests/test_pipeline_processor.py
@@ -111,7 +111,7 @@ class TestProcessItem:
     async def test_failed_sets_error_state(self, processor, group_dir):
         task = _make_task(group_dir)
         with _patch_runner(
-            PipelineResult("failed", failed_step="detect", error="boom")
+            PipelineResult("failed", failed_step="ball_detect", error="boom")
         ):
             await processor.process_item(task)
         state = json.loads((group_dir / "state.json").read_text())

--- a/tests/test_pipeline_reprocess.py
+++ b/tests/test_pipeline_reprocess.py
@@ -144,7 +144,7 @@ def _base_specs() -> list[StepSpec]:
     return [
         StepSpec("stitch_correct", "stitch_correct", {}),
         StepSpec("stabilize", "stabilize", {"stabilization_strength": "heavy"}),
-        StepSpec("detect", "detect", {"detect_confidence": 0.45}),
+        StepSpec("ball_detect", "ball_detect", {"detect_confidence": 0.45}),
         StepSpec("transform_detections", "transform_detections", {}),
         StepSpec("track", "track", {}),
         StepSpec("render", "render", {"render_mode": "broadcast"}),
@@ -170,7 +170,7 @@ def test_strength_patch_replaces_stabilization_strength_only():
     stab = next(s for s in new_specs if s.type == "stabilize")
     assert stab.config["stabilization_strength"] == "extreme"
     # Other steps untouched.
-    detect = next(s for s in new_specs if s.type == "detect")
+    detect = next(s for s in new_specs if s.type == "ball_detect")
     assert detect.config == {"detect_confidence": 0.45}
     assert preseed == []
 
@@ -186,7 +186,7 @@ def test_skip_detect_drops_detect_and_preseeds_its_output():
     new_specs, preseed = apply_overrides(specs, req)
     types = [s.type for s in new_specs]
     # detect is gone; transform_detections (already in the preset) stays.
-    assert "detect" not in types
+    assert "ball_detect" not in types
     assert "transform_detections" in types
     # Step order preserved (minus detect).
     assert types == [
@@ -196,7 +196,7 @@ def test_skip_detect_drops_detect_and_preseeds_its_output():
         "track",
         "render",
     ]
-    assert preseed == ["detect"]
+    assert preseed == ["ball_detect"]
 
 
 def test_both_overrides_compose():
@@ -209,8 +209,8 @@ def test_both_overrides_compose():
     # transform_detections must remain (it was in the input preset and
     # is the consumer of the preseeded detections_path).
     assert any(s.type == "transform_detections" for s in new_specs)
-    assert "detect" not in [s.type for s in new_specs]
-    assert preseed == ["detect"]
+    assert "ball_detect" not in [s.type for s in new_specs]
+    assert preseed == ["ball_detect"]
 
 
 def test_skip_detect_without_detect_in_specs_is_noop():

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -12,11 +12,18 @@ import video_grouper.pipeline.register_steps  # noqa: F401
 from video_grouper.pipeline import create_step, get_step_meta, list_steps
 from video_grouper.pipeline.base import StepContext
 from video_grouper.pipeline.manifest import PipelineManifest
-from video_grouper.pipeline.steps.detect import DetectStep
+from video_grouper.pipeline.steps.ball_detect import BallDetectStep
 from video_grouper.pipeline.steps.stitch_correct import StitchCorrectStep
 from video_grouper.pipeline.steps.track import TrackStep
 
-BUILTINS = {"autocam", "stitch_correct", "field_detect", "detect", "track", "render"}
+BUILTINS = {
+    "autocam",
+    "stitch_correct",
+    "field_detect",
+    "ball_detect",
+    "track",
+    "render",
+}
 
 
 def _ctx(tmp_path):
@@ -28,7 +35,7 @@ def test_register_steps_registers_all_builtins():
 
 
 def test_step_metadata():
-    detect = get_step_meta("detect")
+    detect = get_step_meta("ball_detect")
     assert detect.runtime == "service"
     assert detect.resources == ("gpu",)
     assert detect.requires == ("onnxruntime", "cv2")
@@ -51,8 +58,10 @@ def test_step_metadata():
 
 
 def test_create_detect_step_validates_config():
-    step = create_step("detect", {"model_path": "m.onnx", "detect_confidence": 0.3})
-    assert isinstance(step, DetectStep)
+    step = create_step(
+        "ball_detect", {"model_path": "m.onnx", "detect_confidence": 0.3}
+    )
+    assert isinstance(step, BallDetectStep)
     assert step.config.model_path == "m.onnx"
     assert step.config.detect_confidence == 0.3
     assert step.config.device == "cuda:0"  # default
@@ -116,10 +125,10 @@ async def test_detect_step_local_path(tmp_path, monkeypatch):
         return [{"frame_idx": 0, "cx": 1.0, "cy": 2.0, "w": 3, "h": 4, "conf": 0.9}]
 
     monkeypatch.setattr(
-        "video_grouper.pipeline.steps.detect.create_session", fake_create_session
+        "video_grouper.pipeline.steps.ball_detect.create_session", fake_create_session
     )
     monkeypatch.setattr(
-        "video_grouper.pipeline.steps.detect.detect_video", fake_detect_video
+        "video_grouper.pipeline.steps.ball_detect.detect_video", fake_detect_video
     )
 
     in_path = tmp_path / "game.mp4"
@@ -127,7 +136,7 @@ async def test_detect_step_local_path(tmp_path, monkeypatch):
         tmp_path, str(in_path), str(tmp_path / "out.mp4")
     )
     step = create_step(
-        "detect",
+        "ball_detect",
         {"model_path": "m.onnx", "detect_confidence": 0.3, "detect_frame_interval": 4},
     )
     ok = await step.run(manifest, _ctx(tmp_path))
@@ -148,6 +157,6 @@ async def test_detect_step_errors_without_model(tmp_path):
     manifest = PipelineManifest.load_or_init(
         tmp_path, str(tmp_path / "game.mp4"), str(tmp_path / "out.mp4")
     )
-    step = create_step("detect", {})  # neither model_key nor model_path
+    step = create_step("ball_detect", {})  # neither model_key nor model_path
     with pytest.raises(RuntimeError, match="neither model_key nor model_path"):
         await step.run(manifest, _ctx(tmp_path))

--- a/tests/web/test_config_editor.py
+++ b/tests/web/test_config_editor.py
@@ -215,14 +215,14 @@ _PIPELINE_INI = (
 [PIPELINE]
 enabled = true
 gpu_concurrency = 2
-steps = stitch, detect, track, render
+steps = stitch, ball_detect, track, render
 
 [PIPELINE.stitch]
 type = stitch_correct
 stitch_profile_path = /calib/flash.json
 
-[PIPELINE.detect]
-type = detect
+[PIPELINE.ball_detect]
+type = ball_detect
 model_path = /m/model.onnx
 detect_confidence = 0.5
 
@@ -261,7 +261,7 @@ def test_post_config_preserves_pipeline_section(pipeline_client, pipeline_config
     """
     # Sanity: the pipeline loaded as expected before the edit.
     before = load_config(pipeline_config_path)
-    assert before.pipeline.steps == ["stitch", "detect", "track", "render"]
+    assert before.pipeline.steps == ["stitch", "ball_detect", "track", "render"]
 
     resp = pipeline_client.post(
         "/config",
@@ -280,14 +280,14 @@ def test_post_config_preserves_pipeline_section(pipeline_client, pipeline_config
     # ...and the entire [PIPELINE] survived.
     assert reloaded.pipeline.enabled is True
     assert reloaded.pipeline.gpu_concurrency == 2
-    assert reloaded.pipeline.steps == ["stitch", "detect", "track", "render"]
+    assert reloaded.pipeline.steps == ["stitch", "ball_detect", "track", "render"]
     ordered = reloaded.pipeline.ordered_steps()
     assert [s.type for s in ordered] == [
         "stitch_correct",
-        "detect",
+        "ball_detect",
         "track",
         "render",
     ]
     by_id = {s.step_id: s for s in ordered}
     assert by_id["stitch"].config["stitch_profile_path"] == "/calib/flash.json"
-    assert by_id["detect"].config["model_path"] == "/m/model.onnx"
+    assert by_id["ball_detect"].config["model_path"] == "/m/model.onnx"

--- a/video_grouper/config.ini.dist
+++ b/video_grouper/config.ini.dist
@@ -92,7 +92,7 @@ privacy_status = private
 enabled = false
 
 # Ordered step ids (the homegrown ball-tracking pipeline). Reorder / remove freely.
-steps = stitch, field_detect, detect, track, render
+steps = stitch, field_detect, ball_detect, track, render
 
 # Opt in to loading unsigned community plugins from <storage>/plugins/community/
 # (they run in-process with full privileges — only enable code you trust).
@@ -120,8 +120,8 @@ type = field_detect
 # field_sample_frames = 7    ; frames sampled to pick the best polygon
 # field_min_keypoints = 6    ; confident keypoints a frame needs to qualify
 
-[PIPELINE.detect]
-type = detect
+[PIPELINE.ball_detect]
+type = ball_detect
 # Ball-detection model source — pick ONE:
 #   model_key  : a TTT-provided model (requires a TTT account, free or premium)
 #   model_path : a community / bring-your-own local model (no TTT account)

--- a/video_grouper/pipeline/base.py
+++ b/video_grouper/pipeline/base.py
@@ -72,7 +72,7 @@ class PipelineStep(ABC, Generic[ConfigT]):  # noqa: UP046 - explicit Generic[Con
 
     Class-level declarations:
         name: Registry key — the string that appears as ``type =`` in a
-            ``[PIPELINE.<id>]`` config section (e.g. ``"detect"``).
+            ``[PIPELINE.<id>]`` config section (e.g. ``"ball_detect"``).
         config_model: The step's own Pydantic config schema. The step owns and
             validates only its own fields; the runner hands it a validated
             instance.

--- a/video_grouper/pipeline/config.py
+++ b/video_grouper/pipeline/config.py
@@ -91,7 +91,7 @@ class PipelineConfig(BaseModel):
 # migrated pipeline carries only each step's own options.
 _HOMEGROWN_STAGE_FIELDS: dict[str, list[str]] = {
     "stitch_correct": ["stitch_profile_path"],
-    "detect": [
+    "ball_detect": [
         "model_key",
         "model_path",
         "detect_channel",
@@ -147,6 +147,10 @@ def migrate_ball_tracking_to_pipeline(bt: dict | None) -> dict | None:
             if isinstance(stages_raw, str)
             else list(stages_raw)
         )
+        # Part of the migration: the legacy "detect" stage IS the ball_detect
+        # step (renamed when field_detect arrived and bare "detect" became
+        # ambiguous).
+        stages = ["ball_detect" if s == "detect" else s for s in stages]
         out["steps"] = stages
         for stage in stages:
             fields = _HOMEGROWN_STAGE_FIELDS.get(stage, [])

--- a/video_grouper/pipeline/presets.py
+++ b/video_grouper/pipeline/presets.py
@@ -67,8 +67,8 @@ PRESETS: dict[str, list[_PresetStep]] = {
             },
         ),
         (
-            "detect",
-            "detect",
+            "ball_detect",
+            "ball_detect",
             # Model source intentionally omitted — user supplies model_key
             # (via TTT login) or model_path (local .onnx). Only inference
             # tunables get defaults here.

--- a/video_grouper/pipeline/register_steps.py
+++ b/video_grouper/pipeline/register_steps.py
@@ -41,9 +41,9 @@ except Exception as e:  # noqa: BLE001
     )
 
 try:
-    from video_grouper.pipeline.steps import detect  # noqa: F401
+    from video_grouper.pipeline.steps import ball_detect  # noqa: F401
 except Exception as e:  # noqa: BLE001
-    logger.debug("pipeline: step detect unavailable (%s: %s)", type(e).__name__, e)
+    logger.debug("pipeline: step ball_detect unavailable (%s: %s)", type(e).__name__, e)
 
 try:
     from video_grouper.pipeline.steps import track  # noqa: F401

--- a/video_grouper/pipeline/reprocess.py
+++ b/video_grouper/pipeline/reprocess.py
@@ -183,7 +183,7 @@ def apply_overrides(
             new_specs.append(
                 StepSpec(step_id=spec.step_id, type=spec.type, config=patched)
             )
-        elif spec.type == "detect" and request.skip_detect:
+        elif spec.type == "ball_detect" and request.skip_detect:
             # Drop the detect step; the dropped step's produced
             # ``detections_path`` gets preseeded into the manifest so
             # the downstream ``transform_detections`` step sees the

--- a/video_grouper/pipeline/steps/ball_detect.py
+++ b/video_grouper/pipeline/steps/ball_detect.py
@@ -38,7 +38,7 @@ from video_grouper.pipeline.steps.licensed_model import build_secure_loader_sess
 logger = logging.getLogger(__name__)
 
 
-class DetectStepConfig(BaseModel):
+class BallDetectStepConfig(BaseModel):
     # Pick exactly one source:
     #   model_key:  ask TTT for a license + encrypted artifact (TTT free/premium)
     #   model_path: load a plaintext .onnx from disk (community / bring-your-own)
@@ -89,9 +89,9 @@ def _run_detection_from_path(
     )
 
 
-class DetectStep(PipelineStep[DetectStepConfig]):
-    name = "detect"
-    config_model = DetectStepConfig
+class BallDetectStep(PipelineStep[BallDetectStepConfig]):
+    name = "ball_detect"
+    config_model = BallDetectStepConfig
     consumes = ("input_path",)
     produces = ("detections_path",)
     runtime = "service"
@@ -147,4 +147,4 @@ class DetectStep(PipelineStep[DetectStepConfig]):
         return True
 
 
-register_step(DetectStep.name, DetectStep, DetectStepConfig)
+register_step(BallDetectStep.name, BallDetectStep, BallDetectStepConfig)


### PR DESCRIPTION
With `field_detect` in the pipeline, a bare `detect` step is ambiguous. Renames the step type/id/module/classes (`detect.py` → `ball_detect.py`, `DetectStep` → `BallDetectStep`); the homegrown preset and `config.ini.dist` now read `stitch → field_detect → ball_detect → track → render`.

- Legacy `[BALL_TRACKING.HOMEGROWN]` configs: the migration maps the old `detect` stage name to `ball_detect` inline as part of the migration.
- `skip_detect` keeps its name (TTT API contract: `reprocess_requests.skip_detect`) and now drops the `ball_detect` spec.
- Tunables (`detect_confidence`, `detect_frame_interval`, `detect_channel`, `detect_pipeline_version`) unchanged.
- 1313 unit tests pass; ruff + mypy clean (pre-commit). Pre-launch, so no alias for the old step type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)