### PR TITLE
fix(state-auditor): don't re-queue downloads for terminal-status groups

### DIFF
--- a/tests/test_state_auditor_enhanced.py
+++ b/tests/test_state_auditor_enhanced.py
@@ -768,5 +768,103 @@ class TestStateAuditorPolling:
         auditor.match_info_service.shutdown.assert_called_once()
 
 
+class TestStateAuditorTerminalGroupDownloads:
+    """A group past the download phase must never have its files re-queued for
+    download. Regression guard for the 2026-06-15 reconcile starvation: a stale
+    ``_000000_`` segment (the camera's in-progress listing, later re-listed
+    under its finalized name) lingered at status ``downloading`` inside a
+    ``not_a_game`` group; StateAuditor re-queued it every audit, it 404'd
+    forever, and the never-idle download queue starved the camera poller's
+    reconcile pass so the real 6/15 game was never re-ingested.
+    """
+
+    def _make_state(self, status, file_status):
+        file_obj = Mock()
+        file_obj.skip = False
+        file_obj.status = file_status
+        file_obj.start_time = None
+        file_obj.end_time = None
+        file_obj.file_path = "RecM09_DST20260623_204345_000000_x.mp4"
+        file_obj.metadata = {"size": 1, "path": "/mnt/sda/x.mp4"}
+
+        state = Mock()
+        state.status = status
+        state.files = {file_obj.file_path: file_obj}
+        state.is_ready_for_combining.return_value = False
+        return state
+
+    @patch("video_grouper.task_processors.services.teamsnap_service.TeamSnapAPI")
+    @patch("video_grouper.task_processors.services.playmetrics_service.PlayMetricsAPI")
+    @patch("video_grouper.task_processors.services.ntfy_service.NtfyAPI")
+    @patch("video_grouper.task_processors.state_auditor.DirectoryState")
+    @pytest.mark.asyncio
+    async def test_not_a_game_group_does_not_requeue_downloads(
+        self,
+        mock_dir_state,
+        mock_ntfy,
+        mock_playmetrics,
+        mock_teamsnap,
+        mock_config,
+        tmp_path,
+    ):
+        mock_ntfy.return_value.enabled = True
+        mock_ntfy.return_value.initialize = AsyncMock()
+
+        group_dir = tmp_path / "2026.06.23-20.43.45"
+        group_dir.mkdir()
+        (group_dir / "state.json").write_text('{"status": "not_a_game"}')
+
+        mock_dir_state.return_value = self._make_state(
+            status="not_a_game", file_status="downloading"
+        )
+
+        download_processor = AsyncMock()
+        auditor = StateAuditor(
+            str(tmp_path), mock_config, download_processor, AsyncMock()
+        )
+        auditor.cleanup_service = AsyncMock()
+
+        await auditor._audit_directory(str(group_dir))
+
+        # The zombie file must NOT be re-queued: its group is terminal.
+        download_processor.add_work.assert_not_called()
+
+    @patch("video_grouper.task_processors.services.teamsnap_service.TeamSnapAPI")
+    @patch("video_grouper.task_processors.services.playmetrics_service.PlayMetricsAPI")
+    @patch("video_grouper.task_processors.services.ntfy_service.NtfyAPI")
+    @patch("video_grouper.task_processors.state_auditor.DirectoryState")
+    @pytest.mark.asyncio
+    async def test_active_group_requeues_pending_downloads(
+        self,
+        mock_dir_state,
+        mock_ntfy,
+        mock_playmetrics,
+        mock_teamsnap,
+        mock_config,
+        tmp_path,
+    ):
+        mock_ntfy.return_value.enabled = True
+        mock_ntfy.return_value.initialize = AsyncMock()
+
+        group_dir = tmp_path / "2026.06.15-18.27.13"
+        group_dir.mkdir()
+        (group_dir / "state.json").write_text('{"status": "pending"}')
+
+        mock_dir_state.return_value = self._make_state(
+            status="pending", file_status="pending"
+        )
+
+        download_processor = AsyncMock()
+        auditor = StateAuditor(
+            str(tmp_path), mock_config, download_processor, AsyncMock()
+        )
+        auditor.cleanup_service = AsyncMock()
+
+        await auditor._audit_directory(str(group_dir))
+
+        # A group still in the download phase keeps re-queuing its pending files.
+        download_processor.add_work.assert_called_once()
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/video_grouper/task_processors/state_auditor.py
+++ b/video_grouper/task_processors/state_auditor.py
@@ -23,6 +23,27 @@ from .video_processor import VideoProcessor
 
 logger = logging.getLogger(__name__)
 
+# Group statuses that are past the download phase. Once a group reaches any of
+# these, StateAuditor must never re-queue its files for download. A segment the
+# camera finalized under a new name (e.g. an in-progress "..._000000_..."
+# listing the camera later re-lists as "..._<endtime>_...") lingers in the
+# group's state at a non-terminal file status and 404s on every fetch.
+# Re-queuing it on each audit spins forever AND keeps the download queue
+# non-idle, which starves the camera poller's reconcile pass — exactly what
+# blocked the 2026-06-15 game from being re-ingested (a stale 2026-06-23
+# "_000000_" zombie in a not_a_game group monopolized the queue). Mirrors
+# DownloadProcessor.process_item's skip_statuses, plus not_a_game.
+_DOWNLOAD_DONE_STATUSES = frozenset(
+    {
+        "combined",
+        "trimmed",
+        "ball_tracking_complete",
+        "pipeline_complete",
+        "complete",
+        "not_a_game",
+    }
+)
+
 
 class StateAuditor(PollingProcessor):
     """
@@ -182,25 +203,33 @@ class StateAuditor(PollingProcessor):
                 )
                 await dir_state.update_group_status("pipeline_complete")
 
-            # Audit individual files
-            for file_obj in dir_state.files.values():
-                if file_obj.skip:
-                    continue
+            # Audit individual files. Only (re-)queue downloads while the group
+            # is still in the download phase; a group past download
+            # (combined/.../not_a_game) must never have its files re-fetched
+            # (see _DOWNLOAD_DONE_STATUSES for why — the 2026-06-15 starvation).
+            if dir_state.status not in _DOWNLOAD_DONE_STATUSES:
+                for file_obj in dir_state.files.values():
+                    if file_obj.skip:
+                        continue
 
-                # Queue download tasks for pending/failed/interrupted downloads.
-                # "downloading" status means the app crashed mid-download, so
-                # treat it the same as a failure and re-queue.
-                if file_obj.status in ["pending", "download_failed", "downloading"]:
-                    if self.download_processor:
-                        recording_file = RecordingFile(
-                            start_time=file_obj.start_time,
-                            end_time=file_obj.end_time,
-                            file_path=file_obj.file_path,
-                            metadata=file_obj.metadata,
-                            status=file_obj.status,
-                            skip=file_obj.skip,
-                        )
-                        await self.download_processor.add_work(recording_file)
+                    # Queue download tasks for pending/failed/interrupted
+                    # downloads. "downloading" status means the app crashed
+                    # mid-download, so treat it as a failure and re-queue.
+                    if file_obj.status in [
+                        "pending",
+                        "download_failed",
+                        "downloading",
+                    ]:
+                        if self.download_processor:
+                            recording_file = RecordingFile(
+                                start_time=file_obj.start_time,
+                                end_time=file_obj.end_time,
+                                file_path=file_obj.file_path,
+                                metadata=file_obj.metadata,
+                                status=file_obj.status,
+                                skip=file_obj.skip,
+                            )
+                            await self.download_processor.add_work(recording_file)
 
             # Check if ready for combining
             if dir_state.is_ready_for_combining():


### PR DESCRIPTION
## Problem

The 6/15 game (already discovered + queued by the v0.5.1 reconcile pass) was not downloading. Root cause: a **zombie download in an infinite re-queue loop** monopolizing the download queue.

- The 6/23 test-clip group (`2026.06.23-20.43.45`, status `not_a_game`) has two entries for the same 32s recording: the finalized `..._204417_...` (`downloaded`) and a stale `..._000000_...` (the camera's in-progress listing) still at status `downloading`.
- `_000000_` is **gone from the camera** (finalized/renamed) → every download 404s.
- `StateAuditor._audit_directory` re-queued any file at `pending`/`download_failed`/`downloading` **regardless of group status**, so it re-added the zombie every ~60s audit. Because its group has `.mp4`s, `DownloadProcessor._get_priority()` ranks it **priority 1**, ahead of the queued 6/15 files (priority 2).
- The never-idle queue also starved `CameraPoller._should_reconcile()`.

## Fix

Guard the per-file download re-queue loop so it only runs while the group is still in the download phase — skip `combined`/`trimmed`/`ball_tracking_complete`/`pipeline_complete`/`complete`/`not_a_game`. Once a group is past download, its files must never be re-fetched.

**Self-healing on deploy:** the zombie exhausts its bounded base-queue retries, is not re-added, the queue goes idle, and the already-queued 6/15 files download.

## Tests

`TestStateAuditorTerminalGroupDownloads`: a `not_a_game` group with a `downloading` file is **not** re-queued; an active (`pending`) group still is. Full `test_state_auditor_enhanced.py` (15) + `test_download_processor.py` + `test_camera_poller.py` (62) green; ruff + mypy clean.

## Follow-up (not in this PR)
A 404 "file gone" is currently treated as a retryable failure in `reolink_download` (returns False after 5 sticky retries). Worth making 404-gone terminal so a renamed/deleted segment in a *non-terminal* group also can't loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)