### PR TITLE
Per-frame viewport log in Once AutoCam format

### DIFF
--- a/tests/test_render_broadcast.py
+++ b/tests/test_render_broadcast.py
@@ -240,3 +240,62 @@ def test_long_missing_gap_holds_pan_bearing():
         _tick(state, None, SRC_W, SRC_H, geom, BROADCAST_MODE, cfg, -90.0, 90.0, None)
     # Pan stays on the last bearing (does not collapse toward 0 / mid-field).
     assert abs(state.smoothed_yaw - held_yaw) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Per-frame viewport log (Once AutoCam format)
+# ---------------------------------------------------------------------------
+
+
+def test_viewport_log_line_is_autocam_format_and_round_trips(caplog):
+    """The render loop emits one JSON line per frame, AutoCam-shaped
+    ({"xy":[cx,cy],"f":f,"t":t}), where xy is the source pixel the output
+    frame centre maps to. Verify the format and that the point round-trips
+    back to the view's (yaw, pitch)."""
+    import json
+    import logging
+
+    from video_grouper.inference.cylindrical_view import yaw_pitch_to_pixel
+    from video_grouper.pipeline.steps.render import _frame_view, viewport_logger
+
+    cfg = RenderStepConfig()
+    geom = _geom(cfg)
+    state = _CameraState()
+    state.fps = 20.0
+    # A ball on the far-right of the pano so yaw is clearly non-zero.
+    entry = (SRC_W * 0.8, SRC_H * 0.5, 0.0, 0.0)
+    params, view_yaw = _frame_view(
+        state,
+        entry,
+        geom,
+        BROADCAST_MODE,
+        cfg,
+        -geom.src_hfov_deg / 2,
+        geom.src_hfov_deg / 2,
+        None,
+        SRC_W,
+        SRC_H,
+        cfg.render_output_width,
+        cfg.render_output_height,
+    )
+    center_pitch = params.view_pitch_deg + params.view_pitch_offset_deg
+    cx, cy = yaw_pitch_to_pixel(
+        view_yaw, center_pitch, SRC_W, SRC_H, params.src_hfov_deg
+    )
+
+    # The exact line the step logs.
+    with caplog.at_level(logging.INFO, logger=viewport_logger.name):
+        viewport_logger.info(
+            '{"xy": [%d, %d], "f": %d, "t": %.2f}', round(cx), round(cy), 1, 0.0
+        )
+    rec = json.loads(caplog.records[-1].getMessage())
+    assert set(rec) == {"xy", "f", "t"}
+    assert rec["f"] == 1 and rec["t"] == 0.0
+    assert len(rec["xy"]) == 2
+
+    # Round-trip: the logged pixel maps back to the view's yaw/pitch.
+    back_yaw, back_pitch = pixel_to_yaw_pitch(
+        rec["xy"][0], rec["xy"][1], SRC_W, SRC_H, params.src_hfov_deg
+    )
+    assert abs(back_yaw - view_yaw) < 1.0
+    assert abs(back_pitch - center_pitch) < 1.0

--- a/video_grouper/pipeline/steps/render.py
+++ b/video_grouper/pipeline/steps/render.py
@@ -73,6 +73,14 @@ from video_grouper.pipeline.manifest import PipelineManifest
 
 logger = logging.getLogger(__name__)
 
+# Per-frame viewport log. One JSON line per rendered frame, in Once AutoCam's
+# format ({"xy": [cx, cy], "f": frame, "t": seconds}) so our broadcast camera
+# aim can be diffed against AutoCam's the same way. ``xy`` is the source-pixel
+# the centre of the output frame maps back to. On its own child logger so an
+# operator can route or silence the per-frame volume without touching the
+# step's normal logging.
+viewport_logger = logging.getLogger(__name__ + ".viewport")
+
 
 class RenderStepConfig(BaseModel):
     render_mode: str = "broadcast"  # "broadcast" | "coach"
@@ -1027,6 +1035,28 @@ def _render_video(
                             out_w,
                             out_h,
                         )
+                        # AutoCam-format per-frame viewport line: where the
+                        # centre of this output frame points in source pixels.
+                        cx, cy = yaw_pitch_to_pixel(
+                            view_yaw,
+                            params.view_pitch_deg + params.view_pitch_offset_deg,
+                            src_w,
+                            src_h,
+                            params.src_hfov_deg,
+                        )
+                        t = (
+                            float(frame.pts * in_video.time_base)
+                            if frame.pts is not None and in_video.time_base
+                            else frame_idx / state.fps
+                        )
+                        viewport_logger.info(
+                            '{"xy": [%d, %d], "f": %d, "t": %.2f}',
+                            round(cx),
+                            round(cy),
+                            frame_idx + 1,
+                            t,
+                        )
+
                         rgb = frame.to_ndarray(format="rgb24")
                         rendered = _warp_frame(rgb, geom, cfg, params, view_yaw, warper)
                         new_frame = av.VideoFrame.from_ndarray(rendered, format="rgb24")
@@ -1140,6 +1170,20 @@ class RenderFrameConsumer(FrameConsumer[RenderConsumerConfig]):
             self._sh,
             self._ow,
             self._oh,
+        )
+        cx, cy = yaw_pitch_to_pixel(
+            view_yaw,
+            params.view_pitch_deg + params.view_pitch_offset_deg,
+            self._sw,
+            self._sh,
+            params.src_hfov_deg,
+        )
+        viewport_logger.info(
+            '{"xy": [%d, %d], "f": %d, "t": %.2f}',
+            round(cx),
+            round(cy),
+            frame_idx + 1,
+            frame_idx / self._state.fps,
         )
         rendered = _warp_frame(
             rgb, self._geom, self.config, params, view_yaw, self._warper


### PR DESCRIPTION
The render step computes a per-frame virtual-camera viewport (`view_yaw`, `view_pitch`, zoom) and threw it away after warping. This emits it as a **log line** — one JSON object per frame in AutoCam's exact format `{"xy": [cx, cy], "f": frame, "t": seconds}`, where `xy` is the source pixel the centre of the output frame maps back to (via `yaw_pitch_to_pixel`).

Why: lets our broadcast camera aim be diffed against AutoCam's jsonl the same way we compare ball detections, and gives a per-frame QA record of where the camera pointed.

- Dedicated child logger `...render.viewport` so the per-frame volume routes/silences independently.
- Added to both render paths (single-output `_render_video` + fan-out frame consumer).
- Test: emitted line is valid AutoCam-shaped JSON and the pixel round-trips back to the view's yaw/pitch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)