### PR TITLE
feat(phase): push phases via camera-manager worker route

### DIFF
--- a/tests/test_phase_ttt_push.py
+++ b/tests/test_phase_ttt_push.py
@@ -104,7 +104,7 @@ def test_push_updates_session_with_offset_fields(MockClient):
 
     assert ok is True
     client.get_game_session_by_dir.assert_called_once_with("grp-dir")
-    args, kwargs = client.update_game_session.call_args
+    args, kwargs = client.update_game_session_phases.call_args
     assert args[0] == "sess-1"
     assert kwargs["phase_kickoff_offset"] == 10.0
     assert kwargs["phase_end_offset"] == 5640.0
@@ -136,7 +136,7 @@ def test_push_skips_when_no_session(MockClient):
     ok = push_phases_to_ttt(TTT_CFG, "grp", _payload(kickoff=1.0), "/s")
 
     assert ok is False
-    client.update_game_session.assert_not_called()
+    client.update_game_session_phases.assert_not_called()
 
 
 @patch("video_grouper.api_integrations.ttt_api.TTTApiClient")

--- a/tests/test_reprocess_phase_correction.py
+++ b/tests/test_reprocess_phase_correction.py
@@ -88,7 +88,7 @@ async def test_phase_correction_applies_human_phases_and_repushes(tmp_path: Path
     # NOT the stabilization path
     assert not (group / "reprocess_request.json").exists()
     # re-push to TTT with the human offsets
-    args, kwargs = ttt.update_game_session.call_args
+    args, kwargs = ttt.update_game_session_phases.call_args
     assert args[0] == "sess-1"
     assert kwargs["phase_kickoff_offset"] == 45.0
     assert kwargs["phase_source"] == "human"
@@ -112,7 +112,7 @@ async def test_phase_correction_no_times_reports_failure(tmp_path: Path):
 
     sargs, _ = ttt.update_reprocess_status.call_args
     assert sargs[1] == "failed"
-    ttt.update_game_session.assert_not_called()
+    ttt.update_game_session_phases.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -133,7 +133,7 @@ async def test_phase_correction_repush_skipped_when_no_session(tmp_path: Path):
         json.loads((group / "state.json").read_text())["game_phases"]["source"]
         == "human"
     )
-    ttt.update_game_session.assert_not_called()
+    ttt.update_game_session_phases.assert_not_called()
     assert ttt.update_reprocess_status.call_args[0][1] == "completed"
 
 
@@ -161,7 +161,7 @@ async def test_verify_phases_calls_callback_and_completes(tmp_path: Path):
 
     assert str(called["group_dir"]) == str(group)
     assert ttt.update_reprocess_status.call_args[0][1] == "completed"
-    ttt.update_game_session.assert_not_called()
+    ttt.update_game_session_phases.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -205,7 +205,7 @@ async def test_stabilization_row_unchanged_by_dispatch(tmp_path: Path):
 
     marker = json.loads((group / "reprocess_request.json").read_text())
     assert marker["stabilization_strength"] == "heavy"
-    ttt.update_game_session.assert_not_called()
+    ttt.update_game_session_phases.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -244,7 +244,7 @@ async def test_truncated_start_reruns_and_repushes(tmp_path: Path, monkeypatch):
     gp = json.loads((group / "state.json").read_text())["game_phases"]
     assert gp["truncated_start"] is True
     assert gp["times"]["kickoff"] == 0.0
-    _, kwargs = ttt.update_game_session.call_args
+    _, kwargs = ttt.update_game_session_phases.call_args
     assert kwargs["phase_truncated_start"] is True
     assert kwargs["phase_kickoff_offset"] == 0.0
     assert not (group / "reprocess_request.json").exists()  # not the stabilization path
@@ -283,7 +283,7 @@ async def test_truncated_end_reruns_with_end_flag(tmp_path: Path, monkeypatch):
     )
 
     assert seen == {"ts": False, "te": True}
-    _, kwargs = ttt.update_game_session.call_args
+    _, kwargs = ttt.update_game_session_phases.call_args
     assert kwargs["phase_truncated_end"] is True
     sargs, _ = ttt.update_reprocess_status.call_args
     assert sargs[1] == "completed"

--- a/video_grouper/api_integrations/ttt_api.py
+++ b/video_grouper/api_integrations/ttt_api.py
@@ -694,6 +694,22 @@ class TTTApiClient:
         logger.debug("Updating game session %s", session_id)
         return self._request("PATCH", url, json=fields)
 
+    def update_game_session_phases(
+        self, session_id: str, **fields: Any
+    ) -> dict[str, Any]:
+        """Push detected/verified game-phase fields to a game session.
+
+        Uses the camera-manager-authorized worker route, NOT the team-admin
+        gated user route: soccer-cam runs on the camera manager's hardware and
+        a camera manager need not be a team admin. Only phase_* fields are
+        accepted (TTT ``GameSessionPhaseUpdate``).
+
+        PATCH {api_base_url}/api/internal/game-sessions/{session_id}/phases
+        """
+        url = f"{self.api_base_url}/api/internal/game-sessions/{session_id}/phases"
+        logger.debug("Pushing phases to game session %s", session_id)
+        return self._request("PATCH", url, json=fields)
+
     # ------------------------------------------------------------------
     # Time sync
     # ------------------------------------------------------------------

--- a/video_grouper/task_processors/phase_ttt_push.py
+++ b/video_grouper/task_processors/phase_ttt_push.py
@@ -76,7 +76,7 @@ def push_phases_to_ttt(
     if client is None or session is None:
         return False
     try:
-        client.update_game_session(session["id"], **fields)
+        client.update_game_session_phases(session["id"], **fields)
         logger.info(
             "phase push: updated TTT session %s with %s",
             session["id"],
@@ -118,7 +118,7 @@ def push_phase_verified(
     if client is None or session is None:
         return False
     try:
-        client.update_game_session(session["id"], **{col: verdict})
+        client.update_game_session_phases(session["id"], **{col: verdict})
         logger.info("phase verify: %s=%s on session %s", col, verdict, session["id"])
         return True
     except Exception as e:  # noqa: BLE001 — best-effort

--- a/video_grouper/task_processors/reprocess_request_processor.py
+++ b/video_grouper/task_processors/reprocess_request_processor.py
@@ -281,7 +281,7 @@ class ReprocessRequestProcessor(QueueProcessor):
             )
             if session and session.get("id"):
                 await asyncio.to_thread(
-                    self.ttt_client.update_game_session, session["id"], **fields
+                    self.ttt_client.update_game_session_phases, session["id"], **fields
                 )
         except Exception as exc:  # noqa: BLE001 — re-push is best-effort
             logger.warning("phase_correction: TTT re-push failed (%s)", exc)


### PR DESCRIPTION
## Problem

`phase_ttt_push` wrote game phases via TTT's `PATCH /api/game-sessions/{id}`, which TTT gates on **team-admin**. soccer-cam runs on the camera manager's hardware and a camera manager need not be a team admin, so a non-admin camera manager **silently could not push phases** (best-effort push swallowed the 403).

## Fix

Point the three phase-write call sites at TTT's new camera-manager-authorized worker route `PATCH /api/internal/game-sessions/{id}/phases` (companion PR `mblakley/team-tech-tools` `feat/internal-phase-push`):

- `ttt_api.py`: add `update_game_session_phases()`
- `phase_ttt_push.py`: `push_phases_to_ttt` + `push_phase_verified`
- `reprocess_request_processor.py`: `_repush_phases` (phase_correction / truncated re-run)

`update_game_session()` (the generic user-route client method) is retained for other callers.

## Tests

`test_phase_ttt_push.py` + `test_reprocess_phase_correction.py` updated to assert the new method; full affected suite (78 tests) passes. **Verified live** end-to-end: a non-admin camera manager pushes phases through the new route while the old route 403s them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)