### PR TITLE
Far-ball labeling tool (annotation server)

### DIFF
--- a/training/annotation_server.py
+++ b/training/annotation_server.py
@@ -1763,6 +1763,7 @@ async def submit_far_label(set_id: str, result: dict):
         "action": result.get("action", "ball"),
         "x": result.get("x"),
         "y": result.get("y"),
+        "source": result.get("source", "human"),
         "submitted_at": datetime.now(UTC).isoformat(),
     }
     _save_far_labels(set_id, labels)

--- a/training/annotation_server.py
+++ b/training/annotation_server.py
@@ -1669,6 +1669,106 @@ async def get_field_boundary_panoramic(
     return Response(content=jpeg.tobytes(), media_type="image/jpeg")
 
 
+# ------------------------------------------------------------------
+# Far-ball labeling API (v4)
+# ------------------------------------------------------------------
+# Self-contained click-to-locate labeler for FAR balls — the ones the reference
+# detector (AutoCam) misses, so it can't be ground truth there. Each "set" is a
+# directory under FAR_LABEL_DIR with a manifest.json (built by the far-label
+# builder from a raw clip + far_ball_miner) and pre-extracted far-field crop
+# strips. Labels are collected in SOURCE pixel coords and stored next to the set.
+# Independent of the tile-pack/manifest system (clips aren't tiled).
+
+FAR_LABEL_DIR = Path("D:/training_data/far_label")
+
+
+def _far_set_dir(set_id: str) -> Path:
+    d = FAR_LABEL_DIR / set_id
+    if not (d / "manifest.json").exists():
+        raise HTTPException(404, f"Far-label set not found: {set_id}")
+    return d
+
+
+def _load_far_manifest(set_id: str) -> dict:
+    with open(_far_set_dir(set_id) / "manifest.json") as f:
+        return json.load(f)
+
+
+def _load_far_labels(set_id: str) -> dict[int, dict]:
+    p = FAR_LABEL_DIR / set_id / "labels.json"
+    if not p.exists():
+        return {}
+    with open(p) as f:
+        return {int(r["frame_idx"]): r for r in json.load(f)}
+
+
+def _save_far_labels(set_id: str, labels: dict[int, dict]) -> None:
+    p = FAR_LABEL_DIR / set_id / "labels.json"
+    with open(p, "w") as f:
+        json.dump([labels[k] for k in sorted(labels)], f, indent=2)
+
+
+@app.get("/api/far-label")
+async def list_far_sets():
+    """List far-ball labeling sets with progress."""
+    out = []
+    if not FAR_LABEL_DIR.exists():
+        return out
+    for d in sorted(FAR_LABEL_DIR.iterdir()):
+        if not (d / "manifest.json").exists():
+            continue
+        with open(d / "manifest.json") as f:
+            m = json.load(f)
+        labels = _load_far_labels(d.name)
+        out.append(
+            {
+                "set": d.name,
+                "n_frames": m.get("n_frames", len(m.get("frames", []))),
+                "labeled": len(labels),
+            }
+        )
+    return out
+
+
+@app.get("/api/far-label/{set_id}")
+async def get_far_set(set_id: str):
+    """Manifest + existing labels + progress for a far-label set."""
+    m = _load_far_manifest(set_id)
+    labels = _load_far_labels(set_id)
+    return {**m, "labels": [labels[k] for k in sorted(labels)], "labeled": len(labels)}
+
+
+@app.get("/api/far-label/{set_id}/strip/{frame_idx}")
+async def get_far_strip(set_id: str, frame_idx: int):
+    """Serve a pre-extracted far-field crop strip (native-res JPEG)."""
+    d = _far_set_dir(set_id)
+    strip = d / "strips" / f"f{frame_idx:06d}.jpg"
+    if not strip.exists():
+        raise HTTPException(404, f"Strip not found: {frame_idx}")
+    return FileResponse(strip, media_type="image/jpeg")
+
+
+@app.post("/api/far-label/{set_id}/result")
+async def submit_far_label(set_id: str, result: dict):
+    """Store one far-ball label.
+
+    Expected: {"frame_idx": int, "action": "ball"|"not_visible"|"out_of_play",
+    "x": float|null, "y": float|null}  — x/y are SOURCE pixels.
+    """
+    _load_far_manifest(set_id)  # validate set
+    labels = _load_far_labels(set_id)
+    fi = int(result["frame_idx"])
+    labels[fi] = {
+        "frame_idx": fi,
+        "action": result.get("action", "ball"),
+        "x": result.get("x"),
+        "y": result.get("y"),
+        "submitted_at": datetime.now(UTC).isoformat(),
+    }
+    _save_far_labels(set_id, labels)
+    return {"accepted": True, "labeled": len(labels)}
+
+
 # Static file mount must come AFTER all API routes (catch-all).
 app.mount(
     "/static",

--- a/training/static/far-label.html
+++ b/training/static/far-label.html
@@ -63,7 +63,8 @@
 </div>
 <p class="hint">
   Pre-seeded with AutoCam's labels — near balls are trusted as-is. Press <kbd>F</kbd> to jump to the next
-  <b>far ball to review</b>. Purple marker = AutoCam-seeded (unreviewed), pink = you confirmed.
+  <b>far ball to review</b>. The arrow points at the marked ball from below-left (tip stops short so the ball
+  stays visible): purple = AutoCam-seeded (unreviewed), pink = you confirmed.
   <b>Click</b> the ball to fix it, or <kbd>C</kbd> to accept AutoCam's guess (both auto-advance to the next far ball).
   <kbd>N</kbd> not visible, <kbd>O</kbd> out of play. Scroll = zoom, drag = pan.
 </p>
@@ -128,22 +129,31 @@ function clampPan(){
   if (w < vw) tx=0; if (h < vh) ty=0;
 }
 
-// draw markers in NATURAL image coords (canvas is natural-sized, transformed with wrap)
+// Arrow pointing IN at (nx,ny) from the lower-left; tip stops short so the ball
+// stays visible. Coords are NATURAL px (canvas is natural-sized, transformed with wrap).
+function arrowMark(nx,ny,color,dashed,k){
+  const gap=20*k, len=60*k, head=18*k;        // gap = clearance so the ball shows
+  const dx=0.6, dy=-0.8;                        // direction tail->ball (up-right)
+  const tipx=nx-dx*gap, tipy=ny-dy*gap;         // arrowhead apex, just outside the ball
+  const tailx=nx-dx*(gap+len), taily=ny-dy*(gap+len);
+  ctx.strokeStyle=color; ctx.fillStyle=color; ctx.lineWidth=Math.max(2,4*k);
+  ctx.setLineDash(dashed?[8*k,5*k]:[]);
+  ctx.beginPath(); ctx.moveTo(tailx,taily); ctx.lineTo(tipx,tipy); ctx.stroke();
+  ctx.setLineDash([]);
+  const a=Math.atan2(dy,dx);
+  ctx.beginPath(); ctx.moveTo(tipx,tipy);
+  ctx.lineTo(tipx-head*Math.cos(a-0.45), tipy-head*Math.sin(a-0.45));
+  ctx.lineTo(tipx-head*Math.cos(a+0.45), tipy-head*Math.sin(a+0.45));
+  ctx.closePath(); ctx.fill();
+}
 function draw(){
   ctx.clearRect(0,0,ov.width,ov.height);
-  const f=frame();
-  const lw = 2/ (z||1) * baseScale * 2;   // keep stroke ~visible at any zoom
-  const r1 = 18/(z/baseScale), r2 = 12/(z/baseScale);
-  ctx.lineWidth = Math.max(1.5, 14*baseScale/z);
-  const hnx=f.hint_x-f.crop_x0, hny=f.hint_y-f.crop_y0;
-  ctx.setLineDash([6,5]); ctx.strokeStyle=f.autocam?"#2ecc71":"#ff9f1a";
-  ctx.beginPath(); ctx.arc(hnx,hny,r1,0,7); ctx.stroke(); ctx.setLineDash([]);
+  const f=frame(); const k=baseScale/z;
   const lab=labels[f.frame_idx];
-  if (lab&&lab.action==="ball"&&lab.x!=null){
-    const lx=lab.x-f.crop_x0, ly=lab.y-f.crop_y0;
-    ctx.strokeStyle=(lab.source==="human")?"#ff3b6b":"#9b59ff";
-    ctx.beginPath(); ctx.arc(lx,ly,r2,0,7); ctx.stroke();
-    ctx.beginPath(); ctx.moveTo(lx-r1,ly); ctx.lineTo(lx+r1,ly); ctx.moveTo(lx,ly-r1); ctx.lineTo(lx,ly+r1); ctx.stroke();
+  if (lab && lab.action==="ball" && lab.x!=null){
+    arrowMark(lab.x-f.crop_x0, lab.y-f.crop_y0, lab.source==="human"?"#ff3b6b":"#9b59ff", false, k);
+  } else if (!lab || lab.action==="ball"){   // no label yet -> point at AutoCam's guess (dashed)
+    arrowMark(f.hint_x-f.crop_x0, f.hint_y-f.crop_y0, f.autocam?"#2ecc71":"#ff9f1a", true, k);
   }
 }
 

--- a/training/static/far-label.html
+++ b/training/static/far-label.html
@@ -205,7 +205,7 @@ function next(){ if(cur<frames.length-1){ cur++; show(); } else finish(); }
 function prev(){ if(cur>0){ cur--; show(); } }
 function gotoUnlabeled(){ const i=firstUnlabeled(); if(labels[frames[i].frame_idx]) finish(); else { cur=i; show(); } }
 function isFar(f){ return f.hint_y <= FARY; }
-function needsReview(f){ const l=labels[f.frame_idx]; return isFar(f) && (!l || l.source!=="human"); }
+function needsReview(f){ const l=labels[f.frame_idx]; return (!l || l.source!=="human") && (isFar(f) || f.autocam===false); }
 function gotoFar(){ for(let k=1;k<=frames.length;k++){ const i=(cur+k)%frames.length; if(needsReview(frames[i])){ cur=i; show(); return; } } finish(); }
 function finish(){ document.getElementById("stage").style.display="none"; document.querySelector(".bar").style.display="none";
   document.getElementById("done").style.display="block"; document.getElementById("dlLink").href=`${API}`; }

--- a/training/static/far-label.html
+++ b/training/static/far-label.html
@@ -57,13 +57,15 @@
   <button id="bOut" class="warn">Out of play / off field <kbd>O</kbd></button>
   <button id="bPrev" class="ghost">◀ Prev <kbd>←</kbd></button>
   <button id="bNext" class="ghost">Next ▶ <kbd>→</kbd></button>
+  <button id="bFar" class="primary">▶ Next far to review <kbd>F</kbd></button>
   <button id="bUnlab" class="ghost">Next unlabeled <kbd>U</kbd></button>
   <button id="bReset" class="ghost">Reset zoom <kbd>0</kbd></button>
 </div>
 <p class="hint">
-  Full far-field width. <b>Scroll to zoom</b> toward the cursor, <b>drag to pan</b>, then <b>click the ball</b>
-  to mark it (auto-advances). The dashed circle is AutoCam's guess — it can be wrong (a shoe, a head), so trust
-  your eyes; press <kbd>C</kbd> only if it's truly on the ball. Orange = <b>GAP</b> (AutoCam missed it — these matter most).
+  Pre-seeded with AutoCam's labels — near balls are trusted as-is. Press <kbd>F</kbd> to jump to the next
+  <b>far ball to review</b>. Purple marker = AutoCam-seeded (unreviewed), pink = you confirmed.
+  <b>Click</b> the ball to fix it, or <kbd>C</kbd> to accept AutoCam's guess (both auto-advance to the next far ball).
+  <kbd>N</kbd> not visible, <kbd>O</kbd> out of play. Scroll = zoom, drag = pan.
 </p>
 
 <div id="done">
@@ -74,7 +76,7 @@
 <script>
 const SET = new URLSearchParams(location.search).get("set") || "irondequoit";
 const API = `/api/far-label/${SET}`;
-let M=null, frames=[], byIdx={}, labels={}, cur=0;
+let M=null, frames=[], byIdx={}, labels={}, cur=0, FARY=480;
 let z=1, tx=0, ty=0, baseScale=1;       // view transform (display px), baseScale = fit-to-width
 let dragging=false, moved=0, sx=0, sy=0, stx=0, sty=0;
 const view=document.getElementById("view"), wrap=document.getElementById("wrap");
@@ -84,7 +86,8 @@ async function load(){
   M = await (await fetch(API)).json();
   frames = M.frames; frames.forEach((f,i)=>byIdx[f.frame_idx]=i);
   (M.labels||[]).forEach(l=>labels[l.frame_idx]=l);
-  cur = firstUnlabeled(); show();
+  FARY = Math.min(480, M.far_cut||480);
+  cur = -1; gotoFar();
 }
 function firstUnlabeled(){ for(let i=0;i<frames.length;i++) if(!labels[frames[i].frame_idx]) return i; return 0; }
 function frame(){ return frames[cur]; }
@@ -138,7 +141,7 @@ function draw(){
   const lab=labels[f.frame_idx];
   if (lab&&lab.action==="ball"&&lab.x!=null){
     const lx=lab.x-f.crop_x0, ly=lab.y-f.crop_y0;
-    ctx.strokeStyle="#ff3b6b";
+    ctx.strokeStyle=(lab.source==="human")?"#ff3b6b":"#9b59ff";
     ctx.beginPath(); ctx.arc(lx,ly,r2,0,7); ctx.stroke();
     ctx.beginPath(); ctx.moveTo(lx-r1,ly); ctx.lineTo(lx+r1,ly); ctx.moveTo(lx,ly-r1); ctx.lineTo(lx,ly+r1); ctx.stroke();
   }
@@ -183,14 +186,17 @@ view.addEventListener("pointerup",(e)=>{
 
 async function post(action,x,y){
   const f=frame();
-  labels[f.frame_idx]={frame_idx:f.frame_idx,action,x:x??null,y:y??null}; draw();
+  labels[f.frame_idx]={frame_idx:f.frame_idx,action,x:x??null,y:y??null,source:"human"}; draw();
   try{ await fetch(`${API}/result`,{method:"POST",headers:{"Content-Type":"application/json"},
-    body:JSON.stringify({frame_idx:f.frame_idx,action,x:x??null,y:y??null})}); }catch(err){ console.error(err); }
-  setTimeout(next,120);
+    body:JSON.stringify({frame_idx:f.frame_idx,action,x:x??null,y:y??null,source:"human"})}); }catch(err){ console.error(err); }
+  setTimeout(gotoFar,120);
 }
 function next(){ if(cur<frames.length-1){ cur++; show(); } else finish(); }
 function prev(){ if(cur>0){ cur--; show(); } }
 function gotoUnlabeled(){ const i=firstUnlabeled(); if(labels[frames[i].frame_idx]) finish(); else { cur=i; show(); } }
+function isFar(f){ return f.hint_y <= FARY; }
+function needsReview(f){ const l=labels[f.frame_idx]; return isFar(f) && (!l || l.source!=="human"); }
+function gotoFar(){ for(let k=1;k<=frames.length;k++){ const i=(cur+k)%frames.length; if(needsReview(frames[i])){ cur=i; show(); return; } } finish(); }
 function finish(){ document.getElementById("stage").style.display="none"; document.querySelector(".bar").style.display="none";
   document.getElementById("done").style.display="block"; document.getElementById("dlLink").href=`${API}`; }
 
@@ -199,6 +205,7 @@ document.getElementById("bNot").onclick=()=>post("not_visible",null,null);
 document.getElementById("bOut").onclick=()=>post("out_of_play",null,null);
 document.getElementById("bPrev").onclick=prev;
 document.getElementById("bNext").onclick=next;
+document.getElementById("bFar").onclick=gotoFar;
 document.getElementById("bUnlab").onclick=gotoUnlabeled;
 document.getElementById("bReset").onclick=fitView;
 addEventListener("keydown",(e)=>{
@@ -208,6 +215,7 @@ addEventListener("keydown",(e)=>{
   else if(e.key==="ArrowLeft") prev();
   else if(e.key==="ArrowRight") next();
   else if(e.key==="u"||e.key==="U") gotoUnlabeled();
+  else if(e.key==="f"||e.key==="F") gotoFar();
   else if(e.key==="0") fitView();
 });
 addEventListener("resize", ()=>{ fitView(); });

--- a/training/static/far-label.html
+++ b/training/static/far-label.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Far-ball labeler</title>
+<style>
+  :root { --bg:#11151c; --panel:#1b212b; --fg:#e7edf3; --muted:#8b97a7; --acc:#2ecc71; --gap:#ff9f1a; --click:#ff3b6b; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg); font:14px/1.4 system-ui,Segoe UI,Roboto,sans-serif; }
+  header { display:flex; align-items:center; gap:16px; padding:8px 14px; background:var(--panel); position:sticky; top:0; z-index:5; }
+  header b { font-size:15px; }
+  .prog { flex:1; height:10px; background:#0c0f14; border-radius:6px; overflow:hidden; }
+  .prog > i { display:block; height:100%; background:var(--acc); width:0; transition:width .15s; }
+  .pill { padding:2px 8px; border-radius:10px; background:#0c0f14; color:var(--muted); }
+  .pill.gap { color:#111; background:var(--gap); font-weight:600; }
+  .pill.ac { color:#111; background:var(--acc); font-weight:600; }
+  #stage { position:relative; margin:10px auto; max-width:1500px; }
+  #wrap { position:relative; line-height:0; cursor:crosshair; }
+  #img { width:100%; display:block; border-radius:6px; }
+  #ov { position:absolute; inset:0; pointer-events:none; }
+  #lens { position:absolute; width:240px; height:240px; border:2px solid #fff; border-radius:50%;
+          box-shadow:0 0 0 2px #000, 0 6px 20px rgba(0,0,0,.6); pointer-events:none; display:none; z-index:10;
+          background-repeat:no-repeat; }
+  #lens .cross { position:absolute; left:50%; top:50%; width:18px; height:18px; transform:translate(-50%,-50%);
+                 border:1px solid var(--click); border-radius:50%; }
+  .bar { display:flex; flex-wrap:wrap; gap:8px; justify-content:center; padding:10px; max-width:1500px; margin:0 auto; }
+  button { background:#243042; color:var(--fg); border:1px solid #33414f; border-radius:8px; padding:9px 14px;
+           font-size:14px; cursor:pointer; }
+  button:hover { background:#2c3a4f; }
+  button.primary { background:var(--acc); color:#06210f; border-color:var(--acc); font-weight:700; }
+  button.warn { background:#3a2230; color:#ffb3c6; }
+  button.ghost { background:#1b212b; }
+  kbd { background:#0c0f14; border:1px solid #33414f; border-radius:4px; padding:0 5px; font-size:11px; color:var(--muted); }
+  .hint { text-align:center; color:var(--muted); padding:0 10px 12px; max-width:900px; margin:0 auto; }
+  #done { display:none; text-align:center; padding:40px; }
+  a.dl { color:var(--acc); }
+</style>
+</head>
+<body>
+<header>
+  <b>Far-ball labeler</b>
+  <span id="frameLbl" class="pill">—</span>
+  <span id="kindLbl" class="pill">—</span>
+  <div class="prog"><i id="progBar"></i></div>
+  <span id="progLbl" class="pill">0 / 0</span>
+</header>
+
+<div id="stage">
+  <div id="wrap">
+    <img id="img" alt="" />
+    <canvas id="ov"></canvas>
+    <div id="lens"><div class="cross"></div></div>
+  </div>
+</div>
+
+<div class="bar">
+  <button id="bConfirm" class="primary" title="Accept the marked hint as the ball">✓ Hint is correct <kbd>C</kbd></button>
+  <button id="bNot" class="warn">Ball not visible <kbd>N</kbd></button>
+  <button id="bOut" class="warn">Out of play / off field <kbd>O</kbd></button>
+  <button id="bPrev" class="ghost">◀ Prev <kbd>←</kbd></button>
+  <button id="bNext" class="ghost">Next ▶ <kbd>→</kbd></button>
+  <button id="bUnlab" class="ghost">Next unlabeled <kbd>U</kbd></button>
+</div>
+<p class="hint">
+  Click the ball to mark its exact position (auto-advances). The dashed circle is AutoCam's guess —
+  if it's already on the ball, press <kbd>C</kbd>. Orange = <b>GAP</b> (AutoCam missed it — these matter most).
+  Hover for a magnifier.
+</p>
+
+<div id="done">
+  <h2>All frames labeled 🎉</h2>
+  <p>Labels are saved on the server. <a class="dl" id="dlLink" href="#">Download labels.json</a></p>
+</div>
+
+<script>
+const SET = new URLSearchParams(location.search).get("set") || "irondequoit";
+const API = `/api/far-label/${SET}`;
+let M = null, frames = [], byIdx = {}, labels = {}, cur = 0;
+const img = document.getElementById("img"), ov = document.getElementById("ov"), lens = document.getElementById("lens");
+const ctx = ov.getContext("2d");
+
+async function load() {
+  M = await (await fetch(API)).json();
+  frames = M.frames;
+  frames.forEach((f,i)=>byIdx[f.frame_idx]=i);
+  (M.labels||[]).forEach(l=>labels[l.frame_idx]=l);
+  cur = firstUnlabeled();
+  show();
+}
+function firstUnlabeled(){ for(let i=0;i<frames.length;i++) if(!labels[frames[i].frame_idx]) return i; return 0; }
+function frame(){ return frames[cur]; }
+
+function show(){
+  const f = frame();
+  document.getElementById("done").style.display = "none";
+  document.getElementById("stage").style.display = "";
+  document.querySelector(".bar").style.display = "flex";
+  document.getElementById("frameLbl").textContent = `frame ${f.frame_idx}`;
+  const kl = document.getElementById("kindLbl");
+  kl.textContent = f.autocam ? "AutoCam hint" : "GAP (missed)";
+  kl.className = "pill " + (f.autocam ? "ac" : "gap");
+  const n = frames.length, done = Object.keys(labels).length;
+  document.getElementById("progLbl").textContent = `${done} / ${n}`;
+  document.getElementById("progBar").style.width = (100*done/n)+"%";
+  img.onload = draw;
+  img.src = `${API}/strip/${f.frame_idx}?t=${Date.now()}`;
+  if (img.complete) draw();
+}
+
+function natToDisp(nx, ny){ const s = img.clientWidth / f0().crop_w; return [nx*s, ny*s]; }
+function f0(){ return frame(); }
+
+function draw(){
+  ov.width = img.clientWidth; ov.height = img.clientHeight;
+  ctx.clearRect(0,0,ov.width,ov.height);
+  const f = frame();
+  // hint marker (in crop-native coords)
+  const hnx = f.hint_x - f.crop_x0, hny = f.hint_y - f.crop_y0;
+  const [hx,hy] = natToDisp(hnx,hny);
+  ctx.lineWidth = 2; ctx.setLineDash([5,4]);
+  ctx.strokeStyle = f.autocam ? "#2ecc71" : "#ff9f1a";
+  ctx.beginPath(); ctx.arc(hx,hy,16,0,7); ctx.stroke();
+  ctx.setLineDash([]);
+  // existing label
+  const lab = labels[f.frame_idx];
+  if (lab && lab.action==="ball" && lab.x!=null){
+    const [lx,ly] = natToDisp(lab.x - f.crop_x0, lab.y - f.crop_y0);
+    ctx.strokeStyle = "#ff3b6b"; ctx.lineWidth=2;
+    ctx.beginPath(); ctx.arc(lx,ly,10,0,7); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(lx-14,ly); ctx.lineTo(lx+14,ly); ctx.moveTo(lx,ly-14); ctx.lineTo(lx,ly+14); ctx.stroke();
+  }
+}
+
+// click -> source coords
+img.parentElement.addEventListener("click", (e)=>{
+  const r = img.getBoundingClientRect();
+  const f = frame(), s = f.crop_w / img.clientWidth;
+  const nx = (e.clientX - r.left) * s, ny = (e.clientY - r.top) * s;
+  post("ball", f.crop_x0 + nx, f.crop_y0 + ny);
+});
+
+// magnifier
+img.parentElement.addEventListener("mousemove",(e)=>{
+  const r = img.getBoundingClientRect();
+  const x = e.clientX - r.left, y = e.clientY - r.top;
+  if (x<0||y<0||x>r.width||y>r.height){ lens.style.display="none"; return; }
+  const Z = 3.5, LS = 240;
+  lens.style.display = "block";
+  lens.style.left = (x - LS/2) + "px"; lens.style.top = (y - LS/2) + "px";
+  // background-image from the strip, zoomed and positioned on the cursor's natural point
+  lens.style.backgroundImage = `url(${img.src})`;
+  const natW = img.naturalWidth, natH = img.naturalHeight;
+  const bw = natW * Z * (img.clientWidth/natW), bh = natH * Z * (img.clientHeight/natH);
+  lens.style.backgroundSize = `${bw}px ${bh}px`;
+  lens.style.backgroundPosition = `${-(x*Z - LS/2)}px ${-(y*Z - LS/2)}px`;
+});
+img.parentElement.addEventListener("mouseleave",()=>lens.style.display="none");
+
+async function post(action, x, y){
+  const f = frame();
+  labels[f.frame_idx] = {frame_idx:f.frame_idx, action, x:x??null, y:y??null};
+  draw();
+  try{
+    await fetch(`${API}/result`, {method:"POST", headers:{"Content-Type":"application/json"},
+      body: JSON.stringify({frame_idx:f.frame_idx, action, x:x??null, y:y??null})});
+  }catch(err){ console.error(err); }
+  setTimeout(next, 120);
+}
+function next(){ if (cur < frames.length-1){ cur++; show(); } else finish(); }
+function prev(){ if (cur>0){ cur--; show(); } }
+function gotoUnlabeled(){ const i=firstUnlabeled(); if(labels[frames[i].frame_idx]){ finish(); } else { cur=i; show(); } }
+function finish(){
+  document.getElementById("stage").style.display="none";
+  document.querySelector(".bar").style.display="none";
+  document.getElementById("done").style.display="block";
+  document.getElementById("dlLink").href = `${API}`;
+}
+
+document.getElementById("bConfirm").onclick = ()=>{ const f=frame(); post("ball", f.hint_x, f.hint_y); };
+document.getElementById("bNot").onclick = ()=> post("not_visible", null, null);
+document.getElementById("bOut").onclick = ()=> post("out_of_play", null, null);
+document.getElementById("bPrev").onclick = prev;
+document.getElementById("bNext").onclick = next;
+document.getElementById("bUnlab").onclick = gotoUnlabeled;
+addEventListener("keydown",(e)=>{
+  if (e.key==="c"||e.key==="C") document.getElementById("bConfirm").click();
+  else if (e.key==="n"||e.key==="N") document.getElementById("bNot").click();
+  else if (e.key==="o"||e.key==="O") document.getElementById("bOut").click();
+  else if (e.key==="ArrowLeft") prev();
+  else if (e.key==="ArrowRight") next();
+  else if (e.key==="u"||e.key==="U") gotoUnlabeled();
+});
+addEventListener("resize", draw);
+load();
+</script>
+</body>
+</html>

--- a/training/static/far-label.html
+++ b/training/static/far-label.html
@@ -15,24 +15,19 @@
   .pill { padding:2px 8px; border-radius:10px; background:#0c0f14; color:var(--muted); }
   .pill.gap { color:#111; background:var(--gap); font-weight:600; }
   .pill.ac { color:#111; background:var(--acc); font-weight:600; }
-  #stage { position:relative; margin:10px auto; max-width:1500px; }
-  #wrap { position:relative; line-height:0; cursor:crosshair; }
-  #img { width:100%; display:block; border-radius:6px; }
+  #stage { margin:10px auto; max-width:1700px; }
+  #view { position:relative; overflow:hidden; background:#000; border-radius:6px; touch-action:none; cursor:crosshair; }
+  #wrap { position:absolute; left:0; top:0; transform-origin:0 0; line-height:0; }
+  #img { display:block; }
   #ov { position:absolute; inset:0; pointer-events:none; }
-  #lens { position:absolute; width:240px; height:240px; border:2px solid #fff; border-radius:50%;
-          box-shadow:0 0 0 2px #000, 0 6px 20px rgba(0,0,0,.6); pointer-events:none; display:none; z-index:10;
-          background-repeat:no-repeat; }
-  #lens .cross { position:absolute; left:50%; top:50%; width:18px; height:18px; transform:translate(-50%,-50%);
-                 border:1px solid var(--click); border-radius:50%; }
-  .bar { display:flex; flex-wrap:wrap; gap:8px; justify-content:center; padding:10px; max-width:1500px; margin:0 auto; }
-  button { background:#243042; color:var(--fg); border:1px solid #33414f; border-radius:8px; padding:9px 14px;
-           font-size:14px; cursor:pointer; }
+  .bar { display:flex; flex-wrap:wrap; gap:8px; justify-content:center; padding:10px; max-width:1700px; margin:0 auto; }
+  button { background:#243042; color:var(--fg); border:1px solid #33414f; border-radius:8px; padding:9px 14px; font-size:14px; cursor:pointer; }
   button:hover { background:#2c3a4f; }
   button.primary { background:var(--acc); color:#06210f; border-color:var(--acc); font-weight:700; }
   button.warn { background:#3a2230; color:#ffb3c6; }
   button.ghost { background:#1b212b; }
   kbd { background:#0c0f14; border:1px solid #33414f; border-radius:4px; padding:0 5px; font-size:11px; color:var(--muted); }
-  .hint { text-align:center; color:var(--muted); padding:0 10px 12px; max-width:900px; margin:0 auto; }
+  .hint { text-align:center; color:var(--muted); padding:0 10px 12px; max-width:1000px; margin:0 auto; }
   #done { display:none; text-align:center; padding:40px; }
   a.dl { color:var(--acc); }
 </style>
@@ -42,15 +37,17 @@
   <b>Far-ball labeler</b>
   <span id="frameLbl" class="pill">—</span>
   <span id="kindLbl" class="pill">—</span>
+  <span id="zoomLbl" class="pill">1.0×</span>
   <div class="prog"><i id="progBar"></i></div>
   <span id="progLbl" class="pill">0 / 0</span>
 </header>
 
 <div id="stage">
-  <div id="wrap">
-    <img id="img" alt="" />
-    <canvas id="ov"></canvas>
-    <div id="lens"><div class="cross"></div></div>
+  <div id="view">
+    <div id="wrap">
+      <img id="img" alt="" />
+      <canvas id="ov"></canvas>
+    </div>
   </div>
 </div>
 
@@ -61,11 +58,12 @@
   <button id="bPrev" class="ghost">◀ Prev <kbd>←</kbd></button>
   <button id="bNext" class="ghost">Next ▶ <kbd>→</kbd></button>
   <button id="bUnlab" class="ghost">Next unlabeled <kbd>U</kbd></button>
+  <button id="bReset" class="ghost">Reset zoom <kbd>0</kbd></button>
 </div>
 <p class="hint">
-  Click the ball to mark its exact position (auto-advances). The dashed circle is AutoCam's guess —
-  if it's already on the ball, press <kbd>C</kbd>. Orange = <b>GAP</b> (AutoCam missed it — these matter most).
-  Hover for a magnifier.
+  Full far-field width. <b>Scroll to zoom</b> toward the cursor, <b>drag to pan</b>, then <b>click the ball</b>
+  to mark it (auto-advances). The dashed circle is AutoCam's guess — it can be wrong (a shoe, a head), so trust
+  your eyes; press <kbd>C</kbd> only if it's truly on the ball. Orange = <b>GAP</b> (AutoCam missed it — these matter most).
 </p>
 
 <div id="done">
@@ -76,122 +74,143 @@
 <script>
 const SET = new URLSearchParams(location.search).get("set") || "irondequoit";
 const API = `/api/far-label/${SET}`;
-let M = null, frames = [], byIdx = {}, labels = {}, cur = 0;
-const img = document.getElementById("img"), ov = document.getElementById("ov"), lens = document.getElementById("lens");
-const ctx = ov.getContext("2d");
+let M=null, frames=[], byIdx={}, labels={}, cur=0;
+let z=1, tx=0, ty=0, baseScale=1;       // view transform (display px), baseScale = fit-to-width
+let dragging=false, moved=0, sx=0, sy=0, stx=0, sty=0;
+const view=document.getElementById("view"), wrap=document.getElementById("wrap");
+const img=document.getElementById("img"), ov=document.getElementById("ov"), ctx=ov.getContext("2d");
 
-async function load() {
+async function load(){
   M = await (await fetch(API)).json();
-  frames = M.frames;
-  frames.forEach((f,i)=>byIdx[f.frame_idx]=i);
+  frames = M.frames; frames.forEach((f,i)=>byIdx[f.frame_idx]=i);
   (M.labels||[]).forEach(l=>labels[l.frame_idx]=l);
-  cur = firstUnlabeled();
-  show();
+  cur = firstUnlabeled(); show();
 }
 function firstUnlabeled(){ for(let i=0;i<frames.length;i++) if(!labels[frames[i].frame_idx]) return i; return 0; }
 function frame(){ return frames[cur]; }
 
 function show(){
-  const f = frame();
-  document.getElementById("done").style.display = "none";
-  document.getElementById("stage").style.display = "";
-  document.querySelector(".bar").style.display = "flex";
-  document.getElementById("frameLbl").textContent = `frame ${f.frame_idx}`;
-  const kl = document.getElementById("kindLbl");
-  kl.textContent = f.autocam ? "AutoCam hint" : "GAP (missed)";
-  kl.className = "pill " + (f.autocam ? "ac" : "gap");
-  const n = frames.length, done = Object.keys(labels).length;
-  document.getElementById("progLbl").textContent = `${done} / ${n}`;
-  document.getElementById("progBar").style.width = (100*done/n)+"%";
-  img.onload = draw;
-  img.src = `${API}/strip/${f.frame_idx}?t=${Date.now()}`;
-  if (img.complete) draw();
+  const f=frame();
+  document.getElementById("done").style.display="none";
+  document.getElementById("stage").style.display=""; document.querySelector(".bar").style.display="flex";
+  document.getElementById("frameLbl").textContent=`frame ${f.frame_idx}`;
+  const kl=document.getElementById("kindLbl");
+  kl.textContent=f.autocam?"AutoCam hint":"GAP (missed)"; kl.className="pill "+(f.autocam?"ac":"gap");
+  const n=frames.length, done=Object.keys(labels).length;
+  document.getElementById("progLbl").textContent=`${done} / ${n}`;
+  document.getElementById("progBar").style.width=(100*done/n)+"%";
+  img.onload=()=>{ fitView(); };
+  img.src=`${API}/strip/${f.frame_idx}?t=${Date.now()}`;
+  if (img.complete && img.naturalWidth) fitView();
 }
 
-function natToDisp(nx, ny){ const s = img.clientWidth / f0().crop_w; return [nx*s, ny*s]; }
-function f0(){ return frame(); }
+function fitView(){
+  // size the img to natural; fit width into the view via baseScale; reset zoom
+  img.width = img.naturalWidth; img.height = img.naturalHeight;
+  ov.width = img.naturalWidth; ov.height = img.naturalHeight;
+  view.style.height = Math.round(view.clientWidth * img.naturalHeight / img.naturalWidth) + "px";
+  baseScale = view.clientWidth / img.naturalWidth;
+  z = baseScale; tx = 0; ty = 0;
+  applyTransform(); draw();
+}
+function applyTransform(){
+  wrap.style.transform = `translate(${tx}px,${ty}px) scale(${z})`;
+  document.getElementById("zoomLbl").textContent = (z/baseScale).toFixed(1)+"×";
+}
+function clampPan(){
+  const w=img.naturalWidth*z, h=img.naturalHeight*z;
+  const vw=view.clientWidth, vh=view.clientHeight;
+  tx = Math.min(0, Math.max(tx, vw - w));
+  ty = Math.min(0, Math.max(ty, vh - h));
+  if (w < vw) tx=0; if (h < vh) ty=0;
+}
 
+// draw markers in NATURAL image coords (canvas is natural-sized, transformed with wrap)
 function draw(){
-  ov.width = img.clientWidth; ov.height = img.clientHeight;
   ctx.clearRect(0,0,ov.width,ov.height);
-  const f = frame();
-  // hint marker (in crop-native coords)
-  const hnx = f.hint_x - f.crop_x0, hny = f.hint_y - f.crop_y0;
-  const [hx,hy] = natToDisp(hnx,hny);
-  ctx.lineWidth = 2; ctx.setLineDash([5,4]);
-  ctx.strokeStyle = f.autocam ? "#2ecc71" : "#ff9f1a";
-  ctx.beginPath(); ctx.arc(hx,hy,16,0,7); ctx.stroke();
-  ctx.setLineDash([]);
-  // existing label
-  const lab = labels[f.frame_idx];
-  if (lab && lab.action==="ball" && lab.x!=null){
-    const [lx,ly] = natToDisp(lab.x - f.crop_x0, lab.y - f.crop_y0);
-    ctx.strokeStyle = "#ff3b6b"; ctx.lineWidth=2;
-    ctx.beginPath(); ctx.arc(lx,ly,10,0,7); ctx.stroke();
-    ctx.beginPath(); ctx.moveTo(lx-14,ly); ctx.lineTo(lx+14,ly); ctx.moveTo(lx,ly-14); ctx.lineTo(lx,ly+14); ctx.stroke();
+  const f=frame();
+  const lw = 2/ (z||1) * baseScale * 2;   // keep stroke ~visible at any zoom
+  const r1 = 18/(z/baseScale), r2 = 12/(z/baseScale);
+  ctx.lineWidth = Math.max(1.5, 14*baseScale/z);
+  const hnx=f.hint_x-f.crop_x0, hny=f.hint_y-f.crop_y0;
+  ctx.setLineDash([6,5]); ctx.strokeStyle=f.autocam?"#2ecc71":"#ff9f1a";
+  ctx.beginPath(); ctx.arc(hnx,hny,r1,0,7); ctx.stroke(); ctx.setLineDash([]);
+  const lab=labels[f.frame_idx];
+  if (lab&&lab.action==="ball"&&lab.x!=null){
+    const lx=lab.x-f.crop_x0, ly=lab.y-f.crop_y0;
+    ctx.strokeStyle="#ff3b6b";
+    ctx.beginPath(); ctx.arc(lx,ly,r2,0,7); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(lx-r1,ly); ctx.lineTo(lx+r1,ly); ctx.moveTo(lx,ly-r1); ctx.lineTo(lx,ly+r1); ctx.stroke();
   }
 }
 
-// click -> source coords
-img.parentElement.addEventListener("click", (e)=>{
+// pointer -> natural image coords
+function toNatural(clientX, clientY){
   const r = img.getBoundingClientRect();
-  const f = frame(), s = f.crop_w / img.clientWidth;
-  const nx = (e.clientX - r.left) * s, ny = (e.clientY - r.top) * s;
-  post("ball", f.crop_x0 + nx, f.crop_y0 + ny);
-});
-
-// magnifier
-img.parentElement.addEventListener("mousemove",(e)=>{
-  const r = img.getBoundingClientRect();
-  const x = e.clientX - r.left, y = e.clientY - r.top;
-  if (x<0||y<0||x>r.width||y>r.height){ lens.style.display="none"; return; }
-  const Z = 3.5, LS = 240;
-  lens.style.display = "block";
-  lens.style.left = (x - LS/2) + "px"; lens.style.top = (y - LS/2) + "px";
-  // background-image from the strip, zoomed and positioned on the cursor's natural point
-  lens.style.backgroundImage = `url(${img.src})`;
-  const natW = img.naturalWidth, natH = img.naturalHeight;
-  const bw = natW * Z * (img.clientWidth/natW), bh = natH * Z * (img.clientHeight/natH);
-  lens.style.backgroundSize = `${bw}px ${bh}px`;
-  lens.style.backgroundPosition = `${-(x*Z - LS/2)}px ${-(y*Z - LS/2)}px`;
-});
-img.parentElement.addEventListener("mouseleave",()=>lens.style.display="none");
-
-async function post(action, x, y){
-  const f = frame();
-  labels[f.frame_idx] = {frame_idx:f.frame_idx, action, x:x??null, y:y??null};
-  draw();
-  try{
-    await fetch(`${API}/result`, {method:"POST", headers:{"Content-Type":"application/json"},
-      body: JSON.stringify({frame_idx:f.frame_idx, action, x:x??null, y:y??null})});
-  }catch(err){ console.error(err); }
-  setTimeout(next, 120);
-}
-function next(){ if (cur < frames.length-1){ cur++; show(); } else finish(); }
-function prev(){ if (cur>0){ cur--; show(); } }
-function gotoUnlabeled(){ const i=firstUnlabeled(); if(labels[frames[i].frame_idx]){ finish(); } else { cur=i; show(); } }
-function finish(){
-  document.getElementById("stage").style.display="none";
-  document.querySelector(".bar").style.display="none";
-  document.getElementById("done").style.display="block";
-  document.getElementById("dlLink").href = `${API}`;
+  const nx = (clientX - r.left)/r.width * img.naturalWidth;
+  const ny = (clientY - r.top)/r.height * img.naturalHeight;
+  return [nx, ny];
 }
 
-document.getElementById("bConfirm").onclick = ()=>{ const f=frame(); post("ball", f.hint_x, f.hint_y); };
-document.getElementById("bNot").onclick = ()=> post("not_visible", null, null);
-document.getElementById("bOut").onclick = ()=> post("out_of_play", null, null);
-document.getElementById("bPrev").onclick = prev;
-document.getElementById("bNext").onclick = next;
-document.getElementById("bUnlab").onclick = gotoUnlabeled;
+// wheel zoom toward cursor
+view.addEventListener("wheel",(e)=>{
+  e.preventDefault();
+  const r = view.getBoundingClientRect();
+  const cx = e.clientX - r.left, cy = e.clientY - r.top;        // cursor in view px
+  const ix = (cx - tx)/z, iy = (cy - ty)/z;                      // image natural px under cursor
+  const factor = e.deltaY < 0 ? 1.2 : 1/1.2;
+  z = Math.max(baseScale, Math.min(z*factor, baseScale*16));
+  tx = cx - ix*z; ty = cy - iy*z;
+  clampPan(); applyTransform();
+},{passive:false});
+
+// drag to pan / click to label
+view.addEventListener("pointerdown",(e)=>{ dragging=true; moved=0; sx=e.clientX; sy=e.clientY; stx=tx; sty=ty; view.setPointerCapture(e.pointerId); });
+view.addEventListener("pointermove",(e)=>{
+  if(!dragging) return;
+  const dx=e.clientX-sx, dy=e.clientY-sy; moved=Math.max(moved, Math.abs(dx)+Math.abs(dy));
+  tx=stx+dx; ty=sty+dy; clampPan(); applyTransform();
+});
+view.addEventListener("pointerup",(e)=>{
+  dragging=false;
+  if (moved < 6){ // a click, not a pan
+    const [nx,ny]=toNatural(e.clientX,e.clientY);
+    if (nx>=0&&ny>=0&&nx<=img.naturalWidth&&ny<=img.naturalHeight){
+      const f=frame(); post("ball", f.crop_x0+nx, f.crop_y0+ny);
+    }
+  }
+});
+
+async function post(action,x,y){
+  const f=frame();
+  labels[f.frame_idx]={frame_idx:f.frame_idx,action,x:x??null,y:y??null}; draw();
+  try{ await fetch(`${API}/result`,{method:"POST",headers:{"Content-Type":"application/json"},
+    body:JSON.stringify({frame_idx:f.frame_idx,action,x:x??null,y:y??null})}); }catch(err){ console.error(err); }
+  setTimeout(next,120);
+}
+function next(){ if(cur<frames.length-1){ cur++; show(); } else finish(); }
+function prev(){ if(cur>0){ cur--; show(); } }
+function gotoUnlabeled(){ const i=firstUnlabeled(); if(labels[frames[i].frame_idx]) finish(); else { cur=i; show(); } }
+function finish(){ document.getElementById("stage").style.display="none"; document.querySelector(".bar").style.display="none";
+  document.getElementById("done").style.display="block"; document.getElementById("dlLink").href=`${API}`; }
+
+document.getElementById("bConfirm").onclick=()=>{ const f=frame(); post("ball",f.hint_x,f.hint_y); };
+document.getElementById("bNot").onclick=()=>post("not_visible",null,null);
+document.getElementById("bOut").onclick=()=>post("out_of_play",null,null);
+document.getElementById("bPrev").onclick=prev;
+document.getElementById("bNext").onclick=next;
+document.getElementById("bUnlab").onclick=gotoUnlabeled;
+document.getElementById("bReset").onclick=fitView;
 addEventListener("keydown",(e)=>{
-  if (e.key==="c"||e.key==="C") document.getElementById("bConfirm").click();
-  else if (e.key==="n"||e.key==="N") document.getElementById("bNot").click();
-  else if (e.key==="o"||e.key==="O") document.getElementById("bOut").click();
-  else if (e.key==="ArrowLeft") prev();
-  else if (e.key==="ArrowRight") next();
-  else if (e.key==="u"||e.key==="U") gotoUnlabeled();
+  if(e.key==="c"||e.key==="C") document.getElementById("bConfirm").click();
+  else if(e.key==="n"||e.key==="N") document.getElementById("bNot").click();
+  else if(e.key==="o"||e.key==="O") document.getElementById("bOut").click();
+  else if(e.key==="ArrowLeft") prev();
+  else if(e.key==="ArrowRight") next();
+  else if(e.key==="u"||e.key==="U") gotoUnlabeled();
+  else if(e.key==="0") fitView();
 });
-addEventListener("resize", draw);
+addEventListener("resize", ()=>{ fitView(); });
 load();
 </script>
 </body>


### PR DESCRIPTION
Adds the far-ball labeling tool to the annotation server (far-label API routes + static/far-label.html), cherry-picked cleanly onto a base off main. Consolidates the far-label app that previously existed only on the research branch. py_compile clean; +336 lines / 2 files.