### PR TITLE
docs: confirm game-start default = phase_detection (reconcile stale docs)

### DIFF
--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -4,6 +4,25 @@ Append-only. Never delete entries — if a decision is reversed, add a new entry
 
 ---
 
+## 2026-07-02: Game-start / trim default = phase_detection (confirmed live)
+
+**Context:** STATUS.md (2026-06-30) left an OPEN DECISION — flip the game-start/trim default to the
+phase detector, or keep NTFY and use phases for post-trim display only. The trim-safety bar was met
+(gate `ko_trustworthy`, backup 60s; every trusted, non-truncated KO is early/tiny, within the 60s
+margin); the residual gap is display-quality accuracy (~64% on combined/untrimmed video), which the
+S3 verify-loop + human-verify catches.
+
+**Decision (Mark, 2026-07-02): the default is `phase_detection`.** This was already the shipped state
+on `main` — `[PROCESSING] game_start_method = phase_detection` has been the default since S1
+(`e6a342d`), refined by `fb61a75` (60s backup, decoupled from the NTFY 240s), `6385671` (gate =
+`ko_trustworthy`, not `ok`), `99801b8` / `9ef524d` (truncated-start), `3811224` (parent event-tap
+anchors). Reolink-only; Dahua and any rejected / low-confidence fit fall back to the NTFY walk, so
+behavior is never worse than NTFY. This entry records the decision as made and supersedes the
+"suspended, stays NTFY" note in PHASE_DETECTION_INTEGRATION.md (2026-06-18). Verified 2026-07-02: 131
+phase / NTFY / trim / reprocess unit tests green.
+
+---
+
 ## 2026-06-30: Truncation representation — explicit start/end booleans in game.json
 
 **Context:** Some games' recording missed the kickoff (camera started after KO) or the final whistle

--- a/training/docs/PHASE_DETECTION_INTEGRATION.md
+++ b/training/docs/PHASE_DETECTION_INTEGRATION.md
@@ -1,9 +1,17 @@
 # Plan: Game-phase detection → production pipeline + TTT verify-loop
 
-**Status:** draft for review (2026-06-18). Cross-repo: **soccer-cam** (OSS) + **team-tech-tools** (closed).
+**Status:** S0/S1 **SHIPPED** — game-start default = `phase_detection` on `main` (confirmed 2026-07-02);
+S2–S4 + T1 landed; T2 in progress. Cross-repo: **soccer-cam** (OSS) + **team-tech-tools** (closed).
 **Goal:** make the offline game-phase detector a first-class production feature that (1) can replace the
 NTFY "did the game start?" walk, (2) publishes phase timestamps to TTT for display, and (3) is
 human-verified + correctable through a TTT-triggered, NTFY-screenshot review loop.
+
+> **UPDATE 2026-07-02 — suspension lifted; default flipped.** The 2026-06-18 pivot below (decision 1
+> "suspended", game-start stays NTFY) is **superseded.** The untrimmed-KO detector cleared the
+> trim-safety bar (gate `ko_trustworthy` + 60s backup + Reolink-only + Dahua→NTFY + truncated-start
+> option B); Mark confirmed the flip on 2026-07-02; `[PROCESSING] game_start_method = phase_detection`
+> is the shipped default on `main`. See soccer-cam STATUS.md / DECISIONS.md 2026-07-02. The remaining
+> accuracy gap is display-quality (S3 verify-loop + human-verify), not trim-safety.
 
 ---
 

--- a/training/docs/STATUS.md
+++ b/training/docs/STATUS.md
@@ -1,6 +1,17 @@
 # Current Status
 
-*Last updated: 2026-06-30 (untrimmed-KO / production-safety)*
+*Last updated: 2026-07-02 (game-start default = phase_detection confirmed live + verified)*
+
+## Game-start default = phase_detection — CONFIRMED LIVE + verified (2026-07-02, latest)
+
+The OPEN DECISION below (2026-06-30) is **resolved**: Mark confirmed the game-start / trim default is
+`phase_detection`, and it is already the shipped state on `main` (config default since S1 `e6a342d`;
+gate `ko_trustworthy`, 60s backup, Reolink-only, Dahua→NTFY fallback, truncated-start via option B). No
+code change was needed — the docs were stale, not the code. Verified 2026-07-02: **131 unit tests
+green** (`test_phase_game_start`, `test_phase_fusion`, `test_phase_ttt_push`, `test_phase_detect_step`,
+`test_ntfy_processor`, `test_configurable_end_trim`, `test_video_processor`,
+`test_reprocess_phase_correction`, `test_phase_verify_task`). See DECISIONS.md 2026-07-02; the
+"suspended / stays NTFY" note in PHASE_DETECTION_INTEGRATION.md (2026-06-18) is superseded.
 
 ## Game-phase detection — untrimmed-KO opt-in localize + PRODUCTION-SAFE (2026-06-30, latest)
 
@@ -35,9 +46,10 @@ S3 verify loop / a viewer — rather than interrupt every confident game. The ol
 levers (curve-onset, loosened-clear bench-dip, ball-refine, symmetric-trust) — all in EXP-PHASE-14.
 The 5 combined misses are genuinely signal-limited; 3 correctly untrusted (→NTFY), 2 early/trim-safe.
 
-**OPEN DECISION (Mark):** flip game-start default to phase-detection (proceed S1–S4/T2) accepting 64%
-display accuracy + human-verify, or keep game-start on NTFY and use phases for post-trim display only?
-Safety bar met; the accuracy gap is display-quality (human-verify catches it), not trim-safety.
+**RESOLVED 2026-07-02 (Mark): flip to phase-detection.** (was: flip game-start default to
+phase-detection accepting ~64% display accuracy + human-verify, or keep NTFY for post-trim display
+only.) Safety bar met; the accuracy gap is display-quality (human-verify catches it), not trim-safety.
+See the top-of-file entry + DECISIONS.md 2026-07-02.
 
 ## Game-phase detection — kickoff signature + GT review (2026-06-30, earlier)
 


### PR DESCRIPTION
## What

You asked to "change the default trim from NTFY to our game phase model." **It's already the shipped default on `main`** — no code change was needed. This PR reconciles the docs that still said otherwise.

`[PROCESSING] game_start_method = phase_detection` has been the default since S1 (`e6a342d`), with:
- **Reolink-only** gating; **Dahua → NTFY** fallback (`phase_game_start.py`)
- confidence gate = **`ko_trustworthy`** (not `ok`) — never auto-trims an untrusted KO (`6385671`)
- **60s** trim backup, decoupled from the NTFY 240s (`fb61a75`)
- truncated-start handling (`99801b8`, `9ef524d`)

The stale docs corrected here:
- `STATUS.md` (2026-06-30) framed the flip as an **OPEN DECISION** with the branch "NOT pushed"
- `PHASE_DETECTION_INTEGRATION.md` (2026-06-18) said the decision was **"suspended, stays NTFY"**

## Changes (docs only)
- **DECISIONS.md** — append-only entry recording the decision (Mark, 2026-07-02).
- **STATUS.md** — resolve the OPEN DECISION; record verification.
- **PHASE_DETECTION_INTEGRATION.md** — mark S0/S1 shipped; supersede the 2026-06-18 suspension.

## Verification
131 unit tests green on `main`: `test_phase_game_start`, `test_phase_fusion`, `test_phase_ttt_push`, `test_phase_detect_step`, `test_ntfy_processor`, `test_configurable_end_trim`, `test_video_processor`, `test_reprocess_phase_correction`, `test_phase_verify_task`.

## Residual (not in this PR)
- Dahua stays on NTFY until the homegrown detector clears an accuracy bar (upstream ML work).
- The phase model's HALFTIME/2ND-HALF/END do not yet drive the *end*-trim — only KO→start. That wiring would be new work if wanted.
- Display accuracy on combined video is ~64% (S3 verify-loop + human-verify catch it); trim-safety is met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)