### PR TITLE
feat(ttt): TTT-authoritative schedule consumer + video auto-match (P2a)

### DIFF
--- a/tests/test_match_info_service.py
+++ b/tests/test_match_info_service.py
@@ -1,0 +1,147 @@
+"""Tests for MatchInfoService — TTT schedule consumer integration."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from video_grouper.task_processors.services.match_info_service import MatchInfoService
+
+
+def _mk_service(schedule_service=None):
+    teamsnap_service = MagicMock()
+    teamsnap_service.enabled = False
+    playmetrics_service = MagicMock()
+    playmetrics_service.enabled = False
+    ntfy_service = MagicMock()
+    ntfy_service.enabled = False
+    return MatchInfoService(
+        teamsnap_service=teamsnap_service,
+        playmetrics_service=playmetrics_service,
+        ntfy_service=ntfy_service,
+        schedule_service=schedule_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _collect_games_from_apis
+# ---------------------------------------------------------------------------
+
+
+class TestCollectGamesFromApis:
+    def test_ttt_game_returned_skips_teamsnap_and_pm(self):
+        """When TTT schedule returns a game, TeamSnap and PlayMetrics are not queried."""
+        sched = MagicMock()
+        ttt_game = {
+            "id": "g1",
+            "source": "TTT",
+            "team_name": "Flash",
+            "opponent_name": "Rivals",
+            "location": "Home",
+        }
+        sched.find_game_for_recording.return_value = ttt_game
+
+        svc = _mk_service(schedule_service=sched)
+        svc.teamsnap_service.enabled = True
+        svc.playmetrics_service.enabled = True
+
+        start = datetime(2026, 6, 1, 10, 30)
+        end = datetime(2026, 6, 1, 12, 30)
+        result = svc._collect_games_from_apis(start, end)
+
+        assert result == [ttt_game]
+        svc.teamsnap_service.find_game_for_recording.assert_not_called()
+        svc.playmetrics_service.find_game_for_recording.assert_not_called()
+
+    def test_ttt_returns_none_falls_back_to_teamsnap(self):
+        """When TTT returns None, the service falls through to TeamSnap."""
+        sched = MagicMock()
+        sched.find_game_for_recording.return_value = None
+
+        ts_game = {
+            "source": "TeamSnap",
+            "team_name": "Flash",
+            "opponent_name": "Rivals",
+            "location_name": "Home Field",
+        }
+        svc = _mk_service(schedule_service=sched)
+        svc.teamsnap_service.enabled = True
+        svc.teamsnap_service.find_game_for_recording.return_value = ts_game
+
+        start = datetime(2026, 6, 1, 10, 30)
+        end = datetime(2026, 6, 1, 12, 30)
+        result = svc._collect_games_from_apis(start, end)
+
+        assert ts_game in result
+        svc.teamsnap_service.find_game_for_recording.assert_called_once()
+
+    def test_no_schedule_service_goes_straight_to_apis(self):
+        """When schedule_service is None, TeamSnap/PM are queried directly."""
+        ts_game = {
+            "source": "TeamSnap",
+            "team_name": "Flash",
+            "opponent_name": "X",
+            "location_name": "Y",
+        }
+        svc = _mk_service(schedule_service=None)
+        svc.teamsnap_service.enabled = True
+        svc.teamsnap_service.find_game_for_recording.return_value = ts_game
+
+        start = datetime(2026, 6, 1, 10, 30)
+        end = datetime(2026, 6, 1, 12, 30)
+        result = svc._collect_games_from_apis(start, end)
+
+        assert ts_game in result
+
+
+# ---------------------------------------------------------------------------
+# _convert_game_to_match_info — TTT branch
+# ---------------------------------------------------------------------------
+
+
+class TestConvertGameToMatchInfoTTT:
+    def test_ttt_source_maps_correct_fields(self):
+        svc = _mk_service()
+        game = {
+            "source": "TTT",
+            "team_name": "Flash",
+            "opponent_name": "Rivals",
+            "location": "Home",
+        }
+        result = svc._convert_game_to_match_info(game)
+
+        assert result["my_team_name"] == "Flash"
+        assert result["opponent_team_name"] == "Rivals"
+        assert result["location"] == "Home"
+
+    def test_ttt_source_handles_missing_fields(self):
+        svc = _mk_service()
+        game = {"source": "TTT"}
+        result = svc._convert_game_to_match_info(game)
+
+        assert result["my_team_name"] == ""
+        assert result["opponent_team_name"] == ""
+        assert result["location"] == ""
+
+
+# ---------------------------------------------------------------------------
+# _select_best_game — TTT preference
+# ---------------------------------------------------------------------------
+
+
+class TestSelectBestGameTTT:
+    def test_ttt_preferred_over_teamsnap(self):
+        svc = _mk_service()
+        ttt_game = {"source": "TTT", "id": "ttt-1"}
+        ts_game = {"source": "TeamSnap", "id": "ts-1"}
+
+        result = svc._select_best_game([ts_game, ttt_game])
+
+        assert result == ttt_game
+
+    def test_ttt_preferred_over_playmetrics(self):
+        svc = _mk_service()
+        ttt_game = {"source": "TTT", "id": "ttt-1"}
+        pm_game = {"source": "PlayMetrics", "id": "pm-1"}
+
+        result = svc._select_best_game([pm_game, ttt_game])
+
+        assert result == ttt_game

--- a/tests/test_schedule_service.py
+++ b/tests/test_schedule_service.py
@@ -1,0 +1,229 @@
+"""Tests for ScheduleService — TTT schedule cache and recording auto-match."""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from video_grouper.task_processors.services.schedule_service import ScheduleService
+
+
+def _mk_client(team_id="team-1", schedule=None):
+    client = MagicMock()
+    client.get_team_assignments.return_value = [{"team_id": team_id}]
+    client.get_schedule.return_value = schedule or []
+    return client
+
+
+def _mk_service(tmp_path, client=None, config=None):
+    if client is None:
+        client = _mk_client()
+    if config is None:
+        config = MagicMock()
+        config.ttt.team_name = ""
+    return ScheduleService(str(tmp_path), config, client)
+
+
+# ---------------------------------------------------------------------------
+# refresh()
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_writes_json_and_returns_true(tmp_path):
+    games = [
+        {
+            "id": "g1",
+            "start_time": "2026-06-01T10:00:00",
+            "end_time": "2026-06-01T12:00:00",
+            "opponent_name": "Rivals",
+        }
+    ]
+    client = _mk_client(team_id="team-1", schedule=games)
+    svc = _mk_service(tmp_path, client)
+
+    result = svc.refresh()
+
+    assert result is True
+    cache = tmp_path / "ttt" / "schedule_team-1.json"
+    assert cache.exists()
+    saved = json.loads(cache.read_text())
+    assert saved == games
+
+
+def test_refresh_returns_false_on_client_error(tmp_path):
+    client = _mk_client()
+    client.get_schedule.side_effect = Exception("network failure")
+    svc = _mk_service(tmp_path, client)
+
+    result = svc.refresh()  # must not raise
+
+    assert result is False
+
+
+def test_refresh_returns_false_when_no_team_id(tmp_path):
+    client = MagicMock()
+    client.get_team_assignments.return_value = []
+    svc = _mk_service(tmp_path, client)
+
+    result = svc.refresh()
+
+    assert result is False
+    client.get_schedule.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# find_game_for_recording()
+# ---------------------------------------------------------------------------
+
+
+def _seed_cache(tmp_path, team_id, games):
+    ttt_dir = tmp_path / "ttt"
+    ttt_dir.mkdir(parents=True, exist_ok=True)
+    (ttt_dir / f"schedule_{team_id}.json").write_text(json.dumps(games))
+
+
+def test_find_game_returns_overlapping_game(tmp_path):
+    games = [
+        {
+            "id": "g1",
+            "start_time": "2026-06-01T10:00:00",
+            "end_time": "2026-06-01T12:00:00",
+            "opponent_name": "Rivals",
+            "location": "Home",
+        }
+    ]
+    _seed_cache(tmp_path, "team-1", games)
+    client = _mk_client(team_id="team-1")
+    svc = _mk_service(tmp_path, client)
+
+    # Recording from 10:30 to 11:30 — well within the game window
+    result = svc.find_game_for_recording(
+        datetime(2026, 6, 1, 10, 30),
+        datetime(2026, 6, 1, 11, 30),
+    )
+
+    assert result is not None
+    assert result["id"] == "g1"
+    assert result["source"] == "TTT"
+    assert result["team_name"] == ""  # no team_name in config mock
+
+
+def test_find_game_returns_none_when_no_overlap(tmp_path):
+    games = [
+        {
+            "id": "g1",
+            "start_time": "2026-06-01T10:00:00",
+            "end_time": "2026-06-01T12:00:00",
+            "opponent_name": "Rivals",
+        }
+    ]
+    _seed_cache(tmp_path, "team-1", games)
+    client = _mk_client(team_id="team-1")
+    svc = _mk_service(tmp_path, client)
+
+    # Recording at 15:30–16:00 — game midpoint is 11:00, distance ~4.5h > 2h guard
+    result = svc.find_game_for_recording(
+        datetime(2026, 6, 1, 15, 30),
+        datetime(2026, 6, 1, 16, 0),
+    )
+
+    assert result is None
+
+
+def test_find_game_returns_none_when_no_cache(tmp_path):
+    client = _mk_client(team_id="team-1")
+    svc = _mk_service(tmp_path, client)
+
+    result = svc.find_game_for_recording(
+        datetime(2026, 6, 1, 10, 30),
+        datetime(2026, 6, 1, 11, 30),
+    )
+
+    assert result is None
+
+
+def test_find_game_tags_team_name_from_config(tmp_path):
+    games = [
+        {
+            "id": "g1",
+            "start_time": "2026-06-01T10:00:00",
+            "end_time": "2026-06-01T12:00:00",
+        }
+    ]
+    _seed_cache(tmp_path, "team-1", games)
+    client = _mk_client(team_id="team-1")
+    config = MagicMock()
+    config.ttt.team_name = "Flash"
+    svc = ScheduleService(str(tmp_path), config, client)
+
+    result = svc.find_game_for_recording(
+        datetime(2026, 6, 1, 10, 30),
+        datetime(2026, 6, 1, 11, 30),
+    )
+
+    assert result is not None
+    assert result["team_name"] == "Flash"
+
+
+def test_find_game_tags_team_name_from_assignment(tmp_path):
+    """The /device-link/me assignment carries team_name; it wins over config."""
+    games = [
+        {
+            "id": "g1",
+            "start_time": "2026-06-01T10:00:00",
+            "end_time": "2026-06-01T12:00:00",
+        }
+    ]
+    _seed_cache(tmp_path, "team-1", games)
+    client = MagicMock()
+    client.get_team_assignments.return_value = [
+        {"team_id": "team-1", "team_name": "Heat"}
+    ]
+    config = MagicMock()
+    config.ttt.team_name = "ConfigOverride"
+    svc = ScheduleService(str(tmp_path), config, client)
+
+    result = svc.find_game_for_recording(
+        datetime(2026, 6, 1, 10, 30),
+        datetime(2026, 6, 1, 11, 30),
+    )
+
+    assert result is not None
+    assert result["team_name"] == "Heat"  # assignment wins over config fallback
+
+
+# ---------------------------------------------------------------------------
+# _resolve_team_id()
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_team_id_caches_result(tmp_path):
+    client = _mk_client(team_id="team-1")
+    svc = _mk_service(tmp_path, client)
+
+    id1 = svc._resolve_team_id()
+    id2 = svc._resolve_team_id()
+
+    assert id1 == "team-1"
+    assert id2 == "team-1"
+    # Should only call the API once
+    client.get_team_assignments.assert_called_once()
+
+
+def test_resolve_team_id_returns_none_on_error(tmp_path):
+    client = MagicMock()
+    client.get_team_assignments.side_effect = Exception("network error")
+    svc = _mk_service(tmp_path, client)
+
+    result = svc._resolve_team_id()
+
+    assert result is None
+
+
+def test_resolve_team_id_returns_none_when_no_assignments(tmp_path):
+    client = MagicMock()
+    client.get_team_assignments.return_value = []
+    svc = _mk_service(tmp_path, client)
+
+    result = svc._resolve_team_id()
+
+    assert result is None

--- a/tests/test_schedule_service.py
+++ b/tests/test_schedule_service.py
@@ -191,6 +191,36 @@ def test_find_game_tags_team_name_from_assignment(tmp_path):
     assert result["team_name"] == "Heat"  # assignment wins over config fallback
 
 
+def test_find_game_converts_utc_to_camera_timezone(tmp_path):
+    """Regression: TTT serialises game times as UTC (TIMESTAMPTZ); recording times
+    are naive camera-local. A 14:00 EDT game arrives as 18:00Z and must be
+    converted to 14:00 local — NOT stripped to a naive 18:00 (4h off → never
+    matches within the 2-hour proximity guard)."""
+    games = [
+        {
+            "game_id": "g-utc",
+            "start_time": "2026-06-01T18:00:00+00:00",  # 14:00 EDT (UTC-4 in June)
+            "end_time": "2026-06-01T20:00:00+00:00",  # 16:00 EDT
+            "opponent_name": "Rivals",
+        }
+    ]
+    _seed_cache(tmp_path, "team-1", games)
+    client = _mk_client(team_id="team-1")
+    config = MagicMock()
+    config.ttt.team_name = ""
+    config.app.timezone = "America/New_York"
+    svc = ScheduleService(str(tmp_path), config, client)
+
+    # Recording 14:30–15:30 LOCAL — inside the game once the UTC time is
+    # converted to EDT. With the old naive strip this returned None.
+    result = svc.find_game_for_recording(
+        datetime(2026, 6, 1, 14, 30),
+        datetime(2026, 6, 1, 15, 30),
+    )
+    assert result is not None
+    assert result["game_id"] == "g-utc"
+
+
 # ---------------------------------------------------------------------------
 # _resolve_team_id()
 # ---------------------------------------------------------------------------

--- a/tests/test_ttt_poller.py
+++ b/tests/test_ttt_poller.py
@@ -258,3 +258,35 @@ async def test_cancelled_error_propagates(tmp_path):
 
     with pytest.raises(asyncio.CancelledError):
         await poller.discover_work()
+
+
+# ---------------------------------------------------------------------------
+# Schedule polling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_schedule_calls_refresh_when_set(tmp_path):
+    ttt = _mk_ttt()
+    schedule_service = MagicMock()
+    schedule_service.refresh.return_value = True
+    poller = TTTPoller(
+        storage_path=str(tmp_path),
+        config=_mk_config(),
+        ttt_client=ttt,
+        schedule_service=schedule_service,
+    )
+    await poller._poll_schedule()
+    schedule_service.refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_poll_schedule_noop_when_none(tmp_path):
+    ttt = _mk_ttt()
+    poller = TTTPoller(
+        storage_path=str(tmp_path),
+        config=_mk_config(),
+        ttt_client=ttt,
+    )
+    # Should not raise and should be a no-op
+    await poller._poll_schedule()

--- a/tests/test_ttt_reporter.py
+++ b/tests/test_ttt_reporter.py
@@ -1,6 +1,7 @@
 """Tests for the TTT reporter module."""
 
 import asyncio
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -651,3 +652,56 @@ class TestEnhancedHeartbeat:
             return_value={},
         ):
             await self.reporter.report_heartbeat()  # Should not raise
+
+
+class TestAutoMatchVideo:
+    """Tests for TTTReporter.auto_match_video."""
+
+    def setup_method(self):
+        self.client = MagicMock()
+        self.config = MagicMock()
+        self.config.ttt.camera_id = "cam-1"
+        self.config.ttt.heartbeat_interval = 30
+        self.reporter = TTTReporter(ttt_client=self.client, config=self.config)
+        # Pre-cache team_id so we don't need to mock get_team_assignments here
+        self.reporter._cached_team_id = "team-1"
+
+    @pytest.mark.asyncio
+    async def test_auto_match_video_calls_client_with_correct_args(self):
+        self.client.auto_match_video.return_value = {"matched": True, "message": "ok"}
+        recorded_at = datetime(2026, 6, 1, 10, 30, 0)
+
+        await self.reporter.auto_match_video("/tmp/group", "vid123", recorded_at)
+
+        self.client.auto_match_video.assert_called_once_with(
+            "team-1",
+            "https://youtu.be/vid123",
+            recorded_at.isoformat(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_auto_match_video_swallows_client_error(self):
+        self.client.auto_match_video.side_effect = Exception("network error")
+        recorded_at = datetime(2026, 6, 1, 10, 30, 0)
+
+        # Must not raise
+        await self.reporter.auto_match_video("/tmp/group", "vid123", recorded_at)
+
+    @pytest.mark.asyncio
+    async def test_auto_match_video_noop_when_disabled(self):
+        reporter = TTTReporter(ttt_client=None, config=self.config)
+        recorded_at = datetime(2026, 6, 1, 10, 30, 0)
+
+        # Must not raise and must not call client
+        await reporter.auto_match_video("/tmp/group", "vid123", recorded_at)
+        self.client.auto_match_video.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_auto_match_video_noop_when_no_team_id(self):
+        self.reporter._cached_team_id = None
+        self.client.get_team_assignments.return_value = []
+        recorded_at = datetime(2026, 6, 1, 10, 30, 0)
+
+        await self.reporter.auto_match_video("/tmp/group", "vid123", recorded_at)
+
+        self.client.auto_match_video.assert_not_called()

--- a/video_grouper/api_integrations/ttt_reporter.py
+++ b/video_grouper/api_integrations/ttt_reporter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from datetime import datetime
 
 from video_grouper.utils.error_tracker import ErrorTracker
 from video_grouper.utils.system_metrics import get_system_metrics
@@ -524,3 +525,49 @@ class TTTReporter:
         except Exception as e:
             logger.warning("TTT: Failed to get high water mark: %s", e)
             return None
+
+    async def auto_match_video(
+        self,
+        group_dir: str,
+        youtube_video_id: str,
+        recorded_at: datetime,
+    ) -> None:
+        """Auto-match an uploaded video to a TTT game based on recording time.
+
+        Best-effort — swallows all errors, never raises, never blocks the caller.
+        """
+        if not self.enabled:
+            return
+        try:
+            team_id = await asyncio.get_event_loop().run_in_executor(
+                None, self._get_team_id_sync
+            )
+            if not team_id:
+                logger.debug(
+                    "TTT: No team_id available, skipping auto_match_video for %s",
+                    group_dir,
+                )
+                return
+            video_url = f"https://youtu.be/{youtube_video_id}"
+            recorded_at_str = recorded_at.isoformat()
+            result = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: self.client.auto_match_video(
+                    team_id, video_url, recorded_at_str
+                ),
+            )
+            if result:
+                matched = result.get("matched", False)
+                message = result.get("message", "")
+                logger.info(
+                    "TTT: auto_match_video for %s: matched=%s %s",
+                    group_dir,
+                    matched,
+                    message,
+                )
+            else:
+                logger.debug(
+                    "TTT: auto_match_video returned no result for %s", group_dir
+                )
+        except Exception as exc:
+            logger.warning("TTT: auto_match_video failed for %s: %s", group_dir, exc)

--- a/video_grouper/task_processors/services/match_info_service.py
+++ b/video_grouper/task_processors/services/match_info_service.py
@@ -35,6 +35,7 @@ class MatchInfoService:
         teamsnap_service: TeamSnapService,
         playmetrics_service: PlayMetricsService,
         ntfy_service: NtfyService,
+        schedule_service=None,
     ):
         """
         Initialize match info service.
@@ -43,10 +44,12 @@ class MatchInfoService:
             teamsnap_service: TeamSnap service instance
             playmetrics_service: PlayMetrics service instance
             ntfy_service: NTFY service instance
+            schedule_service: Optional ScheduleService for TTT-authoritative schedule
         """
         self.teamsnap_service = teamsnap_service
         self.playmetrics_service = playmetrics_service
         self.ntfy_service = ntfy_service
+        self.schedule_service = schedule_service
 
     def _get_recording_timespan(
         self, group_dir: str
@@ -166,6 +169,27 @@ class MatchInfoService:
         )
         games = []
 
+        # TTT schedule is authoritative — if it returns a match, skip TeamSnap/PlayMetrics
+        if self.schedule_service is not None:
+            try:
+                logger.info("Querying TTT schedule for games...")
+                ttt_game = self.schedule_service.find_game_for_recording(
+                    recording_start, recording_end
+                )
+                if ttt_game:
+                    logger.info(
+                        f"Found TTT game: {ttt_game.get('team_name', 'Unknown')} vs "
+                        f"{ttt_game.get('opponent_name', 'Unknown')} at "
+                        f"{ttt_game.get('location', 'Unknown')}"
+                    )
+                    return [ttt_game]
+                else:
+                    logger.info(
+                        "No TTT game found for the recording timespan, falling back to APIs"
+                    )
+            except Exception as e:
+                logger.error(f"Error getting game from TTT schedule: {e}")
+
         # Try TeamSnap
         logger.info(f"TeamSnap service enabled: {self.teamsnap_service.enabled}")
         if self.teamsnap_service.enabled:
@@ -224,6 +248,12 @@ class MatchInfoService:
         if len(games) == 1:
             return games[0]
 
+        # Prefer TTT (authoritative) over all other sources
+        for game in games:
+            if game.get("source") == "TTT":
+                logger.info(f"Selected TTT game over {len(games) - 1} other options")
+                return game
+
         # For now, prefer TeamSnap over PlayMetrics
         # TODO: Implement more sophisticated selection logic
         for game in games:
@@ -251,7 +281,15 @@ class MatchInfoService:
         source = game.get("source", "Unknown")
         logger.info(f"Game source: {source}")
 
-        if source == "TeamSnap":
+        if source == "TTT":
+            match_info = {
+                "my_team_name": game.get("team_name", ""),
+                "opponent_team_name": game.get("opponent_name", ""),
+                "location": game.get("location", ""),
+            }
+            logger.info(f"TTT conversion result: {match_info}")
+            return match_info
+        elif source == "TeamSnap":
             # Prefer the team_name field that TeamSnapService added
             my_team = game.get("team_name", "")
 

--- a/video_grouper/task_processors/services/schedule_service.py
+++ b/video_grouper/task_processors/services/schedule_service.py
@@ -1,0 +1,204 @@
+"""TTT schedule cache and game auto-match for recordings."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from video_grouper.api_integrations.ttt_api import TTTApiClient
+    from video_grouper.utils.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class ScheduleService:
+    """Fetches and caches the TTT team schedule, then matches recordings to games.
+
+    All public methods are best-effort and never raise — errors are logged and
+    safe return values (False / None) are returned instead.
+    """
+
+    def __init__(
+        self,
+        storage_path: str | Path,
+        config: Config,
+        ttt_client: TTTApiClient,
+    ):
+        self._storage_path = Path(storage_path)
+        self._config = config
+        self._ttt_client = ttt_client
+        self._team_id: str | None = None
+        self._team_name: str | None = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_team_id(self) -> str | None:
+        """Resolve team_id from TTT assignments; cached after first call."""
+        if self._team_id:
+            return self._team_id
+        try:
+            assignments = self._ttt_client.get_team_assignments()
+            if not assignments:
+                return None
+            if len(assignments) > 1:
+                logger.debug(
+                    "ScheduleService: %d team assignments; using first (team_id=%s)",
+                    len(assignments),
+                    assignments[0].get("team_id"),
+                )
+            team_id = assignments[0].get("team_id")
+            if team_id:
+                self._team_id = team_id
+                # /device-link/me carries the TTT team_name — use it for the
+                # {team}__... naming convention (config has no TTT team name).
+                self._team_name = assignments[0].get("team_name") or None
+            return team_id
+        except Exception as exc:
+            logger.error("ScheduleService: failed to resolve team_id: %s", exc)
+            return None
+
+    def _get_team_name(self) -> str:
+        """Return the TTT team name resolved from the device-link assignment.
+
+        Falls back to a ``config.ttt.team_name`` override if present, else "".
+        """
+        if self._team_name:
+            return self._team_name
+        try:
+            ttt_cfg = getattr(self._config, "ttt", None)
+            name = getattr(ttt_cfg, "team_name", None)
+            if name:
+                return str(name)
+        except Exception:
+            pass
+        return ""
+
+    def _cache_path(self, team_id: str) -> Path:
+        return self._storage_path / "ttt" / f"schedule_{team_id}.json"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def refresh(self) -> bool:
+        """Fetch the schedule from TTT and write it to the local cache.
+
+        Returns True on success, False on any error (never raises).
+        Window: −30 days to +180 days from today.
+        """
+        team_id = self._resolve_team_id()
+        if not team_id:
+            return False
+        try:
+            today = datetime.now()
+            start_date = (today - timedelta(days=30)).strftime("%Y-%m-%d")
+            end_date = (today + timedelta(days=180)).strftime("%Y-%m-%d")
+            schedule = self._ttt_client.get_schedule(
+                team_id,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            ttt_dir = self._storage_path / "ttt"
+            ttt_dir.mkdir(parents=True, exist_ok=True)
+            dest = self._cache_path(team_id)
+            # Atomic write via rename
+            fd, tmp_path = tempfile.mkstemp(dir=str(ttt_dir), suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    json.dump(schedule, fh)
+                os.replace(tmp_path, dest)
+            except Exception:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+            logger.debug(
+                "ScheduleService: wrote %d game(s) to %s",
+                len(schedule or []),
+                dest,
+            )
+            return True
+        except Exception as exc:
+            logger.error("ScheduleService: refresh failed: %s", exc)
+            return False
+
+    def find_game_for_recording(
+        self,
+        start: datetime,
+        end: datetime,
+    ) -> dict[str, Any] | None:
+        """Find the best TTT game that overlaps the recording window.
+
+        Reads the local cache written by :meth:`refresh`; returns ``None``
+        when the cache is absent, empty, or no game is close enough (per the
+        2-hour proximity guard in
+        :func:`~video_grouper.utils.game_selection.select_best_game`).
+
+        Tags the returned dict with ``source="TTT"`` and ``team_name``.
+        Never raises.
+        """
+        team_id = self._resolve_team_id()
+        if not team_id:
+            return None
+        cache = self._cache_path(team_id)
+        if not cache.exists():
+            return None
+        try:
+            games: list[dict[str, Any]] = (
+                json.loads(cache.read_text(encoding="utf-8")) or []
+            )
+        except Exception as exc:
+            logger.warning("ScheduleService: could not read schedule cache: %s", exc)
+            return None
+
+        from video_grouper.utils.game_selection import select_best_game
+
+        candidates = []
+        for game in games:
+            try:
+                g_start_raw = game.get("start_time")
+                g_end_raw = game.get("end_time")
+                if not g_start_raw:
+                    continue
+                g_start = datetime.fromisoformat(g_start_raw)
+                # Strip timezone so naive Reolink recording times compare cleanly
+                if g_start.tzinfo is not None:
+                    g_start = g_start.replace(tzinfo=None)
+                if g_end_raw:
+                    g_end = datetime.fromisoformat(g_end_raw)
+                    if g_end.tzinfo is not None:
+                        g_end = g_end.replace(tzinfo=None)
+                else:
+                    g_end = g_start + timedelta(hours=2)
+                candidates.append((game, g_start, g_end))
+            except (ValueError, TypeError) as exc:
+                logger.debug(
+                    "ScheduleService: skipping game with unparseable time: %s", exc
+                )
+
+        if not candidates:
+            return None
+
+        selected = select_best_game(
+            candidates,
+            start,
+            end,
+            game_label_fn=lambda g: g.get("id", "?"),
+        )
+        if selected is None:
+            return None
+
+        # Tag with source and team name; copy so we don't mutate the cached dict
+        result = dict(selected)
+        result["source"] = "TTT"
+        result["team_name"] = self._get_team_name()
+        return result

--- a/video_grouper/task_processors/services/schedule_service.py
+++ b/video_grouper/task_processors/services/schedule_service.py
@@ -9,12 +9,18 @@ import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo
 
 if TYPE_CHECKING:
     from video_grouper.api_integrations.ttt_api import TTTApiClient
     from video_grouper.utils.config import Config
 
 logger = logging.getLogger(__name__)
+
+# Don't hammer the TTT schedule endpoint every poll cycle — the schedule barely
+# changes. Refresh at most this often; the local cache serves reads in between.
+_REFRESH_MIN_INTERVAL = timedelta(hours=1)
+_DEFAULT_TZ = "America/New_York"
 
 
 class ScheduleService:
@@ -35,6 +41,7 @@ class ScheduleService:
         self._ttt_client = ttt_client
         self._team_id: str | None = None
         self._team_name: str | None = None
+        self._last_refresh_at: datetime | None = None
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -68,7 +75,7 @@ class ScheduleService:
     def _get_team_name(self) -> str:
         """Return the TTT team name resolved from the device-link assignment.
 
-        Falls back to a ``config.ttt.team_name`` override if present, else "".
+        Falls back to a ``config.ttt.team_name`` if set, else "".
         """
         if self._team_name:
             return self._team_name
@@ -84,6 +91,21 @@ class ScheduleService:
     def _cache_path(self, team_id: str) -> Path:
         return self._storage_path / "ttt" / f"schedule_{team_id}.json"
 
+    def _camera_tz(self) -> ZoneInfo:
+        """The camera's local timezone (config.app.timezone), used to convert
+        TTT's UTC game times to the same naive-local frame as recording times.
+        """
+        tz_name = _DEFAULT_TZ
+        try:
+            app_cfg = getattr(self._config, "app", None)
+            tz_name = getattr(app_cfg, "timezone", None) or _DEFAULT_TZ
+        except Exception:
+            pass
+        try:
+            return ZoneInfo(tz_name)
+        except Exception:
+            return ZoneInfo(_DEFAULT_TZ)
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -97,10 +119,17 @@ class ScheduleService:
         team_id = self._resolve_team_id()
         if not team_id:
             return False
+        now = datetime.now()
+        if (
+            self._last_refresh_at is not None
+            and now - self._last_refresh_at < _REFRESH_MIN_INTERVAL
+        ):
+            # Cache is still fresh — the poller calls this every cycle; don't
+            # hit the API more than once per _REFRESH_MIN_INTERVAL.
+            return True
         try:
-            today = datetime.now()
-            start_date = (today - timedelta(days=30)).strftime("%Y-%m-%d")
-            end_date = (today + timedelta(days=180)).strftime("%Y-%m-%d")
+            start_date = (now - timedelta(days=30)).strftime("%Y-%m-%d")
+            end_date = (now + timedelta(days=180)).strftime("%Y-%m-%d")
             schedule = self._ttt_client.get_schedule(
                 team_id,
                 start_date=start_date,
@@ -121,6 +150,7 @@ class ScheduleService:
                 except OSError:
                     pass
                 raise
+            self._last_refresh_at = now
             logger.debug(
                 "ScheduleService: wrote %d game(s) to %s",
                 len(schedule or []),
@@ -162,6 +192,17 @@ class ScheduleService:
 
         from video_grouper.utils.game_selection import select_best_game
 
+        cam_tz = self._camera_tz()
+
+        def _to_local_naive(raw: str) -> datetime:
+            # TTT serialises game times as UTC (TIMESTAMPTZ). Recording times are
+            # naive camera-local. Convert UTC -> camera tz BEFORE dropping tzinfo,
+            # or a naive-UTC value would be off by the UTC offset and never match.
+            dt = datetime.fromisoformat(raw)
+            if dt.tzinfo is not None:
+                dt = dt.astimezone(cam_tz).replace(tzinfo=None)
+            return dt
+
         candidates = []
         for game in games:
             try:
@@ -169,16 +210,12 @@ class ScheduleService:
                 g_end_raw = game.get("end_time")
                 if not g_start_raw:
                     continue
-                g_start = datetime.fromisoformat(g_start_raw)
-                # Strip timezone so naive Reolink recording times compare cleanly
-                if g_start.tzinfo is not None:
-                    g_start = g_start.replace(tzinfo=None)
-                if g_end_raw:
-                    g_end = datetime.fromisoformat(g_end_raw)
-                    if g_end.tzinfo is not None:
-                        g_end = g_end.replace(tzinfo=None)
-                else:
-                    g_end = g_start + timedelta(hours=2)
+                g_start = _to_local_naive(g_start_raw)
+                g_end = (
+                    _to_local_naive(g_end_raw)
+                    if g_end_raw
+                    else g_start + timedelta(hours=2)
+                )
                 candidates.append((game, g_start, g_end))
             except (ValueError, TypeError) as exc:
                 logger.debug(
@@ -192,7 +229,7 @@ class ScheduleService:
             candidates,
             start,
             end,
-            game_label_fn=lambda g: g.get("id", "?"),
+            game_label_fn=lambda g: g.get("game_id", g.get("id", "?")),
         )
         if selected is None:
             return None

--- a/video_grouper/task_processors/ttt_poller.py
+++ b/video_grouper/task_processors/ttt_poller.py
@@ -61,6 +61,7 @@ class TTTPoller(PollingProcessor):
         highlight_reel_processor: HighlightReelProcessor | None = None,
         ttt_job_processor: TTTJobProcessor | None = None,
         reprocess_request_processor: ReprocessRequestProcessor | None = None,
+        schedule_service=None,
         poll_interval: int = 60,
     ):
         super().__init__(storage_path, config, poll_interval)
@@ -69,6 +70,7 @@ class TTTPoller(PollingProcessor):
         self.highlight_reel_processor = highlight_reel_processor
         self.ttt_job_processor = ttt_job_processor
         self.reprocess_request_processor = reprocess_request_processor
+        self.schedule_service = schedule_service
         # TTT-job service registration + heartbeat live here.
         self._service_id: str | None = None
         # Reprocess-request lifecycle tracking — request_id -> group_dir.
@@ -81,6 +83,7 @@ class TTTPoller(PollingProcessor):
                 ("highlight_reels", highlight_reel_processor),
                 ("ttt_jobs", ttt_job_processor),
                 ("reprocess_requests", reprocess_request_processor),
+                ("schedule", schedule_service),
             )
             if p is not None
         ]
@@ -101,6 +104,7 @@ class TTTPoller(PollingProcessor):
         await self._safe_poll("highlight_reels", self._poll_highlight_reels)
         await self._safe_poll("ttt_jobs", self._poll_ttt_jobs)
         await self._safe_poll("reprocess_requests", self._poll_reprocess_requests)
+        await self._safe_poll("schedule", self._poll_schedule)
 
     async def _safe_poll(self, name: str, fn) -> None:
         try:
@@ -185,6 +189,11 @@ class TTTPoller(PollingProcessor):
                 # reporting inline. Light I/O, no queue needed.
                 await self._propagate_cancel_if_set(req)
                 await self._report_progress_if_changed(req)
+
+    async def _poll_schedule(self) -> None:
+        if self.schedule_service is None:
+            return
+        await asyncio.to_thread(self.schedule_service.refresh)
 
     # ------------------------------------------------------------------
     # TTTJob: service registration + heartbeat

--- a/video_grouper/task_processors/upload_processor.py
+++ b/video_grouper/task_processors/upload_processor.py
@@ -152,6 +152,25 @@ class UploadProcessor(QueueProcessor):
                         )
                     except Exception:
                         pass  # Never block upload on TTT
+
+                # Auto-match uploaded video with TTT game schedule (best-effort)
+                if self.ttt_reporter:
+                    yt_video_id = getattr(item, "youtube_video_id", None)
+                    if yt_video_id:
+                        group_dir = item.get_item_path()
+                        try:
+                            from video_grouper.models import DirectoryState
+
+                            dir_state = DirectoryState(group_dir)
+                            files = list(dir_state.files.values())
+                            if files:
+                                files.sort(key=lambda f: f.start_time)
+                                recorded_at = files[0].start_time
+                                await self.ttt_reporter.auto_match_video(
+                                    group_dir, yt_video_id, recorded_at
+                                )
+                        except Exception:
+                            pass  # Never block upload on TTT
             else:
                 logger.error(f"UPLOAD: Task execution failed: {item}")
                 # Report upload failure to TTT (best-effort)

--- a/video_grouper/video_grouper_app.py
+++ b/video_grouper/video_grouper_app.py
@@ -466,6 +466,31 @@ class VideoGrouperApp:
                 logger.info("TTT ReprocessRequestProcessor initialized")
 
                 self._ttt_client = ttt_client
+
+                # Schedule service — caches TTT team schedule and auto-matches
+                # recordings to games. Best-effort; never blocks startup.
+                try:
+                    from video_grouper.task_processors.services.schedule_service import (
+                        ScheduleService,
+                    )
+
+                    schedule_service = ScheduleService(
+                        self.storage_path, self.config, ttt_client
+                    )
+                    self._schedule_service = schedule_service
+                    # Wire into match_info_service if the NTFY block already created it
+                    if (
+                        self.ntfy_processor is not None
+                        and getattr(self.ntfy_processor, "match_info_service", None)
+                        is not None
+                    ):
+                        self.ntfy_processor.match_info_service.schedule_service = (
+                            schedule_service
+                        )
+                except Exception:
+                    logger.warning(
+                        "ScheduleService failed to initialize", exc_info=True
+                    )
             except Exception as e:
                 logger.error(f"Failed to initialize TTT processors: {e}")
 
@@ -589,6 +614,7 @@ class VideoGrouperApp:
                         reprocess_request_processor=getattr(
                             self, "reprocess_request_processor", None
                         ),
+                        schedule_service=getattr(self, "_schedule_service", None),
                         poll_interval=self.config.ttt.clip_request_poll_interval,
                     )
                     logger.info("TTTPoller initialized")


### PR DESCRIPTION
## What

Wire up the soccer-cam device-link consumers (plan item **P2a**). soccer-cam had the TTT client methods for schedule/roster/auto-match but nothing consuming them. Implements the decided design: **TTT is the authoritative schedule source; the existing TeamSnap/PlayMetrics sync becomes the fallback.**

- **`ScheduleService`** — resolves `team_id` + `team_name` at runtime via `/device-link/me`, caches the TTT schedule under `storage/ttt/schedule_<team>.json` (atomic write), matches a recording window to a game (`source="TTT"`). Best-effort; never raises.
- **`MatchInfoService`** — queries TTT **first**; uses the TTT game if found, else falls back to TeamSnap/PlayMetrics. This is the "prefer TTT, fall back to local" seam.
- **`TTTPoller`** — refreshes the schedule cache on the existing poll cadence (respects the single-TTT-poller invariant — no new PollingProcessor).
- **`TTTReporter.auto_match_video` + `UploadProcessor` hook** — after a successful YouTube upload, best-effort POST the video to `/device-link/auto-match-video`.
- Wiring in `video_grouper_app`; every new path is gated on TTT being enabled, so installs without TTT are unaffected.

## Scope note

Roster / schedule-providers consumers are **intentionally not built**: soccer-cam's pipeline doesn't consume rosters (that's the moment-tagger app), and schedule-providers is onboarding config, not a pipeline worker. The plan lists them under P2a but they have no soccer-cam-worker use.

## Verification

- Unit: `schedule_service` (12), `match_info_service` (7), `ttt_poller` (+2), `ttt_reporter` auto-match (4). Affected suite **304 passed, 67 skipped**. Ruff + mypy clean.
- **Live** against the local TTT device-link endpoints as a camera manager: `/me` (team+name resolved), `get_schedule` 200, `get_roster` 200, `auto_match_video` 200 (`matched=false` with no game seeded), `ScheduleService.refresh()` → cache written, `team_name` resolved (`GU12 - Smith`).

Companion: this consumes existing TTT endpoints — no TTT change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)