### PR TITLE
annotation: game.json-backed field + phase editors

### DIFF
--- a/training/annotation_server.py
+++ b/training/annotation_server.py
@@ -1773,6 +1773,11 @@ async def submit_far_label(set_id: str, result: dict):
     return {"accepted": True, "labeled": len(labels)}
 
 
+# game.json-backed field + phase editors (/api/fieldv2/*, /api/phasesv2/*).
+from training import field_edit_v2 as _field_edit_v2  # noqa: E402
+
+app.include_router(_field_edit_v2.router)
+
 # Static file mount must come AFTER all API routes (catch-all).
 app.mount(
     "/static",

--- a/training/field_edit_v2.py
+++ b/training/field_edit_v2.py
@@ -1,0 +1,364 @@
+"""Field-boundary editor backed by the canonical per-game ``game.json`` sidecars (next to each
+video on F:), independent of the legacy ``manifest.db`` / ``v4_fields`` store. Lets a human review
+and drag-correct the 10-point field polygon for ANY registry game (including the auto-seeded,
+``field_polygon_verified=false`` ones), with the canvas background decoded straight from the video.
+
+Mounted into the annotation server via ``app.include_router(field_edit_v2.router)``; the page lives at
+``/static/field-edit.html`` and talks to ``/api/fieldv2/*``. Saving sets
+``field_polygon_source='human_field_edit'`` + ``field_polygon_verified=true``.
+"""
+
+import glob
+import io
+import json
+import os
+
+import av
+from fastapi import APIRouter, HTTPException, Request, Response
+from PIL import Image
+
+router = APIRouter()
+
+REG = os.environ.get("GAME_REGISTRY", r"F:\training_data\game_registry.json")
+DISP_W = 1280
+
+
+def _games():
+    with open(REG, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _resolve(gid):
+    """Return (video_dir, game_json_path) for a game id, or (None, None)."""
+    for g in _games():
+        if g["game_id"] == gid:
+            p = g.get("path")
+            if not p:
+                return None, None
+            vd = os.path.dirname(p) if os.path.isfile(p) else p
+            return vd, os.path.join(vd, "game.json")
+    return None, None
+
+
+def _seg_file(vd, seg):
+    for c in (seg + ".mp4", seg + ".MP4"):
+        if os.path.exists(os.path.join(vd, c)):
+            return os.path.join(vd, c)
+    vids = [
+        h
+        for h in glob.glob(os.path.join(vd, glob.escape(seg) + "*"))
+        if h.lower().endswith((".mp4", ".mov", ".mkv"))
+    ]
+    return vids[0] if vids else None
+
+
+def _any_footage(vd):
+    for cand in glob.glob(os.path.join(vd, "**", "*.mp4"), recursive=True):
+        b = os.path.basename(cand).lower()
+        if any(k in b for k in ("[f]", "_ch", "recm09", "raw", "combined")):
+            return cand
+    return None
+
+
+def _decode_mid(path):
+    """Decode a ~mid-game frame as a PIL image via PyAV (the annotation venv has no cv2)."""
+    container = av.open(path)
+    try:
+        stream = container.streams.video[0]
+        stream.thread_type = "AUTO"
+        if stream.duration and stream.time_base:
+            dur = float(stream.duration * stream.time_base)
+        elif container.duration:
+            dur = container.duration / av.time_base
+        else:
+            dur = 0.0
+        t = dur * 0.5
+        if stream.time_base and t > 0:
+            container.seek(int(t / stream.time_base), stream=stream, backward=True)
+        for frame in container.decode(stream):
+            return frame.to_image()  # PIL RGB
+        return None
+    finally:
+        container.close()
+
+
+@router.get("/api/fieldv2/games")
+def games_list():
+    """All registry games that have a game.json, with polygon/verify status (for the picker)."""
+    out = []
+    for g in _games():
+        gjp = _resolve(g["game_id"])[1]
+        if not gjp or not os.path.exists(gjp):
+            continue
+        gj = json.load(open(gjp, encoding="utf-8"))
+        hp = bool(gj.get("field_polygon"))
+        src = str(gj.get("field_polygon_source", ""))
+        out.append(
+            {
+                "game_id": g["game_id"],
+                "trainable": bool(g.get("trainable")),
+                "camera": gj.get("camera") or gj.get("video_format"),
+                "has_polygon": hp,
+                "source": gj.get("field_polygon_source"),
+                # verified: explicit flag, else true if a human/manifest polygon exists, else false
+                "verified": gj.get(
+                    "field_polygon_verified", hp and not src.startswith("auto_")
+                ),
+                "note": gj.get("field_polygon_note"),
+                "mean_score": gj.get("field_polygon_mean_score"),
+            }
+        )
+    return out
+
+
+@router.get("/api/fieldv2/{gid}")
+def get_one(gid: str):
+    gjp = _resolve(gid)[1]
+    if not gjp or not os.path.exists(gjp):
+        raise HTTPException(404, "no game.json for %s" % gid)
+    gj = json.load(open(gjp, encoding="utf-8"))
+    segs = gj.get("segments") or []
+    mid = segs[len(segs) // 2] if segs else {}
+    return {
+        "game_id": gid,
+        "polygon": gj.get("field_polygon"),
+        "source": gj.get("field_polygon_source"),
+        "verified": gj.get("field_polygon_verified"),
+        "mean_score": gj.get("field_polygon_mean_score"),
+        "note": gj.get("field_polygon_note"),
+        "src_w": mid.get("w"),
+        "src_h": mid.get("h"),
+        "disp_w": DISP_W,
+    }
+
+
+@router.get("/api/fieldv2/{gid}/bg.jpg")
+def background(gid: str):
+    vd, gjp = _resolve(gid)
+    if not gjp or not os.path.exists(gjp):
+        raise HTTPException(404, "no game.json")
+    gj = json.load(open(gjp, encoding="utf-8"))
+    segs = gj.get("segments") or []
+    f = _seg_file(vd, segs[len(segs) // 2]["seg"]) if segs else None
+    if not f:
+        f = _any_footage(vd)
+    if not f:
+        raise HTTPException(404, "no video for %s" % gid)
+    img = _decode_mid(f)
+    if img is None:
+        raise HTTPException(404, "decode failed")
+    # PyAV ignores the display-rotation tag (unlike cv2, which the polygon coords assume) -> apply it
+    if gj.get("video_rotation") in (180, -180):
+        img = img.transpose(Image.ROTATE_180)
+    w, h = img.size
+    disp = img.resize((DISP_W, max(1, int(h * DISP_W / w))))
+    buf = io.BytesIO()
+    disp.save(buf, format="JPEG", quality=85)
+    return Response(
+        content=buf.getvalue(),
+        media_type="image/jpeg",
+        headers={"X-Src-W": str(w), "X-Src-H": str(h), "Cache-Control": "no-store"},
+    )
+
+
+@router.post("/api/fieldv2/{gid}")
+async def save(gid: str, request: Request):
+    gjp = _resolve(gid)[1]
+    if not gjp or not os.path.exists(gjp):
+        raise HTTPException(404, "no game.json")
+    body = await request.json()
+    poly = body.get("polygon")
+    if not poly or len(poly) < 4:
+        raise HTTPException(
+            400, "need >= 4 points (got %s)" % (len(poly) if poly else 0)
+        )
+    gj = json.load(open(gjp, encoding="utf-8"))
+    gj["field_polygon"] = [[round(float(x), 1), round(float(y), 1)] for x, y in poly]
+    gj["field_polygon_source"] = "human_field_edit"
+    gj["field_polygon_verified"] = True
+    gj.pop("field_polygon_note", None)
+    tmp = gjp + ".tmp"
+    json.dump(gj, open(tmp, "w", encoding="utf-8"), indent=1)
+    os.replace(tmp, gjp)
+    return {"ok": True, "game_id": gid, "points": len(poly)}
+
+
+# ===================== game_state (phase) editor =====================
+# Verify/correct the 5 game phases by scrubbing the boundary frames. Reads/writes game.json
+# game_state ([{phase, start:[seg,f], end:[seg,f], source}]). play_windows-seeded boundaries are
+# offset (upload-time vs recording-time), so the human scrubs each boundary to the true frame.
+import bisect  # noqa: E402
+
+PHASES = ("pre_game", "first_half", "halftime", "second_half", "post_game")
+
+
+def _seg_index(gj):
+    segs = gj.get("segments") or []
+    offs = [int(s["global_offset"]) for s in segs]
+    names = [s["seg"] for s in segs]
+    frs = [int(s["frames"]) for s in segs]
+    return offs, names, frs
+
+
+def _g2sf(g0, offs, names, frs):
+    total = sum(frs)
+    g0 = max(0, min(total - 1, g0)) if total else 0
+    i = bisect.bisect_right(offs, g0) - 1
+    if i < 0:
+        i = 0
+    floc = g0 - offs[i]
+    if frs[i] and floc >= frs[i]:
+        floc = frs[i] - 1
+    return [names[i], int(floc)]
+
+
+def _sf2g(seg, f, offs, names):
+    if seg in names:
+        return offs[names.index(seg)] + int(f)
+    return int(f)
+
+
+def _decode_frame(path, f, fps):
+    c = av.open(path)
+    try:
+        st = c.streams.video[0]
+        st.thread_type = "AUTO"
+        t = f / (fps or 25.0)
+        if st.time_base and t > 0:
+            c.seek(int(t / st.time_base), stream=st, backward=True)
+        for fr in c.decode(st):
+            return fr.to_image()
+    finally:
+        c.close()
+    return None
+
+
+@router.get("/api/phasesv2/games")
+def phases_games():
+    out = []
+    for g in _games():
+        gjp = _resolve(g["game_id"])[1]
+        if not gjp or not os.path.exists(gjp):
+            continue
+        gj = json.load(open(gjp, encoding="utf-8"))
+        ps = gj.get("game_state") or []
+        srcs = {p.get("source") for p in ps}
+        out.append(
+            {
+                "game_id": g["game_id"],
+                "trainable": bool(g.get("trainable")),
+                "has_phases": len(ps) > 0,
+                "verified": len(ps) > 0 and srcs <= {"human", "whistle"},
+                "source": ",".join(sorted(s for s in srcs if s)) or None,
+            }
+        )
+    return out
+
+
+@router.get("/api/phasesv2/{gid}")
+def phases_get(gid: str):
+    gjp = _resolve(gid)[1]
+    if not gjp or not os.path.exists(gjp):
+        raise HTTPException(404, "no game.json")
+    gj = json.load(open(gjp, encoding="utf-8"))
+    offs, names, frs = _seg_index(gj)
+    total = sum(frs)
+    fps = (gj.get("segments") or [{}])[0].get("fps") or 25.0
+    ps = gj.get("game_state") or []
+
+    def bound(phase, which):
+        for p in ps:
+            if p["phase"] == phase:
+                seg, f = p[which]
+                return _sf2g(seg, f, offs, names)
+        return None
+
+    b = {
+        "kickoff": bound("first_half", "start"),
+        "half_start": bound("halftime", "start"),
+        "half_end": bound("second_half", "start"),
+        "end": bound("post_game", "start"),
+    }
+    if not ps and total:  # no phases yet -> sensible default scrub positions
+        b = {
+            "kickoff": int(total * 0.05),
+            "half_start": int(total * 0.45),
+            "half_end": int(total * 0.52),
+            "end": int(total * 0.95),
+        }
+    return {
+        "game_id": gid,
+        "total_frames": total,
+        "fps": fps,
+        "boundaries": b,
+        "source": (ps[0]["source"] if ps else None),
+    }
+
+
+@router.get("/api/phasesv2/{gid}/frame")
+def phases_frame(gid: str, g: int = 0):
+    vd, gjp = _resolve(gid)
+    if not gjp or not os.path.exists(gjp):
+        raise HTTPException(404, "no game.json")
+    gj = json.load(open(gjp, encoding="utf-8"))
+    offs, names, frs = _seg_index(gj)
+    fps = (gj.get("segments") or [{}])[0].get("fps") or 25.0
+    sf = _g2sf(int(g), offs, names, frs)
+    f = _seg_file(vd, sf[0])
+    if not f:
+        raise HTTPException(404, "no segment file")
+    img = _decode_frame(f, sf[1], fps)
+    if img is None:
+        raise HTTPException(404, "decode failed")
+    if gj.get("video_rotation") in (180, -180):
+        img = img.transpose(Image.ROTATE_180)
+    img = img.resize((960, max(1, int(img.height * 960 / img.width))))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=80)
+    return Response(
+        content=buf.getvalue(),
+        media_type="image/jpeg",
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.post("/api/phasesv2/{gid}")
+async def phases_save(gid: str, request: Request):
+    gjp = _resolve(gid)[1]
+    if not gjp or not os.path.exists(gjp):
+        raise HTTPException(404, "no game.json")
+    gj = json.load(open(gjp, encoding="utf-8"))
+    offs, names, frs = _seg_index(gj)
+    total = sum(frs)
+    b = (await request.json()).get("boundaries") or {}
+    try:
+        kf, hs, he, en = (
+            int(b["kickoff"]),
+            int(b["half_start"]),
+            int(b["half_end"]),
+            int(b["end"]),
+        )
+    except (KeyError, TypeError, ValueError) as e:
+        raise HTTPException(
+            400, "need integer boundaries kickoff/half_start/half_end/end"
+        ) from e
+
+    def sf(g0):
+        return _g2sf(g0, offs, names, frs)
+
+    gj["game_state"] = [
+        {"phase": "pre_game", "start": [names[0], 0], "end": sf(kf), "source": "human"},
+        {"phase": "first_half", "start": sf(kf), "end": sf(hs), "source": "human"},
+        {"phase": "halftime", "start": sf(hs), "end": sf(he), "source": "human"},
+        {"phase": "second_half", "start": sf(he), "end": sf(en), "source": "human"},
+        {
+            "phase": "post_game",
+            "start": sf(en),
+            "end": sf(total - 1),
+            "source": "human",
+        },
+    ]
+    tmp = gjp + ".tmp"
+    json.dump(gj, open(tmp, "w", encoding="utf-8"), indent=1)
+    os.replace(tmp, gjp)
+    return {"ok": True, "game_id": gid, "phases": 5}

--- a/training/static/field-edit.html
+++ b/training/static/field-edit.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Field editor (game.json)</title>
+<style>
+  body { margin: 0; font-family: sans-serif; background: #111; color: #eee; display: flex; height: 100vh; }
+  #side { width: 320px; overflow-y: auto; border-right: 1px solid #333; padding: 8px; font-size: 13px; }
+  #side .g { padding: 6px; cursor: pointer; border-bottom: 1px solid #222; display: flex; justify-content: space-between; gap: 6px; align-items: center; }
+  #side .g:hover { background: #1c2536; }
+  #side .g.sel { background: #1f3a2a; }
+  .badge { font-size: 10px; padding: 1px 6px; border-radius: 8px; white-space: nowrap; }
+  .b-ver { background: #1a7f37; } .b-auto { background: #9a6700; color: #000; } .b-none { background: #7a1f1f; } .b-exc { background: #444; }
+  #main { flex: 1; display: flex; flex-direction: column; padding: 10px; overflow: auto; }
+  #wrap { position: relative; display: inline-block; }
+  canvas { border: 1px solid #444; cursor: crosshair; max-width: 100%; }
+  #bar { margin: 8px 0; }
+  button { background: #243; color: #eee; border: 1px solid #456; padding: 7px 13px; margin-right: 6px; cursor: pointer; border-radius: 4px; }
+  button:hover { background: #365; }
+  #msg { margin-left: 10px; }
+  h2 { margin: 4px 0; font-size: 15px; }
+  .hint { color: #9ab; font-size: 12px; max-width: 1100px; }
+</style>
+</head>
+<body>
+<div id="side"><h2>Games</h2><div id="list">loading…</div></div>
+<div id="main">
+  <h2 id="title">Pick a game</h2>
+  <div class="hint">Drag the numbered points onto the field corners. <b>0–4 = near sideline (bottom), 5–9 = far sideline (top)</b> — this ordering is load-bearing for the far-margin lift. Blue = near, gold = far. Save sets source=human_field_edit + verified.</div>
+  <div id="bar">
+    <button onclick="save()">Save &amp; mark verified</button>
+    <button onclick="resetDefault()">Reset to default box</button>
+    <span id="msg"></span>
+  </div>
+  <div id="wrap"><canvas id="cv"></canvas></div>
+</div>
+<script>
+let GID = null, pts = [], srcW = 0, dispW = 1280, dispH = 720, scale = 1, drag = -1;
+const bg = new Image();
+const cv = document.getElementById('cv'), ctx = cv.getContext('2d');
+
+async function loadList() {
+  const gs = await (await fetch('/api/fieldv2/games')).json();
+  gs.sort((a, b) => (a.verified - b.verified) || a.game_id.localeCompare(b.game_id));
+  const el = document.getElementById('list'); el.innerHTML = '';
+  for (const g of gs) {
+    let cls = 'b-none', txt = 'none';
+    if (g.note) { cls = 'b-exc'; txt = 'exclude?'; }
+    else if (g.verified) { cls = 'b-ver'; txt = 'verified'; }
+    else if (g.has_polygon) { cls = 'b-auto'; txt = 'auto ' + (g.mean_score || ''); }
+    const d = document.createElement('div'); d.className = 'g'; d.dataset.gid = g.game_id;
+    d.innerHTML = '<span>' + g.game_id + '</span><span class="badge ' + cls + '">' + txt + '</span>';
+    d.onclick = () => load(g.game_id);
+    el.appendChild(d);
+  }
+}
+
+async function load(gid) {
+  GID = gid; document.getElementById('title').textContent = gid;
+  document.querySelectorAll('#side .g').forEach(e => e.classList.toggle('sel', e.dataset.gid === gid));
+  const m = await (await fetch('/api/fieldv2/' + encodeURIComponent(gid))).json();
+  srcW = m.src_w || 1; dispW = m.disp_w || 1280; scale = dispW / srcW;
+  bg.onload = () => {
+    dispH = bg.naturalHeight; cv.width = dispW; cv.height = dispH;
+    if (m.polygon && m.polygon.length >= 4) pts = m.polygon.map(p => [p[0] * scale, p[1] * scale]);
+    else defaultPts();
+    draw();
+  };
+  bg.src = '/api/fieldv2/' + encodeURIComponent(gid) + '/bg.jpg?t=' + Date.now();
+  document.getElementById('msg').textContent = m.note ? ('⚠ ' + m.note) : (m.source || '');
+}
+
+function defaultPts() {
+  pts = [];
+  for (let i = 0; i < 5; i++) pts.push([(0.1 + 0.2 * i) * dispW, 0.72 * dispH]); // near 0-4 bottom L->R
+  for (let j = 0; j < 5; j++) pts.push([(0.9 - 0.2 * j) * dispW, 0.30 * dispH]); // far 5-9 top R->L
+}
+function resetDefault() { if (GID) { defaultPts(); draw(); } }
+
+function draw() {
+  ctx.clearRect(0, 0, cv.width, cv.height);
+  if (bg.complete) ctx.drawImage(bg, 0, 0, dispW, dispH);
+  if (!pts.length) return;
+  ctx.strokeStyle = '#0f0'; ctx.lineWidth = 2; ctx.beginPath(); ctx.moveTo(pts[0][0], pts[0][1]);
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i][0], pts[i][1]);
+  ctx.closePath(); ctx.stroke();
+  for (let i = 0; i < pts.length; i++) {
+    ctx.fillStyle = i < 5 ? '#4cf' : '#fc4';
+    ctx.beginPath(); ctx.arc(pts[i][0], pts[i][1], 7, 0, 7); ctx.fill();
+    ctx.fillStyle = '#000'; ctx.font = '11px sans-serif'; ctx.fillText(i, pts[i][0] - 3, pts[i][1] + 4);
+  }
+}
+
+cv.onmousedown = e => {
+  const r = cv.getBoundingClientRect();
+  const x = (e.clientX - r.left) * (cv.width / r.width), y = (e.clientY - r.top) * (cv.height / r.height);
+  drag = -1;
+  for (let i = 0; i < pts.length; i++) if (Math.hypot(pts[i][0] - x, pts[i][1] - y) < 14) { drag = i; break; }
+};
+cv.onmousemove = e => {
+  if (drag < 0) return;
+  const r = cv.getBoundingClientRect();
+  pts[drag] = [(e.clientX - r.left) * (cv.width / r.width), (e.clientY - r.top) * (cv.height / r.height)];
+  draw();
+};
+window.onmouseup = () => { drag = -1; };
+
+async function save() {
+  if (!GID || pts.length < 4) { alert('no game / not enough points'); return; }
+  const poly = pts.map(p => [p[0] / scale, p[1] / scale]);
+  const r = await fetch('/api/fieldv2/' + encodeURIComponent(GID), {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ polygon: poly })
+  });
+  const j = await r.json();
+  document.getElementById('msg').textContent = r.ok ? ('✓ saved verified (' + j.points + ' pts)') : ('save failed');
+  if (r.ok) loadList();
+}
+
+loadList();
+</script>
+</body>
+</html>

--- a/training/static/phase-edit.html
+++ b/training/static/phase-edit.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Phase editor (game.json)</title>
+<style>
+  body { margin: 0; font-family: sans-serif; background: #111; color: #eee; display: flex; height: 100vh; }
+  #side { width: 320px; overflow-y: auto; border-right: 1px solid #333; padding: 8px; font-size: 13px; }
+  #side .g { padding: 6px; cursor: pointer; border-bottom: 1px solid #222; display: flex; justify-content: space-between; gap: 6px; align-items: center; }
+  #side .g:hover { background: #1c2536; } #side .g.sel { background: #1f3a2a; }
+  .badge { font-size: 10px; padding: 1px 6px; border-radius: 8px; white-space: nowrap; }
+  .b-ver { background: #1a7f37; } .b-pw { background: #9a6700; color: #000; } .b-none { background: #7a1f1f; }
+  #main { flex: 1; display: flex; flex-direction: column; padding: 10px; overflow-y: auto; }
+  h2 { margin: 4px 0; font-size: 15px; } .hint { color: #9ab; font-size: 12px; }
+  .row { display: flex; gap: 14px; align-items: flex-start; margin: 10px 0; border-bottom: 1px solid #222; padding-bottom: 10px; }
+  .row img { width: 480px; border: 1px solid #444; background: #000; }
+  .ctl { display: flex; flex-direction: column; gap: 6px; }
+  .ctl .lab { font-weight: bold; font-size: 14px; } .ctl .t { color: #6cf; font-variant-numeric: tabular-nums; }
+  button { background: #243; color: #eee; border: 1px solid #456; padding: 6px 10px; cursor: pointer; border-radius: 4px; }
+  button:hover { background: #365; } .nav button { margin: 2px; }
+  #save { background: #1a5; padding: 9px 16px; font-size: 14px; }
+</style>
+</head>
+<body>
+<div id="side"><h2>Games</h2><div id="list">loading…</div></div>
+<div id="main">
+  <h2 id="title">Pick a game</h2>
+  <div class="hint">Scrub each boundary to the true frame (kickoff = ball at center / teams set; half boundaries = whistle). play_windows seeds are offset (upload-time), so expect to nudge. Save writes verified phases.</div>
+  <div id="rows"></div>
+  <div style="margin:12px 0"><button id="save" onclick="save()">Save &amp; mark verified</button> <span id="msg"></span></div>
+</div>
+<script>
+const BNDS = [["kickoff", "Kickoff (1st-half start)"], ["half_start", "Halftime start"], ["half_end", "2nd-half start"], ["end", "Game end"]];
+let GID = null, FPS = 25, TOTAL = 0, B = {};
+
+function fmt(g) { const s = g / FPS; const m = Math.floor(s / 60), sec = Math.floor(s % 60); return m + ":" + String(sec).padStart(2, "0") + " (f" + g + ")"; }
+
+async function loadList() {
+  const gs = await (await fetch('/api/phasesv2/games')).json();
+  gs.sort((a, b) => (a.verified - b.verified) || a.game_id.localeCompare(b.game_id));
+  const el = document.getElementById('list'); el.innerHTML = '';
+  for (const g of gs) {
+    let cls = 'b-none', txt = 'none';
+    if (g.verified) { cls = 'b-ver'; txt = 'verified'; }
+    else if (g.has_phases) { cls = 'b-pw'; txt = g.source || 'seed'; }
+    const d = document.createElement('div'); d.className = 'g'; d.dataset.gid = g.game_id;
+    d.innerHTML = '<span>' + g.game_id + '</span><span class="badge ' + cls + '">' + txt + '</span>';
+    d.onclick = () => load(g.game_id);
+    el.appendChild(d);
+  }
+}
+
+async function load(gid) {
+  GID = gid; document.getElementById('title').textContent = gid;
+  document.querySelectorAll('#side .g').forEach(e => e.classList.toggle('sel', e.dataset.gid === gid));
+  const m = await (await fetch('/api/phasesv2/' + encodeURIComponent(gid))).json();
+  FPS = m.fps || 25; TOTAL = m.total_frames || 0; B = {};
+  const rows = document.getElementById('rows'); rows.innerHTML = '';
+  for (const [key, label] of BNDS) {
+    B[key] = m.boundaries[key] != null ? m.boundaries[key] : 0;
+    const row = document.createElement('div'); row.className = 'row';
+    row.innerHTML =
+      '<img id="img_' + key + '">' +
+      '<div class="ctl"><div class="lab">' + label + '</div><div class="t" id="t_' + key + '"></div>' +
+      '<div class="nav">' +
+      [-300, -30, -5, -1].map(d => '<button onclick="nudge(\'' + key + '\',' + d + ')">' + d + 's</button>').join('') +
+      '</div><div class="nav">' +
+      [1, 5, 30, 300].map(d => '<button onclick="nudge(\'' + key + '\',' + d + ')">+' + d + 's</button>').join('') +
+      '</div></div>';
+    rows.appendChild(row);
+    refresh(key);
+  }
+  document.getElementById('msg').textContent = m.source ? ('loaded: ' + m.source) : 'no phases yet';
+}
+
+function refresh(key) {
+  document.getElementById('t_' + key).textContent = fmt(B[key]);
+  document.getElementById('img_' + key).src = '/api/phasesv2/' + encodeURIComponent(GID) + '/frame?g=' + B[key];
+}
+function nudge(key, secs) {
+  B[key] = Math.max(0, Math.min(TOTAL - 1, B[key] + Math.round(secs * FPS)));
+  refresh(key);
+}
+
+async function save() {
+  if (!GID) return;
+  const r = await fetch('/api/phasesv2/' + encodeURIComponent(GID), {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ boundaries: B })
+  });
+  const j = await r.json();
+  document.getElementById('msg').textContent = r.ok ? ('✓ saved verified (' + j.phases + ' phases)') : 'save failed';
+  if (r.ok) loadList();
+}
+loadList();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Two review tools for the annotation server, both backed by the canonical per-game `game.json` sidecars — reconstructed as clean additions onto `main` from the annotation server's local (never-pushed) branch.

**Field editor** — `/static/field-edit.html`, `/api/fieldv2/*`
Review + drag-correct the 10-point field polygon for any registry game (including auto-seeded `field_polygon_verified=false` ones), canvas decoded straight from the video. Saving sets `field_polygon_source='human_field_edit'` + `field_polygon_verified=true`.

**Phase editor** — `/static/phase-edit.html`, `/api/phasesv2/*`
Verify/correct the 5 game phases by scrubbing boundary frames; reads/writes `game.json` `game_state`.

Both live on one `APIRouter` in `field_edit_v2.py`, wired with `app.include_router(field_edit_v2.router)` before the static mount. New files only + a 3-line server hookup — no changes to existing routes. Imports cleanly; 8 routes register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)