### PR TITLE
Game active-play window labeler (annotation server)

### DIFF
--- a/training/annotation_server.py
+++ b/training/annotation_server.py
@@ -20,6 +20,7 @@ from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, Resp
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
+from training.game_windows_api import register_game_windows
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,10 @@ REVIEW_PACKETS_DIR = Path("D:/training_data/review_packets")
 LABELS_OUTPUT_DIR = Path("training_data/labels/annotations")
 
 app = FastAPI(title="Ball Tracking Annotation Server", version="0.1.0")
+
+# Game active-play window labeler (scrub embedded YouTube -> play_windows.json):
+#   page at /static/game-windows.html
+register_game_windows(app)
 
 
 class NoCacheStaticMiddleware(BaseHTTPMiddleware):

--- a/training/game_windows_api.py
+++ b/training/game_windows_api.py
@@ -1,0 +1,227 @@
+"""Game active-play window labeler (web): scrub the embedded Full Field YouTube video and capture
+kickoff / halftime-start / halftime-end / final-whistle for each game. Writes
+G:/ballresearch/play_windows.json (windows in frames @ 20 fps) -- the active-play windows the
+training curve consumes, in the SAME schema as add_play_windows.py:
+   {fps, start, half_start, half_end, end, windows}
+No YouTube API/token needed (the embed plays in the browser).
+
+YouTube auto-matching is unreliable (duplicate opponents share identical titles; upload date != game
+date), so the tool SUGGESTS candidate videos and the user confirms/picks/pastes the URL. The confirmed
+choice is remembered in G:/ballresearch/game_youtube_map.json (kept OUT of play_windows.json for schema
+consistency). Wired in via `register_game_windows(app)` (appended to annotation_server.py).
+"""
+
+import json
+import os
+import re
+from pathlib import Path
+
+from fastapi import HTTPException
+
+PLAY_WINDOWS = Path("G:/ballresearch/play_windows.json")
+YT_MAP = Path("G:/ballresearch/game_youtube_map.json")   # {game_id: video_id} confirmed by the user
+YOUTUBE = Path("G:/ballresearch/youtube_uploads.json")
+ARCH = Path("F:/archive/ball_distill")
+STORAGE = Path("D:/soccer-cam-storage")
+FPS = 20
+HELD_OUT = "spencerport"
+_STOP = {"sc", "fc", "the", "vs", "bu14", "bu13", "bu15", "u15", "u14", "u13", "guzzetta", "flash", "hilton", "heat"}
+
+
+def _load_json(p, default):
+    try:
+        return json.loads(Path(p).read_text(encoding="utf-8", errors="replace"))
+    except Exception:
+        return default
+
+
+def _write_json(p, obj):
+    p = Path(p)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(json.dumps(obj, indent=1), encoding="utf-8")
+    os.replace(tmp, p)
+
+
+def _slug(s):
+    return re.sub(r"[^A-Za-z0-9]+", "_", s).strip("_")[:40]
+
+
+def _gid_from_storage(gname, dirname):
+    m = re.search(r"(2026\.\d{2}\.\d{2})", gname) or re.search(r"(2026\.\d{2}\.\d{2})", dirname)
+    date = m.group(1) if m else os.path.basename(dirname)[:10]
+    low = gname.lower()
+    team = "guzzetta" if "guzzetta" in low else ("flash" if "flash" in low else "team")
+    v = re.search(r"\bvs\b\s+(.+?)(?:\s*\(|$)", gname, re.I)
+    return f"{team}__{date}_vs_{_slug(v.group(1)) if v else 'opponent'}"
+
+
+def _storage_games():
+    out = []
+    if not STORAGE.exists():
+        return out
+    for d in sorted(STORAGE.glob("2026*")):
+        if not d.is_dir() or not list(d.glob("RecM09_*.mp4")):
+            continue
+        subs = [x for x in d.glob("*") if x.is_dir()]
+        if subs:
+            out.append(_gid_from_storage(subs[0].name, str(d)))
+    return out
+
+
+def _archived_games():
+    if not ARCH.exists():
+        return []
+    return [d.name for d in sorted(ARCH.iterdir()) if d.is_dir() and (d / "ball_track.json").exists()]
+
+
+def _words(s):
+    return [w for w in re.split(r"[^a-z0-9]+", (s or "").lower()) if w]
+
+
+def _opp_tokens(gid):
+    opp = gid.split("_vs_")[-1] if "_vs_" in gid else ""
+    return [w for w in _words(opp) if w not in _STOP]
+
+
+def _candidates(gid, ups):
+    """Ranked candidate videos for a game: whole-word opponent overlap, Full Field preferred.
+    Upload date is NOT used (it's the upload date, not the game date)."""
+    toks = set(_opp_tokens(gid))
+    scored = []
+    for u in ups:
+        twords = set(_words(u.get("title")))
+        overlap = len(toks & twords)
+        if overlap == 0:
+            continue
+        title = (u.get("title") or "").lower()
+        score = overlap * 10
+        if "full field" in title:
+            score += 5
+        if "raw" in title:
+            score -= 3
+        scored.append((score, u))
+    scored.sort(key=lambda x: (-x[0], x[1].get("date", "")))
+    return [u for _, u in scored]
+
+
+def _mmss(x):
+    x = int(round(x))
+    if x >= 3600:
+        return f"{x // 3600}:{(x % 3600) // 60:02d}:{x % 60:02d}"
+    return f"{x // 60}:{x % 60:02d}"
+
+
+def _verify_kickoff(gid, kickoff_frame):
+    p = ARCH / gid / "ball_track.json"
+    if not p.exists():
+        return {"archived": False, "note": "not archived yet -- windows saved, alignment will be checkable after detection"}
+    try:
+        import numpy as np
+    except Exception:
+        return {"archived": True, "note": "numpy unavailable; alignment check skipped"}
+    try:
+        bt = json.loads(p.read_text())
+        segs = bt["segments"]
+        nseg = max(s["index"] for s in segs) + 1
+        nf = {s["index"]: s["n_frames"] for s in segs}
+        offs, acc = {}, 0
+        for i in range(nseg):
+            offs[i] = acc
+            acc += nf.get(i, 0)
+        tot = acc
+        tx = np.full(tot, np.nan)
+        for s in segs:
+            for f, xy in (s.get("track") or {}).items():
+                g = offs[s["index"]] + int(f)
+                if 0 <= g < tot:
+                    tx[g] = xy[0]
+
+        def act(lo, hi):
+            xs = tx[max(0, lo):min(tot, hi)]
+            ok = np.isfinite(xs)
+            cov = float(ok.mean()) if len(xs) else 0.0
+            d = float(np.nanmean(np.abs(np.diff(xs[ok])))) if ok.sum() > 3 else 0.0
+            return [round(cov, 2), round(d, 1)]
+
+        before = act(kickoff_frame - 600, kickoff_frame)
+        after = act(kickoff_frame, kickoff_frame + 600)
+        aligned = (after[0] > before[0] + 0.1) or (after[1] > before[1] * 1.3)
+        return {"archived": True, "before_cov_disp": before, "after_cov_disp": after,
+                "aligned": bool(aligned), "total_frames": int(tot)}
+    except Exception as e:  # noqa: BLE001
+        return {"archived": True, "error": str(e)}
+
+
+def register_game_windows(app):
+    @app.get("/api/game-windows")
+    def list_game_windows():
+        ups = _load_json(YOUTUBE, [])
+        pw = _load_json(PLAY_WINDOWS, {})
+        ymap = _load_json(YT_MAP, {})
+        archived = set(_archived_games())
+        gids = sorted(set(_storage_games()) | archived)
+        rows = []
+        for gid in gids:
+            if HELD_OUT in gid.lower():
+                continue
+            cands = _candidates(gid, ups)
+            vid = ymap.get(gid) or (cands[0].get("video_id") if cands else None)
+            existing = pw.get(gid) or {}
+            rows.append({
+                "game_id": gid,
+                "video_id": vid,
+                "confirmed": gid in ymap,
+                "n_candidates": len(cands),
+                "archived": gid in archived,
+                "has_windows": bool(existing.get("windows")),
+            })
+        rows.sort(key=lambda r: (r["has_windows"], r["game_id"]))
+        return {"games": rows, "needs_windows": sum(1 for r in rows if not r["has_windows"])}
+
+    @app.get("/api/game-windows/{game_id}")
+    def get_game_window(game_id: str):
+        ups = _load_json(YOUTUBE, [])
+        pw = _load_json(PLAY_WINDOWS, {})
+        ymap = _load_json(YT_MAP, {})
+        cands = _candidates(game_id, ups)
+        confirmed = ymap.get(game_id)
+        existing = pw.get(game_id) or {}
+        return {
+            "game_id": game_id,
+            "confirmed_video_id": confirmed,
+            "suggested_video_id": confirmed or (cands[0].get("video_id") if cands else None),
+            "candidates": [{"video_id": c.get("video_id"), "title": c.get("title"), "date": c.get("date")} for c in cands[:12]],
+            "archived": (ARCH / game_id / "ball_track.json").exists(),
+            "existing": {k: existing.get(k) for k in ("start", "half_start", "half_end", "end")},
+        }
+
+    @app.post("/api/game-windows/{game_id}")
+    async def save_game_window(game_id: str, body: dict):
+        try:
+            ts = {k: float(body[k]) for k in ("start", "half_start", "half_end", "end")}
+        except Exception:
+            raise HTTPException(400, "need numeric seconds: start, half_start, half_end, end")
+        if not (ts["start"] < ts["half_start"] <= ts["half_end"] < ts["end"]):
+            raise HTTPException(400, "need start < half_start <= half_end < end")
+        windows = [[int(ts["start"] * FPS), int(ts["half_start"] * FPS)],
+                   [int(ts["half_end"] * FPS), int(ts["end"] * FPS)]]
+        # standard schema only (matches add_play_windows.py / existing games)
+        pw = _load_json(PLAY_WINDOWS, {})
+        pw[game_id] = {
+            "fps": FPS,
+            "start": _mmss(ts["start"]),
+            "half_start": _mmss(ts["half_start"]),
+            "half_end": _mmss(ts["half_end"]),
+            "end": _mmss(ts["end"]),
+            "windows": windows,
+        }
+        _write_json(PLAY_WINDOWS, pw)
+        # remember which video was used, OUT of play_windows.json (schema consistency)
+        vid = body.get("video_id")
+        if vid:
+            ymap = _load_json(YT_MAP, {})
+            ymap[game_id] = vid
+            _write_json(YT_MAP, ymap)
+        return {"ok": True, "game_id": game_id, "windows": windows,
+                "verify": _verify_kickoff(game_id, windows[0][0]), "n_games": len(pw)}

--- a/training/static/game-windows.html
+++ b/training/static/game-windows.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Game Window Labeler</title>
+<style>
+  :root { color-scheme: dark; }
+  body { font-family: system-ui, sans-serif; margin: 0; background: #111; color: #eee; }
+  header { padding: 10px 14px; background: #1b1b1b; border-bottom: 1px solid #333; position: sticky; top: 0; z-index: 5; }
+  h1 { font-size: 17px; margin: 0 0 6px; }
+  .row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+  select, input, button { font-size: 15px; padding: 7px 9px; background: #222; color: #eee; border: 1px solid #444; border-radius: 6px; }
+  button { cursor: pointer; }
+  button.primary { background: #2563eb; border-color: #2563eb; font-weight: 600; }
+  button.mark { background: #15803d; border-color: #15803d; min-width: 110px; }
+  button.small { padding: 4px 8px; font-size: 13px; min-width: auto; }
+  #wrap { max-width: 920px; margin: 0 auto; padding: 12px 14px 60px; }
+  #player { width: 100%; aspect-ratio: 16/9; background: #000; border-radius: 8px; }
+  .marks { margin-top: 14px; }
+  .mk { display: grid; grid-template-columns: 150px 90px 1fr; gap: 8px; align-items: center; padding: 7px 0; border-bottom: 1px solid #262626; }
+  .mk .lbl { font-weight: 600; }
+  .mk .val { font-variant-numeric: tabular-nums; font-size: 18px; color: #8ee; }
+  .mk .val.unset { color: #666; }
+  .muted { color: #999; font-size: 13px; }
+  .ok { color: #4ade80; } .warn { color: #fbbf24; } .err { color: #f87171; }
+  #status { margin-top: 12px; min-height: 22px; font-size: 14px; }
+  .pill { display:inline-block; padding:1px 7px; border-radius:10px; font-size:12px; background:#333; }
+  a { color: #7ab8ff; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Game Window Labeler <span class="pill" id="counter">…</span></h1>
+  <div class="row">
+    <select id="gameSel" style="min-width:340px"></select>
+    <button class="small" id="prevBtn">‹ prev</button>
+    <button class="small" id="nextBtn">next ›</button>
+    <span class="muted" id="archTag"></span>
+  </div>
+</header>
+<div id="wrap">
+  <div class="row" style="margin-bottom:8px">
+    <select id="vidSel" style="min-width:420px"></select>
+    <button class="small" id="loadVidBtn">load</button>
+  </div>
+  <div class="row" style="margin-bottom:8px">
+    <input id="urlBox" placeholder="…or paste a YouTube URL / ID" style="flex:1; min-width:240px" />
+    <button class="small" id="urlBtn">use URL</button>
+    <a id="ytLink" href="#" target="_blank" rel="noopener">open on YouTube ↗</a>
+  </div>
+  <div id="player"></div>
+
+  <div class="marks" id="marks"></div>
+
+  <div class="row" style="margin-top:14px">
+    <button class="primary" id="saveBtn">Save windows</button>
+    <span class="muted">Scrub the player, pause on the moment, then click its “Mark”. fps=20.</span>
+  </div>
+  <div id="status"></div>
+</div>
+
+<script>
+const MARKS = [
+  ["start",      "① Kickoff (1st half)"],
+  ["half_start", "② Halftime start"],
+  ["half_end",   "③ 2nd half kickoff"],
+  ["end",        "④ Final whistle"],
+];
+let games = [], cur = null, player = null, ytReady = false, pendingVid = null;
+const marks = { start:null, half_start:null, half_end:null, end:null };
+
+function fmt(s){ if(s==null) return "—"; s=Math.max(0,s); const h=Math.floor(s/3600), m=Math.floor(s%3600/60), x=(s%60); return (h?h+":"+String(m).padStart(2,"0"):m)+":"+x.toFixed(1).padStart(4,"0"); }
+function parseVid(u){ if(!u) return null; u=u.trim(); let m=u.match(/(?:v=|youtu\.be\/|embed\/)([A-Za-z0-9_-]{6,})/); return m?m[1]:(/^[A-Za-z0-9_-]{6,}$/.test(u)?u:null); }
+function setStatus(html){ document.getElementById("status").innerHTML = html; }
+
+function onYouTubeIframeAPIReady(){ ytReady = true; if(pendingVid){ loadVideo(pendingVid); pendingVid=null; } }
+function loadVideo(vid){
+  if(!vid){ return; }
+  document.getElementById("ytLink").href = "https://youtu.be/"+vid;
+  if(!ytReady){ pendingVid = vid; return; }
+  if(player && player.loadVideoById){ player.loadVideoById(vid); }
+  else { player = new YT.Player("player", { videoId: vid, playerVars:{ rel:0, modestbranding:1, playsinline:1 } }); }
+}
+function curTime(){ return (player && player.getCurrentTime) ? player.getCurrentTime() : 0; }
+function seek(t){ if(player && player.seekTo){ player.seekTo(Math.max(0,t), true); } }
+
+function renderMarks(){
+  const c = document.getElementById("marks"); c.innerHTML = "";
+  for(const [k,label] of MARKS){
+    const v = marks[k];
+    const row = document.createElement("div"); row.className = "mk";
+    row.innerHTML = `<div class="lbl">${label}</div>
+      <div class="val ${v==null?'unset':''}" id="val_${k}">${fmt(v)}</div>
+      <div class="row">
+        <button class="mark" data-mark="${k}">Mark</button>
+        <button class="small" data-seek="${k}">seek</button>
+        <button class="small" data-nudge="${k}" data-d="-2">−2s</button>
+        <button class="small" data-nudge="${k}" data-d="-0.5">−.5</button>
+        <button class="small" data-nudge="${k}" data-d="0.5">+.5</button>
+        <button class="small" data-nudge="${k}" data-d="2">+2s</button>
+      </div>`;
+    c.appendChild(row);
+  }
+}
+document.getElementById("marks").addEventListener("click", e=>{
+  const b = e.target.closest("button"); if(!b) return;
+  if(b.dataset.mark){ marks[b.dataset.mark] = curTime(); renderMarks(); }
+  else if(b.dataset.seek){ const v=marks[b.dataset.seek]; if(v!=null) seek(v); }
+  else if(b.dataset.nudge){ const k=b.dataset.nudge; if(marks[k]!=null){ marks[k]=Math.max(0,marks[k]+parseFloat(b.dataset.d)); seek(marks[k]); renderMarks(); } }
+});
+
+async function loadGames(){
+  const r = await fetch("/api/game-windows"); const j = await r.json();
+  games = j.games;
+  document.getElementById("counter").textContent = j.needs_windows + " need windows";
+  const sel = document.getElementById("gameSel"); sel.innerHTML = "";
+  for(const g of games){
+    const o = document.createElement("option"); o.value = g.game_id;
+    o.textContent = (g.has_windows?"✓ ":"○ ") + g.game_id + (g.archived?"":" (detecting…)");
+    sel.appendChild(o);
+  }
+  if(games.length) selectGame(games[0].game_id);
+}
+async function selectGame(gid){
+  document.getElementById("gameSel").value = gid;
+  const r = await fetch("/api/game-windows/"+encodeURIComponent(gid)); cur = await r.json();
+  marks.start=marks.half_start=marks.half_end=marks.end=null;
+  renderMarks();
+  document.getElementById("archTag").textContent = cur.archived ? "archived ✓ (alignment will be checked)" : "not archived yet";
+  // candidate dropdown
+  const vs = document.getElementById("vidSel"); vs.innerHTML = "";
+  (cur.candidates||[]).forEach(c=>{
+    const o=document.createElement("option"); o.value=c.video_id;
+    o.textContent = `${c.title||c.video_id}  [${c.date||""}]`;
+    vs.appendChild(o);
+  });
+  const v = cur.suggested_video_id || (cur.candidates[0]&&cur.candidates[0].video_id);
+  if(v){ vs.value=v; loadVideo(v); }
+  let note = cur.confirmed_video_id ? '<span class="ok">video remembered from last time</span>'
+           : (cur.candidates.length>1 ? '<span class="warn">'+cur.candidates.length+' candidate videos — confirm the right game (teams) before marking</span>'
+                                       : (cur.candidates.length? 'suggested 1 candidate':'<span class="err">no candidate video — paste the URL</span>'));
+  setStatus(note + (cur.existing && cur.existing.start ? ` · existing: ${cur.existing.start}/${cur.existing.half_start}/${cur.existing.half_end}/${cur.existing.end}` : ""));
+}
+
+document.getElementById("gameSel").onchange = e => selectGame(e.target.value);
+function step(d){ const i=games.findIndex(g=>g.game_id===cur.game_id); const n=games[(i+d+games.length)%games.length]; if(n) selectGame(n.game_id); }
+document.getElementById("prevBtn").onclick = ()=>step(-1);
+document.getElementById("nextBtn").onclick = ()=>step(1);
+document.getElementById("loadVidBtn").onclick = ()=>{ const v=document.getElementById("vidSel").value; if(v) loadVideo(v); };
+document.getElementById("urlBtn").onclick = ()=>{ const v=parseVid(document.getElementById("urlBox").value); if(v){ loadVideo(v); } else setStatus('<span class="err">could not parse a video id from that</span>'); };
+
+document.getElementById("saveBtn").onclick = async ()=>{
+  for(const [k] of MARKS){ if(marks[k]==null){ setStatus('<span class="err">set all four marks first</span>'); return; } }
+  if(!(marks.start<marks.half_start && marks.half_start<=marks.half_end && marks.half_end<marks.end)){
+    setStatus('<span class="err">need kickoff &lt; halftime-start ≤ 2nd-kickoff &lt; final-whistle</span>'); return;
+  }
+  const vid = (player&&player.getVideoData)? player.getVideoData().video_id : (document.getElementById("vidSel").value||null);
+  const body = { start:marks.start, half_start:marks.half_start, half_end:marks.half_end, end:marks.end, video_id:vid };
+  const r = await fetch("/api/game-windows/"+encodeURIComponent(cur.game_id), {method:"POST", headers:{"Content-Type":"application/json"}, body:JSON.stringify(body)});
+  if(!r.ok){ setStatus('<span class="err">save failed: '+(await r.text())+'</span>'); return; }
+  const j = await r.json();
+  let v = j.verify || {};
+  let vtxt = !v.archived ? '<span class="muted">(not archived yet — alignment check pending)</span>'
+           : v.aligned ? '<span class="ok">✓ ball activity starts at your kickoff — looks aligned</span>'
+           : '<span class="warn">⚠ no activity jump at kickoff — video may be trimmed; double-check before moving on</span>';
+  setStatus(`saved <b>${j.game_id}</b> · windows ${JSON.stringify(j.windows)} · ${vtxt}`);
+  await loadGames();  // refresh ✓ marks
+  document.getElementById("gameSel").value = cur.game_id;
+};
+
+loadGames();
+</script>
+<script src="https://www.youtube.com/iframe_api"></script>
+</body>
+</html>


### PR DESCRIPTION
Adds a web tool (annotation server) to label each game's active-play windows by scrubbing the embedded Full Field YouTube video.

- training/static/game-windows.html (YouTube IFrame player + capture UI)
- training/game_windows_api.py (routes: list / get+candidates / save)
- register_game_windows(app) wired into annotation_server.py

Writes play_windows.json in the SAME schema as add_play_windows.py. Game->video auto-match is unreliable (duplicate opponents share titles; upload date != game date), so the UI suggests candidates and the user confirms/picks/pastes; the choice is remembered in game_youtube_map.json. A ball-track activity check flags trimmed videos.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)