### PR TITLE
fix(download): require full byte count before marking a Reolink file downloaded

### DIFF
--- a/tests/test_download_processor.py
+++ b/tests/test_download_processor.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from video_grouper.models import RecordingFile
+from video_grouper.models import DirectoryState, RecordingFile
 from video_grouper.task_processors.download_processor import DownloadProcessor
 from video_grouper.task_processors.tasks.video import CombineTask
 from video_grouper.utils.config import (
@@ -26,12 +26,38 @@ from video_grouper.utils.config import (
     YouTubeConfig,
 )
 
+# The autouse ``mock_file_system`` fixture in conftest.py globally stubs
+# os.makedirs / os.path.exists / os.path.getsize for the whole suite. The
+# truncated-vs-full download tests below need REAL filesystem behavior (they
+# create actual temp files and rely on getsize to distinguish a 270-byte
+# truncated file from a 1MB complete one). Capture the genuine functions at
+# import time — before any patching — so the ``real_filesystem`` fixture can
+# restore them for those tests.
+_REAL_MAKEDIRS = os.makedirs
+_REAL_EXISTS = os.path.exists
+_REAL_GETSIZE = os.path.getsize
+_REAL_ACCESS = os.access
+
 
 @pytest.fixture
 def temp_storage():
     """Create a temporary storage directory for tests."""
     with tempfile.TemporaryDirectory() as temp_dir:
         yield temp_dir
+
+
+@pytest.fixture
+def real_filesystem(mock_file_system):
+    """Restore genuine os filesystem calls over the autouse mock_file_system.
+
+    Tests that exercise DirectoryState against real temp files need
+    os.makedirs/exists/getsize/access to actually hit disk.
+    """
+    mock_file_system["makedirs"].side_effect = _REAL_MAKEDIRS
+    mock_file_system["exists"].side_effect = _REAL_EXISTS
+    mock_file_system["getsize"].side_effect = _REAL_GETSIZE
+    mock_file_system["access"].side_effect = _REAL_ACCESS
+    yield
 
 
 @pytest.fixture
@@ -107,6 +133,9 @@ class TestDownloadProcessor:
 
         # Mock DirectoryState
         mock_dir_state_instance = Mock()
+        mock_dir_state_instance.get_file_by_path = Mock(return_value=recording_file)
+        mock_dir_state_instance.is_file_fully_downloaded = Mock(return_value=True)
+        mock_dir_state_instance.get_incomplete_downloads = Mock(return_value=[])
         mock_dir_state_instance.update_file_state = AsyncMock()
         mock_dir_state_instance.is_ready_for_combining = Mock(return_value=True)
         mock_directory_state.return_value = mock_dir_state_instance
@@ -159,6 +188,9 @@ class TestDownloadProcessor:
 
         # Mock DirectoryState
         mock_dir_state_instance = Mock()
+        mock_dir_state_instance.get_file_by_path = Mock(return_value=recording_file)
+        mock_dir_state_instance.is_file_fully_downloaded = Mock(return_value=True)
+        mock_dir_state_instance.get_incomplete_downloads = Mock(return_value=[])
         mock_dir_state_instance.update_file_state = AsyncMock()
         mock_dir_state_instance.is_ready_for_combining = Mock(return_value=False)
         mock_directory_state.return_value = mock_dir_state_instance
@@ -285,6 +317,9 @@ class TestDownloadProcessor:
 
         # Mock DirectoryState
         mock_dir_state_instance = Mock()
+        mock_dir_state_instance.get_file_by_path = Mock(return_value=recording_file)
+        mock_dir_state_instance.is_file_fully_downloaded = Mock(return_value=True)
+        mock_dir_state_instance.get_incomplete_downloads = Mock(return_value=[])
         mock_dir_state_instance.update_file_state = AsyncMock()
         mock_directory_state.return_value = mock_dir_state_instance
 
@@ -309,6 +344,122 @@ class TestDownloadProcessor:
         mock_dir_state_instance.update_file_state.assert_any_call(
             "/test/group/test.dav", status="downloaded"
         )
+
+    @pytest.mark.asyncio
+    async def test_truncated_download_is_requeued_not_combined(
+        self, temp_storage, mock_config, real_filesystem
+    ):
+        """A short read that produces a truncated file must NOT be marked
+        fully-downloaded: the file is left pending, re-queued for download,
+        and the combine task is never handed off."""
+        group_dir = os.path.join(temp_storage, "2023.01.01-10.00.00")
+        os.makedirs(group_dir, exist_ok=True)
+        file_path = os.path.join(group_dir, "RecM09_x.mp4")
+
+        item = RecordingFile(
+            start_time=datetime(2023, 1, 1, 10, 0, 0),
+            end_time=datetime(2023, 1, 1, 10, 5, 0),
+            file_path=file_path,
+            metadata={"path": "/cam/RecM09_x.mp4", "size": 1_000_000},
+        )
+
+        # Pre-populate the on-disk state with a real DirectoryState (no mock).
+        ds = DirectoryState(group_dir)
+        await ds.add_file(item.file_path, item)
+
+        async def _write_truncated(file_path, local_path):
+            # Server served only a partial first segment — 270 bytes.
+            with open(local_path, "wb") as f:
+                f.write(b"\x00" * 270)
+            return True
+
+        camera = Mock()
+        camera.name = "reolink"
+        camera.check_availability = Mock(return_value=True)
+        camera.download_file = AsyncMock(side_effect=_write_truncated)
+
+        video_processor = Mock()
+        video_processor.add_work = AsyncMock()
+
+        processor = DownloadProcessor(
+            temp_storage, mock_config, camera, video_processor
+        )
+        # Capture the re-queue without re-running the queue machinery.
+        processor.add_work = AsyncMock()
+
+        await processor.process_item(item)
+
+        # download_file invoked the way process_item calls it.
+        camera.download_file.assert_called_once_with(
+            file_path=item.metadata["path"], local_path=file_path
+        )
+
+        # Status rolled back to pending so the truncated file is fetched again.
+        reloaded = DirectoryState(group_dir)
+        assert reloaded.get_file_by_path(item.file_path).status == "pending"
+
+        # The item was re-queued for download exactly once.
+        processor.add_work.assert_awaited_once_with(item)
+
+        # A truncated file must never reach the combine step.
+        video_processor.add_work.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_full_download_is_downloaded_and_combined(
+        self, temp_storage, mock_config, real_filesystem
+    ):
+        """A full-size download is marked 'downloaded' and the group is handed
+        off to the video processor for combining."""
+        group_dir = os.path.join(temp_storage, "2023.01.01-11.00.00")
+        os.makedirs(group_dir, exist_ok=True)
+        file_path = os.path.join(group_dir, "RecM09_x.mp4")
+
+        item = RecordingFile(
+            start_time=datetime(2023, 1, 1, 11, 0, 0),
+            end_time=datetime(2023, 1, 1, 11, 5, 0),
+            file_path=file_path,
+            metadata={"path": "/cam/RecM09_x.mp4", "size": 1_000_000},
+        )
+
+        ds = DirectoryState(group_dir)
+        await ds.add_file(item.file_path, item)
+
+        async def _write_full(file_path, local_path):
+            with open(local_path, "wb") as f:
+                f.write(b"\x00" * 1_000_000)
+            return True
+
+        camera = Mock()
+        camera.name = "reolink"
+        camera.check_availability = Mock(return_value=True)
+        camera.download_file = AsyncMock(side_effect=_write_full)
+
+        video_processor = Mock()
+        video_processor.add_work = AsyncMock()
+
+        processor = DownloadProcessor(
+            temp_storage, mock_config, camera, video_processor
+        )
+        processor.add_work = AsyncMock()
+
+        await processor.process_item(item)
+
+        camera.download_file.assert_called_once_with(
+            file_path=item.metadata["path"], local_path=file_path
+        )
+
+        # Status is 'downloaded' once the full file is on disk.
+        reloaded = DirectoryState(group_dir)
+        assert reloaded.get_file_by_path(item.file_path).status == "downloaded"
+
+        # A complete file is never re-queued for download.
+        processor.add_work.assert_not_called()
+
+        # The group is handed off to the video processor for combining.
+        video_processor.add_work.assert_awaited_once()
+        queued_task = video_processor.add_work.call_args[0][0]
+        assert isinstance(queued_task, CombineTask)
+        assert queued_task.group_dir == group_dir
 
     def test_get_item_key_recording_file(self, temp_storage, mock_config, mock_camera):
         """Test getting unique key for RecordingFile."""

--- a/video_grouper/models/directory_state.py
+++ b/video_grouper/models/directory_state.py
@@ -205,6 +205,52 @@ class DirectoryState:
         """Check if a file is already in the directory state."""
         return file_path in self.files
 
+    # A file within this fraction of the camera-reported size counts as
+    # complete. The HTTP fast path is byte-identical to the camera file; the
+    # Baichuan path remuxes, shifting the size slightly — 1% absorbs that while
+    # still catching truncated downloads (a partial first segment is far smaller
+    # than its real ~780MB).
+    _SIZE_TOLERANCE = 0.01
+
+    def expected_size(self, file_obj: RecordingFile) -> int | None:
+        """Camera-reported recorded size for a file, if known (Search metadata)."""
+        try:
+            size = (file_obj.metadata or {}).get("size")
+            return int(size) if size else None
+        except (TypeError, ValueError):
+            return None
+
+    def is_file_fully_downloaded(self, file_obj: RecordingFile) -> bool:
+        """A file is fully downloaded only if its status is 'downloaded' AND the
+        bytes on disk match the camera-reported size (within tolerance).
+
+        ``download_file`` can report success after a short read (it received all
+        the bytes the server offered — e.g. the boot-time first-segment race
+        serves a truncated file), so status alone is not proof of a complete
+        file. If the camera never reported a size, fall back to trusting status.
+        """
+        if file_obj.status != "downloaded":
+            return False
+        expected = self.expected_size(file_obj)
+        if not expected:
+            return True
+        try:
+            actual = os.path.getsize(file_obj.file_path)
+        except OSError:
+            return False
+        return actual > 0 and abs(actual - expected) / expected < self._SIZE_TOLERANCE
+
+    def get_incomplete_downloads(self) -> list[RecordingFile]:
+        """Non-skipped files marked 'downloaded' whose on-disk size does not match
+        the camera-reported size — truncated/partial, must be re-downloaded."""
+        return [
+            f
+            for f in self.files.values()
+            if not f.skip
+            and f.status == "downloaded"
+            and not self.is_file_fully_downloaded(f)
+        ]
+
     def is_ready_for_combining(self) -> bool:
         """Check if all non-skipped files are downloaded and ready for combining."""
         if not self.files:
@@ -217,8 +263,10 @@ class DirectoryState:
         if not files_to_consider:
             return False
 
-        # All of the remaining files must be in the 'downloaded' state.
-        return all(f.status == "downloaded" for f in files_to_consider)
+        # Every remaining file must be FULLY downloaded — status 'downloaded'
+        # AND its bytes on disk match the camera-reported size. A truncated
+        # file must never reach the combine step.
+        return all(self.is_file_fully_downloaded(f) for f in files_to_consider)
 
     async def mark_file_as_skipped(self, file_path: str) -> None:
         """Marks a file to be skipped in future processing, without changing its status."""

--- a/video_grouper/task_processors/download_processor.py
+++ b/video_grouper/task_processors/download_processor.py
@@ -199,6 +199,30 @@ class DownloadProcessor(QueueProcessor):
 
             if download_successful:
                 await dir_state.update_file_state(file_path, status="downloaded")
+
+                # "downloaded" must mean FULLY downloaded. download_file can
+                # report success on a short read — it received all the bytes the
+                # server offered, but the camera may serve a truncated file (the
+                # boot-time first-segment race). Verify the bytes on disk match
+                # the camera-reported size; if not, the file is not actually
+                # downloaded — leave it pending and re-queue so it is fetched
+                # again, and never let it reach the combine step.
+                file_obj = dir_state.get_file_by_path(file_path)
+                if file_obj is not None and not dir_state.is_file_fully_downloaded(
+                    file_obj
+                ):
+                    actual = (
+                        os.path.getsize(file_path) if os.path.exists(file_path) else 0
+                    )
+                    logger.warning(
+                        f"DOWNLOAD: {file_name} incomplete — {actual} bytes on disk, "
+                        f"camera reports {dir_state.expected_size(file_obj)}; "
+                        f"re-queueing for download."
+                    )
+                    await dir_state.update_file_state(file_path, status="pending")
+                    await self.add_work(item)
+                    return
+
                 if self.ttt_reporter:
                     await self.ttt_reporter.update_recording_status(
                         dir_state.ttt_recording_id, "download", "downloaded"
@@ -206,6 +230,19 @@ class DownloadProcessor(QueueProcessor):
                 logger.info(
                     f"DOWNLOAD: Successfully downloaded {os.path.basename(file_path)}"
                 )
+
+                # Re-queue any sibling already marked 'downloaded' whose bytes
+                # don't match the camera size (e.g. truncated before this guard
+                # existed) so the group waits for a clean copy before combining.
+                for incomplete in dir_state.get_incomplete_downloads():
+                    logger.warning(
+                        f"DOWNLOAD: re-queueing incomplete "
+                        f"{os.path.basename(incomplete.file_path)} (size mismatch)"
+                    )
+                    await dir_state.update_file_state(
+                        incomplete.file_path, status="pending"
+                    )
+                    await self.add_work(incomplete)
 
                 # Check if all files in the group are downloaded and ready for combining
                 if dir_state.is_ready_for_combining():


### PR DESCRIPTION
## Root cause

The Reolink download path marked a file `downloaded` whenever `download_file` returned success. But `download_file` reports success on a **short read** — it received all the bytes the server *offered*, which during the boot-time first-segment race is a **truncated first segment**, far smaller than the real ~780MB file.

Because status `downloaded` was the only signal, a truncated file silently passed the combine gate (`is_ready_for_combining`) and got combined into the final video.

## Fix

`"downloaded"` now means **fully** downloaded: the bytes on disk must match the camera-reported size (within a 1% tolerance to absorb the slight size shift from the Baichuan remux path; the HTTP fast path is byte-identical).

- **`DirectoryState`**: adds `expected_size()`, `is_file_fully_downloaded()`, and `get_incomplete_downloads()`. `is_ready_for_combining()` now requires every non-skipped file to be *fully* downloaded, so a truncated file can never reach the combine step.
- **`DownloadProcessor.process_item`**: after a successful download, verifies the on-disk size. On a mismatch it rolls the file status back to `pending` and re-queues the item instead of advancing. It also re-queues any sibling already marked `downloaded` whose bytes don't match (e.g. truncated before this guard existed) before checking combine-readiness. When the camera never reported a size, it falls back to trusting status (no behavior change).

## Tests

- Updated the three successful-download tests for the new `DirectoryState` calls (`get_file_by_path`, `is_file_fully_downloaded`, `get_incomplete_downloads`).
- Added two tests using a **real** `DirectoryState` with real temp files:
  - `test_truncated_download_is_requeued_not_combined` — a 270-byte truncated download is left `pending`, re-queued exactly once, and **never** handed to the video processor.
  - `test_full_download_is_downloaded_and_combined` — a full 1MB download is marked `downloaded` and a `CombineTask` is handed off.

`tests/test_download_processor.py`: **9 passed**. Full unit suite (`-m "not integration and not e2e"`): **1347 passed, 1 skipped**. ruff check + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)