### PR TITLE
Fix camera poller losing games that age past the lookback window

### DIFF
--- a/tests/integration/test_full_pipeline_e2e.py
+++ b/tests/integration/test_full_pipeline_e2e.py
@@ -124,9 +124,19 @@ def mock_camera():
     camera = Mock()
     camera.check_availability = AsyncMock(return_value=True)
     camera.get_file_list = AsyncMock(return_value=[])
+    camera.get_file_size = AsyncMock(return_value=0)
     camera.get_connected_timeframes = Mock(return_value=[])
     camera.download_file = AsyncMock(return_value=True)
     camera.close = AsyncMock()
+    # Real string identity so camera_name/camera_type metadata stays
+    # JSON-serializable when the poller writes state.json (a Mock here makes
+    # every per-group save fail, so find_existing_group_for can't match prior
+    # files and each file lands in its own group).
+    camera.name = "default"
+    cam_config = Mock()
+    cam_config.type = "dahua"
+    cam_config.name = "default"
+    camera.config = cam_config
     return camera
 
 

--- a/tests/test_camera_poller.py
+++ b/tests/test_camera_poller.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import tempfile
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -81,6 +81,7 @@ def mock_camera():
     camera = Mock()
     camera.check_availability = AsyncMock(return_value=True)
     camera.get_file_list = AsyncMock(return_value=[])
+    camera.get_file_size = AsyncMock(return_value=0)
     camera.get_connected_timeframes = Mock(return_value=[])
     camera.download_file = AsyncMock(return_value=True)
     camera.stop_recording = AsyncMock(return_value=True)
@@ -90,6 +91,7 @@ def mock_camera():
     camera.supports_file_deletion = True
     camera.is_connected = True
     camera.close = AsyncMock()
+    camera.name = "default"
     cam_config = Mock()
     cam_config.type = "dahua"
     cam_config.name = "default"
@@ -770,17 +772,26 @@ class TestUnplugNotification:
         """Notification sent when camera connected, no new files, download queue empty."""
         mock_config.ntfy.enabled = True
 
-        # Simulate: first poll finds files, second poll finds none
-        mock_camera.get_file_list.side_effect = [
+        # Simulate: first poll finds files, second poll finds none. The first
+        # poll's queue is idle, so the reconcile pass also queries the camera
+        # (returns []); the second poll's reconcile is rate-limited, so its
+        # sync needs one more []. Use a function so any extra call returns [].
+        _responses = iter(
             [
-                {
-                    "path": "/test1.dav",
-                    "startTime": "2023-01-01 10:00:00",
-                    "endTime": "2023-01-01 10:05:00",
-                }
-            ],
-            [],
-        ]
+                [
+                    {
+                        "path": "/test1.dav",
+                        "startTime": "2023-01-01 10:00:00",
+                        "endTime": "2023-01-01 10:05:00",
+                    }
+                ],
+            ]
+        )
+
+        async def _get_file_list(*_a, **_k):
+            return next(_responses, [])
+
+        mock_camera.get_file_list.side_effect = _get_file_list
         mock_download_processor = Mock()
         mock_download_processor.get_queue_size = Mock(return_value=0)
         mock_download_processor._in_progress_item = None
@@ -1041,3 +1052,383 @@ class TestRuntDetection:
             return_value="/storage/2026.05.28-10.00.00",
         ):
             assert _identify_runt_recordings(files, ["/storage/x"]) == set()
+
+
+def _idle_download_processor():
+    """A download processor mock that reports an idle queue (reconcile fires)."""
+    dp = Mock()
+    dp.add_work = AsyncMock()
+    dp.get_queue_size = Mock(return_value=0)
+    dp._in_progress_item = None
+    return dp
+
+
+class TestReconciliationPass:
+    """The reconcile pass re-queues camera files missing/incomplete on disk,
+    regardless of the high-water mark or whether they're known in state."""
+
+    @pytest.mark.asyncio
+    async def test_old_missing_game_requeued_by_reconcile(
+        self, temp_storage, mock_config, mock_camera, mock_file_system
+    ):
+        """A game older than max_lookback_hours, missing on disk, is re-queued
+        by the reconcile pass even though the incremental sync would never
+        look back that far. Regression guard for the 2026-06-15 loss."""
+        old_file = {
+            "path": "/old_game.dav",
+            # ~10 days ago: far outside the 48h incremental lookback window.
+            "startTime": (datetime.now() - timedelta(days=10)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
+            "endTime": (
+                datetime.now() - timedelta(days=10) + timedelta(minutes=30)
+            ).strftime("%Y-%m-%d %H:%M:%S"),
+            "size": 5_000_000,
+        }
+
+        # The local .mp4 is MISSING on disk. os.path.exists is globally mocked
+        # True by the autouse fixture, so return False for the .dav local path
+        # while keeping every other path (state.json, dirs) as-is.
+        def _exists(path):
+            return not str(path).endswith("old_game.dav")
+
+        mock_file_system["exists"].side_effect = _exists
+
+        # Incremental sync returns nothing (HWM is recent); reconcile returns
+        # the old file. get_file_list is called by both passes.
+        mock_camera.get_file_list = AsyncMock(side_effect=[[], [old_file]])
+
+        dp = _idle_download_processor()
+        poller = CameraPoller(temp_storage, mock_config, mock_camera, dp)
+
+        await poller.discover_work()
+
+        dp.add_work.assert_called_once()
+        queued = dp.add_work.call_args[0][0]
+        assert queued.file_path.endswith("old_game.dav")
+
+    @pytest.mark.asyncio
+    @patch("video_grouper.task_processors.camera_poller.DirectoryState")
+    @patch("video_grouper.task_processors.camera_poller.find_group_directory")
+    @patch("video_grouper.task_processors.camera_poller._identify_runt_recordings")
+    async def test_file_present_at_correct_size_not_requeued(
+        self,
+        mock_runts,
+        mock_find_group,
+        mock_dir_state_cls,
+        temp_storage,
+        mock_config,
+        mock_camera,
+        mock_file_system,
+    ):
+        """A file already on disk at the camera-reported size is NOT re-queued
+        by the reconcile pass."""
+        mock_runts.return_value = set()
+        mock_find_group.return_value = os.path.join(temp_storage, "2026.06.18-10.00.00")
+        size = 4_000_000
+        cam_file = {
+            "path": "/present.dav",
+            "startTime": (datetime.now() - timedelta(days=5)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
+            "endTime": (
+                datetime.now() - timedelta(days=5) + timedelta(minutes=20)
+            ).strftime("%Y-%m-%d %H:%M:%S"),
+            "size": size,
+        }
+
+        # File present on disk at the exact camera-reported size.
+        mock_file_system["exists"].return_value = True
+        mock_file_system["getsize"].return_value = size
+
+        # No prior state entry for the file.
+        ds = Mock()
+        ds.get_file_by_path = Mock(return_value=None)
+        mock_dir_state_cls.return_value = ds
+
+        mock_camera.get_file_list = AsyncMock(side_effect=[[], [cam_file]])
+
+        dp = _idle_download_processor()
+        poller = CameraPoller(temp_storage, mock_config, mock_camera, dp)
+
+        await poller.discover_work()
+
+        dp.add_work.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("video_grouper.task_processors.camera_poller.DirectoryState")
+    @patch("video_grouper.task_processors.camera_poller.find_group_directory")
+    @patch("video_grouper.task_processors.camera_poller._identify_runt_recordings")
+    async def test_known_in_state_but_short_on_disk_requeued(
+        self,
+        mock_runts,
+        mock_find_group,
+        mock_dir_state_cls,
+        temp_storage,
+        mock_config,
+        mock_camera,
+        mock_file_system,
+    ):
+        """A file already known in state but SHORT on disk (partial download)
+        is re-queued — 'known in state' is not treated as 'done'."""
+        mock_runts.return_value = set()
+        mock_find_group.return_value = os.path.join(temp_storage, "2026.06.19-10.00.00")
+        size = 6_000_000
+        cam_file = {
+            "path": "/partial.dav",
+            "startTime": (datetime.now() - timedelta(days=4)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
+            "endTime": (
+                datetime.now() - timedelta(days=4) + timedelta(minutes=15)
+            ).strftime("%Y-%m-%d %H:%M:%S"),
+            "size": size,
+        }
+
+        # File present but only HALF the expected size on disk -> incomplete.
+        mock_file_system["exists"].return_value = True
+        mock_file_system["getsize"].return_value = size // 2
+
+        # Known in state as 'pending' (not a terminal "have the bytes" state).
+        known = RecordingFile(
+            start_time=datetime.now() - timedelta(days=4),
+            end_time=datetime.now() - timedelta(days=4) + timedelta(minutes=15),
+            file_path=os.path.join(mock_find_group.return_value, "partial.dav"),
+            status="pending",
+            metadata={"path": "/partial.dav", "size": size},
+        )
+        ds = Mock()
+        ds.get_file_by_path = Mock(return_value=known)
+        ds.add_file = AsyncMock()
+        mock_dir_state_cls.return_value = ds
+
+        mock_camera.get_file_list = AsyncMock(side_effect=[[], [cam_file]])
+
+        dp = _idle_download_processor()
+        poller = CameraPoller(temp_storage, mock_config, mock_camera, dp)
+
+        await poller.discover_work()
+
+        dp.add_work.assert_called_once()
+        queued = dp.add_work.call_args[0][0]
+        assert queued.file_path.endswith("partial.dav")
+
+    @pytest.mark.asyncio
+    async def test_reconcile_skipped_when_queue_busy(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """Reconcile does not run while the download queue is busy."""
+        mock_camera.get_file_list = AsyncMock(return_value=[])
+
+        dp = Mock()
+        dp.add_work = AsyncMock()
+        dp.get_queue_size = Mock(return_value=3)  # busy
+        dp._in_progress_item = None
+
+        poller = CameraPoller(temp_storage, mock_config, mock_camera, dp)
+        await poller.discover_work()
+
+        # Only the incremental sync should have queried the camera.
+        assert mock_camera.get_file_list.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_reconcile_rate_limited(self, temp_storage, mock_config, mock_camera):
+        """A second idle poll within the min interval does not re-run reconcile."""
+        mock_camera.get_file_list = AsyncMock(return_value=[])
+
+        dp = _idle_download_processor()
+        poller = CameraPoller(temp_storage, mock_config, mock_camera, dp)
+
+        await poller.discover_work()  # sync + reconcile (2 calls)
+        first_count = mock_camera.get_file_list.await_count
+        assert first_count == 2
+
+        await poller.discover_work()  # sync only; reconcile rate-limited
+        assert mock_camera.get_file_list.await_count == first_count + 1
+
+
+class TestOpenConnectedSession:
+    """An open-ended (never-closed) connected session must not blanket-skip
+    historical recordings as home footage."""
+
+    @pytest.mark.asyncio
+    async def test_stale_open_session_does_not_skip_recent_game(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """A connected session that opened long ago and never closed must not
+        skip a game recorded days later."""
+        # Open connect event 30 days ago, no matching disconnect: an open
+        # session that a forward-to-now bound would stretch over everything.
+        stale_connect = datetime.now(pytz.utc) - timedelta(days=30)
+        mock_camera.get_connected_timeframes.return_value = [(stale_connect, None)]
+
+        # A real game recorded yesterday (local time).
+        game_start = datetime.now() - timedelta(days=1)
+        mock_camera.get_file_list.return_value = [
+            {
+                "path": "/real_game.dav",
+                "startTime": game_start.strftime("%Y-%m-%d %H:%M:%S"),
+                "endTime": (game_start + timedelta(minutes=30)).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                ),
+            }
+        ]
+
+        dp = Mock()
+        dp.add_work = AsyncMock()
+        dp.get_queue_size = Mock(return_value=1)  # keep reconcile from firing
+        dp._in_progress_item = None
+
+        poller = CameraPoller(temp_storage, mock_config, mock_camera, dp)
+        await poller._sync_files_from_camera()
+
+        dp.add_work.assert_called_once()
+        queued = dp.add_work.call_args[0][0]
+        assert queued.file_path.endswith("real_game.dav")
+
+
+class TestReolinkOpenSessionHorizon:
+    """ReolinkCamera.get_connected_timeframes bounds an open session."""
+
+    def _make_reolink(self, temp_storage, events):
+        from video_grouper.cameras.reolink import ReolinkCamera
+        from video_grouper.utils.config import CameraConfig
+
+        cam = ReolinkCamera(
+            CameraConfig(
+                name="reo",
+                type="reolink",
+                device_ip="127.0.0.1",
+                username="u",
+                password="p",
+            ),
+            temp_storage,
+        )
+        cam._connection_events = events
+        return cam
+
+    def test_stale_open_session_bounded_not_ongoing(self, temp_storage):
+        """An open session whose horizon is already in the past is reported
+        as a closed [start, horizon] window, not ongoing (end is not None)."""
+        stale = (datetime.now(pytz.utc) - timedelta(days=30)).isoformat()
+        cam = self._make_reolink(
+            temp_storage,
+            [{"event_datetime": stale, "event_type": "connected", "message": ""}],
+        )
+        frames = cam.get_connected_timeframes()
+        assert len(frames) == 1
+        start, end = frames[0]
+        assert end is not None  # bounded, not ongoing
+        expected = start + timedelta(hours=cam.OPEN_CONNECTED_SESSION_HORIZON_HOURS)
+        assert end == expected
+
+    def test_recent_open_session_still_ongoing(self, temp_storage):
+        """A session that opened just now is still reported as ongoing so a
+        genuinely-current home recording is still filtered."""
+        recent = datetime.now(pytz.utc).isoformat()
+        cam = self._make_reolink(
+            temp_storage,
+            [{"event_datetime": recent, "event_type": "connected", "message": ""}],
+        )
+        frames = cam.get_connected_timeframes()
+        assert len(frames) == 1
+        _, end = frames[0]
+        assert end is None  # still ongoing
+
+
+class TestAtomicStateWrites:
+    """camera_state.json writes are atomic (temp + os.replace) and never leave
+    a truncated/empty file the reader can catch."""
+
+    @pytest.mark.asyncio
+    async def test_update_latest_processed_time_uses_atomic_replace(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """_update_latest_processed_time writes via os.replace (atomic)."""
+        poller = _make_poller(temp_storage, mock_config, mock_camera)
+        ts = datetime(2026, 6, 15, 14, 30, 0)
+
+        # Capture the real os.replace BEFORE patching: patching reolink/poller
+        # os.replace patches it on the shared os module, so wrap the real one.
+        real_replace = os.replace
+        with patch(
+            "video_grouper.task_processors.camera_poller.os.replace",
+            wraps=real_replace,
+        ) as mock_replace:
+            await poller._update_latest_processed_time(ts)
+            # Wrote via a temp file then os.replace (atomic), not a direct
+            # truncating open() of the live file.
+            assert mock_replace.called
+            tmp_arg, dest_arg = mock_replace.call_args[0]
+            assert str(tmp_arg).endswith(".tmp")
+            assert str(dest_arg).endswith("camera_state.json")
+
+        # Value round-trips back through the reader.
+        got = await poller._get_latest_processed_time()
+        assert got == ts
+
+    @pytest.mark.asyncio
+    async def test_update_preserves_other_camera_fields(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """Writing the HWM read-merges, preserving connection_events written by
+        the camera's own _save_state into the same file."""
+        import json
+
+        state_path = os.path.join(temp_storage, "camera_state.json")
+        with open(state_path, "w") as f:
+            json.dump(
+                {"default": {"connection_events": [{"x": 1}], "is_connected": True}},
+                f,
+            )
+
+        poller = _make_poller(temp_storage, mock_config, mock_camera)
+        await poller._update_latest_processed_time(datetime(2026, 6, 15, 12, 0, 0))
+
+        with open(state_path) as f:
+            state = json.load(f)
+        assert state["default"]["connection_events"] == [{"x": 1}]
+        assert state["default"]["is_connected"] is True
+        assert state["default"]["latest_video_time"] == "2026-06-15 12:00:00"
+
+    def test_reolink_save_state_atomic_and_merges_hwm(self, temp_storage):
+        """ReolinkCamera._save_state writes atomically and preserves a HWM
+        field written by the poller into the same camera entry."""
+        import json
+
+        from video_grouper.cameras.reolink import ReolinkCamera
+        from video_grouper.utils.config import CameraConfig
+
+        state_path = os.path.join(temp_storage, "camera_state.json")
+        # Poller wrote a HWM first.
+        with open(state_path, "w") as f:
+            json.dump({"reo": {"latest_video_time": "2026-06-15 10:00:00"}}, f)
+
+        cam = ReolinkCamera(
+            CameraConfig(
+                name="reo",
+                type="reolink",
+                device_ip="127.0.0.1",
+                username="u",
+                password="p",
+            ),
+            temp_storage,
+        )
+        cam._connection_events = [
+            {"event_datetime": "2026-06-15T09:00:00", "event_type": "connected"}
+        ]
+        cam._is_connected = True
+
+        real_replace = os.replace
+        with patch(
+            "video_grouper.cameras.reolink.os.replace", wraps=real_replace
+        ) as mock_replace:
+            cam._save_state()
+            assert mock_replace.called
+
+        with open(state_path) as f:
+            state = json.load(f)
+        # HWM preserved by the read-merge.
+        assert state["reo"]["latest_video_time"] == "2026-06-15 10:00:00"
+        assert state["reo"]["is_connected"] is True
+        assert state["reo"]["connection_events"]

--- a/video_grouper/cameras/reolink.py
+++ b/video_grouper/cameras/reolink.py
@@ -11,6 +11,7 @@ import pytz
 
 from video_grouper.models import ConnectionEvent
 from video_grouper.utils.config import CameraConfig
+from video_grouper.utils.locking import FileLock
 from video_grouper.utils.paths import get_camera_state_path
 
 from . import register_camera
@@ -247,18 +248,30 @@ class ReolinkCamera(Camera):
             logger.error(f"Error loading camera state: {e}")
 
     def _save_state(self):
+        # Atomic write under a shared FileLock. CameraPoller writes the
+        # high-water mark into the SAME camera_state.json file from a
+        # different code path; a plain truncate-then-write here can leave the
+        # reader (CameraPoller._get_latest_processed_time) catching an empty
+        # or half-written file and silently resetting the HWM. Read-merge,
+        # write to a temp file, then os.replace so the on-disk file is always
+        # a complete, valid JSON document.
         try:
-            all_state = {}
-            if os.path.exists(self._state_file):
-                with open(self._state_file) as f:
-                    all_state = json.load(f)
-            all_state[self.config.name] = {
-                "connection_events": self._connection_events,
-                "is_connected": self._is_connected,
-            }
             os.makedirs(os.path.dirname(self._state_file), exist_ok=True)
-            with open(self._state_file, "w") as f:
-                json.dump(all_state, f, indent=4)
+            with FileLock(self._state_file):
+                all_state = {}
+                if os.path.exists(self._state_file):
+                    try:
+                        with open(self._state_file) as f:
+                            all_state = json.load(f)
+                    except (json.JSONDecodeError, FileNotFoundError):
+                        all_state = {}
+                cam_state = all_state.setdefault(self.config.name, {})
+                cam_state["connection_events"] = self._connection_events
+                cam_state["is_connected"] = self._is_connected
+                temp_path = self._state_file + ".tmp"
+                with open(temp_path, "w") as f:
+                    json.dump(all_state, f, indent=4)
+                os.replace(temp_path, self._state_file)
         except Exception as e:
             logger.error(f"Error saving camera state: {e}")
 
@@ -284,6 +297,16 @@ class ReolinkCamera(Camera):
         self._connection_events.append(event)
         self._save_state()
 
+    # How far past its start a still-open (never-closed) "connected" session
+    # is allowed to extend when classifying home footage. A trailing
+    # `connected` event with no matching `disconnected` used to be treated as
+    # open-ended (end=None -> "now"), so a single stale connect event
+    # blanketed every recording made since as "recorded at home" and the
+    # poller skipped real game footage forever. The camera is plugged in at
+    # home for at most a few hours before it goes to a field, so we bound the
+    # open session to this horizon instead of letting it run to now.
+    OPEN_CONNECTED_SESSION_HORIZON_HOURS = 12
+
     def get_connected_timeframes(self) -> list[tuple[datetime, datetime | None]]:
         timeframes = []
         start_time = None
@@ -307,7 +330,23 @@ class ReolinkCamera(Camera):
                     start_time = None
 
         if start_time is not None:
-            timeframes.append((start_time, None))
+            # Open-ended session: never let it stretch to "now" and blanket
+            # historical recordings as home footage. Bound it to a short
+            # horizon past its start. If that horizon is already in the past
+            # the session is treated as closed at the horizon; only a session
+            # whose horizon is still in the future is reported as ongoing
+            # (end=None) so genuinely-current home recordings are still
+            # filtered.
+            from datetime import timedelta
+
+            horizon = start_time + timedelta(
+                hours=self.OPEN_CONNECTED_SESSION_HORIZON_HOURS
+            )
+            now = datetime.now(pytz.utc)
+            if horizon <= now:
+                timeframes.append((start_time, horizon))
+            else:
+                timeframes.append((start_time, None))
 
         return timeframes
 

--- a/video_grouper/task_processors/camera_poller.py
+++ b/video_grouper/task_processors/camera_poller.py
@@ -9,6 +9,7 @@ from video_grouper.cameras.base import Camera
 from video_grouper.models import DirectoryState, RecordingFile
 from video_grouper.task_processors.download_processor import DownloadProcessor
 from video_grouper.utils.config import Config
+from video_grouper.utils.locking import FileLock
 from video_grouper.utils.paths import get_camera_state_path, get_home_cleanup_state_path
 
 from .base_polling_processor import PollingProcessor
@@ -26,6 +27,14 @@ GROUP_GAP_SECONDS = 5
 # A recording shorter than this is only meaningful as a runt when it also
 # has no neighbors — see _identify_runt_recordings.
 MIN_SEGMENT_SECONDS = 5
+# How far past its start a still-open (never-closed) "connected" session is
+# allowed to extend when classifying home footage in the skip block below.
+# A trailing `connected` event with no matching `disconnected` used to be
+# treated as open-ended (frame_end or now), so one stale connect event
+# blanketed every recording made since as "recorded at home" and the poller
+# skipped real game footage forever — the 2026-06-15 loss. Bound the open
+# session to this horizon past its start instead of letting it run to now.
+OPEN_CONNECTED_SESSION_HORIZON_HOURS = 12
 
 
 def create_directory(path):
@@ -206,6 +215,17 @@ class CameraPoller(PollingProcessor):
         self.ntfy_service = None
         self.ttt_reporter = None
         self._cleanup_state_path = get_home_cleanup_state_path(storage_path)
+        # Reconciliation pass: a full re-scan of a much larger window than the
+        # incremental sync, run when the download queue is idle. The
+        # incremental sync only moves forward (HWM .. now, clamped to
+        # max_lookback_hours), so any game that ages past that window before
+        # it was fully captured is never re-queried. The reconcile pass
+        # re-discovers anything still on the camera that is missing or
+        # incomplete on disk, regardless of the HWM. Tracked so we don't issue
+        # a wide camera search on every single poll while the queue happens to
+        # be idle.
+        self._last_reconcile_time: datetime | None = None
+        self._reconcile_min_interval_seconds = 3600
 
     async def discover_work(self) -> None:
         """
@@ -233,11 +253,45 @@ class CameraPoller(PollingProcessor):
 
             await self._sync_files_from_camera()
 
+            # Self-healing reconciliation. When the download queue is idle,
+            # re-scan a much larger window than the incremental sync and
+            # re-queue anything still on the camera that is missing or
+            # incomplete on disk — regardless of the high-water mark. This is
+            # the safety net for games that aged past max_lookback_hours
+            # before they were fully captured (the 2026-06-15 loss).
+            if self._should_reconcile():
+                await self._reconcile_files_from_camera()
+
             # Check if all downloads are complete and notify to unplug
             await self._check_downloads_complete()
 
         except Exception as e:
             logger.error(f"CAMERA_POLLER: Error during camera polling: {e}")
+
+    def _should_reconcile(self) -> bool:
+        """Whether to run a full reconcile pass on this poll.
+
+        Gate: the download queue must be idle (nothing queued, nothing in
+        progress) so we don't fight the incremental sync for camera bandwidth,
+        AND at least ``_reconcile_min_interval_seconds`` must have elapsed
+        since the last reconcile so an idle queue doesn't trigger a wide
+        camera search on every single poll.
+        """
+        dp = self.download_processor
+        if dp is None:
+            return False
+        try:
+            if dp.get_queue_size() > 0:
+                return False
+            if getattr(dp, "_in_progress_item", None) is not None:
+                return False
+        except Exception:
+            return False
+
+        if self._last_reconcile_time is None:
+            return True
+        elapsed = (datetime.now() - self._last_reconcile_time).total_seconds()
+        return elapsed >= self._reconcile_min_interval_seconds
 
     async def _sync_files_from_camera(self) -> None:
         """Sync files from camera and group them."""
@@ -369,7 +423,20 @@ class CameraPoller(PollingProcessor):
                     file_end_utc = file_end_local.astimezone(pytz.utc)
 
                     for frame_start, frame_end in connected_timeframes:
-                        frame_end_or_now = frame_end or datetime.now(pytz.utc)
+                        # Bound an open-ended (never-closed) connected session
+                        # to a short horizon past its start rather than letting
+                        # it run to "now" and blanket every later recording as
+                        # home footage. A session still within its horizon is
+                        # genuinely current, so it extends to now; a stale one
+                        # (horizon already past) closes at its horizon.
+                        if frame_end is not None:
+                            frame_end_or_now = frame_end
+                        else:
+                            now_utc = datetime.now(pytz.utc)
+                            horizon = frame_start + timedelta(
+                                hours=OPEN_CONNECTED_SESSION_HORIZON_HOURS
+                            )
+                            frame_end_or_now = now_utc if horizon > now_utc else horizon
 
                         # Check for overlap: if file starts before frame ends AND file ends after frame starts
                         logger.info(
@@ -506,14 +573,186 @@ class CameraPoller(PollingProcessor):
                 total_seen,
             )
 
+    async def _file_needs_download(
+        self, local_path: str, dir_state: DirectoryState, expected_size: int | None
+    ) -> bool:
+        """Decide whether a reconcile-discovered file must be (re)queued.
+
+        Returns True when the on-disk reality does NOT match a completed
+        download, REGARDLESS of whether the file is already known in state.
+        Treating "known in state" as "done" is exactly the bug that lost the
+        2026-06-15 game — a file can be in state as ``pending``/
+        ``download_failed`` (or its bytes can be missing/short) yet never get
+        re-queued. We check the actual disk instead:
+
+          - the local file is missing -> needs download
+          - the local file is present but its size doesn't match the
+            camera-reported size (within 1%, to tolerate remux container
+            framing differences) -> needs download
+          - the file's recorded state is not a terminal "have the bytes"
+            state (downloaded/combined/trimmed/complete/...) -> needs download
+        """
+        if not os.path.exists(local_path):
+            return True
+
+        if expected_size and expected_size > 0:
+            try:
+                actual_size = os.path.getsize(local_path)
+            except OSError:
+                actual_size = 0
+            if actual_size <= 0:
+                return True
+            if abs(actual_size - expected_size) / expected_size >= 0.01:
+                return True
+
+        done_statuses = {
+            "downloaded",
+            "combined",
+            "trimmed",
+            "ball_tracking_complete",
+            "pipeline_complete",
+            "complete",
+            "skipped",
+        }
+        existing = dir_state.get_file_by_path(local_path)
+        if existing is not None and existing.status not in done_statuses:
+            return True
+
+        return False
+
+    async def _reconcile_files_from_camera(self) -> None:
+        """Full reconcile pass: re-queue anything on the camera missing on disk.
+
+        Unlike the incremental sync (which only queries a forward-moving
+        window and trusts the high-water mark + ``is_file_in_state``), this
+        walks a much larger window and decides purely on on-disk
+        completeness. It never advances the HWM. Self-healing: a game that
+        aged past ``max_lookback_hours`` before it was fully downloaded gets
+        rediscovered here.
+        """
+        self._last_reconcile_time = datetime.now()
+
+        reconcile_days = getattr(self.config.app, "reconcile_lookback_days", 14)
+        end_time = datetime.now()
+        start_time = end_time - timedelta(days=reconcile_days)
+
+        logger.info(
+            "CAMERA_POLLER: Reconcile pass scanning %s to %s (%d days)",
+            start_time,
+            end_time,
+            reconcile_days,
+        )
+
+        files = await self.camera.get_file_list(
+            start_time=start_time, end_time=end_time
+        )
+        if not files:
+            logger.debug("CAMERA_POLLER: Reconcile found no files on the camera.")
+            return
+
+        existing_dirs = [
+            os.path.join(self.storage_path, d)
+            for d in os.listdir(self.storage_path)
+            if os.path.isdir(os.path.join(self.storage_path, d))
+        ]
+
+        # Reuse the runt filter so the reconcile pass doesn't re-queue lone
+        # startup stubs the incremental sync already (correctly) drops.
+        runt_paths = _identify_runt_recordings(files, existing_dirs)
+
+        requeued = 0
+        for file_info in files:
+            try:
+                if file_info["path"] in runt_paths:
+                    continue
+
+                file_start_time, file_end_time = _parse_recording_times(file_info)
+                if file_start_time is None:
+                    continue
+                if file_end_time is None or file_end_time <= file_start_time:
+                    file_end_time = file_start_time
+
+                filename = os.path.basename(file_info["path"])
+                group_dir = find_group_directory(
+                    file_start_time, self.storage_path, existing_dirs
+                )
+                if group_dir not in existing_dirs:
+                    existing_dirs.append(group_dir)
+                local_path = os.path.join(group_dir, filename)
+
+                # Prefer the camera-reported size from search metadata; fall
+                # back to an explicit size probe so a short/partial local file
+                # is detected even when the search result omitted size.
+                expected_size = file_info.get("size")
+                if not expected_size:
+                    try:
+                        expected_size = await self.camera.get_file_size(
+                            file_info["path"]
+                        )
+                    except Exception:
+                        expected_size = None
+
+                dir_state = DirectoryState(group_dir)
+                if not await self._file_needs_download(
+                    local_path, dir_state, expected_size
+                ):
+                    continue
+
+                file_info["camera_name"] = self.camera.name
+                file_info["camera_type"] = self.camera.config.type
+                if expected_size:
+                    file_info["size"] = expected_size
+
+                recording_file = RecordingFile(
+                    start_time=file_start_time,
+                    end_time=file_end_time,
+                    file_path=local_path,
+                    metadata=file_info,
+                )
+
+                existing_file_obj = dir_state.get_file_by_path(local_path)
+                if existing_file_obj:
+                    recording_file.skip = existing_file_obj.skip
+
+                await dir_state.add_file(local_path, recording_file)
+
+                if not recording_file.skip and self.download_processor:
+                    await self.download_processor.add_work(recording_file)
+                    requeued += 1
+                    logger.info(
+                        "CAMERA_POLLER: Reconcile re-queued %s (missing/incomplete "
+                        "on disk)",
+                        filename,
+                    )
+            except Exception as e:
+                logger.error(
+                    "CAMERA_POLLER: Reconcile error on file %s: %s", file_info, e
+                )
+
+        logger.info(
+            "CAMERA_POLLER: Reconcile pass complete -- %d file(s) re-queued of "
+            "%d scanned.",
+            requeued,
+            len(files),
+        )
+
     async def _get_latest_processed_time(self) -> datetime | None:
-        """Get the timestamp of the last processed video file for this camera."""
+        """Get the timestamp of the last processed video file for this camera.
+
+        Reads camera_state.json under the same FileLock the writers use, so it
+        can never observe a half-written/truncated file. Writers now write
+        atomically (temp + os.replace), so even a brief lock contention can't
+        surface a partial document. Returning None here resets the HWM to the
+        max_lookback window, which is exactly how the 2026-06-15 game got lost,
+        so we read defensively.
+        """
         state_path = get_camera_state_path(self.storage_path)
         if not os.path.exists(state_path):
             return None
         try:
-            with open(state_path) as f:
-                all_state = json.load(f)
+            with FileLock(state_path):
+                with open(state_path) as f:
+                    all_state = json.load(f)
             cam_state = all_state.get(self.camera.name, {})
             timestamp_str = cam_state.get("latest_video_time")
             if not timestamp_str:
@@ -696,17 +935,33 @@ class CameraPoller(PollingProcessor):
             self.ntfy_service.unregister_response_handler("keep home recordings")
 
     async def _update_latest_processed_time(self, timestamp: datetime):
-        """Update the high-water mark for this camera in camera_state.json."""
+        """Update the high-water mark for this camera in camera_state.json.
+
+        Atomic, read-merge write under FileLock. ReolinkCamera._save_state
+        writes connection_events/is_connected into the SAME file from a
+        different code path; a plain truncate-then-write here could race that
+        writer (or the reader) and leave camera_state.json empty/half-written,
+        which resets the HWM and silently re-downloads or drops files. Read
+        the current state under the lock, merge our field, write to a temp
+        file, then os.replace so the on-disk file is always complete.
+        """
         try:
             state_path = get_camera_state_path(self.storage_path)
-            all_state = {}
-            if os.path.exists(state_path):
-                with open(state_path) as f:
-                    all_state = json.load(f)
-            cam_state = all_state.setdefault(self.camera.name, {})
-            cam_state["latest_video_time"] = timestamp.strftime(default_date_format)
-            with open(state_path, "w") as f:
-                json.dump(all_state, f, indent=4)
+            os.makedirs(os.path.dirname(state_path) or ".", exist_ok=True)
+            with FileLock(state_path):
+                all_state = {}
+                if os.path.exists(state_path):
+                    try:
+                        with open(state_path) as f:
+                            all_state = json.load(f)
+                    except (json.JSONDecodeError, FileNotFoundError):
+                        all_state = {}
+                cam_state = all_state.setdefault(self.camera.name, {})
+                cam_state["latest_video_time"] = timestamp.strftime(default_date_format)
+                temp_path = state_path + ".tmp"
+                with open(temp_path, "w") as f:
+                    json.dump(all_state, f, indent=4)
+                os.replace(temp_path, state_path)
             logger.debug(
                 f"CAMERA_POLLER: Updated latest processed time to: {timestamp}"
             )

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -105,6 +105,15 @@ class AppConfig(BaseModel):
     max_lookback_hours: int = 48
     max_files_per_poll: int = 50
     recording_end_date: str | None = None
+    # Reconciliation pass lookback. The incremental sync only queries a
+    # forward-moving window (max_lookback_hours back from now), so a game
+    # that ages past that window before it was fully captured is never
+    # re-queried and is lost. When the download queue is idle, the poller
+    # runs a full reconcile over this much larger window and re-queues any
+    # camera file that is missing/short/incomplete on disk — regardless of
+    # the high-water mark. 14 days covers a typical multi-week gap between
+    # plugging the camera in.
+    reconcile_lookback_days: int = 14
     # Auto-upgrade settings. auto_update=true (Chrome-style) silently installs
     # detected updates once the pipeline is quiescent; =false stops after
     # download+verify and waits for the tray's POST /api/update/apply.


### PR DESCRIPTION
## Problem

The camera poller never re-downloaded a game still on the camera once it aged past the ~48h forward-only lookback window. This lost a **2026-06-15** game. Three independent root causes were diagnosed.

## Root causes & fixes

### 1. Forward-only discovery (the core bug)
`CameraPoller._sync_files_from_camera` only queries `max(HWM, now − max_lookback_hours) … now`. Any game older than the window that wasn't fully captured while in-window is never queried again, and `is_file_in_state` is treated as "done" even when the bytes aren't on disk.

**Fix — self-healing reconciliation pass.** When the download queue is idle, `discover_work` runs `_reconcile_files_from_camera`, which re-scans a much larger window and (re)queues any camera file where:
- the local `.mp4` is **missing**, OR
- its on-disk size != the camera-reported size (within 1%, via search metadata or `get_file_size`), OR
- its recorded state is not a terminal "have the bytes" state (`downloaded`/`combined`/`trimmed`/`complete`/…).

This is decided purely on **on-disk completeness** — being "known in state" is explicitly *not* treated as done. The pass never advances the HWM and reuses the existing runt filter. It's gated to run only when nothing is queued/in-progress, and rate-limited to once per hour so an idle queue doesn't trigger a wide camera search every poll.

### 2. Open-ended home-connected skip blanketed historical games
The skip block used `frame_end or datetime.now()`, so a trailing `connected` event with **no** matching `disconnected` (an open `(start, None)` window from `get_connected_timeframes`) stretched to *now* and classified every later recording as home footage.

**Fix.** An open (never-closed) session is bounded to a **12h horizon** past its start in both `reolink.get_connected_timeframes` and the poller skip block. A session still within its horizon stays ongoing (`end=None`), so genuinely-current home recordings are still filtered; a stale one closes at its horizon and no longer blankets real game footage.

### 3. Non-atomic `camera_state.json` writes raced the reader
`_update_latest_processed_time` (poller) and `ReolinkCamera._save_state` truncated-then-wrote `camera_state.json`. The reader (`_get_latest_processed_time`) could catch a truncated/empty file, hit a JSON-decode error, return `None`, and **reset the HWM** to the max-lookback window.

**Fix.** Both writers now read-merge under `FileLock` and write via a temp file + `os.replace()` (atomic); the reader reads under the same `FileLock`. The read-merge also stops `_save_state` from clobbering the poller's `latest_video_time` (and vice-versa) since both share the file.

## New config knob

`[APP] reconcile_lookback_days` (default **14**) on `AppConfig`, wired from the INI `[APP]` section. 14 days covers a typical multi-week gap between plugging the camera in. Bump it if the camera holds older footage you still want self-healed.

Other defaults chosen (adjust if needed):
- Reconcile rate-limit: once per **3600s** while the queue is idle.
- Open-connected-session horizon: **12h**.

## Tests

Added/extended `tests/test_camera_poller.py`:
- (a) a game older than `max_lookback_hours`, missing on disk, **is** re-queued by reconcile;
- (b) a file present on disk at the correct size is **not** re-queued;
- (c) a file known in state but short on disk **is** re-queued;
- reconcile is skipped while the queue is busy and rate-limited on a second idle poll;
- (d) atomic `camera_state.json` writes (temp + `os.replace`, value round-trips, fields preserved) for both poller and reolink;
- open-session horizon, poller-side and `reolink.get_connected_timeframes`-side.

Also fixed a **pre-existing** failure in `tests/integration/test_full_pipeline_e2e.py::test_camera_groups_files_by_gap_tolerance` — its mock camera's `config.type` was a non-serializable `Mock`, making every per-group state save fail so each file landed in its own group.

## Verification

- `uv run ruff check` / `ruff format --check` — clean
- pre-commit (ruff + mypy) — passed
- `uv run pytest tests/test_camera_poller.py -q` — **53 passed**
- `uv run pytest -m "not integration and not e2e" -q` — **1356 passed, 1 skipped**
- `uv run pytest tests/integration/test_full_pipeline_e2e.py -q` — **9 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)