### PR TITLE
fix(combine): reactively detect + recover corrupt-but-byte-complete camera segments

### DIFF
--- a/tests/test_audio_padding.py
+++ b/tests/test_audio_padding.py
@@ -12,7 +12,12 @@ import os
 
 import pytest
 
-from video_grouper.utils.ffmpeg_utils import combine_videos, detect_audio_video_gaps
+from video_grouper.utils.ffmpeg_utils import (
+    combine_videos,
+    decode_probe,
+    detect_audio_video_gaps,
+    detect_video_decode_corruption,
+)
 
 
 # --- Override conftest's autouse mocks for this module (use real PyAV/IO) ---
@@ -165,3 +170,152 @@ async def test_combine_trims_long_audio_segment(tmp_path):
     # audio tracks the ~6s of video rather than running out to ~8s.
     assert audio_seconds == pytest.approx(video_seconds, abs=1.0)
     assert audio_seconds < 7.0
+
+
+# --- Decode-corruption (byte-complete-but-corrupt) tests ---------------------
+#
+# These model the 06.08 case: a segment downloaded at EXACTLY the camera-
+# reported size (PR #88's completeness check passes) yet decodes fine for a
+# while and then hits an undecodable HEVC region (InvalidDataError from
+# avcodec_send_packet). A size check can't see it and a stream-copy mux can't
+# either (a pure mux never decodes). Only forcing a decode trips on it. Real
+# media is required: a mocked av.open can't actually fail mid-stream.
+
+
+def _write_decodable_clip(path, video_seconds, fps=10, rate=16000):
+    """Write a real mp4 with random (non-flat) frames so its bitstream breaks
+    realistically when bytes are zeroed mid-file."""
+    import av
+    import numpy as np
+
+    with av.open(str(path), "w", format="mp4") as container:
+        vstream = container.add_stream("mpeg4", rate=fps)
+        vstream.width = 64
+        vstream.height = 64
+        vstream.pix_fmt = "yuv420p"
+        astream = container.add_stream("aac", rate=rate)
+
+        rng = np.random.default_rng(0)
+        for i in range(int(round(video_seconds * fps))):
+            img = (rng.random((64, 64, 3)) * 255).astype(np.uint8)
+            frame = av.VideoFrame.from_ndarray(img, format="rgb24").reformat(
+                format="yuv420p"
+            )
+            frame.pts = i
+            for pkt in vstream.encode(frame):
+                container.mux(pkt)
+        for pkt in vstream.encode(None):
+            container.mux(pkt)
+
+        total_samples = int(round(video_seconds * rate))
+        written = 0
+        while written < total_samples:
+            n = min(1024, total_samples - written)
+            arr = np.zeros((2, n), dtype="float32")
+            aframe = av.AudioFrame.from_ndarray(arr, format="fltp", layout="stereo")
+            aframe.sample_rate = rate
+            for pkt in astream.encode(aframe):
+                container.mux(pkt)
+            written += n
+        for pkt in astream.encode(None):
+            container.mux(pkt)
+
+
+def _corrupt_mid_file(path, frac_start=0.80, frac_end=0.92):
+    """Zero a byte range deep in the mdat so the file decodes for a while and
+    then hits an undecodable region — the byte-complete-but-corrupt case."""
+    data = bytearray(path.read_bytes())
+    n = len(data)
+    for i in range(int(n * frac_start), int(n * frac_end)):
+        data[i] = 0
+    path.write_bytes(bytes(data))
+
+
+@pytest.mark.asyncio
+async def test_decode_probe_clean_vs_corrupt(tmp_path):
+    """decode_probe returns None for a clean clip and a corrupt-start second for
+    one that decodes partway then fails."""
+    clean = tmp_path / "clean.mp4"
+    corrupt = tmp_path / "corrupt.mp4"
+    _write_decodable_clip(clean, video_seconds=20.0)
+    _write_decodable_clip(corrupt, video_seconds=20.0)
+    _corrupt_mid_file(corrupt)
+
+    assert await decode_probe(str(clean)) is None
+
+    corrupt_start = await decode_probe(str(corrupt))
+    assert corrupt_start is not None
+    # The corruption sits in the back of the file: it must decode cleanly for a
+    # while first (proving this is the mid-file case, not a wholly-broken file)
+    # and the cut point must land before the segment's full 20s.
+    assert 1.0 < corrupt_start < 20.0
+
+
+def test_detect_video_decode_corruption_flags_only_corrupt(tmp_path):
+    """The detector flags the corrupt segment with its lost extent, not the
+    clean one."""
+    clean = tmp_path / "clean.mp4"
+    corrupt = tmp_path / "corrupt.mp4"
+    _write_decodable_clip(clean, video_seconds=20.0)
+    _write_decodable_clip(corrupt, video_seconds=20.0)
+    _corrupt_mid_file(corrupt)
+
+    found = detect_video_decode_corruption([str(clean), str(corrupt)])
+
+    assert len(found) == 1
+    entry = found[0]
+    assert os.path.basename(entry["path"]) == "corrupt.mp4"
+    assert entry["lost_seconds"] > 0
+    assert entry["corrupt_start_seconds"] < entry["video_seconds"]
+
+
+@pytest.mark.asyncio
+async def test_combine_degrades_corrupt_segment(tmp_path):
+    """Combining a corrupt segment cuts the dead video region instead of muxing
+    garbage: the combined output decodes clean end-to-end, is shorter than the
+    naive sum by ~the lost span, and audio stays aligned to the kept video."""
+    good = tmp_path / "a.mp4"
+    bad = tmp_path / "b.mp4"
+    out = tmp_path / "combined.mp4"
+    _write_decodable_clip(good, video_seconds=20.0)
+    _write_decodable_clip(bad, video_seconds=20.0)
+    _corrupt_mid_file(bad)
+
+    corruption = detect_video_decode_corruption([str(good), str(bad)])
+    assert len(corruption) == 1
+    corrupt_starts = {c["path"]: c["corrupt_start_seconds"] for c in corruption}
+
+    ok = await combine_videos(
+        [str(good), str(bad)], str(out), corrupt_starts=corrupt_starts
+    )
+    assert ok is True
+
+    # The whole combined output must now decode cleanly — the garbage tail of
+    # the bad segment was cut, not muxed (this is what a naive stream-copy got
+    # wrong: it would silently ship the corrupt span).
+    assert await decode_probe(str(out)) is None
+
+    video_seconds, audio_seconds = _decode_durations(out)
+    # ~20s good + the kept (pre-corruption) part of bad, so well under the
+    # naive 40s sum, and audio stays aligned to the kept video.
+    assert video_seconds < 38.0
+    assert audio_seconds == pytest.approx(video_seconds, abs=1.5)
+
+
+@pytest.mark.asyncio
+async def test_combine_clean_segments_unaffected(tmp_path):
+    """A combine with no corruption still produces a clean, full-length output
+    (the degrade path is inert when corrupt_starts is empty)."""
+    a = tmp_path / "a.mp4"
+    b = tmp_path / "b.mp4"
+    out = tmp_path / "combined.mp4"
+    _write_decodable_clip(a, video_seconds=6.0)
+    _write_decodable_clip(b, video_seconds=6.0)
+
+    assert detect_video_decode_corruption([str(a), str(b)]) == []
+
+    ok = await combine_videos([str(a), str(b)], str(out))
+    assert ok is True
+    assert await decode_probe(str(out)) is None
+    video_seconds, _ = _decode_durations(out)
+    assert video_seconds == pytest.approx(12.0, abs=1.5)

--- a/tests/test_audio_padding.py
+++ b/tests/test_audio_padding.py
@@ -13,6 +13,7 @@ import os
 import pytest
 
 from video_grouper.utils.ffmpeg_utils import (
+    _last_keyframe_pts_seconds,
     combine_videos,
     decode_probe,
     detect_audio_video_gaps,
@@ -231,6 +232,91 @@ def _corrupt_mid_file(path, frac_start=0.80, frac_end=0.92):
     path.write_bytes(bytes(data))
 
 
+def _h264_codec_available():
+    """True if a usable H.264 encoder is present (real-GOP fixtures need it)."""
+    import av
+
+    for name in ("libx264", "h264", "h264_nvenc"):
+        try:
+            if av.codec.Codec(name, "w") is not None:
+                return name
+        except Exception:
+            continue
+    return None
+
+
+def _write_gop_clip(path, video_seconds, fps=10, gop_size=12, rate=16000, codec=None):
+    """Write a real mp4 with genuine GOP structure: an H.264 stream with a
+    keyframe every ``gop_size`` frames and P/B frames in between.
+
+    This is the fixture that exposes the keyframe-aware-cut defect. With the old
+    mid-GOP cut, dropping packets at the raw corrupt second leaves dangling P/B
+    frames whose GOP is incomplete, so the combined output explodes
+    ``avcodec_send_packet`` on decode. Only ending on a GOP boundary (the last
+    keyframe at/before the cut) keeps the output decodable — which is exactly
+    what a flat all-I-frame mpeg4 fixture could never prove.
+    """
+    import av
+    import numpy as np
+
+    codec = codec or _h264_codec_available()
+    with av.open(str(path), "w", format="mp4") as container:
+        vstream = container.add_stream(codec, rate=fps)
+        vstream.width = 64
+        vstream.height = 64
+        vstream.pix_fmt = "yuv420p"
+        vstream.gop_size = gop_size
+        # Deterministic, real keyframe interval; let the encoder also place
+        # keyframes only at GOP boundaries (no scene-cut keyframes).
+        vstream.options = {
+            "g": str(gop_size),
+            "keyint_min": str(gop_size),
+            "sc_threshold": "0",
+        }
+        astream = container.add_stream("aac", rate=rate)
+
+        rng = np.random.default_rng(0)
+        n_frames = int(round(video_seconds * fps))
+        for i in range(n_frames):
+            # Moving, non-flat content so P/B frames carry real residual.
+            img = (rng.random((64, 64, 3)) * 255).astype(np.uint8)
+            frame = av.VideoFrame.from_ndarray(img, format="rgb24").reformat(
+                format="yuv420p"
+            )
+            frame.pts = i
+            for pkt in vstream.encode(frame):
+                container.mux(pkt)
+        for pkt in vstream.encode(None):
+            container.mux(pkt)
+
+        total_samples = int(round(video_seconds * rate))
+        written = 0
+        while written < total_samples:
+            n = min(1024, total_samples - written)
+            arr = np.zeros((2, n), dtype="float32")
+            aframe = av.AudioFrame.from_ndarray(arr, format="fltp", layout="stereo")
+            aframe.sample_rate = rate
+            for pkt in astream.encode(aframe):
+                container.mux(pkt)
+            written += n
+        for pkt in astream.encode(None):
+            container.mux(pkt)
+
+
+def _keyframe_pts_seconds(path):
+    """Return the sorted list of keyframe pts (seconds) in the video stream."""
+    import av
+
+    kfs = []
+    with av.open(str(path)) as container:
+        vstream = next(s for s in container.streams if s.type == "video")
+        tb = vstream.time_base
+        for packet in container.demux(vstream):
+            if packet.pts is not None and packet.is_keyframe:
+                kfs.append(float(packet.pts * tb))
+    return sorted(kfs)
+
+
 @pytest.mark.asyncio
 async def test_decode_probe_clean_vs_corrupt(tmp_path):
     """decode_probe returns None for a clean clip and a corrupt-start second for
@@ -319,3 +405,168 @@ async def test_combine_clean_segments_unaffected(tmp_path):
     assert await decode_probe(str(out)) is None
     video_seconds, _ = _decode_durations(out)
     assert video_seconds == pytest.approx(12.0, abs=1.5)
+
+
+# --- Keyframe-aware cut on REAL GOP structure --------------------------------
+#
+# These are the tests that would have CAUGHT the production defect. The earlier
+# corrupt-segment tests use an all-I-frame mpeg4 fixture, so any cut point is a
+# self-contained frame boundary and a naive mid-GOP cut "works" by accident. On
+# real HEVC/H.264 with a GOP, cutting at the raw corrupt second lands mid-GOP and
+# leaves dangling P/B frames whose access unit is incomplete — the combined
+# output then explodes ``avcodec_send_packet`` on decode (the 06.08 failure).
+# Only ending the muxed stream on a keyframe (GOP boundary) keeps it decodable.
+
+
+def _full_decode_errors(path):
+    """Decode EVERY frame of EVERY stream; return the count of decoded video
+    frames and the first decode exception encountered (or None).
+
+    This is the hard end-to-end gate: ``decode_probe`` only samples windows, but
+    here we force the decoder over the entire muxed stream so a dangling-GOP
+    failure anywhere cannot hide between sampled windows.
+    """
+    import av
+
+    frames = 0
+    with av.open(str(path)) as container:
+        streams = [s for s in container.streams if s.type in ("video", "audio")]
+        try:
+            for packet in container.demux(streams):
+                for _frame in packet.decode():
+                    if packet.stream.type == "video":
+                        frames += 1
+        except (av.error.InvalidDataError, av.error.FFmpegError) as exc:
+            return frames, exc
+    return frames, None
+
+
+@pytest.mark.asyncio
+async def test_combine_corrupt_gop_cuts_on_keyframe_and_fully_decodes(tmp_path):
+    """The miniature of the 06.08 case on a REAL GOP structure.
+
+    A clean segment + an H.264 segment with a real keyframe interval that is
+    corrupted MID-GOP. The combine must cut on a keyframe boundary so the output
+    decodes end-to-end with zero error. A naive mid-GOP cut (the old behavior)
+    fails this: it ships dangling P/B frames and the full decode raises.
+    """
+    codec = _h264_codec_available()
+    if codec is None:
+        pytest.skip("no H.264 encoder available for a real-GOP fixture")
+
+    good = tmp_path / "seg00_good.mp4"
+    bad = tmp_path / "seg01_bad.mp4"
+    out = tmp_path / "combined.mp4"
+    gop = 12
+    fps = 10
+    _write_gop_clip(good, video_seconds=8.0, fps=fps, gop_size=gop, codec=codec)
+    _write_gop_clip(bad, video_seconds=20.0, fps=fps, gop_size=gop, codec=codec)
+    # Corrupt the back of the bad segment so it decodes for a while then fails,
+    # with the corruption deliberately landing mid-GOP.
+    _corrupt_mid_file(bad, frac_start=0.80, frac_end=0.92)
+
+    corruption = detect_video_decode_corruption([str(good), str(bad)])
+    assert len(corruption) == 1
+    entry = corruption[0]
+    assert os.path.basename(entry["path"]) == "seg01_bad.mp4"
+    # The reported cut must be a real keyframe boundary, and lost_seconds must
+    # reflect that keyframe cut (>= the raw corrupt-second loss, never less).
+    bad_keyframes = _keyframe_pts_seconds(bad)
+    assert entry["cut_seconds"] is not None
+    assert any(
+        entry["cut_seconds"] == pytest.approx(kf, abs=1e-3) for kf in bad_keyframes
+    ), f"cut {entry['cut_seconds']} not on a keyframe; kfs={bad_keyframes}"
+    assert entry["cut_seconds"] <= entry["corrupt_start_seconds"] + 1e-6
+    assert (
+        entry["lost_seconds"] >= entry["video_seconds"] - entry["corrupt_start_seconds"]
+    )
+
+    # _last_keyframe_pts_seconds (the helper the combine uses to place the cut)
+    # must agree it's a keyframe at/before the corrupt second.
+    kf = _last_keyframe_pts_seconds(str(bad), entry["corrupt_start_seconds"])
+    assert kf is not None
+    assert any(kf == pytest.approx(k, abs=1e-3) for k in bad_keyframes)
+
+    corrupt_starts = {c["path"]: c["corrupt_start_seconds"] for c in corruption}
+    ok = await combine_videos(
+        [str(good), str(bad)], str(out), corrupt_starts=corrupt_starts
+    )
+    assert ok is True
+
+    # HARD GATE: the entire combined output must decode end-to-end with zero
+    # InvalidDataError. This is what the old mid-GOP cut got wrong.
+    frames, err = _full_decode_errors(out)
+    assert err is None, (
+        f"combined output failed full decode after {frames} frames: {err}"
+    )
+    assert frames > 0
+    # Belt-and-suspenders: the sampled probe is also clean.
+    assert await decode_probe(str(out)) is None
+
+    # DECISIVE: the combine must cut on the keyframe BOUNDARY, not the raw
+    # corrupt second. Measure the actual kept duration of the corrupt segment
+    # from the output (output video minus the good segment) and assert it tracks
+    # the keyframe cut, NOT corrupt_start. The keyframe cut here is 14.4s and the
+    # raw corrupt second is 15.0s — well separated. Under the old mid-GOP cut the
+    # kept duration would track corrupt_start (~15.0s); the keyframe-aware cut
+    # keeps only up to the keyframe (~14.4-14.5s, inclusive of that I-frame).
+    video_seconds, audio_seconds = _decode_durations(out)
+    good_seconds, _ = _decode_durations(good)
+    kept_bad_seconds = video_seconds - good_seconds
+    dist_to_keyframe = abs(kept_bad_seconds - entry["cut_seconds"])
+    dist_to_corrupt = abs(kept_bad_seconds - entry["corrupt_start_seconds"])
+    assert dist_to_keyframe < dist_to_corrupt, (
+        f"kept {kept_bad_seconds:.3f}s tracks the raw corrupt second "
+        f"{entry['corrupt_start_seconds']:.3f}s (mid-GOP cut!), not the keyframe "
+        f"boundary {entry['cut_seconds']:.3f}s"
+    )
+    # The keyframe-inclusive cut keeps up to and including the I-frame at
+    # cut_seconds, so kept is within ~a couple frames of that keyframe.
+    assert kept_bad_seconds == pytest.approx(entry["cut_seconds"], abs=0.35), (
+        f"kept {kept_bad_seconds:.3f}s not aligned to keyframe cut "
+        f"{entry['cut_seconds']:.3f}s"
+    )
+
+    # The dead region was removed: output video is well under the naive 28s sum,
+    # and audio tracks the kept video.
+    assert video_seconds < 27.0
+    assert audio_seconds == pytest.approx(video_seconds, abs=1.5)
+
+
+@pytest.mark.asyncio
+async def test_combine_corruption_in_first_gop_drops_segment_video(tmp_path):
+    """If corruption hits the very first GOP (no clean keyframe to end on), the
+    segment's video is dropped entirely rather than emitting a broken stream —
+    and the combined output still decodes clean.
+
+    The first keyframe of a camera segment is at pts 0, so 'no keyframe
+    at/before the cut' means the corruption is before that first keyframe — a
+    corrupt_start strictly less than 0. ``_last_keyframe_pts_seconds`` returns
+    None there, which is the combine's signal to drop the whole segment's video.
+    """
+    codec = _h264_codec_available()
+    if codec is None:
+        pytest.skip("no H.264 encoder available for a real-GOP fixture")
+
+    good = tmp_path / "seg00_good.mp4"
+    bad = tmp_path / "seg01_bad.mp4"
+    out = tmp_path / "combined.mp4"
+    gop = 12
+    fps = 10
+    _write_gop_clip(good, video_seconds=6.0, fps=fps, gop_size=gop, codec=codec)
+    _write_gop_clip(bad, video_seconds=12.0, fps=fps, gop_size=gop, codec=codec)
+
+    # No keyframe precedes a cut before pts 0 => the helper signals "drop".
+    assert _last_keyframe_pts_seconds(str(bad), -0.5) is None
+
+    # Drive the combine with that first-GOP-corruption case and confirm the
+    # output is clean and contains only the good segment's video.
+    ok = await combine_videos(
+        [str(good), str(bad)], str(out), corrupt_starts={str(bad): -0.5}
+    )
+    assert ok is True
+    frames, err = _full_decode_errors(out)
+    assert err is None, f"output failed full decode after {frames} frames: {err}"
+    video_seconds, _ = _decode_durations(out)
+    # Only the ~6s good segment survives (bad segment's video fully dropped).
+    assert video_seconds == pytest.approx(6.0, abs=1.5)

--- a/tests/test_corrupt_recovery.py
+++ b/tests/test_corrupt_recovery.py
@@ -1,0 +1,215 @@
+"""Real-media tests for the reactive corruption-recovery orchestration.
+
+These drive :func:`recover_pipeline_input` end-to-end on REAL mp4 clips: a
+byte-complete-but-corrupt segment can only be localized + repaired by a true
+decode, which a mocked ``av.open`` can't reproduce. So this module overrides
+conftest's autouse mocks (same pattern as tests/test_audio_padding.py) and runs
+real PyAV + real filesystem.
+
+The recovery is the REACTIVE half of the proactive->reactive rework: it runs only
+after a pipeline decode step has already failed on a game, rebuilds the trimmed
+``-raw.mp4`` the pipeline reads with the corrupt region keyframe-cut, flags the
+loss, warns the user, and invalidates the manifest so the re-run starts fresh.
+"""
+
+import os
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from video_grouper.models import DirectoryState
+from video_grouper.pipeline.manifest import PipelineManifest
+from video_grouper.task_processors.corrupt_recovery import recover_pipeline_input
+from video_grouper.utils.ffmpeg_utils import combine_videos, decode_probe, trim_video
+
+
+# --- Override conftest's autouse mocks for this module (use real PyAV/IO) ---
+@pytest.fixture(autouse=True)
+def mock_ffmpeg():
+    yield
+
+
+@pytest.fixture(autouse=True)
+def mock_file_system():
+    yield
+
+
+@pytest.fixture(autouse=True)
+def mock_httpx():
+    yield
+
+
+def _write_decodable_clip(path, video_seconds, fps=10, rate=16000):
+    """Write a real mp4 with random (non-flat) frames so its bitstream breaks
+    realistically when bytes are zeroed mid-file."""
+    import av
+    import numpy as np
+
+    with av.open(str(path), "w", format="mp4") as container:
+        vstream = container.add_stream("mpeg4", rate=fps)
+        vstream.width = 64
+        vstream.height = 64
+        vstream.pix_fmt = "yuv420p"
+        astream = container.add_stream("aac", rate=rate)
+
+        rng = np.random.default_rng(0)
+        for i in range(int(round(video_seconds * fps))):
+            img = (rng.random((64, 64, 3)) * 255).astype(np.uint8)
+            frame = av.VideoFrame.from_ndarray(img, format="rgb24").reformat(
+                format="yuv420p"
+            )
+            frame.pts = i
+            for pkt in vstream.encode(frame):
+                container.mux(pkt)
+        for pkt in vstream.encode(None):
+            container.mux(pkt)
+
+        total_samples = int(round(video_seconds * rate))
+        written = 0
+        while written < total_samples:
+            n = min(1024, total_samples - written)
+            arr = np.zeros((2, n), dtype="float32")
+            aframe = av.AudioFrame.from_ndarray(arr, format="fltp", layout="stereo")
+            aframe.sample_rate = rate
+            for pkt in astream.encode(aframe):
+                container.mux(pkt)
+            written += n
+        for pkt in astream.encode(None):
+            container.mux(pkt)
+
+
+def _corrupt_mid_file(path, frac_start=0.80, frac_end=0.92):
+    data = bytearray(path.read_bytes())
+    n = len(data)
+    for i in range(int(n * frac_start), int(n * frac_end)):
+        data[i] = 0
+    path.write_bytes(bytes(data))
+
+
+def _write_match_info(group_dir):
+    (group_dir / "match_info.ini").write_text(
+        "[MATCH]\n"
+        "my_team_name = Flash\n"
+        "opponent_team_name = Test\n"
+        "location = Home\n"
+        "start_time_offset = 00:00:00\n"
+        "total_duration = 00:00:00\n"
+    )
+
+
+async def _build_corrupt_pipeline_input(group_dir):
+    """Set up a game whose trimmed ``-raw.mp4`` carries source corruption.
+
+    Two top-level segments (one corrupt), a combined.mp4 and a trimmed
+    ``-raw.mp4`` produced by the same stream-copy path the real pipeline uses (so
+    the corruption rides straight through). Returns the input_path the pipeline
+    would read.
+    """
+    good = group_dir / "seg00.mp4"
+    bad = group_dir / "seg01.mp4"
+    _write_decodable_clip(good, video_seconds=20.0)
+    _write_decodable_clip(bad, video_seconds=20.0)
+    _corrupt_mid_file(bad)
+
+    combined = group_dir / "combined.mp4"
+    # Stream-copy combine with NO corrupt_starts: corruption rides through, exactly
+    # as the production combine (which never decodes) leaves it.
+    assert await combine_videos([str(good), str(bad)], str(combined))
+
+    subdir = group_dir / "sub"
+    subdir.mkdir()
+    raw = subdir / "flash-test-home-06-08-2024-raw.mp4"
+    assert await trim_video(str(combined), str(raw), "00:00:00", None)
+    return str(raw)
+
+
+def _make_config(trim_end=False):
+    cfg = Mock()
+    cfg.processing.trim_end_enabled = trim_end
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_recover_repairs_input_flags_loss_and_notifies(tmp_path):
+    """Full reactive recovery: localize -> keyframe-cut re-combine -> re-trim,
+    leaving a clean ``-raw.mp4``, a video_loss flag, an NTFY warning, and a wiped
+    manifest so the pipeline re-runs fresh."""
+    group_dir = tmp_path / "2024.06.08-10.00.00"
+    group_dir.mkdir()
+    _write_match_info(group_dir)
+    raw = await _build_corrupt_pipeline_input(group_dir)
+
+    # Precondition: the pipeline input really is corrupt (a decode step would fail).
+    assert await decode_probe(raw) is not None
+
+    # A stale manifest exists; recovery must wipe it so the re-run starts fresh.
+    manifest_path = PipelineManifest.path_for(str(group_dir))
+    PipelineManifest.load_or_init(
+        str(group_dir), raw, str(group_dir / "out.mp4")
+    ).save()
+    assert os.path.exists(manifest_path)
+
+    ntfy_api = Mock(send_notification=AsyncMock())
+    ntfy_processor = Mock(ntfy_service=Mock(ntfy_api=ntfy_api))
+
+    outcome = await recover_pipeline_input(
+        str(group_dir),
+        str(tmp_path),
+        raw,
+        config=_make_config(),
+        ntfy_processor=ntfy_processor,
+    )
+
+    assert outcome.repaired is True
+    assert outcome.lost_seconds > 0
+
+    # The pipeline input now decodes clean end-to-end (the dead span was cut).
+    assert await decode_probe(raw) is None
+
+    # The game is durably flagged — not shipped as if perfect.
+    marker = DirectoryState(str(group_dir)).get_video_loss()
+    assert marker is not None and marker["lost_seconds"] > 0
+
+    # The camera manager was warned about the lost footage.
+    ntfy_api.send_notification.assert_awaited_once()
+    assert "lost" in ntfy_api.send_notification.await_args.kwargs["title"].lower()
+
+    # The manifest was invalidated so the re-run re-decodes the repaired input.
+    assert not os.path.exists(manifest_path)
+
+
+@pytest.mark.asyncio
+async def test_recover_no_source_corruption_is_not_repaired(tmp_path):
+    """If the source segments are clean (the decode failure wasn't a cuttable
+    source corruption), recovery does NOT repair, flag, or notify — the caller
+    fails the game terminally rather than looping."""
+    group_dir = tmp_path / "2024.06.08-11.00.00"
+    group_dir.mkdir()
+    _write_match_info(group_dir)
+
+    good_a = group_dir / "seg00.mp4"
+    good_b = group_dir / "seg01.mp4"
+    _write_decodable_clip(good_a, video_seconds=6.0)
+    _write_decodable_clip(good_b, video_seconds=6.0)
+    subdir = group_dir / "sub"
+    subdir.mkdir()
+    raw = subdir / "flash-test-home-06-08-2024-raw.mp4"
+    combined = group_dir / "combined.mp4"
+    assert await combine_videos([str(good_a), str(good_b)], str(combined))
+    assert await trim_video(str(combined), str(raw), "00:00:00", None)
+
+    ntfy_api = Mock(send_notification=AsyncMock())
+    ntfy_processor = Mock(ntfy_service=Mock(ntfy_api=ntfy_api))
+
+    outcome = await recover_pipeline_input(
+        str(group_dir),
+        str(tmp_path),
+        str(raw),
+        config=_make_config(),
+        ntfy_processor=ntfy_processor,
+    )
+
+    assert outcome.repaired is False
+    assert outcome.reason is not None
+    assert DirectoryState(str(group_dir)).get_video_loss() is None
+    ntfy_api.send_notification.assert_not_awaited()

--- a/tests/test_pipeline_processor.py
+++ b/tests/test_pipeline_processor.py
@@ -154,6 +154,108 @@ class TestProcessItemPrecheck:
         runner_factory.assert_called_once()
 
 
+class TestCorruptionRecovery:
+    """Reactive recovery when a pipeline decode step fails on a corrupt input.
+
+    Covers the trigger (decode_corruption failure -> recover -> re-run), and the
+    BOUND that stops the N=16 retry-storm: recovery is attempted at most once per
+    game, and a corruption it can't repair fails terminally instead of looping.
+    """
+
+    def _failed_corruption(self):
+        return PipelineResult(
+            "failed",
+            failed_step="render",
+            error="exception: Invalid data found",
+            error_kind="decode_corruption",
+        )
+
+    def _patch_runner_seq(self, results):
+        runner = MagicMock()
+        runner.run = AsyncMock(side_effect=list(results))
+        return (
+            patch("video_grouper.pipeline.runner.PipelineRunner", return_value=runner),
+            runner,
+        )
+
+    @pytest.mark.asyncio
+    async def test_decode_corruption_recovers_and_reruns(self, processor, group_dir):
+        from video_grouper.task_processors.corrupt_recovery import RecoveryOutcome
+
+        task = _make_task(group_dir)
+        runner_patch, runner = self._patch_runner_seq(
+            [self._failed_corruption(), PipelineResult("complete")]
+        )
+        recover = AsyncMock(
+            return_value=RecoveryOutcome(repaired=True, lost_seconds=13.0)
+        )
+        with (
+            runner_patch,
+            patch(
+                "video_grouper.task_processors.corrupt_recovery.recover_pipeline_input",
+                new=recover,
+            ),
+        ):
+            await processor.process_item(task)
+
+        recover.assert_awaited_once()
+        assert runner.run.await_count == 2  # original run + one re-run on repair
+        state = json.loads((group_dir / "state.json").read_text())
+        assert state["status"] == "pipeline_complete"
+        assert state["corrupt_recovery_attempted"] is True
+
+    @pytest.mark.asyncio
+    async def test_recovery_not_retried_when_already_attempted(
+        self, processor, group_dir
+    ):
+        # The bound: a game already marked recovered must NOT recover again — it
+        # fails terminally instead of looping.
+        (group_dir / "state.json").write_text(
+            json.dumps({"status": "trimmed", "corrupt_recovery_attempted": True})
+        )
+        task = _make_task(group_dir)
+        runner_patch, runner = self._patch_runner_seq([self._failed_corruption()])
+        recover = AsyncMock()
+        with (
+            runner_patch,
+            patch(
+                "video_grouper.task_processors.corrupt_recovery.recover_pipeline_input",
+                new=recover,
+            ),
+        ):
+            await processor.process_item(task)
+
+        recover.assert_not_awaited()
+        assert runner.run.await_count == 1  # no re-run
+        state = json.loads((group_dir / "state.json").read_text())
+        assert state["status"] == "pipeline_failed"
+
+    @pytest.mark.asyncio
+    async def test_unrepairable_corruption_fails_terminally(self, processor, group_dir):
+        from video_grouper.task_processors.corrupt_recovery import RecoveryOutcome
+
+        task = _make_task(group_dir)
+        runner_patch, runner = self._patch_runner_seq([self._failed_corruption()])
+        recover = AsyncMock(
+            return_value=RecoveryOutcome(repaired=False, reason="no corruption found")
+        )
+        with (
+            runner_patch,
+            patch(
+                "video_grouper.task_processors.corrupt_recovery.recover_pipeline_input",
+                new=recover,
+            ),
+        ):
+            await processor.process_item(task)
+
+        recover.assert_awaited_once()
+        assert runner.run.await_count == 1  # not repaired -> no re-run
+        state = json.loads((group_dir / "state.json").read_text())
+        assert state["status"] == "pipeline_failed"
+        # Marked attempted (written before recovery) so it can't loop next pass.
+        assert state["corrupt_recovery_attempted"] is True
+
+
 class TestGetItemKey:
     def test_keys_equal_for_identical_tasks(self, processor, group_dir):
         a = _make_task(group_dir)

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -132,6 +132,30 @@ class StepReader(PipelineStep):
         return True
 
 
+class StepDecodeError(PipelineStep):
+    """Raises a libav decode error, as the real decode steps do on a corrupt input."""
+
+    name = "t_decode_err"
+    config_model = _Cfg
+    runtime = "service"
+
+    async def run(self, manifest, ctx):
+        import av.error
+
+        raise av.error.InvalidDataError(1094995529, "Invalid data found")
+
+
+class StepOtherError(PipelineStep):
+    """Raises a non-decode error (must NOT be classified as decode_corruption)."""
+
+    name = "t_other_err"
+    config_model = _Cfg
+    runtime = "service"
+
+    async def run(self, manifest, ctx):
+        raise ValueError("not a decode problem")
+
+
 class StepUnavail(PipelineStep):
     name = "t_unavail"
     config_model = _Cfg
@@ -174,6 +198,8 @@ for _s in (
     StepRebind,
     StepReader,
     StepUnavail,
+    StepDecodeError,
+    StepOtherError,
 ):
     register_step(_s.name, _s, _Cfg)
 
@@ -318,6 +344,27 @@ async def test_rebind_step_reruns_after_output_deleted(tmp_path):
     assert r2.ok  # recovered, not stuck
     assert RUN_COUNTS == {"t_rebind": 2, "t_reader": 2}
     assert (tmp_path / "corrected.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_decode_corruption_error_is_classified(tmp_path):
+    # A step raising a libav decode error must be tagged error_kind=
+    # "decode_corruption" so the pipeline_processor can fire reactive recovery.
+    result = await PipelineRunner([_spec("d", "t_decode_err")]).run(
+        str(tmp_path / "g.mp4"), str(tmp_path / "o.mp4"), _ctx(tmp_path)
+    )
+    assert result.status == "failed"
+    assert result.error_kind == "decode_corruption"
+
+
+@pytest.mark.asyncio
+async def test_non_decode_exception_not_classified(tmp_path):
+    # A non-decode exception must NOT be tagged as corruption (no recovery fired).
+    result = await PipelineRunner([_spec("o", "t_other_err")]).run(
+        str(tmp_path / "g.mp4"), str(tmp_path / "o.mp4"), _ctx(tmp_path)
+    )
+    assert result.status == "failed"
+    assert result.error_kind is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_video_loss_flag.py
+++ b/tests/test_video_loss_flag.py
@@ -1,10 +1,14 @@
-"""Tests that combine durably flags video lost to camera-recording corruption.
+"""Tests for the ``video_loss`` flag and the (reactive-only) decode cost of combine.
 
-A byte-complete-but-corrupt segment (PR #88's size check passes, yet a region is
-undecodable) is unrecoverable — re-downloading returns identical bytes — so the
-combine cuts the dead span and the game still ships. The requirement these tests
-guard is that it is NOT shipped as if perfect: combine persists a ``video_loss``
-marker on state.json so the dashboard / auditor / camera manager can see it.
+Two guarantees here:
+
+1. ``DirectoryState.set_video_loss`` round-trips the marker that records a game
+   lost footage to a camera SD-card recording error (set by the reactive recovery,
+   not by combine — see tests/test_corrupt_recovery.py).
+2. Combine pays ZERO decode cost: it is a fast stream-copy and must NOT decode the
+   video to hunt for in-file corruption (that ~realtime probe is reserved for the
+   reactive recovery, which only runs on a game already known to be corrupt). A
+   clean game therefore never decodes during combine.
 
 Real PyAV + real filesystem are required end-to-end (a mocked av.open can't fail
 mid-stream, and the flag is real file I/O), so this module overrides conftest's
@@ -17,6 +21,7 @@ import pytest
 
 from video_grouper.models import DirectoryState
 from video_grouper.task_processors.tasks.video import CombineTask
+from video_grouper.utils import ffmpeg_utils
 
 
 # --- Override conftest's autouse mocks for this module (use real PyAV/IO) ---
@@ -95,12 +100,16 @@ def test_directory_state_video_loss_roundtrip(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_combine_task_flags_corruption_end_to_end(tmp_path):
-    """CombineTask probes, cuts the corrupt region, and flags the loss.
+async def test_combine_does_not_proactively_decode(tmp_path, monkeypatch):
+    """Combine is a fast stream-copy: it must NOT decode the video to look for
+    in-file corruption — even when a segment IS corrupt.
 
-    Drives the real execute() path: it must detect the corrupt segment, populate
-    self.video_corruption (which VideoProcessor turns into the NTFY warning),
-    produce a combined.mp4 that decodes cleanly, and persist the video_loss flag.
+    This is the heart of the proactive->reactive rework: decoding every segment at
+    combine time costs ~realtime and would punish every clean game. We spy on the
+    decode-probe primitive (``_decode_probe_sync``, which every corruption-decode
+    path goes through) and assert combine never calls it. The combine still
+    succeeds via stream-copy; the corruption is left to be caught reactively by a
+    downstream decode step.
     """
     group_dir = tmp_path / "flash__2024.06.08_vs_Test_home"
     group_dir.mkdir()
@@ -110,6 +119,15 @@ async def test_combine_task_flags_corruption_end_to_end(tmp_path):
     _write_decodable_clip(bad, video_seconds=20.0)
     _corrupt_mid_file(bad)
 
+    probe_calls = {"n": 0}
+    real_probe = ffmpeg_utils._decode_probe_sync
+
+    def _spy(*args, **kwargs):
+        probe_calls["n"] += 1
+        return real_probe(*args, **kwargs)
+
+    monkeypatch.setattr(ffmpeg_utils, "_decode_probe_sync", _spy)
+
     task = CombineTask(group_dir=str(group_dir))
     # CombineTask resolves output via storage_path; point it at the group's parent.
     task.storage_path = str(tmp_path)
@@ -117,19 +135,13 @@ async def test_combine_task_flags_corruption_end_to_end(tmp_path):
     ok = await task.execute()
     assert ok is True
 
-    # The corruption was detected and recorded for the NTFY warning path.
-    assert len(task.video_corruption) == 1
-    assert os.path.basename(task.video_corruption[0]["path"]) == bad.name
-    assert task.video_corruption[0]["lost_seconds"] > 0
+    # ZERO decode cost: combine never decode-probed a single segment.
+    assert probe_calls["n"] == 0
+    # Combine no longer surfaces a corruption list (that moved to recovery).
+    assert not hasattr(task, "video_corruption")
 
-    # The combined output exists and decodes cleanly end-to-end (no garbage tail).
-    from video_grouper.utils.ffmpeg_utils import decode_probe
+    # The combined output still exists (stream-copied through, corruption and all).
+    assert os.path.exists(task.get_output_path())
 
-    out = task.get_output_path()
-    assert os.path.exists(out)
-    assert await decode_probe(out) is None
-
-    # The game is flagged — not silently shipped as if perfect.
-    marker = DirectoryState(str(group_dir)).get_video_loss()
-    assert marker is not None
-    assert marker["lost_seconds"] > 0
+    # And combine did NOT flag video_loss — the game is not yet known corrupt.
+    assert DirectoryState(str(group_dir)).get_video_loss() is None

--- a/tests/test_video_loss_flag.py
+++ b/tests/test_video_loss_flag.py
@@ -1,0 +1,135 @@
+"""Tests that combine durably flags video lost to camera-recording corruption.
+
+A byte-complete-but-corrupt segment (PR #88's size check passes, yet a region is
+undecodable) is unrecoverable — re-downloading returns identical bytes — so the
+combine cuts the dead span and the game still ships. The requirement these tests
+guard is that it is NOT shipped as if perfect: combine persists a ``video_loss``
+marker on state.json so the dashboard / auditor / camera manager can see it.
+
+Real PyAV + real filesystem are required end-to-end (a mocked av.open can't fail
+mid-stream, and the flag is real file I/O), so this module overrides conftest's
+autouse mocks the same way tests/test_audio_padding.py does.
+"""
+
+import os
+
+import pytest
+
+from video_grouper.models import DirectoryState
+from video_grouper.task_processors.tasks.video import CombineTask
+
+
+# --- Override conftest's autouse mocks for this module (use real PyAV/IO) ---
+@pytest.fixture(autouse=True)
+def mock_ffmpeg():
+    yield
+
+
+@pytest.fixture(autouse=True)
+def mock_file_system():
+    yield
+
+
+@pytest.fixture(autouse=True)
+def mock_httpx():
+    yield
+
+
+def _write_decodable_clip(path, video_seconds, fps=10, rate=16000):
+    """Write a real mp4 with random frames (breaks realistically when corrupted)."""
+    import av
+    import numpy as np
+
+    with av.open(str(path), "w", format="mp4") as container:
+        vstream = container.add_stream("mpeg4", rate=fps)
+        vstream.width = 64
+        vstream.height = 64
+        vstream.pix_fmt = "yuv420p"
+        astream = container.add_stream("aac", rate=rate)
+
+        rng = np.random.default_rng(0)
+        for i in range(int(round(video_seconds * fps))):
+            img = (rng.random((64, 64, 3)) * 255).astype(np.uint8)
+            frame = av.VideoFrame.from_ndarray(img, format="rgb24").reformat(
+                format="yuv420p"
+            )
+            frame.pts = i
+            for pkt in vstream.encode(frame):
+                container.mux(pkt)
+        for pkt in vstream.encode(None):
+            container.mux(pkt)
+
+        total_samples = int(round(video_seconds * rate))
+        written = 0
+        while written < total_samples:
+            n = min(1024, total_samples - written)
+            arr = np.zeros((2, n), dtype="float32")
+            aframe = av.AudioFrame.from_ndarray(arr, format="fltp", layout="stereo")
+            aframe.sample_rate = rate
+            for pkt in astream.encode(aframe):
+                container.mux(pkt)
+            written += n
+        for pkt in astream.encode(None):
+            container.mux(pkt)
+
+
+def _corrupt_mid_file(path, frac_start=0.80, frac_end=0.92):
+    data = bytearray(path.read_bytes())
+    n = len(data)
+    for i in range(int(n * frac_start), int(n * frac_end)):
+        data[i] = 0
+    path.write_bytes(bytes(data))
+
+
+def test_directory_state_video_loss_roundtrip(tmp_path):
+    """set_video_loss persists and get_video_loss reads back the marker."""
+    state = DirectoryState(str(tmp_path))
+    assert state.get_video_loss() is None
+
+    state.set_video_loss(13.0, "seg2.mp4 ~13s@287s")
+
+    marker = state.get_video_loss()
+    assert marker is not None
+    assert marker["lost_seconds"] == pytest.approx(13.0)
+    assert "seg2.mp4" in marker["detail"]
+
+
+@pytest.mark.asyncio
+async def test_combine_task_flags_corruption_end_to_end(tmp_path):
+    """CombineTask probes, cuts the corrupt region, and flags the loss.
+
+    Drives the real execute() path: it must detect the corrupt segment, populate
+    self.video_corruption (which VideoProcessor turns into the NTFY warning),
+    produce a combined.mp4 that decodes cleanly, and persist the video_loss flag.
+    """
+    group_dir = tmp_path / "flash__2024.06.08_vs_Test_home"
+    group_dir.mkdir()
+    good = group_dir / "00.00.00-00.05.00.mp4"
+    bad = group_dir / "00.05.00-00.10.00.mp4"
+    _write_decodable_clip(good, video_seconds=20.0)
+    _write_decodable_clip(bad, video_seconds=20.0)
+    _corrupt_mid_file(bad)
+
+    task = CombineTask(group_dir=str(group_dir))
+    # CombineTask resolves output via storage_path; point it at the group's parent.
+    task.storage_path = str(tmp_path)
+
+    ok = await task.execute()
+    assert ok is True
+
+    # The corruption was detected and recorded for the NTFY warning path.
+    assert len(task.video_corruption) == 1
+    assert os.path.basename(task.video_corruption[0]["path"]) == bad.name
+    assert task.video_corruption[0]["lost_seconds"] > 0
+
+    # The combined output exists and decodes cleanly end-to-end (no garbage tail).
+    from video_grouper.utils.ffmpeg_utils import decode_probe
+
+    out = task.get_output_path()
+    assert os.path.exists(out)
+    assert await decode_probe(out) is None
+
+    # The game is flagged — not silently shipped as if perfect.
+    marker = DirectoryState(str(group_dir)).get_video_loss()
+    assert marker is not None
+    assert marker["lost_seconds"] > 0

--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -147,50 +147,22 @@ class TestVideoProcessor:
         key = processor.get_item_key(combine_task)
         assert key == "combine:/test/group"
 
+        # Test trim task with new constructor
+        trim_task = TrimTask(
+            group_dir="/test/group", start_time="00:05:00", end_time="01:35:00"
+        )
+        assert processor.get_item_key(trim_task) == "trim:/test/group"
+
     @pytest.mark.asyncio
-    async def test_combine_with_video_corruption_sends_ntfy(
+    async def test_combine_no_longer_sends_corruption_ntfy(
         self, temp_storage, mock_config
     ):
-        """A completed combine that cut a corrupt video region sends an NTFY
-        warning so the game isn't shipped as if perfect."""
-        mock_upload_processor = Mock()
-        ntfy_api = Mock()
-        ntfy_api.send_notification = AsyncMock()
-        ntfy_processor = Mock()
-        ntfy_processor.ntfy_service = Mock(ntfy_api=ntfy_api)
+        """Combine no longer hunts for / warns about video corruption.
 
-        processor = VideoProcessor(
-            temp_storage,
-            mock_config,
-            mock_upload_processor,
-            ntfy_processor=ntfy_processor,
-        )
-
-        combine_task = CombineTask(group_dir="/test/group")
-        combine_task.video_corruption = [
-            {
-                "path": "/test/group/seg2.mp4",
-                "corrupt_start_seconds": 287.0,
-                "video_seconds": 300.0,
-                "lost_seconds": 13.0,
-            }
-        ]
-
-        with (
-            patch.object(combine_task, "execute", new_callable=AsyncMock) as mock_exec,
-            patch.object(processor, "_on_combine_complete", new_callable=AsyncMock),
-        ):
-            mock_exec.return_value = True
-            await processor.process_item(combine_task)
-
-        ntfy_api.send_notification.assert_awaited_once()
-        kwargs = ntfy_api.send_notification.await_args.kwargs
-        assert "13" in kwargs["message"]  # ~13s lost
-        assert "warning" in kwargs.get("tags", [])
-
-    @pytest.mark.asyncio
-    async def test_combine_no_corruption_no_ntfy(self, temp_storage, mock_config):
-        """A clean combine sends no corruption warning."""
+        That moved to the reactive recovery path (a pipeline decode step failing),
+        so a completed combine — even one whose output happens to carry corruption
+        — fires no corruption NTFY from the combine-complete transition.
+        """
         ntfy_api = Mock()
         ntfy_api.send_notification = AsyncMock()
         ntfy_processor = Mock()
@@ -201,7 +173,6 @@ class TestVideoProcessor:
         )
 
         combine_task = CombineTask(group_dir="/test/group")
-        combine_task.video_corruption = []
 
         with (
             patch.object(combine_task, "execute", new_callable=AsyncMock) as mock_exec,
@@ -211,13 +182,6 @@ class TestVideoProcessor:
             await processor.process_item(combine_task)
 
         ntfy_api.send_notification.assert_not_awaited()
-
-        # Test trim task with new constructor
-        trim_task = TrimTask(
-            group_dir="/test/group", start_time="00:05:00", end_time="01:35:00"
-        )
-        key = processor.get_item_key(trim_task)
-        assert key == "trim:/test/group"
 
     @pytest.mark.asyncio
     async def test_init_with_optional_services(self, temp_storage, mock_config):

--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -147,6 +147,71 @@ class TestVideoProcessor:
         key = processor.get_item_key(combine_task)
         assert key == "combine:/test/group"
 
+    @pytest.mark.asyncio
+    async def test_combine_with_video_corruption_sends_ntfy(
+        self, temp_storage, mock_config
+    ):
+        """A completed combine that cut a corrupt video region sends an NTFY
+        warning so the game isn't shipped as if perfect."""
+        mock_upload_processor = Mock()
+        ntfy_api = Mock()
+        ntfy_api.send_notification = AsyncMock()
+        ntfy_processor = Mock()
+        ntfy_processor.ntfy_service = Mock(ntfy_api=ntfy_api)
+
+        processor = VideoProcessor(
+            temp_storage,
+            mock_config,
+            mock_upload_processor,
+            ntfy_processor=ntfy_processor,
+        )
+
+        combine_task = CombineTask(group_dir="/test/group")
+        combine_task.video_corruption = [
+            {
+                "path": "/test/group/seg2.mp4",
+                "corrupt_start_seconds": 287.0,
+                "video_seconds": 300.0,
+                "lost_seconds": 13.0,
+            }
+        ]
+
+        with (
+            patch.object(combine_task, "execute", new_callable=AsyncMock) as mock_exec,
+            patch.object(processor, "_on_combine_complete", new_callable=AsyncMock),
+        ):
+            mock_exec.return_value = True
+            await processor.process_item(combine_task)
+
+        ntfy_api.send_notification.assert_awaited_once()
+        kwargs = ntfy_api.send_notification.await_args.kwargs
+        assert "13" in kwargs["message"]  # ~13s lost
+        assert "warning" in kwargs.get("tags", [])
+
+    @pytest.mark.asyncio
+    async def test_combine_no_corruption_no_ntfy(self, temp_storage, mock_config):
+        """A clean combine sends no corruption warning."""
+        ntfy_api = Mock()
+        ntfy_api.send_notification = AsyncMock()
+        ntfy_processor = Mock()
+        ntfy_processor.ntfy_service = Mock(ntfy_api=ntfy_api)
+
+        processor = VideoProcessor(
+            temp_storage, mock_config, Mock(), ntfy_processor=ntfy_processor
+        )
+
+        combine_task = CombineTask(group_dir="/test/group")
+        combine_task.video_corruption = []
+
+        with (
+            patch.object(combine_task, "execute", new_callable=AsyncMock) as mock_exec,
+            patch.object(processor, "_on_combine_complete", new_callable=AsyncMock),
+        ):
+            mock_exec.return_value = True
+            await processor.process_item(combine_task)
+
+        ntfy_api.send_notification.assert_not_awaited()
+
         # Test trim task with new constructor
         trim_task = TrimTask(
             group_dir="/test/group", start_time="00:05:00", end_time="01:35:00"

--- a/video_grouper/models/directory_state.py
+++ b/video_grouper/models/directory_state.py
@@ -313,6 +313,60 @@ class DirectoryState:
             f"Set youtube_playlist_name to '{playlist_name}' in {self.state_file_path}"
         )
 
+    def set_video_loss(self, lost_seconds: float, detail: str) -> None:
+        """Durably flag that combine dropped an undecodable region from this game.
+
+        Byte-complete-but-corrupt camera segments are unrecoverable (re-download
+        returns identical bytes), so combine cuts the dead span and the game
+        still ships — but it must NOT be shipped as if perfect. This persists a
+        ``video_loss`` marker on state.json (total seconds lost + a per-segment
+        detail string) so the dashboard, state auditor, and the camera manager
+        can see the game lost footage to a camera recording error. It's a flag,
+        not a status change: the trim/upload flow continues normally.
+        """
+        try:
+            with FileLock(self.state_file_path):
+                state_data = {"files": {}, "status": "pending", "error_message": None}
+                if os.path.exists(self.state_file_path):
+                    try:
+                        with open(self.state_file_path) as f:
+                            state_data = json.load(f)
+                    except (json.JSONDecodeError, FileNotFoundError):
+                        pass
+
+                state_data["video_loss"] = {
+                    "lost_seconds": round(lost_seconds, 1),
+                    "detail": detail,
+                }
+
+                os.makedirs(os.path.dirname(self.state_file_path), exist_ok=True)
+                temp_path = self.state_file_path + ".tmp"
+                with open(temp_path, "w") as f:
+                    json.dump(state_data, f, indent=4)
+                os.replace(temp_path, self.state_file_path)
+        except TimeoutError as e:
+            logger.error(f"Timeout setting video_loss for {self.directory_path}: {e}")
+        logger.warning(
+            "Flagged %.1fs of video loss in %s (%s)",
+            lost_seconds,
+            self.state_file_path,
+            detail,
+        )
+
+    def get_video_loss(self) -> dict | None:
+        """Return the ``video_loss`` marker (lost_seconds + detail) if any."""
+        try:
+            with FileLock(self.state_file_path):
+                if os.path.exists(self.state_file_path):
+                    try:
+                        with open(self.state_file_path) as f:
+                            return json.load(f).get("video_loss")
+                    except (json.JSONDecodeError, FileNotFoundError):
+                        return None
+        except TimeoutError as e:
+            logger.error(f"Timeout reading video_loss for {self.directory_path}: {e}")
+        return None
+
     async def set_ttt_recording_id(self, recording_id: str) -> None:
         """Persist the TTT recording ID for this group to state.json."""
         async with self._lock:

--- a/video_grouper/pipeline/runner.py
+++ b/video_grouper/pipeline/runner.py
@@ -57,6 +57,12 @@ class PipelineResult:
     awaiting_runtime: str | None = None
     failed_step: str | None = None
     error: str | None = None
+    # Set to ``"decode_corruption"`` when the step failed because libav couldn't
+    # decode the (stream-copied) input — an undecodable region a camera wrote to
+    # its SD card that combine/trim rode straight through. The pipeline_processor
+    # keys on this to fire reactive recovery (localize → keyframe-cut re-combine)
+    # instead of failing the game outright. ``None`` for every other failure.
+    error_kind: str | None = None
 
     @property
     def ok(self) -> bool:
@@ -208,7 +214,18 @@ class PipelineRunner:
                 ok = await self._run_step(step, manifest, ctx)
             except Exception as e:  # noqa: BLE001 — surface as a failed step
                 logger.exception("pipeline: step %s raised", spec.step_id)
-                return self._fail(manifest, spec.step_id, f"exception: {e}", spec.type)
+                # Classify a libav decode failure so the pipeline_processor can
+                # fire reactive corruption recovery instead of a terminal fail.
+                from video_grouper.utils.ffmpeg_utils import is_decode_corruption_error
+
+                kind = "decode_corruption" if is_decode_corruption_error(e) else None
+                return self._fail(
+                    manifest,
+                    spec.step_id,
+                    f"exception: {e}",
+                    spec.type,
+                    error_kind=kind,
+                )
 
             if not ok:
                 return self._fail(
@@ -276,7 +293,10 @@ class PipelineRunner:
         step_id: str,
         error: str,
         step_type: str | None = None,
+        error_kind: str | None = None,
     ) -> PipelineResult:
         logger.error("pipeline: step %s failed: %s", step_id, error)
         manifest.mark_failed(step_id, error, step_type=step_type)
-        return PipelineResult("failed", failed_step=step_id, error=error)
+        return PipelineResult(
+            "failed", failed_step=step_id, error=error, error_kind=error_kind
+        )

--- a/video_grouper/task_processors/corrupt_recovery.py
+++ b/video_grouper/task_processors/corrupt_recovery.py
@@ -1,0 +1,258 @@
+"""Reactive recovery for byte-complete-but-corrupt camera segments.
+
+Combine and trim are fast stream-copies that never decode video, so a camera
+segment with an undecodable HEVC region (byte-complete — PR #88's size check
+passes — yet corrupt on the SD card) rides straight through into the trimmed
+``-raw.mp4`` the config-driven pipeline consumes. The FIRST step that actually
+DECODES the video (stitch_correct / field_detect / render / frame_fanout — see
+the ``homegrown`` preset order) is where it surfaces, as an
+``av.error.InvalidDataError`` propagating out of the step.
+
+Rather than decode every game proactively to catch the rare corrupt one
+(~realtime cost on every clean game — 90-150 min for a 90-min game), recovery is
+REACTIVE: when a pipeline decode step fails, :class:`PipelineProcessor` calls
+:func:`recover_pipeline_input` on that game — already known to be corrupt — which:
+
+1. **Localizes** the corruption by null-decoding the SOURCE segments
+   (:func:`detect_video_decode_corruption` — the one expensive decode, ONLY here).
+2. **Repairs** by re-combining the segments with the corrupt one cut at its last
+   clean keyframe (:func:`combine_videos` ``corrupt_starts=`` — the proven path)
+   then re-trimming to the same ``-raw.mp4`` the pipeline reads.
+3. **Surfaces** the loss: a durable ``video_loss`` flag on state.json + the NTFY
+   warning, so the game isn't shipped as if perfect.
+4. **Invalidates** the pipeline manifest so the re-run starts fresh on the
+   repaired input.
+
+The decode steps run BEFORE upload (upload is queued only on ``pipeline_complete``),
+so recovery yields a clean output pre-upload — no re-upload of a corrupt version is
+needed. :class:`PipelineProcessor` bounds this to a single attempt per game (a
+persisted marker) so a corruption the cut can't resolve fails terminally instead of
+looping (the original N=16 retry-storm symptom).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Raw camera segments to re-combine live at the top of the group dir. Mirrors
+# CombineTask.VIDEO_EXTENSIONS / EXCLUDE_PREFIXES so recovery re-combines exactly
+# the inputs the original combine used (the trimmed ``-raw.mp4`` lives in a
+# subdirectory, so a top-level listing never picks it up).
+_SOURCE_EXTENSIONS = (".dav", ".mp4")
+_EXCLUDE_PREFIXES = ("combined",)
+
+
+@dataclass
+class RecoveryOutcome:
+    """Result of a recovery attempt.
+
+    ``repaired`` is True only when source corruption was localized AND the
+    combined/trimmed input was successfully rebuilt; the caller then re-runs the
+    pipeline on the repaired input. When False, ``reason`` says why (no localized
+    corruption, or a repair step failed) and the caller fails the game terminally.
+    """
+
+    repaired: bool
+    lost_seconds: float = 0.0
+    corruptions: list[dict] = field(default_factory=list)
+    reason: str | None = None
+
+
+def _source_segments(group_dir: str) -> list[str]:
+    """Top-level raw camera segments in *group_dir* (same selection as CombineTask)."""
+    segments: list[str] = []
+    try:
+        for name in sorted(os.listdir(group_dir)):
+            low = name.lower()
+            if low.endswith(_SOURCE_EXTENSIONS) and not low.startswith(
+                _EXCLUDE_PREFIXES
+            ):
+                segments.append(os.path.join(group_dir, name))
+    except FileNotFoundError:
+        pass
+    return segments
+
+
+def _camera_metadata(group_dir: str) -> tuple[str | None, str | None]:
+    """Best-effort camera name/type from state.json (re-stamped on the rebuild)."""
+    try:
+        from video_grouper.models import DirectoryState
+
+        first_file = DirectoryState(group_dir).get_first_file()
+        if first_file and first_file.metadata:
+            meta = first_file.metadata
+            name = meta.get("camera_name")
+            ctype = meta.get("camera_type")
+            return (
+                str(name) if name is not None else None,
+                str(ctype) if ctype is not None else None,
+            )
+    except Exception:  # noqa: BLE001 — metadata is optional, never block recovery
+        pass
+    return None, None
+
+
+async def notify_video_corruption(
+    ntfy_processor: Any, group_dir: str, corruptions: list[dict]
+) -> None:
+    """Notify the camera manager (via NTFY) that footage was lost to camera
+    recording corruption.
+
+    Unlike an audio gap (auto-corrected, no footage lost), this is a genuine loss:
+    a segment was byte-complete but had an undecodable region the camera wrote to
+    its SD card, which is unrecoverable (re-downloading returns identical bytes).
+    Recovery cut the dead span so the rest of the game stays in sync; this tells the
+    user roughly how much video the camera lost. Best-effort: never let a
+    notification failure affect recovery.
+    """
+    try:
+        ntfy_api = None
+        ntfy_service = getattr(ntfy_processor, "ntfy_service", None)
+        if ntfy_service is not None:
+            ntfy_api = getattr(ntfy_service, "ntfy_api", None)
+        if ntfy_api is None:
+            return
+
+        total_lost = sum(c["lost_seconds"] for c in corruptions)
+        game = os.path.basename(group_dir.rstrip("/\\"))
+        message = (
+            f"~{total_lost:.0f}s of {game} was lost to a camera recording "
+            f"error ({len(corruptions)} segment(s) had an undecodable video "
+            f"region). The dead span was cut so the rest stays in sync. This "
+            f"is unrecoverable — the camera's own recording is corrupt, "
+            f"re-downloading would return the same bad bytes."
+        )
+        await ntfy_api.send_notification(
+            message=message,
+            title=f"Video lost in {game}",
+            tags=["warning"],
+            priority=4,
+        )
+        logger.warning(
+            "RECOVERY: %.0fs of video lost to camera corruption in %s across "
+            "%d segment(s); cut the dead region and notified user",
+            total_lost,
+            group_dir,
+            len(corruptions),
+        )
+    except Exception as e:  # noqa: BLE001 — notification is best-effort
+        logger.error(
+            "RECOVERY: failed to send video-corruption NTFY for %s: %s", group_dir, e
+        )
+
+
+async def recover_pipeline_input(
+    group_dir: str,
+    storage_path: str,
+    input_path: str,
+    *,
+    config: Any,
+    ntfy_processor: Any = None,
+) -> RecoveryOutcome:
+    """Localize source corruption and rebuild the pipeline's input from it.
+
+    Called by :class:`PipelineProcessor` after a pipeline decode step failed with a
+    corruption error. ``input_path`` is the trimmed ``-raw.mp4`` the pipeline reads;
+    on success it is overwritten with a clean rebuild. See the module docstring.
+    """
+    from video_grouper.models import DirectoryState, MatchInfo
+    from video_grouper.pipeline.manifest import PipelineManifest
+    from video_grouper.task_processors.tasks.video import TrimTask
+    from video_grouper.utils.ffmpeg_utils import (
+        combine_videos,
+        detect_video_decode_corruption,
+        trim_video,
+    )
+    from video_grouper.utils.paths import get_combined_video_path
+
+    group_dir = str(group_dir)
+    sources = _source_segments(group_dir)
+    if not sources:
+        return RecoveryOutcome(False, reason="no source segments found to re-combine")
+
+    # Localize: the one expensive null-decode of every source segment, run ONLY
+    # here (game already known corrupt), never proactively.
+    corruptions = await asyncio.to_thread(detect_video_decode_corruption, sources)
+    if not corruptions:
+        # The decode failure wasn't a source-segment corruption we can cut around
+        # (e.g. a transient/codec issue). Don't loop — let the caller fail it.
+        return RecoveryOutcome(
+            False, reason="no decodable corruption localized in source segments"
+        )
+
+    corrupt_starts = {c["path"]: c["corrupt_start_seconds"] for c in corruptions}
+    total_lost = sum(c["lost_seconds"] for c in corruptions)
+    detail = "; ".join(
+        f"{os.path.basename(c['path'])} "
+        f"~{c['lost_seconds']:.0f}s@{c['corrupt_start_seconds']:.0f}s"
+        for c in corruptions
+    )
+    logger.error(
+        "RECOVERY: %d corrupt segment(s) in %s (~%.0fs lost); rebuilding "
+        "combined/trimmed with keyframe-aware cut: %s",
+        len(corruptions),
+        os.path.basename(group_dir),
+        total_lost,
+        detail,
+    )
+
+    # Repair (combine): re-combine with the corrupt region cut at its last clean
+    # keyframe — the proven _combine_copy degrade path. e6a339f's audio-align keeps
+    # A/V synced across the cut.
+    camera_name, camera_type = _camera_metadata(group_dir)
+    combined_path = get_combined_video_path(group_dir, storage_path)
+    ok = await combine_videos(
+        sources,
+        combined_path,
+        camera_name=camera_name,
+        camera_type=camera_type,
+        corrupt_starts=corrupt_starts,
+    )
+    if not ok:
+        return RecoveryOutcome(
+            False,
+            corruptions=corruptions,
+            reason="re-combine of source segments failed",
+        )
+
+    # Repair (trim): re-trim the rebuilt combined back to the SAME -raw.mp4 the
+    # pipeline consumes, using the offsets the original trim used.
+    match_info, _ = MatchInfo.get_or_create(group_dir, storage_path)
+    if match_info is None:
+        return RecoveryOutcome(
+            False, corruptions=corruptions, reason="no match_info to re-derive trim"
+        )
+    trim_end = getattr(getattr(config, "processing", None), "trim_end_enabled", False)
+    trim = TrimTask.from_match_info(group_dir, match_info, trim_end_enabled=trim_end)
+    ok = await trim_video(combined_path, input_path, trim.start_time, trim.end_time)
+    if not ok:
+        return RecoveryOutcome(
+            False, corruptions=corruptions, reason="re-trim of rebuilt combined failed"
+        )
+
+    # Surface: durable video_loss flag + NTFY warning, so it isn't shipped as if
+    # perfect.
+    try:
+        DirectoryState(group_dir).set_video_loss(total_lost, detail)
+    except Exception as e:  # noqa: BLE001 — flag is best-effort, repair already done
+        logger.error("RECOVERY: failed to flag video_loss for %s: %s", group_dir, e)
+    await notify_video_corruption(ntfy_processor, group_dir, corruptions)
+
+    # Invalidate the manifest so the pipeline re-runs every step on the repaired
+    # input (same path, new bytes — resume would otherwise replay stale outputs).
+    manifest_path = PipelineManifest.path_for(group_dir)
+    try:
+        if os.path.exists(manifest_path):
+            os.remove(manifest_path)
+    except OSError as e:
+        logger.warning("RECOVERY: could not delete manifest %s: %s", manifest_path, e)
+
+    return RecoveryOutcome(
+        repaired=True, lost_seconds=total_lost, corruptions=corruptions
+    )

--- a/video_grouper/task_processors/pipeline_processor.py
+++ b/video_grouper/task_processors/pipeline_processor.py
@@ -50,10 +50,15 @@ class PipelineProcessor(QueueProcessor):
         upload_processor=None,
         runtime: str = "service",
         resource_manager=None,
+        ntfy_processor=None,
     ):
         super().__init__(storage_path, config)
         self.upload_processor = upload_processor
         self.runtime = runtime
+        # Used by the reactive corruption-recovery path to warn the camera
+        # manager when a game lost footage to a camera SD-card recording error.
+        # Set post-construction by the app (ntfy is built after this processor).
+        self.ntfy_processor = ntfy_processor
         # One ResourceManager shared by every run this processor drives. Built
         # from config when not supplied so a standalone processor still gates
         # GPU/RAM-heavy/UI steps correctly.
@@ -148,6 +153,20 @@ class PipelineProcessor(QueueProcessor):
             )
             result = await runner.run(item.input_path, item.output_path, ctx)
 
+            # Reactive corruption recovery: a decode step rode into an undecodable
+            # region a camera wrote to its SD card (combine/trim stream-copied it
+            # through). Localize + keyframe-cut re-combine the source, then re-run
+            # the pipeline ONCE on the repaired input. Bounded to a single attempt
+            # per game (persisted marker) so a cut that can't fix it fails
+            # terminally instead of looping.
+            if result.status == "failed" and result.error_kind == "decode_corruption":
+                if await self._attempt_corruption_recovery(item):
+                    logger.info(
+                        "PIPELINE: re-running %s after corruption recovery",
+                        item.group_dir.name,
+                    )
+                    result = await runner.run(item.input_path, item.output_path, ctx)
+
             if result.status == "complete":
                 logger.info("PIPELINE: task completed: %s", item)
                 await self._handle_successful_completion(item)
@@ -175,6 +194,86 @@ class PipelineProcessor(QueueProcessor):
                 await self._mark_failed(item, result.error)
         except Exception as e:
             logger.error("PIPELINE: error processing task %s: %s", item, e)
+
+    async def _attempt_corruption_recovery(self, item: PipelineTask) -> bool:
+        """Try to repair a game whose pipeline failed on an undecodable region.
+
+        Returns True when the source corruption was localized and the
+        combined/trimmed input was rebuilt clean (caller re-runs the pipeline),
+        False otherwise (caller fails the game terminally).
+
+        BOUNDED: a ``corrupt_recovery_attempted`` marker is written to state.json
+        BEFORE recovery runs, and a game that already carries it is refused. So a
+        corruption the keyframe cut can't resolve (or a crash mid-recovery) fails
+        terminally on the next pass instead of looping forever — the N=16 symptom.
+        """
+        name = item.group_dir.name
+        if self._recovery_already_attempted(item.group_dir):
+            logger.error(
+                "PIPELINE: corruption persisted after recovery for %s; "
+                "failing terminally (recovery already attempted)",
+                name,
+            )
+            return False
+        # Persist the attempt FIRST: even if recovery crashes, the next pass must
+        # not retry it.
+        self._mark_recovery_attempted(item.group_dir)
+
+        from video_grouper.task_processors.corrupt_recovery import (
+            recover_pipeline_input,
+        )
+
+        try:
+            outcome = await recover_pipeline_input(
+                str(item.group_dir),
+                self.storage_path,
+                item.input_path,
+                config=self.config,
+                ntfy_processor=self.ntfy_processor,
+            )
+        except Exception as e:  # noqa: BLE001 — recovery is best-effort
+            logger.error("PIPELINE: corruption recovery raised for %s: %s", name, e)
+            return False
+
+        if outcome.repaired:
+            logger.warning(
+                "PIPELINE: recovered %s (~%.0fs lost to camera corruption); "
+                "re-running pipeline on the repaired input",
+                name,
+                outcome.lost_seconds,
+            )
+            return True
+        logger.error(
+            "PIPELINE: could not recover %s from corruption: %s", name, outcome.reason
+        )
+        return False
+
+    @staticmethod
+    def _recovery_already_attempted(group_dir: Path) -> bool:
+        state_file = group_dir / "state.json"
+        try:
+            with open(state_file) as f:
+                return bool(json.load(f).get("corrupt_recovery_attempted"))
+        except (OSError, json.JSONDecodeError):
+            return False
+
+    @staticmethod
+    def _mark_recovery_attempted(group_dir: Path) -> None:
+        state_file = group_dir / "state.json"
+        try:
+            state_data: dict = {}
+            if state_file.exists():
+                with open(state_file) as f:
+                    state_data = json.load(f)
+            state_data["corrupt_recovery_attempted"] = True
+            with open(state_file, "w") as f:
+                json.dump(state_data, f, indent=4)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error(
+                "PIPELINE: could not mark recovery attempt for %s: %s",
+                group_dir.name,
+                e,
+            )
 
     @staticmethod
     def _read_team_name(group_dir: Path) -> str | None:

--- a/video_grouper/task_processors/tasks/video/combine_task.py
+++ b/video_grouper/task_processors/tasks/video/combine_task.py
@@ -11,7 +11,6 @@ from video_grouper.models import DirectoryState
 from video_grouper.utils.ffmpeg_utils import (
     combine_videos,
     detect_audio_video_gaps,
-    detect_video_decode_corruption,
 )
 from video_grouper.utils.paths import (
     get_combined_video_path,
@@ -97,13 +96,9 @@ class CombineTask(BaseFfmpegTask):
         """
         # Segments whose audio is materially shorter than their video, detected
         # before combining. The combine itself pads each gap with silence (see
-        # _combine_copy); VideoProcessor reads this list to warn the user.
+        # _combine_copy); VideoProcessor reads this list to warn the user. This is
+        # a CHEAP metadata-only probe (container durations), not a decode.
         self.audio_gaps: list[dict] = []
-        # Segments with an undecodable video region (byte-complete but corrupt
-        # on the camera's SD card — unrecoverable, see detect_video_decode_
-        # corruption). The combine cuts the dead span; VideoProcessor reads this
-        # list to warn the user and flag the game as shipped-with-loss.
-        self.video_corruption: list[dict] = []
 
         dav_files = self.get_dav_files()
         if not dav_files:
@@ -123,26 +118,15 @@ class CombineTask(BaseFfmpegTask):
                 ),
             )
 
-        # Decode-probe each segment for in-file corruption a size check can't
-        # see. PR #88 already guarantees byte-complete downloads, so anything
-        # this finds is camera-side and unrecoverable — degrade (cut the dead
-        # region in combine), don't re-download.
-        self.video_corruption = detect_video_decode_corruption(dav_files)
-        corrupt_starts = {
-            c["path"]: c["corrupt_start_seconds"] for c in self.video_corruption
-        }
-        if self.video_corruption:
-            logger.error(
-                "COMBINE: %d segment(s) in %s have an undecodable video region; "
-                "cutting the dead span (camera recording error, unrecoverable): %s",
-                len(self.video_corruption),
-                os.path.basename(self.group_dir),
-                ", ".join(
-                    f"{os.path.basename(c['path'])} "
-                    f"(~{c['lost_seconds']:.0f}s lost from {c['corrupt_start_seconds']:.0f}s)"
-                    for c in self.video_corruption
-                ),
-            )
+        # NOTE: combine is a fast stream-copy and deliberately does NOT decode the
+        # video to hunt for in-file (byte-complete-but-corrupt) HEVC corruption.
+        # A full decode-probe of every segment costs ~realtime (90-150 min on a
+        # 90-min game) and clean games would pay it for nothing. Instead the
+        # corruption rides through the stream-copy and is caught REACTIVELY when a
+        # downstream pipeline step first actually decodes the video and fails —
+        # see video_grouper.task_processors.corrupt_recovery, which only then
+        # localizes (decode-probe) and re-combines this segment list with the
+        # corrupt region keyframe-cut via combine_videos(corrupt_starts=...).
 
         output_path = self.get_output_path()
 
@@ -159,15 +143,15 @@ class CombineTask(BaseFfmpegTask):
             pass  # Non-critical: metadata is optional
 
         try:
-            # Pass file paths directly to combine_videos (PyAV-based).
-            # corrupt_starts tells combine where to cut each segment's
-            # undecodable video region so the dead span is dropped, not muxed.
+            # Pass file paths directly to combine_videos (PyAV-based). No
+            # corrupt_starts here: combine never decodes, so it can't (and
+            # shouldn't) localize corruption — that's the reactive recovery's job
+            # if a downstream decode step fails.
             success = await combine_videos(
                 dav_files,
                 output_path,
                 camera_name=camera_name,
                 camera_type=camera_type,
-                corrupt_starts=corrupt_starts,
             )
 
             if success:
@@ -189,18 +173,6 @@ class CombineTask(BaseFfmpegTask):
 
             logger.info(f"COMBINE: Successfully combined videos in {self.group_dir}")
             await dir_state.update_group_status("combined")
-
-            # If combine had to cut a corrupt (unrecoverable) video region,
-            # durably flag the game so it isn't shipped as if perfect. This is a
-            # marker, not a status change — the trim/upload flow continues.
-            if self.video_corruption:
-                total_lost = sum(c["lost_seconds"] for c in self.video_corruption)
-                detail = "; ".join(
-                    f"{os.path.basename(c['path'])} "
-                    f"~{c['lost_seconds']:.0f}s@{c['corrupt_start_seconds']:.0f}s"
-                    for c in self.video_corruption
-                )
-                dir_state.set_video_loss(total_lost, detail)
 
             # Match info gathering is triggered by VideoProcessor._on_combine_complete()
             # which fires async API lookups and NTFY questions after this task completes.

--- a/video_grouper/task_processors/tasks/video/combine_task.py
+++ b/video_grouper/task_processors/tasks/video/combine_task.py
@@ -8,7 +8,11 @@ from dataclasses import dataclass
 from typing import Any
 
 from video_grouper.models import DirectoryState
-from video_grouper.utils.ffmpeg_utils import combine_videos, detect_audio_video_gaps
+from video_grouper.utils.ffmpeg_utils import (
+    combine_videos,
+    detect_audio_video_gaps,
+    detect_video_decode_corruption,
+)
 from video_grouper.utils.paths import (
     get_combined_video_path,
     resolve_path,
@@ -95,6 +99,11 @@ class CombineTask(BaseFfmpegTask):
         # before combining. The combine itself pads each gap with silence (see
         # _combine_copy); VideoProcessor reads this list to warn the user.
         self.audio_gaps: list[dict] = []
+        # Segments with an undecodable video region (byte-complete but corrupt
+        # on the camera's SD card — unrecoverable, see detect_video_decode_
+        # corruption). The combine cuts the dead span; VideoProcessor reads this
+        # list to warn the user and flag the game as shipped-with-loss.
+        self.video_corruption: list[dict] = []
 
         dav_files = self.get_dav_files()
         if not dav_files:
@@ -114,6 +123,27 @@ class CombineTask(BaseFfmpegTask):
                 ),
             )
 
+        # Decode-probe each segment for in-file corruption a size check can't
+        # see. PR #88 already guarantees byte-complete downloads, so anything
+        # this finds is camera-side and unrecoverable — degrade (cut the dead
+        # region in combine), don't re-download.
+        self.video_corruption = detect_video_decode_corruption(dav_files)
+        corrupt_starts = {
+            c["path"]: c["corrupt_start_seconds"] for c in self.video_corruption
+        }
+        if self.video_corruption:
+            logger.error(
+                "COMBINE: %d segment(s) in %s have an undecodable video region; "
+                "cutting the dead span (camera recording error, unrecoverable): %s",
+                len(self.video_corruption),
+                os.path.basename(self.group_dir),
+                ", ".join(
+                    f"{os.path.basename(c['path'])} "
+                    f"(~{c['lost_seconds']:.0f}s lost from {c['corrupt_start_seconds']:.0f}s)"
+                    for c in self.video_corruption
+                ),
+            )
+
         output_path = self.get_output_path()
 
         # Extract camera metadata from the group's state.json
@@ -129,9 +159,15 @@ class CombineTask(BaseFfmpegTask):
             pass  # Non-critical: metadata is optional
 
         try:
-            # Pass file paths directly to combine_videos (PyAV-based)
+            # Pass file paths directly to combine_videos (PyAV-based).
+            # corrupt_starts tells combine where to cut each segment's
+            # undecodable video region so the dead span is dropped, not muxed.
             success = await combine_videos(
-                dav_files, output_path, camera_name=camera_name, camera_type=camera_type
+                dav_files,
+                output_path,
+                camera_name=camera_name,
+                camera_type=camera_type,
+                corrupt_starts=corrupt_starts,
             )
 
             if success:
@@ -153,6 +189,18 @@ class CombineTask(BaseFfmpegTask):
 
             logger.info(f"COMBINE: Successfully combined videos in {self.group_dir}")
             await dir_state.update_group_status("combined")
+
+            # If combine had to cut a corrupt (unrecoverable) video region,
+            # durably flag the game so it isn't shipped as if perfect. This is a
+            # marker, not a status change — the trim/upload flow continues.
+            if self.video_corruption:
+                total_lost = sum(c["lost_seconds"] for c in self.video_corruption)
+                detail = "; ".join(
+                    f"{os.path.basename(c['path'])} "
+                    f"~{c['lost_seconds']:.0f}s@{c['corrupt_start_seconds']:.0f}s"
+                    for c in self.video_corruption
+                )
+                dir_state.set_video_loss(total_lost, detail)
 
             # Match info gathering is triggered by VideoProcessor._on_combine_complete()
             # which fires async API lookups and NTFY questions after this task completes.

--- a/video_grouper/task_processors/video_processor.py
+++ b/video_grouper/task_processors/video_processor.py
@@ -101,6 +101,14 @@ class VideoProcessor(QueueProcessor):
                         await self._send_audio_gap_warning(
                             item.get_item_path(), audio_gaps
                         )
+                    # Warn separately if combine had to cut an undecodable video
+                    # region (camera SD-card corruption, unrecoverable — the
+                    # game shipped with that span removed, not as if perfect).
+                    video_corruption = getattr(item, "video_corruption", None)
+                    if video_corruption:
+                        await self._send_video_corruption_warning(
+                            item.get_item_path(), video_corruption
+                        )
                     asyncio.create_task(self._on_combine_complete(item.get_item_path()))
                 elif (
                     item.task_type == "trim"
@@ -248,6 +256,55 @@ class VideoProcessor(QueueProcessor):
             )
         except Exception as e:
             logger.error(f"VIDEO: Failed to send audio-gap NTFY for {group_dir}: {e}")
+
+    async def _send_video_corruption_warning(
+        self, group_dir: str, corruptions: list[dict]
+    ) -> None:
+        """Notify the camera manager (via NTFY) that footage was lost to camera
+        recording corruption.
+
+        Reuses the same NTFY plumbing as ``_send_audio_gap_warning``. Unlike an
+        audio gap (auto-corrected, no footage lost), this is a genuine loss: the
+        segment was byte-complete but had an undecodable region the camera wrote
+        to its SD card, which is unrecoverable (re-downloading returns identical
+        bytes). Combine cut the dead span so the rest of the game stays in sync;
+        this tells the user roughly how much video the camera lost.
+        Best-effort: never let a notification failure affect video processing.
+        """
+        try:
+            ntfy_api = None
+            ntfy_service = getattr(self.ntfy_processor, "ntfy_service", None)
+            if ntfy_service is not None:
+                ntfy_api = getattr(ntfy_service, "ntfy_api", None)
+            if ntfy_api is None:
+                return
+
+            total_lost = sum(c["lost_seconds"] for c in corruptions)
+            game = os.path.basename(group_dir.rstrip("/\\"))
+            message = (
+                f"~{total_lost:.0f}s of {game} was lost to a camera recording "
+                f"error ({len(corruptions)} segment(s) had an undecodable video "
+                f"region). The dead span was cut so the rest stays in sync. This "
+                f"is unrecoverable — the camera's own recording is corrupt, "
+                f"re-downloading would return the same bad bytes."
+            )
+            await ntfy_api.send_notification(
+                message=message,
+                title=f"Video lost in {game}",
+                tags=["warning"],
+                priority=4,
+            )
+            logger.warning(
+                "VIDEO: %.0fs of video lost to camera corruption in %s across "
+                "%d segment(s); cut the dead region and notified user",
+                total_lost,
+                group_dir,
+                len(corruptions),
+            )
+        except Exception as e:
+            logger.error(
+                f"VIDEO: Failed to send video-corruption NTFY for {group_dir}: {e}"
+            )
 
     async def _on_trim_complete(self, group_dir: str) -> None:
         """Skip post-trim processing and transition directly to upload.

--- a/video_grouper/task_processors/video_processor.py
+++ b/video_grouper/task_processors/video_processor.py
@@ -101,14 +101,12 @@ class VideoProcessor(QueueProcessor):
                         await self._send_audio_gap_warning(
                             item.get_item_path(), audio_gaps
                         )
-                    # Warn separately if combine had to cut an undecodable video
-                    # region (camera SD-card corruption, unrecoverable — the
-                    # game shipped with that span removed, not as if perfect).
-                    video_corruption = getattr(item, "video_corruption", None)
-                    if video_corruption:
-                        await self._send_video_corruption_warning(
-                            item.get_item_path(), video_corruption
-                        )
+                    # NOTE: combine no longer hunts for undecodable video regions
+                    # (that would mean decoding every clean game). In-file camera
+                    # corruption is caught + surfaced REACTIVELY when a pipeline
+                    # decode step first fails — see corrupt_recovery, which sends
+                    # the video-corruption NTFY via _send_video_corruption_warning's
+                    # shared notifier at that point.
                     asyncio.create_task(self._on_combine_complete(item.get_item_path()))
                 elif (
                     item.task_type == "trim"
@@ -263,48 +261,18 @@ class VideoProcessor(QueueProcessor):
         """Notify the camera manager (via NTFY) that footage was lost to camera
         recording corruption.
 
-        Reuses the same NTFY plumbing as ``_send_audio_gap_warning``. Unlike an
-        audio gap (auto-corrected, no footage lost), this is a genuine loss: the
-        segment was byte-complete but had an undecodable region the camera wrote
-        to its SD card, which is unrecoverable (re-downloading returns identical
-        bytes). Combine cut the dead span so the rest of the game stays in sync;
-        this tells the user roughly how much video the camera lost.
-        Best-effort: never let a notification failure affect video processing.
+        Thin wrapper over the shared
+        :func:`~video_grouper.task_processors.corrupt_recovery.notify_video_corruption`
+        notifier, which the reactive recovery path also uses. Kept here so the
+        same NTFY plumbing (``ntfy_processor.ntfy_service.ntfy_api``) has one
+        home and one message format. Best-effort: never let a notification
+        failure affect video processing.
         """
-        try:
-            ntfy_api = None
-            ntfy_service = getattr(self.ntfy_processor, "ntfy_service", None)
-            if ntfy_service is not None:
-                ntfy_api = getattr(ntfy_service, "ntfy_api", None)
-            if ntfy_api is None:
-                return
+        from video_grouper.task_processors.corrupt_recovery import (
+            notify_video_corruption,
+        )
 
-            total_lost = sum(c["lost_seconds"] for c in corruptions)
-            game = os.path.basename(group_dir.rstrip("/\\"))
-            message = (
-                f"~{total_lost:.0f}s of {game} was lost to a camera recording "
-                f"error ({len(corruptions)} segment(s) had an undecodable video "
-                f"region). The dead span was cut so the rest stays in sync. This "
-                f"is unrecoverable — the camera's own recording is corrupt, "
-                f"re-downloading would return the same bad bytes."
-            )
-            await ntfy_api.send_notification(
-                message=message,
-                title=f"Video lost in {game}",
-                tags=["warning"],
-                priority=4,
-            )
-            logger.warning(
-                "VIDEO: %.0fs of video lost to camera corruption in %s across "
-                "%d segment(s); cut the dead region and notified user",
-                total_lost,
-                group_dir,
-                len(corruptions),
-            )
-        except Exception as e:
-            logger.error(
-                f"VIDEO: Failed to send video-corruption NTFY for {group_dir}: {e}"
-            )
+        await notify_video_corruption(self.ntfy_processor, group_dir, corruptions)
 
     async def _on_trim_complete(self, group_dir: str) -> None:
         """Skip post-trim processing and transition directly to upload.

--- a/video_grouper/utils/ffmpeg_utils.py
+++ b/video_grouper/utils/ffmpeg_utils.py
@@ -132,6 +132,22 @@ def av_open_write(
     return av.open(path, "w", format=format, timeout=timeout, **kwargs)
 
 
+def is_decode_corruption_error(exc: BaseException) -> bool:
+    """True if *exc* is a libav decode error (corrupt / undecodable bitstream).
+
+    PyAV raises ``av.error.InvalidDataError`` (a subclass of ``FFmpegError``) from
+    ``avcodec_send_packet`` when a stream-copied segment carries a region the camera
+    wrote corrupt to its own SD card — a fault a size check and a stream-copy mux both
+    ride straight through, and which only a real decode trips. The pipeline's decode
+    steps (stitch/field/render/fanout) let it propagate; this classifier lets the
+    runner tag the failure so the *reactive* recovery path (localize → keyframe-cut
+    re-combine) fires ONLY when a decode step actually hit one, never proactively.
+    """
+    # InvalidDataError is a subclass of FFmpegError, so the base catches both; the
+    # union spells out the headline case for the reader.
+    return isinstance(exc, av.error.InvalidDataError | av.error.FFmpegError)
+
+
 def _scaled_timeout(file_paths: list[str], base_timeout: int = FFMPEG_TIMEOUT) -> int:
     """Scale the FFmpeg timeout based on total input file size.
 
@@ -880,9 +896,14 @@ def detect_video_decode_corruption(
     segment's container duration, and ``lost_seconds`` the trailing span removed
     by the combine degrade path (measured from ``cut_seconds`` so it reflects the
     real, keyframe-aligned cut). ``_combine_copy`` consumes ``corrupt_start_seconds``
-    to locate the same keyframe and drop the dead video region on a GOP boundary;
-    ``VideoProcessor`` surfaces the list as an NTFY warning and flags the game so
-    it isn't shipped as if perfect.
+    to locate the same keyframe and drop the dead video region on a GOP boundary.
+
+    This is an EXPENSIVE full decode-and-discard of every segment, so it is NOT run
+    proactively. It is the *localize* half of the reactive recovery
+    (:mod:`video_grouper.task_processors.corrupt_recovery`): it runs only after a
+    pipeline decode step has already failed on a game, i.e. one already known to be
+    corrupt. The recovery then re-combines with these cuts, flags ``video_loss``, and
+    sends the NTFY warning, so a corrupt game isn't shipped as if perfect.
     """
     corruptions: list[dict] = []
     for path in file_paths:

--- a/video_grouper/utils/ffmpeg_utils.py
+++ b/video_grouper/utils/ffmpeg_utils.py
@@ -52,6 +52,25 @@ _AUDIO_PAD_EPSILON_SECONDS = 0.5
 # encoder framing. Padding still happens regardless; this only gates the alert.
 AUDIO_GAP_WARN_THRESHOLD_SECONDS = 3.0
 
+# Decode-probe tuning. PR #88 guarantees every downloaded segment is
+# byte-complete (size == camera-reported), but a byte-complete file can still
+# carry a corrupt HEVC region the camera wrote to its own SD card: it decodes
+# fine for minutes, then avcodec_send_packet raises InvalidDataError and the
+# rest of the segment is undecodable. A size check can't see this and a
+# stream-copy combine can't either (a pure mux never calls the decoder, so the
+# garbage packets get muxed straight through). Only forcing a real decode trips
+# on it — see decode_probe / detect_video_decode_corruption below.
+#
+# DECODE_PROBE_WINDOW_SECONDS: how many seconds to actually decode per sampled
+# window. Big enough to force avcodec_send_packet over a meaningful run of
+# packets, small enough that probing a multi-hour recording stays a few seconds.
+DECODE_PROBE_WINDOW_SECONDS = 3.0
+# DECODE_PROBE_STEP_SECONDS: spacing between sampled windows when scanning a
+# whole segment for the first decode failure. The 06.08 corruption sat ~287s
+# into a 300s file, so a coarse sweep across the segment (not just first/mid/
+# last) is what localizes the dead region cheaply.
+DECODE_PROBE_STEP_SECONDS = 30.0
+
 # numpy dtype (as a string) to allocate silence for each libav sample format.
 _SILENCE_DTYPE = {
     "dbl": "float64",
@@ -178,6 +197,159 @@ async def get_video_duration(file_path: str) -> float | None:
         return await asyncio.to_thread(_get_video_duration_sync, file_path)
     except Exception as e:
         logger.error(f"Error getting video duration: {e}")
+        return None
+
+
+def _decode_window_sync(
+    container, video_stream, start_sec: float, window_seconds: float
+) -> None:
+    """Decode ~``window_seconds`` of *video_stream* starting at *start_sec*.
+
+    Seeks to the window start and decodes packets, which is where libav calls
+    ``avcodec_send_packet`` — the exact call that raises on a corrupt HEVC
+    packet that size-only validation can't see (demux alone never decodes, so
+    it never trips). Raises ``av.error.FFmpegError`` / ``av.error.Invalid
+    DataError`` on corruption; returns normally when the window decodes clean.
+    """
+    time_base = video_stream.time_base
+    if start_sec > 0 and time_base:
+        container.seek(int(start_sec / time_base), stream=video_stream)
+
+    first_pts_sec = None
+    for packet in container.demux(video_stream):
+        for frame in packet.decode():
+            if frame.pts is not None and time_base:
+                frame_sec = float(frame.pts * time_base)
+                if first_pts_sec is None:
+                    first_pts_sec = frame_sec
+                elif frame_sec - first_pts_sec >= window_seconds:
+                    return
+
+
+def _window_decodes_clean(
+    container, video_stream, start_sec: float, window_seconds: float
+) -> bool:
+    """True if a ``window_seconds`` window from *start_sec* decodes without error."""
+    try:
+        _decode_window_sync(container, video_stream, start_sec, window_seconds)
+        return True
+    except (av.error.InvalidDataError, av.error.FFmpegError):
+        return False
+
+
+def _decode_probe_sync(file_path: str, window_seconds: float) -> float | None:
+    """Synchronous implementation of :func:`decode_probe`.
+
+    Two passes, so the whole file isn't re-decoded yet the cut point is precise:
+
+    1. *Coarse sweep* — decode a window at 0, then every
+       ``DECODE_PROBE_STEP_SECONDS``, then the tail, until one fails.
+    2. *Refine* — walk forward in ``window_seconds`` steps from the last clean
+       window to the failing one to localize the FIRST undecodable second.
+
+    Returns ``None`` if every sampled window decodes cleanly, else the refined
+    second where decoding first fails — the start of the undecodable region, so
+    the combine cuts there and drops the dead tail (not a window-rounded
+    over-cut that would leave bad packets straddling the join).
+    """
+    with av_open_read(file_path) as container:
+        if not container.streams.video:
+            logger.warning("DECODE_PROBE: no video stream in %s", file_path)
+            return 0.0
+        video_stream = container.streams.video[0]
+
+        duration = None
+        time_base = video_stream.time_base
+        if video_stream.duration is not None and time_base:
+            duration = float(video_stream.duration * time_base)
+        elif container.duration is not None:
+            duration = container.duration / av.time_base
+
+        # Coarse sweep: 0, body @ STEP spacing, then the tail.
+        window_starts = [0.0]
+        if duration is not None and duration > window_seconds:
+            t = DECODE_PROBE_STEP_SECONDS
+            while t < duration - window_seconds:
+                window_starts.append(t)
+                t += DECODE_PROBE_STEP_SECONDS
+            window_starts.append(max(0.0, duration - window_seconds))
+        window_starts = sorted(set(window_starts))
+
+        last_clean = 0.0
+        coarse_fail = None
+        for start_sec in window_starts:
+            if _window_decodes_clean(
+                container, video_stream, start_sec, window_seconds
+            ):
+                last_clean = start_sec + window_seconds
+            else:
+                coarse_fail = start_sec
+                break
+
+        if coarse_fail is None:
+            return None
+
+        # Refine: walk window-by-window from the last clean point up to the
+        # coarse failure to find the first failing second precisely.
+        refine = last_clean
+        while refine < coarse_fail:
+            if _window_decodes_clean(container, video_stream, refine, window_seconds):
+                refine += window_seconds
+            else:
+                break
+
+        first_bad = refine if refine <= coarse_fail else coarse_fail
+        logger.warning(
+            "DECODE_PROBE: %s first undecodable region near %.1fs",
+            os.path.basename(file_path),
+            first_bad,
+        )
+        return first_bad
+
+
+async def decode_probe(
+    file_path: str, window_seconds: float = DECODE_PROBE_WINDOW_SECONDS
+) -> float | None:
+    """Probe *file_path* for an undecodable region by forcing a real decode.
+
+    Size checks can't see in-file corruption: a camera segment can download at
+    EXACTLY the reported byte count (so PR #88's completeness check passes) yet
+    carry a corrupt HEVC packet the camera wrote to its SD card, which explodes
+    the decoder (``InvalidDataError`` from ``avcodec_send_packet``) only when
+    something actually decodes the stream — combine/trim stream-copy never does,
+    so the garbage rides straight through into the shipped video.
+
+    This samples windows across the file and forces a decode over each, which is
+    cheap (no full re-decode) but reliably trips on the bad packet.
+
+    Returns ``None`` when every sampled window decodes cleanly, or the
+    approximate second where the first decode failure starts (so the combine can
+    cut from there). A missing-file / missing-stream case returns ``0.0`` (whole
+    segment is unusable).
+    """
+    if not os.path.exists(file_path):
+        logger.error("DECODE_PROBE: file not found: %s", file_path)
+        return 0.0
+    try:
+        return await _run_in_thread_with_timeout(
+            _decode_probe_sync, file_path, window_seconds, timeout=120
+        )
+    except (av.error.InvalidDataError, av.error.FFmpegError) as e:
+        logger.warning(
+            "DECODE_PROBE: %s failed decode probe: %s",
+            os.path.basename(file_path),
+            e,
+        )
+        return 0.0
+    except TimeoutError:
+        logger.error("DECODE_PROBE: timed out probing %s", os.path.basename(file_path))
+        return None
+    except Exception as e:
+        logger.error(
+            "DECODE_PROBE: unexpected error probing %s: %s",
+            os.path.basename(file_path),
+            e,
+        )
         return None
 
 
@@ -651,17 +823,73 @@ def detect_audio_video_gaps(
     return gaps
 
 
+def detect_video_decode_corruption(
+    file_paths: list[str],
+    window_seconds: float = DECODE_PROBE_WINDOW_SECONDS,
+) -> list[dict]:
+    """Return source segments that decode partway then hit a corrupt region.
+
+    The sibling of :func:`detect_audio_video_gaps` for the case audio/video
+    *duration* matching can't catch: the 06.08 segment decoded fine to 287.07s,
+    then ``avcodec_send_packet`` raised and ~13s was undecodable, yet the
+    container's *duration* still read the full 300s (the corrupt packets carry
+    PTS), so the audio-gap detector saw nothing wrong. Only a decode probe trips
+    on it.
+
+    Each entry is ``{"path", "corrupt_start_seconds", "video_seconds",
+    "lost_seconds"}`` where ``corrupt_start_seconds`` is where decoding first
+    failed (the cut point), ``video_seconds`` the segment's container duration,
+    and ``lost_seconds`` the trailing span that gets removed by the combine
+    degrade path. ``_combine_copy`` consumes ``corrupt_start_seconds`` to drop
+    the dead video region; ``VideoProcessor`` surfaces the list as an NTFY
+    warning and flags the game so it isn't shipped as if perfect.
+    """
+    corruptions: list[dict] = []
+    for path in file_paths:
+        try:
+            corrupt_start = _decode_probe_sync(path, window_seconds)
+        except Exception as exc:
+            logger.warning(f"COMBINE: decode probe failed for {path}: {exc}")
+            continue
+        if corrupt_start is None:
+            continue
+        video_seconds = corrupt_start
+        try:
+            dur = _get_video_duration_sync(path)
+            if dur is not None:
+                video_seconds = dur
+        except Exception:
+            pass
+        lost_seconds = max(0.0, video_seconds - corrupt_start)
+        corruptions.append(
+            {
+                "path": path,
+                "corrupt_start_seconds": corrupt_start,
+                "video_seconds": video_seconds,
+                "lost_seconds": lost_seconds,
+            }
+        )
+    return corruptions
+
+
 def _combine_videos_sync(
     file_paths: list[str],
     output_path: str,
     camera_name: str | None = None,
     camera_type: str | None = None,
+    corrupt_starts: dict[str, float] | None = None,
 ) -> bool:
     """Synchronous implementation: concatenate multiple video files (video copy, AAC re-encode).
 
     Uses stream copy for video regardless of codec (H.264, HEVC, etc.) for speed.
     HEVC-to-H.264 transcoding is deferred to later pipeline stages (trim/autocam)
     where the video is shorter and transcoding is practical.
+
+    ``corrupt_starts`` maps a segment path to the second where its video becomes
+    undecodable (from :func:`detect_video_decode_corruption`). The combine cuts
+    each such segment's video at that point so the dead region is dropped instead
+    of muxed as garbage; the audio-align step then trims that segment's audio to
+    the shortened video, keeping A/V in sync with the corrupt span removed.
     """
     if not file_paths:
         raise ValueError("No files to combine")
@@ -697,12 +925,20 @@ def _combine_videos_sync(
             raise ValueError("No video stream found in first input file")
 
         return _combine_copy(
-            file_paths, output_container, out_video_stream, out_audio_stream
+            file_paths,
+            output_container,
+            out_video_stream,
+            out_audio_stream,
+            corrupt_starts or {},
         )
 
 
 def _combine_copy(
-    file_paths: list[str], output_container, out_video_stream, out_audio_stream
+    file_paths: list[str],
+    output_container,
+    out_video_stream,
+    out_audio_stream,
+    corrupt_starts: dict[str, float] | None = None,
 ) -> bool:
     """Concatenate files using stream copy (fast path for H.264 input).
 
@@ -720,13 +956,25 @@ def _combine_copy(
     (audio longer than video), the excess audio is trimmed so it can't push
     later segments' audio ahead of their video. ``detect_audio_video_gaps``
     surfaces either condition to the user as an NTFY warning.
+
+    ``corrupt_starts`` (path -> second) marks segments with an undecodable
+    region (from :func:`detect_video_decode_corruption`). For such a segment we
+    DEGRADE rather than mux garbage: video packets at/after the corrupt second
+    are dropped, so the dead span is cut. The per-segment audio target is
+    shrunk to the cut point too, so the existing audio-trim/pad logic re-aligns
+    that segment's audio to its now-shorter video — A/V stays in sync with the
+    corrupt region removed.
     """
+    corrupt_starts = corrupt_starts or {}
     video_pts_offset = 0
     # A decoded real frame, reused as the format/layout/rate template for any
     # silence we synthesize. Captured from the first segment that has audio.
     audio_template = None
 
     for file_path in file_paths:
+        # If this segment was flagged corrupt, cut its video at the first
+        # undecodable second instead of muxing the garbage that follows.
+        seg_cut_s = corrupt_starts.get(file_path)
         with av_open_read(file_path) as input_container:
             in_video = None
             in_audio = None
@@ -752,6 +1000,21 @@ def _combine_copy(
             seg_video_target_s = None
             if in_video is not None and in_video.duration:
                 seg_video_target_s = float(in_video.duration * in_video.time_base)
+            # A corrupt segment's metadata duration still reads the full length
+            # (the bad packets carry PTS), so clamp the audio target to the cut
+            # point — otherwise audio would be trimmed/padded to dead video.
+            if seg_cut_s is not None:
+                seg_video_target_s = (
+                    seg_cut_s
+                    if seg_video_target_s is None
+                    else min(seg_video_target_s, seg_cut_s)
+                )
+                logger.warning(
+                    "COMBINE: cutting corrupt video region in %s at %.1fs "
+                    "(dropping the undecodable tail)",
+                    os.path.basename(file_path),
+                    seg_cut_s,
+                )
 
             for packet in input_container.demux(streams_to_demux):
                 if packet.dts is None:
@@ -765,6 +1028,17 @@ def _combine_copy(
                         packet.dts -= first_dts[in_video.index]
                         packet.pts -= first_dts[in_video.index]
                         if packet.dts < 0:
+                            continue
+
+                        # Cut the dead region: once this corrupt segment reaches
+                        # the undecodable second, stop muxing its video so the
+                        # garbage tail never lands in the output.
+                        if (
+                            seg_cut_s is not None
+                            and in_video.time_base
+                            and packet.pts is not None
+                            and float(packet.pts * in_video.time_base) >= seg_cut_s
+                        ):
                             continue
 
                         # Track max pts for offset calculation
@@ -838,6 +1112,7 @@ async def combine_videos(
     output_path: str,
     camera_name: str | None = None,
     camera_type: str | None = None,
+    corrupt_starts: dict[str, float] | None = None,
 ) -> bool:
     """Combines multiple video files into a single MP4 using PyAV.
 
@@ -849,6 +1124,10 @@ async def combine_videos(
         output_path: Path for the combined output file.
         camera_name: Optional camera name to embed in MP4 metadata.
         camera_type: Optional camera type to embed in MP4 metadata.
+        corrupt_starts: Optional map of segment path -> second where its video
+            becomes undecodable (from :func:`detect_video_decode_corruption`).
+            Each such segment's video is cut at that point so the dead region is
+            dropped rather than muxed as garbage.
     """
     logger.info(
         f"Combining {len(file_paths)} videos to {os.path.basename(output_path)}"
@@ -862,6 +1141,7 @@ async def combine_videos(
             temp_output,
             camera_name,
             camera_type,
+            corrupt_starts,
             timeout=timeout,
         )
         if result:

--- a/video_grouper/utils/ffmpeg_utils.py
+++ b/video_grouper/utils/ffmpeg_utils.py
@@ -823,6 +823,42 @@ def detect_audio_video_gaps(
     return gaps
 
 
+def _last_keyframe_pts_seconds(file_path: str, before_seconds: float) -> float | None:
+    """Return the largest keyframe pts (in seconds) at or before *before_seconds*.
+
+    A cheap metadata-only pass: demux the video stream without decoding and track
+    the latest keyframe whose pts is <= *before_seconds*. The cut for a corrupt
+    segment must land here so the muxed stream ends on a complete I-frame with no
+    dangling P/B references — cutting at the raw corrupt second lands mid-GOP and
+    leaves an incomplete access unit that ``avcodec_send_packet`` later rejects.
+
+    Returns ``None`` if no keyframe exists at/before *before_seconds* (corruption
+    in the very first GOP), in which case the caller must drop the segment's video
+    entirely rather than emit a broken stream.
+    """
+    with av_open_read(file_path) as container:
+        if not container.streams.video:
+            return None
+        video_stream = container.streams.video[0]
+        time_base = video_stream.time_base
+        if time_base is None:
+            return None
+        last_kf_pts: float | None = None
+        for packet in container.demux(video_stream):
+            if packet.pts is None or not packet.is_keyframe:
+                continue
+            pts_s = float(packet.pts * time_base)
+            if pts_s <= before_seconds:
+                if last_kf_pts is None or pts_s > last_kf_pts:
+                    last_kf_pts = pts_s
+            else:
+                # Packets are demuxed in dts order; once a keyframe's pts passes
+                # the threshold we could still see an earlier-pts keyframe (open
+                # GOP reordering), so don't break — but the common case stops here.
+                continue
+        return last_kf_pts
+
+
 def detect_video_decode_corruption(
     file_paths: list[str],
     window_seconds: float = DECODE_PROBE_WINDOW_SECONDS,
@@ -836,13 +872,17 @@ def detect_video_decode_corruption(
     PTS), so the audio-gap detector saw nothing wrong. Only a decode probe trips
     on it.
 
-    Each entry is ``{"path", "corrupt_start_seconds", "video_seconds",
-    "lost_seconds"}`` where ``corrupt_start_seconds`` is where decoding first
-    failed (the cut point), ``video_seconds`` the segment's container duration,
-    and ``lost_seconds`` the trailing span that gets removed by the combine
-    degrade path. ``_combine_copy`` consumes ``corrupt_start_seconds`` to drop
-    the dead video region; ``VideoProcessor`` surfaces the list as an NTFY
-    warning and flags the game so it isn't shipped as if perfect.
+    Each entry is ``{"path", "corrupt_start_seconds", "cut_seconds",
+    "video_seconds", "lost_seconds"}`` where ``corrupt_start_seconds`` is where
+    decoding first failed, ``cut_seconds`` is the keyframe-aligned point where the
+    combine actually cuts the segment's video (the last GOP boundary at/before the
+    corrupt second — ``None`` if no keyframe precedes it), ``video_seconds`` the
+    segment's container duration, and ``lost_seconds`` the trailing span removed
+    by the combine degrade path (measured from ``cut_seconds`` so it reflects the
+    real, keyframe-aligned cut). ``_combine_copy`` consumes ``corrupt_start_seconds``
+    to locate the same keyframe and drop the dead video region on a GOP boundary;
+    ``VideoProcessor`` surfaces the list as an NTFY warning and flags the game so
+    it isn't shipped as if perfect.
     """
     corruptions: list[dict] = []
     for path in file_paths:
@@ -860,11 +900,23 @@ def detect_video_decode_corruption(
                 video_seconds = dur
         except Exception:
             pass
-        lost_seconds = max(0.0, video_seconds - corrupt_start)
+        # Keyframe-align the cut so lost_seconds reflects the real GOP-boundary
+        # cut the combine will make, not the raw corrupt second.
+        cut_seconds: float | None
+        try:
+            cut_seconds = _last_keyframe_pts_seconds(path, corrupt_start)
+        except Exception as exc:
+            logger.warning(f"COMBINE: keyframe scan failed for {path}: {exc}")
+            cut_seconds = None
+        # No keyframe at/before the corrupt point => first-GOP corruption; the
+        # combine drops the whole segment's video, so the entire span is lost.
+        effective_cut = cut_seconds if cut_seconds is not None else 0.0
+        lost_seconds = max(0.0, video_seconds - effective_cut)
         corruptions.append(
             {
                 "path": path,
                 "corrupt_start_seconds": corrupt_start,
+                "cut_seconds": cut_seconds,
                 "video_seconds": video_seconds,
                 "lost_seconds": lost_seconds,
             }
@@ -959,11 +1011,18 @@ def _combine_copy(
 
     ``corrupt_starts`` (path -> second) marks segments with an undecodable
     region (from :func:`detect_video_decode_corruption`). For such a segment we
-    DEGRADE rather than mux garbage: video packets at/after the corrupt second
-    are dropped, so the dead span is cut. The per-segment audio target is
-    shrunk to the cut point too, so the existing audio-trim/pad logic re-aligns
-    that segment's audio to its now-shorter video — A/V stays in sync with the
-    corrupt region removed.
+    DEGRADE rather than mux garbage, and the cut is KEYFRAME-AWARE: we first scan
+    the segment's video packets for the last keyframe (``packet.is_keyframe``)
+    whose pts is at/before the corrupt second, then mux only video packets up to
+    and including that keyframe's GOP. Cutting at the raw corrupt second would
+    land mid-GOP and leave dangling P/B frames whose access unit is incomplete,
+    so the muxed stream would still explode ``avcodec_send_packet`` on decode —
+    the exact defect this guards against. Ending on a GOP boundary keeps the
+    output fully decodable. If no keyframe precedes the corrupt second (corruption
+    in the first GOP), the segment's video is dropped entirely rather than emit a
+    broken stream. The per-segment audio target is shrunk to the keyframe cut too,
+    so the existing audio-trim/pad logic re-aligns that segment's audio to its
+    now-shorter video — A/V stays in sync with the corrupt region removed.
     """
     corrupt_starts = corrupt_starts or {}
     video_pts_offset = 0
@@ -972,9 +1031,32 @@ def _combine_copy(
     audio_template = None
 
     for file_path in file_paths:
-        # If this segment was flagged corrupt, cut its video at the first
-        # undecodable second instead of muxing the garbage that follows.
-        seg_cut_s = corrupt_starts.get(file_path)
+        # If this segment was flagged corrupt, cut its video on a GOP boundary
+        # (the last keyframe at/before the corrupt second) instead of muxing the
+        # garbage that follows. A raw mid-GOP cut leaves an incomplete access
+        # unit the decoder later rejects, so first resolve the keyframe pts.
+        seg_corrupt_s = corrupt_starts.get(file_path)
+        # Keyframe-aligned cut point (raw pts seconds) for a corrupt segment;
+        # 0.0 when its video is dropped wholesale. Only meaningful when
+        # ``seg_corrupt_s`` is not None.
+        seg_cut_s: float = 0.0
+        drop_segment_video = False
+        if seg_corrupt_s is not None:
+            last_kf_pts = _last_keyframe_pts_seconds(file_path, seg_corrupt_s)
+            if last_kf_pts is None:
+                # Corruption in the very first GOP: there is no clean keyframe to
+                # end on, so dropping the whole segment's video is the only way to
+                # avoid emitting a broken stream.
+                drop_segment_video = True
+                seg_cut_s = 0.0
+                logger.error(
+                    "COMBINE: %s is corrupt within its first GOP (no keyframe "
+                    "at/before %.1fs); dropping this segment's video entirely",
+                    os.path.basename(file_path),
+                    seg_corrupt_s,
+                )
+            else:
+                seg_cut_s = last_kf_pts
         with av_open_read(file_path) as input_container:
             in_video = None
             in_audio = None
@@ -1001,20 +1083,24 @@ def _combine_copy(
             if in_video is not None and in_video.duration:
                 seg_video_target_s = float(in_video.duration * in_video.time_base)
             # A corrupt segment's metadata duration still reads the full length
-            # (the bad packets carry PTS), so clamp the audio target to the cut
-            # point — otherwise audio would be trimmed/padded to dead video.
-            if seg_cut_s is not None:
+            # (the bad packets carry PTS), so clamp the audio target to the
+            # keyframe cut point — otherwise audio would be trimmed/padded to dead
+            # video.
+            if seg_corrupt_s is not None:
                 seg_video_target_s = (
                     seg_cut_s
                     if seg_video_target_s is None
                     else min(seg_video_target_s, seg_cut_s)
                 )
-                logger.warning(
-                    "COMBINE: cutting corrupt video region in %s at %.1fs "
-                    "(dropping the undecodable tail)",
-                    os.path.basename(file_path),
-                    seg_cut_s,
-                )
+                if not drop_segment_video:
+                    logger.warning(
+                        "COMBINE: cutting corrupt video region in %s at GOP "
+                        "boundary %.3fs (corruption first seen ~%.1fs; dropping "
+                        "the undecodable tail)",
+                        os.path.basename(file_path),
+                        seg_cut_s,
+                        seg_corrupt_s,
+                    )
 
             for packet in input_container.demux(streams_to_demux):
                 if packet.dts is None:
@@ -1022,23 +1108,32 @@ def _combine_copy(
 
                 try:
                     if packet.stream == in_video:
+                        # Cut the dead region on a GOP boundary BEFORE normalizing:
+                        # ``seg_cut_s`` is the keyframe pts in *raw* seconds (same
+                        # frame of reference as :func:`_last_keyframe_pts_seconds`),
+                        # so compare the raw pts here. Drop this corrupt segment's
+                        # video once its pts passes the keyframe cut, so the muxed
+                        # stream ends on a complete I-frame (no dangling P/B
+                        # references) and the garbage tail never lands in the
+                        # output. ``drop_segment_video`` drops it wholesale when no
+                        # clean keyframe precedes the corruption.
+                        if drop_segment_video:
+                            continue
+                        if (
+                            seg_corrupt_s is not None
+                            and seg_cut_s is not None
+                            and in_video.time_base
+                            and packet.pts is not None
+                            and float(packet.pts * in_video.time_base) > seg_cut_s
+                        ):
+                            continue
+
                         # Normalize and offset
                         if in_video.index not in first_dts:
                             first_dts[in_video.index] = packet.dts
                         packet.dts -= first_dts[in_video.index]
                         packet.pts -= first_dts[in_video.index]
                         if packet.dts < 0:
-                            continue
-
-                        # Cut the dead region: once this corrupt segment reaches
-                        # the undecodable second, stop muxing its video so the
-                        # garbage tail never lands in the output.
-                        if (
-                            seg_cut_s is not None
-                            and in_video.time_base
-                            and packet.pts is not None
-                            and float(packet.pts * in_video.time_base) >= seg_cut_s
-                        ):
                             continue
 
                         # Track max pts for offset calculation

--- a/video_grouper/video_grouper_app.py
+++ b/video_grouper/video_grouper_app.py
@@ -310,6 +310,11 @@ class VideoGrouperApp:
             self.video_processor.match_info_service = match_info_service
             self.video_processor.ntfy_processor = self.ntfy_processor
 
+            # Wire ntfy into the PipelineProcessor so reactive corruption
+            # recovery can warn the camera manager about lost footage.
+            if self.pipeline_processor is not None:
+                self.pipeline_processor.ntfy_processor = self.ntfy_processor
+
             # Wire ntfy_service into UploadProcessor for auth failure notifications
             # and playlist name requests
             self.upload_processor.ntfy_service = ntfy_service


### PR DESCRIPTION
## Problem

A camera segment can download at exactly its camera-reported byte size (so PR #88's size check passes) yet contain an **undecodable HEVC region the camera wrote badly to its own SD card** — the real 06.08 case: decodes fine to 287s, then `avcodec_send_packet()` throws and ~13s is unrecoverable (re-downloading returns byte-identical data). A size check can't see it and a stream-copy combine can't either, so the corruption was muxed straight into the combined/uploaded video (silent glitch with `autocam_gui`) or silently dead-dropped the game (homegrown render crash → never retried).

This also explains the 06.08 audio offset: e6a339f's audio-align padded the missing audio, but the underlying **video** corruption was never handled.

## Approach — reactive, not proactive

Decoding every game to find the rare corrupt one costs ~realtime (90–150 min/game) — unacceptable. So combine/trim stay fast stream-copies (**clean games add zero decode**), and corruption is caught **reactively**: when the first real video-decode step in the pipeline (`render`, which runs **before** upload) raises an av decode error, the runner tags it `decode_corruption` and `PipelineProcessor`:

1. **Localizes** by null-decoding the source segments (the one expensive decode, only on a game already known corrupt)
2. **Repairs** by re-combining with the corrupt segment cut at its last clean **keyframe** (so the output ends on a complete GOP), re-trimming to the same input
3. **Surfaces** the loss: durable `video_loss` flag on state.json + NTFY warning
4. **Re-runs** the pipeline once on the clean output — no re-upload needed (decode fails before upload)

Recovery is **bounded to one attempt** per game via a persisted marker, eliminating the infinite-retry storm.

## Verification

- Keyframe cut: real-data PASS on 06.08 (full decode, zero errors, A/V synced).
- Full-pipeline E2E on real 06.08 corruption: **23/23 checks** — silent combine → decode-fail tagged → recovery → `video_loss`(13s) + NTFY → clean re-run completes → repaired input decodes fully clean → bounded retry caps a still-corrupt game terminally.
- 1376 unit tests pass, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)