### PR TITLE
feat(annotation): far-ball labeling queue — set generator + obscured/distractor + context overlay

### DIFF
--- a/training/annotation_server.py
+++ b/training/annotation_server.py
@@ -1670,6 +1670,110 @@ async def get_field_boundary_panoramic(
 
 
 # Static file mount must come AFTER all API routes (catch-all).
+# ------------------------------------------------------------------
+# Far-ball labeling sets. A "set" is a directory under FAR_LABEL_DIR with a
+# manifest.json (built by cli/build_far_label_queue) + pre-extracted full-frame
+# strips. Labels are collected in SOURCE pixel coords, stored next to the set.
+# Independent of the tile-pack/manifest system (clips aren't tiled).
+
+FAR_LABEL_DIR = Path("D:/training_data/far_label")
+
+
+def _far_set_dir(set_id: str) -> Path:
+    d = FAR_LABEL_DIR / set_id
+    if not (d / "manifest.json").exists():
+        raise HTTPException(404, f"Far-label set not found: {set_id}")
+    return d
+
+
+def _load_far_manifest(set_id: str) -> dict:
+    with open(_far_set_dir(set_id) / "manifest.json") as f:
+        return json.load(f)
+
+
+def _load_far_labels(set_id: str) -> dict[int, dict]:
+    p = FAR_LABEL_DIR / set_id / "labels.json"
+    if not p.exists():
+        return {}
+    with open(p) as f:
+        return {int(r["frame_idx"]): r for r in json.load(f)}
+
+
+def _save_far_labels(set_id: str, labels: dict[int, dict]) -> None:
+    p = FAR_LABEL_DIR / set_id / "labels.json"
+    with open(p, "w") as f:
+        json.dump([labels[k] for k in sorted(labels)], f, indent=2)
+
+
+@app.get("/api/far-label")
+async def list_far_sets():
+    """List far-ball labeling sets with progress."""
+    out = []
+    if not FAR_LABEL_DIR.exists():
+        return out
+    for d in sorted(FAR_LABEL_DIR.iterdir()):
+        if not (d / "manifest.json").exists():
+            continue
+        with open(d / "manifest.json") as f:
+            m = json.load(f)
+        labels = _load_far_labels(d.name)
+        out.append(
+            {
+                "set": d.name,
+                "n_frames": m.get("n_frames", len(m.get("frames", []))),
+                "labeled": len(labels),
+                "criteria": m.get("criteria"),
+            }
+        )
+    return out
+
+
+@app.get("/api/far-label/{set_id}")
+async def get_far_set(set_id: str):
+    """Manifest + existing labels + progress for a far-label set."""
+    m = _load_far_manifest(set_id)
+    labels = _load_far_labels(set_id)
+    return {**m, "labels": [labels[k] for k in sorted(labels)], "labeled": len(labels)}
+
+
+@app.get("/api/far-label/{set_id}/strip/{frame_idx}")
+async def get_far_strip(set_id: str, frame_idx: int):
+    """Serve a pre-extracted full-frame strip (native-res JPEG)."""
+    d = _far_set_dir(set_id)
+    strip = d / "strips" / f"f{frame_idx:06d}.jpg"
+    if not strip.exists():
+        raise HTTPException(404, f"Strip not found: {frame_idx}")
+    return FileResponse(strip, media_type="image/jpeg")
+
+
+@app.post("/api/far-label/{set_id}/result")
+async def submit_far_label(set_id: str, result: dict):
+    """Store one far-ball label.
+
+    Expected: ``{"frame_idx": int, "action": str, "x": float|null, "y": float|null}`` — x/y are
+    SOURCE pixels. ``action`` is one of ``ball`` (visible, at x/y), ``obscured`` (occluded behind a
+    player — x/y is the human's best-guess path position; used as tracker GT, NOT detector-positive),
+    ``not_game_ball`` (a distractor, e.g. sideline/adjacent-field ball — a hard negative),
+    ``out_of_play`` / ``not_visible`` (no findable game ball). ``reason`` (the set's selection reason)
+    is stored verbatim if sent.
+    """
+    _load_far_manifest(set_id)  # validate set
+    labels = _load_far_labels(set_id)
+    fi = int(result["frame_idx"])
+    labels[fi] = {
+        "frame_idx": fi,
+        "action": result.get("action", "ball"),
+        "x": result.get("x"),
+        "y": result.get("y"),
+        "reason": result.get("reason"),
+        "source": result.get("source", "human"),
+        "submitted_at": datetime.now(UTC).isoformat(),
+    }
+    _save_far_labels(set_id, labels)
+    return {"accepted": True, "labeled": len(labels)}
+
+
+# Static file mount must come AFTER all API routes (catch-all).
 app.mount(
     "/static",
     StaticFiles(directory=Path(__file__).parent / "static"),

--- a/training/cli/build_far_label_queue.py
+++ b/training/cli/build_far_label_queue.py
@@ -1,0 +1,370 @@
+r"""Build a far-label review SET for a game — active-learning selection of the *hard* frames.
+
+Consolidates the ad-hoc ``build_*farlabel*`` / ``build_0615_*`` one-off scripts into ONE committed,
+parameterized CLI. Selects the frames where AutoCam loses or doubts the ball — which is usually
+**occlusion** (the ball behind a player), plus far-field and distractor ambiguity — extracts
+full-frame strips, and writes the ``manifest.json`` the annotation server + ``far-label.html`` consume
+(``D:/training_data/far_label/<set>/{manifest.json, strips/f######.jpg}``). It NEVER writes
+``labels.json`` (server-owned). Self-contained: no dependency outside ``av`` / ``cv2`` / ``numpy``.
+
+Selection criteria (``--criteria``):
+  * ``lost``       — no on-field AutoCam detection that frame (ball lost = occlusion / gone far).
+  * ``lowconf``    — top on-field detection confidence in ``[lc_lo, lc_hi)`` (detector unsure).
+  * ``distractor`` — 2+ on-field candidates of similar confidence (which one is the game ball?).
+  * ``hard``       — the union (default): the frames AutoCam struggles with, the high-value tail.
+
+Frames are restricted to active play (``game_state``), temporally spread into ``--max-frames`` bins
+(most-ambiguous per bin, so no clustering), and any frames already in ``--exclude-sets`` are skipped.
+
+    python -m training.cli.build_far_label_queue \
+        --game-dir "F:/Heat_2012s/2026.06.07 - vs Lakefront SC (home)" \
+        --criteria hard --max-frames 160
+    # --analyze prints the selection stats/yields WITHOUT decoding or writing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+
+# --------------------------------------------------------------------------- #
+# Canonical per-game sidecar helpers (inlined so this tool is self-contained). #
+# --------------------------------------------------------------------------- #
+def seg_offsets(segments: list[dict]) -> dict[str, int]:
+    """``{segment_name: global_offset}`` from ``game.json`` ``segments`` (global = offset + f)."""
+    return {s["seg"]: int(s["global_offset"]) for s in segments}
+
+
+def active_play_ranges(segments, game_state) -> list[tuple[int, int]]:
+    """Global-frame ``[(lo, hi), ...]`` for the halves (``first_half``/``second_half``) from
+    ``game.json`` ``game_state`` — drops warm-up / halftime / pre- & post-game. ``[]`` if unknown."""
+    offs = seg_offsets(segments)
+    out: list[tuple[int, int]] = []
+    for ph in game_state or []:
+        if ph.get("phase") in ("first_half", "second_half"):
+            s, e = ph.get("start"), ph.get("end")
+            if s and e and s[0] in offs and e[0] in offs:
+                out.append((offs[s[0]] + int(s[1]), offs[e[0]] + int(e[1])))
+    return out
+
+
+def load_detections(jsonl_path, offsets: dict[str, int]) -> dict[int, list[tuple]]:
+    """Parse ``autocam_detections.jsonl`` -> ``{global_frame: [(x, y, conf), ...]}`` (conf-desc)."""
+    out: dict[int, list[tuple]] = defaultdict(list)
+    with open(jsonl_path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or '"_meta"' in line[:12]:
+                continue
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "x" not in o or "y" not in o or o.get("seg") not in offsets:
+                continue
+            g = offsets[o["seg"]] + int(o["f"])
+            out[g].append((float(o["x"]), float(o["y"]), float(o.get("conf", 0.0))))
+    for g in out:
+        out[g].sort(key=lambda c: c[2], reverse=True)
+    return dict(out)
+
+
+def resolve_video_rotation(video_path, explicit=None) -> int:
+    """Display-rotation for a video: ``explicit`` if set, else ``game.json`` ``video_rotation``, else 0."""
+    if explicit:
+        return int(explicit)
+    try:
+        gj = Path(video_path).parent / "game.json"
+        if gj.exists():
+            return int(json.loads(gj.read_text()).get("video_rotation", 0) or 0)
+    except Exception:  # noqa: BLE001
+        pass
+    return 0
+
+
+def apply_display_rotation(img, video_rotation):
+    """PyAV ignores the container display-matrix; flip 180 for the upside-down-mounted games."""
+    if video_rotation in (180, -180):
+        import cv2
+
+        return cv2.flip(img, -1)
+    return img
+
+
+# --------------------------------------------------------------------------- #
+# Frame selection                                                             #
+# --------------------------------------------------------------------------- #
+def _in_field(poly_np: np.ndarray, x: float, y: float, margin: float) -> bool:
+    import cv2
+
+    return cv2.pointPolygonTest(poly_np, (float(x), float(y)), True) >= margin
+
+
+# frame offsets whose AutoCam ball position is shown to the human as ghost context — so an occluded
+# ball can be placed by interpolating the path just before/after it (the tracker's job, done by eye).
+_CTX_OFFSETS = (-24, -16, -8, -4, 4, 8, 16, 24)
+
+
+def _context(dets, poly_np, margin, f: int, stride: int) -> list[dict]:
+    ctx = []
+    for d in _CTX_OFFSETS:
+        g = f + d * stride
+        for c in dets.get(g, ()):
+            if _in_field(poly_np, c[0], c[1], margin):
+                ctx.append(
+                    {
+                        "df": d,
+                        "x": round(float(c[0]), 1),
+                        "y": round(float(c[1]), 1),
+                        "conf": round(float(c[2]), 3),
+                    }
+                )
+                break
+    return ctx
+
+
+def select_frames(
+    dets: dict[int, list],
+    poly_np: np.ndarray,
+    in_active,
+    *,
+    criteria: str,
+    lc_lo: float,
+    lc_hi: float,
+    dist_ratio: float,
+    target: int,
+    exclude: set[int],
+    margin: float,
+    stride: int,
+) -> list[dict]:
+    """Return chosen frames as manifest ``frames[]`` dicts, temporally spread over ``target`` bins."""
+    pool: list[list] = []  # [frame, reason, (hx, hy), conf, score, autocam]
+    for f in sorted(dets):
+        if f in exclude or not in_active(f):
+            continue
+        onfield = [c for c in dets[f] if _in_field(poly_np, c[0], c[1], margin)]
+        if not onfield:
+            if criteria in ("lost", "hard"):
+                pool.append([f, "lost", (3840.0, 1080.0), 0.0, 1.0, False])
+            continue
+        onfield.sort(key=lambda c: -float(c[2]))
+        top = onfield[0]
+        conf = float(top[2])
+        reason, score = None, 0.0
+        if criteria in ("lowconf", "hard") and lc_lo <= conf < lc_hi:
+            reason, score = "lowconf_visible", (lc_hi - conf)
+        elif (
+            criteria in ("distractor", "hard")
+            and len(onfield) >= 2
+            and float(onfield[1][2]) >= dist_ratio * conf
+            and conf >= lc_hi
+        ):
+            reason, score = "distractor", float(onfield[1][2]) / max(conf, 1e-6)
+        if reason:
+            pool.append([f, reason, (float(top[0]), float(top[1])), conf, score, True])
+    if not pool:
+        return []
+    fmin, fmax = pool[0][0], pool[-1][0]
+    span = max(1, fmax - fmin)
+    bins: dict[int, list] = {}
+    for c in pool:
+        b = int((c[0] - fmin) / span * (target - 1))
+        if b not in bins or c[4] > bins[b][4]:
+            bins[b] = c
+    chosen = sorted(bins.values(), key=lambda r: r[0])
+    return [
+        {
+            "frame_idx": int(f),
+            "file": f"f{int(f):06d}.jpg",
+            "hint_x": round(hx, 1),
+            "hint_y": round(hy, 1),
+            "autocam": bool(ac),
+            "hint_conf": round(conf, 3),
+            "reason": reason,
+            "context": _context(dets, poly_np, margin, f, stride),
+        }
+        for (f, reason, (hx, hy), conf, _score, ac) in chosen
+    ]
+
+
+def _load_exclusions(out_dir: Path, sets: list[str]) -> set[int]:
+    excl: set[int] = set()
+    for s in sets:
+        m = out_dir / s / "manifest.json"
+        if m.exists():
+            try:
+                excl |= {
+                    int(e["frame_idx"])
+                    for e in json.loads(m.read_text()).get("frames", [])
+                }
+            except Exception:  # noqa: BLE001
+                pass
+    return excl
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--game-dir", required=True)
+    ap.add_argument("--out", default="D:/training_data/far_label")
+    ap.add_argument("--set-name", default=None, help="default: <game_id>__<criteria>")
+    ap.add_argument(
+        "--criteria", choices=["hard", "lowconf", "lost", "distractor"], default="hard"
+    )
+    ap.add_argument("--lc-lo", type=float, default=0.05)
+    ap.add_argument("--lc-hi", type=float, default=0.25)
+    ap.add_argument("--dist-ratio", type=float, default=0.7)
+    ap.add_argument("--max-frames", type=int, default=160)
+    ap.add_argument(
+        "--margin", type=float, default=-40.0, help="in-field test margin (px)"
+    )
+    ap.add_argument("--exclude-sets", nargs="*", default=[])
+    ap.add_argument("--no-hwaccel", action="store_true")
+    ap.add_argument(
+        "--analyze", action="store_true", help="print stats, write nothing, no decode"
+    )
+    args = ap.parse_args()
+
+    vdir = Path(args.game_dir)
+    gj = json.loads((vdir / "game.json").read_text(encoding="utf-8", errors="ignore"))
+    gid = gj["game_id"]
+    poly = gj["field_polygon"]
+    poly_np = np.array(poly, np.float32)
+    offs = seg_offsets(gj["segments"])
+    dets = load_detections(vdir / "autocam_detections.jsonl", offs)
+    _df = sorted(dets)
+    _gaps = [_df[i] - _df[i - 1] for i in range(1, len(_df))]
+    stride = (
+        int(np.median(_gaps)) if _gaps else 1
+    )  # detection cadence (for context offsets)
+
+    ranges = active_play_ranges(gj["segments"], gj.get("game_state"))
+    if ranges:
+
+        def in_active(f: int) -> bool:
+            return any(lo <= f < hi for lo, hi in ranges)
+    else:
+        print("[warn] no game_state active-play ranges — using ALL frames", flush=True)
+
+        def in_active(f: int) -> bool:  # noqa: ARG001
+            return True
+
+    excl = _load_exclusions(Path(args.out), args.exclude_sets)
+    frames = select_frames(
+        dets,
+        poly_np,
+        in_active,
+        criteria=args.criteria,
+        lc_lo=args.lc_lo,
+        lc_hi=args.lc_hi,
+        dist_ratio=args.dist_ratio,
+        target=args.max_frames,
+        exclude=excl,
+        margin=args.margin,
+        stride=stride,
+    )
+    reasons: dict[str, int] = {}
+    for e in frames:
+        reasons[e["reason"]] = reasons.get(e["reason"], 0) + 1
+    print(
+        f"[select] {gid}: {len(dets)} det-frames, exclude {len(excl)} -> {len(frames)} chosen "
+        f"(criteria={args.criteria}); reasons={reasons}",
+        flush=True,
+    )
+    if not frames:
+        raise SystemExit("no frames selected")
+    if args.analyze:
+        return
+
+    video = gj.get("combined_video")
+    if not video or not Path(video).exists():
+        cands = list(vdir.glob("combined*.mp4")) or list(vdir.glob("*-raw.mp4"))
+        if not cands:
+            raise SystemExit(f"no video in {vdir}")
+        video = str(cands[0])
+
+    set_name = args.set_name or f"{gid}__{args.criteria}"
+    out = Path(args.out) / set_name
+    strips = out / "strips"
+    strips.mkdir(parents=True, exist_ok=True)
+    for old in strips.glob("*.jpg"):
+        old.unlink()
+
+    import av
+    import cv2
+
+    vrot = resolve_video_rotation(video, gj.get("video_rotation"))
+    _hw = None
+    if not args.no_hwaccel:
+        try:
+            _hw = av.codec.hwaccel.HWAccel(
+                device_type="cuda", allow_software_fallback=True
+            )
+        except Exception:  # noqa: BLE001
+            _hw = None
+    container = av.open(video, hwaccel=_hw) if _hw else av.open(video)
+    stream = container.streams.video[0]
+    if _hw is None:
+        stream.thread_type = "AUTO"
+    sw, sh = stream.codec_context.width, stream.codec_context.height
+
+    # SEQUENTIAL decode (combined video is re-encoded — seeking silently misaligns).
+    want = {e["frame_idx"] for e in frames}
+    hi = max(want)
+    written = 0
+    idx = -1
+    for fr in container.decode(stream):
+        idx += 1
+        if idx in want:
+            img = apply_display_rotation(fr.to_ndarray(format="bgr24"), vrot)
+            cv2.imwrite(
+                str(strips / f"f{idx:06d}.jpg"), img, [cv2.IMWRITE_JPEG_QUALITY, 88]
+            )
+            written += 1
+            if written % 20 == 0:
+                print(f"  wrote {written}/{len(want)} strips (frame {idx})", flush=True)
+        if idx >= hi:
+            break
+    container.close()
+
+    kept = [e for e in frames if (strips / e["file"]).exists()]
+    for e in kept:
+        e.update(
+            {
+                "crop_x0": 0,
+                "crop_y0": 0,
+                "crop_w": int(sw),
+                "crop_h": int(sh),
+                "band": "normal",
+            }
+        )
+    manifest = {
+        "set": set_name,
+        "clip": video,
+        "fps": float(gj.get("fps", 20.0)),
+        "src_w": int(sw),
+        "src_h": int(sh),
+        "strip_y0": 0,
+        "strip_y1": int(sh),
+        "crop_w": int(sw),
+        "full_frame": True,
+        "criteria": args.criteria,
+        "polygon": poly,
+        "n_frames": len(kept),
+        "n_autocam": sum(1 for e in kept if e["autocam"]),
+        "frames": kept,
+    }
+    (out / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    print(
+        f"WROTE {out}/manifest.json: {len(kept)} frames, {manifest['n_autocam']} AutoCam-seeded "
+        f"(reasons={reasons})",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/training/static/far-label.html
+++ b/training/static/far-label.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Far-ball labeler</title>
+<style>
+  :root { --bg:#11151c; --panel:#1b212b; --fg:#e7edf3; --muted:#8b97a7; --acc:#2ecc71; --gap:#ff9f1a; --click:#ff3b6b; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg); font:14px/1.4 system-ui,Segoe UI,Roboto,sans-serif; }
+  header { display:flex; align-items:center; gap:16px; padding:8px 14px; background:var(--panel); position:sticky; top:0; z-index:5; }
+  header b { font-size:15px; }
+  .prog { flex:1; height:10px; background:#0c0f14; border-radius:6px; overflow:hidden; }
+  .prog > i { display:block; height:100%; background:var(--acc); width:0; transition:width .15s; }
+  .pill { padding:2px 8px; border-radius:10px; background:#0c0f14; color:var(--muted); }
+  .pill.gap { color:#111; background:var(--gap); font-weight:600; }
+  .pill.ac { color:#111; background:var(--acc); font-weight:600; }
+  #stage { margin:10px auto; max-width:1700px; }
+  #view { position:relative; overflow:hidden; background:#000; border-radius:6px; touch-action:none; cursor:crosshair; }
+  #wrap { position:absolute; left:0; top:0; transform-origin:0 0; line-height:0; }
+  #img { display:block; }
+  #ov { position:absolute; inset:0; pointer-events:none; }
+  .bar { display:flex; flex-wrap:wrap; gap:8px; justify-content:center; padding:10px; max-width:1700px; margin:0 auto; }
+  button { background:#243042; color:var(--fg); border:1px solid #33414f; border-radius:8px; padding:9px 14px; font-size:14px; cursor:pointer; }
+  button:hover { background:#2c3a4f; }
+  button.primary { background:var(--acc); color:#06210f; border-color:var(--acc); font-weight:700; }
+  button.warn { background:#3a2230; color:#ffb3c6; }
+  button.ghost { background:#1b212b; }
+  kbd { background:#0c0f14; border:1px solid #33414f; border-radius:4px; padding:0 5px; font-size:11px; color:var(--muted); }
+  .hint { text-align:center; color:var(--muted); padding:0 10px 12px; max-width:1000px; margin:0 auto; }
+  #done { display:none; text-align:center; padding:40px; }
+  a.dl { color:var(--acc); }
+</style>
+</head>
+<body>
+<header>
+  <b>Far-ball labeler</b>
+  <span id="frameLbl" class="pill">—</span>
+  <span id="kindLbl" class="pill">—</span>
+  <span id="zoomLbl" class="pill">1.0×</span>
+  <div class="prog"><i id="progBar"></i></div>
+  <span id="progLbl" class="pill">0 / 0</span>
+</header>
+
+<div id="stage">
+  <div id="view">
+    <div id="wrap">
+      <img id="img" alt="" />
+      <canvas id="ov"></canvas>
+    </div>
+  </div>
+</div>
+
+<div class="bar">
+  <button id="bConfirm" class="primary" title="Accept the marked hint as the ball">✓ Hint is correct <kbd>C</kbd></button>
+  <button id="bObsc" class="warn" title="Ball is occluded (behind a player) — click its best-guess position from the ghost path">Obscured <kbd>B</kbd></button>
+  <button id="bDist" class="warn" title="This blob is a distractor (bench/sideline/adjacent-field ball), not the game ball">Distractor <kbd>D</kbd></button>
+  <button id="bNot" class="warn">Ball not visible <kbd>N</kbd></button>
+  <button id="bOut" class="warn">Out of play / off field <kbd>O</kbd></button>
+  <button id="bPrev" class="ghost">◀ Prev <kbd>←</kbd></button>
+  <button id="bNext" class="ghost">Next ▶ <kbd>→</kbd></button>
+  <button id="bFar" class="primary">▶ Next far to review <kbd>F</kbd></button>
+  <button id="bUnlab" class="ghost">Next unlabeled <kbd>U</kbd></button>
+  <button id="bReset" class="ghost">Reset zoom <kbd>0</kbd></button>
+</div>
+<p class="hint">
+  <b>Click</b> the ball to place it, or <kbd>C</kbd> to accept AutoCam's guess (arrow: purple = AutoCam-seeded,
+  pink = you). If it's <b>occluded behind a player</b>, press <kbd>B</kbd> then click its best-guess position
+  — the blue→orange <b>ghost dots</b> are AutoCam's ball just before/after this frame, so interpolate the path.
+  <kbd>D</kbd> = distractor (not the game ball), <kbd>N</kbd> = not visible, <kbd>O</kbd> = out of play.
+  <kbd>F</kbd> next to review, <kbd>U</kbd> next unlabeled. Scroll = zoom, drag = pan.
+</p>
+
+<div id="done">
+  <h2>All frames labeled 🎉</h2>
+  <p>Labels are saved on the server. <a class="dl" id="dlLink" href="#">Download labels.json</a></p>
+</div>
+
+<script>
+const SET = new URLSearchParams(location.search).get("set") || "irondequoit";
+const API = `/api/far-label/${SET}`;
+let M=null, frames=[], byIdx={}, labels={}, cur=0, FARY=480;
+let pending="ball";   // the action the NEXT click applies: "ball" (visible) or "obscured" (occluded best-guess)
+let z=1, tx=0, ty=0, baseScale=1;       // view transform (display px), baseScale = fit-to-width
+let dragging=false, moved=0, sx=0, sy=0, stx=0, sty=0;
+const view=document.getElementById("view"), wrap=document.getElementById("wrap");
+const img=document.getElementById("img"), ov=document.getElementById("ov"), ctx=ov.getContext("2d");
+
+async function load(){
+  M = await (await fetch(API)).json();
+  frames = M.frames; frames.forEach((f,i)=>byIdx[f.frame_idx]=i);
+  (M.labels||[]).forEach(l=>labels[l.frame_idx]=l);
+  FARY = Math.min(480, M.far_cut||480);
+  cur = -1; gotoFar();
+}
+function firstUnlabeled(){ for(let i=0;i<frames.length;i++) if(!labels[frames[i].frame_idx]) return i; return 0; }
+function frame(){ return frames[cur]; }
+
+function show(){
+  const f=frame();
+  document.getElementById("done").style.display="none";
+  document.getElementById("stage").style.display=""; document.querySelector(".bar").style.display="flex";
+  document.getElementById("frameLbl").textContent=`frame ${f.frame_idx}`;
+  const kl=document.getElementById("kindLbl");
+  kl.textContent=f.autocam?"AutoCam hint":"GAP (missed)"; kl.className="pill "+(f.autocam?"ac":"gap");
+  const n=frames.length, done=Object.keys(labels).length;
+  document.getElementById("progLbl").textContent=`${done} / ${n}`;
+  document.getElementById("progBar").style.width=(100*done/n)+"%";
+  img.onload=()=>{ fitView(); };
+  img.src=`${API}/strip/${f.frame_idx}?t=${Date.now()}`;
+  if (img.complete && img.naturalWidth) fitView();
+}
+
+function setupCanvas(){
+  img.width = img.naturalWidth; img.height = img.naturalHeight;
+  ov.width = img.naturalWidth; ov.height = img.naturalHeight;
+  view.style.height = Math.round(view.clientWidth * img.naturalHeight / img.naturalWidth) + "px";
+}
+let viewInit=false, lastNW=0, lastNH=0;
+// Called on every frame load. PRESERVE the current zoom + pan across frames (so you
+// stay zoomed into the same region) — only fit-to-width on the very first frame or if
+// the strip dimensions change. Use resetView() ("Reset zoom" / key 0) to snap back.
+function fitView(){
+  setupCanvas();
+  const newBase = view.clientWidth / img.naturalWidth;
+  const sizeChanged = (img.naturalWidth!==lastNW || img.naturalHeight!==lastNH);
+  if (!viewInit || sizeChanged){ baseScale=newBase; z=newBase; tx=0; ty=0; viewInit=true; }
+  else { if (newBase!==baseScale){ const ratio=z/baseScale; baseScale=newBase; z=newBase*ratio; } clampPan(); }
+  lastNW=img.naturalWidth; lastNH=img.naturalHeight;
+  applyTransform(); draw();
+}
+// Explicit reset to fit-width (Reset zoom button / key 0).
+function resetView(){
+  setupCanvas();
+  baseScale = view.clientWidth / img.naturalWidth;
+  z = baseScale; tx = 0; ty = 0;
+  applyTransform(); draw();
+}
+function applyTransform(){
+  wrap.style.transform = `translate(${tx}px,${ty}px) scale(${z})`;
+  document.getElementById("zoomLbl").textContent = (z/baseScale).toFixed(1)+"×";
+}
+function clampPan(){
+  const w=img.naturalWidth*z, h=img.naturalHeight*z;
+  const vw=view.clientWidth, vh=view.clientHeight;
+  tx = Math.min(0, Math.max(tx, vw - w));
+  ty = Math.min(0, Math.max(ty, vh - h));
+  if (w < vw) tx=0; if (h < vh) ty=0;
+}
+
+// Arrow pointing IN at (nx,ny) from the lower-left; tip stops short so the ball
+// stays visible. Coords are NATURAL px (canvas is natural-sized, transformed with wrap).
+function arrowMark(nx,ny,color,dashed,k){
+  const gap=20*k, len=60*k, head=18*k;        // gap = clearance so the ball shows
+  const dx=0.6, dy=-0.8;                        // direction tail->ball (up-right)
+  const tipx=nx-dx*gap, tipy=ny-dy*gap;         // arrowhead apex, just outside the ball
+  const tailx=nx-dx*(gap+len), taily=ny-dy*(gap+len);
+  ctx.strokeStyle=color; ctx.fillStyle=color; ctx.lineWidth=Math.max(2,4*k);
+  ctx.setLineDash(dashed?[8*k,5*k]:[]);
+  ctx.beginPath(); ctx.moveTo(tailx,taily); ctx.lineTo(tipx,tipy); ctx.stroke();
+  ctx.setLineDash([]);
+  const a=Math.atan2(dy,dx);
+  ctx.beginPath(); ctx.moveTo(tipx,tipy);
+  ctx.lineTo(tipx-head*Math.cos(a-0.45), tipy-head*Math.sin(a-0.45));
+  ctx.lineTo(tipx-head*Math.cos(a+0.45), tipy-head*Math.sin(a+0.45));
+  ctx.closePath(); ctx.fill();
+}
+function draw(){
+  ctx.clearRect(0,0,ov.width,ov.height);
+  const f=frame(); const k=baseScale/z;
+  // Context ghosts: AutoCam's ball just BEFORE (blue) / AFTER (orange) this frame. When the ball is
+  // occluded here, interpolate between the blue and orange dots to place its best-guess position.
+  (f.context||[]).forEach(c=>{
+    const gx=c.x-f.crop_x0, gy=c.y-f.crop_y0, r=Math.max(3,5*k);
+    ctx.beginPath(); ctx.arc(gx,gy,r,0,2*Math.PI);
+    ctx.fillStyle = c.df<0 ? "rgba(80,170,255,0.55)" : "rgba(255,160,40,0.55)";
+    ctx.fill();
+  });
+  const lab=labels[f.frame_idx];
+  if (lab && lab.action==="obscured" && lab.x!=null){          // occluded best-guess: dashed ring
+    const ox=lab.x-f.crop_x0, oy=lab.y-f.crop_y0;
+    ctx.strokeStyle="#ffd24a"; ctx.lineWidth=Math.max(2,3*k); ctx.setLineDash([6*k,4*k]);
+    ctx.beginPath(); ctx.arc(ox,oy,Math.max(6,10*k),0,2*Math.PI); ctx.stroke(); ctx.setLineDash([]);
+  } else if (lab && lab.action==="ball" && lab.x!=null){
+    arrowMark(lab.x-f.crop_x0, lab.y-f.crop_y0, lab.source==="human"?"#ff3b6b":"#9b59ff", false, k);
+  } else if (!lab){                                            // unlabeled -> AutoCam guess (dashed)
+    arrowMark(f.hint_x-f.crop_x0, f.hint_y-f.crop_y0, f.autocam?"#2ecc71":"#ff9f1a", true, k);
+  }
+}
+
+// pointer -> natural image coords
+function toNatural(clientX, clientY){
+  const r = img.getBoundingClientRect();
+  const nx = (clientX - r.left)/r.width * img.naturalWidth;
+  const ny = (clientY - r.top)/r.height * img.naturalHeight;
+  return [nx, ny];
+}
+
+// wheel zoom toward cursor
+view.addEventListener("wheel",(e)=>{
+  e.preventDefault();
+  const r = view.getBoundingClientRect();
+  const cx = e.clientX - r.left, cy = e.clientY - r.top;        // cursor in view px
+  const ix = (cx - tx)/z, iy = (cy - ty)/z;                      // image natural px under cursor
+  const factor = e.deltaY < 0 ? 1.2 : 1/1.2;
+  z = Math.max(baseScale, Math.min(z*factor, baseScale*16));
+  tx = cx - ix*z; ty = cy - iy*z;
+  clampPan(); applyTransform();
+},{passive:false});
+
+// drag to pan / click to label
+view.addEventListener("pointerdown",(e)=>{ dragging=true; moved=0; sx=e.clientX; sy=e.clientY; stx=tx; sty=ty; view.setPointerCapture(e.pointerId); });
+view.addEventListener("pointermove",(e)=>{
+  if(!dragging) return;
+  const dx=e.clientX-sx, dy=e.clientY-sy; moved=Math.max(moved, Math.abs(dx)+Math.abs(dy));
+  tx=stx+dx; ty=sty+dy; clampPan(); applyTransform();
+});
+view.addEventListener("pointerup",(e)=>{
+  dragging=false;
+  if (moved < 6){ // a click, not a pan
+    const [nx,ny]=toNatural(e.clientX,e.clientY);
+    if (nx>=0&&ny>=0&&nx<=img.naturalWidth&&ny<=img.naturalHeight){
+      const f=frame(); post(pending, f.crop_x0+nx, f.crop_y0+ny); setPending("ball");
+    }
+  }
+});
+
+async function post(action,x,y){
+  const f=frame();
+  labels[f.frame_idx]={frame_idx:f.frame_idx,action,x:x??null,y:y??null,source:"human"}; draw();
+  try{ await fetch(`${API}/result`,{method:"POST",headers:{"Content-Type":"application/json"},
+    body:JSON.stringify({frame_idx:f.frame_idx,action,x:x??null,y:y??null,source:"human"})}); }catch(err){ console.error(err); }
+  setTimeout(gotoFar,120);
+}
+function next(){ if(cur<frames.length-1){ cur++; show(); } else finish(); }
+function prev(){ if(cur>0){ cur--; show(); } }
+function gotoUnlabeled(){ const i=firstUnlabeled(); if(labels[frames[i].frame_idx]) finish(); else { cur=i; show(); } }
+function isFar(f){ return f.hint_y <= FARY; }
+function needsReview(f){ const l=labels[f.frame_idx]; return (!l || l.source!=="human") && (isFar(f) || f.autocam===false); }
+function gotoFar(){ for(let k=1;k<=frames.length;k++){ const i=(cur+k)%frames.length; if(needsReview(frames[i])){ cur=i; show(); return; } } finish(); }
+function finish(){ document.getElementById("stage").style.display="none"; document.querySelector(".bar").style.display="none";
+  document.getElementById("done").style.display="block"; document.getElementById("dlLink").href=`${API}`; }
+
+function setPending(a){ pending=a; document.getElementById("bObsc").classList.toggle("primary", a==="obscured");
+  view.style.cursor = a==="obscured" ? "cell" : "crosshair"; }
+document.getElementById("bConfirm").onclick=()=>{ const f=frame(); post("ball",f.hint_x,f.hint_y); };
+document.getElementById("bObsc").onclick=()=>setPending(pending==="obscured"?"ball":"obscured");
+document.getElementById("bDist").onclick=()=>post("not_game_ball",null,null);
+document.getElementById("bNot").onclick=()=>post("not_visible",null,null);
+document.getElementById("bOut").onclick=()=>post("out_of_play",null,null);
+document.getElementById("bPrev").onclick=prev;
+document.getElementById("bNext").onclick=next;
+document.getElementById("bFar").onclick=gotoFar;
+document.getElementById("bUnlab").onclick=gotoUnlabeled;
+document.getElementById("bReset").onclick=resetView;
+addEventListener("keydown",(e)=>{
+  if(e.key==="c"||e.key==="C") document.getElementById("bConfirm").click();
+  else if(e.key==="b"||e.key==="B") document.getElementById("bObsc").click();
+  else if(e.key==="d"||e.key==="D") document.getElementById("bDist").click();
+  else if(e.key==="n"||e.key==="N") document.getElementById("bNot").click();
+  else if(e.key==="o"||e.key==="O") document.getElementById("bOut").click();
+  else if(e.key==="ArrowLeft") prev();
+  else if(e.key==="ArrowRight") next();
+  else if(e.key==="u"||e.key==="U") gotoUnlabeled();
+  else if(e.key==="f"||e.key==="F") gotoFar();
+  else if(e.key==="0") resetView();
+});
+addEventListener("resize", ()=>{ fitView(); });
+load();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What
A single, focused, **additive, training-only** PR that consolidates the far-ball labeling tooling onto `main`.

### The set generator (the consolidation)
`training/cli/build_far_label_queue.py` — one committed, parameterized CLI that replaces the pile of uncommitted one-off scripts on `G:\ballresearch` (`build_0615_lowconf_visible.py`, `farlabel_multi.py`, `build_0615_set_gamewide.py`, …). It does active-learning selection of the frames **AutoCam struggles with** — occlusion / ball-lost / low-confidence / distractor — extracts full-frame strips, and writes the manifest the annotation server + `far-label.html` consume. Self-contained (`av`/`cv2`/`numpy` only).

```
python -m training.cli.build_far_label_queue --game-dir "F:/Heat_2012s/2026.06.07 - vs Lakefront SC (home)" --criteria hard --max-frames 160
python -m training.cli.build_far_label_queue --game-dir ... --analyze   # stats only, no decode/write
```

### Brings the far-ball labeler to `main` (was missing there)
- `training/static/far-label.html` (served by the existing static mount).
- `/api/far-label` endpoints added **additively** to `annotation_server.py` (+104 lines, no existing behavior touched).

### New capabilities for the occlusion/distractor cases
- **`obscured`**: the ball is occluded behind a player — the human places a best-guess position, stored as **tracker ground truth, never a detector positive** (no hallucination training).
- **`not_game_ball`**: a distractor (bench/sideline/adjacent-field ball) — a hard negative.
- **Detection-context ghost overlay**: AutoCam's ball just *before* (blue) / *after* (orange) each frame, so an occluded ball is placed by interpolating the path by eye (press `B`, then click).

## Why
The detector is now the bottleneck for both far and near ball tracking; targeted human labels on exactly these hard frames are the highest-leverage input. This makes that labeling a real, committed tool instead of scattered scripts.

## Notes
- Additive + training-only; `main`'s `annotation_server.py` already had `not_game_ball`/`obscured` in the gap-review flow, so those actions are storage-compatible.
- Supersedes the uncommitted `G:\ballresearch\build_*farlabel*` scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)