### PR TITLE
chore: fix stale moment-reel smoke + guard Drive against Web OAuth clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -372,6 +372,7 @@ torchvision = { index = "pytorch-cu126" }
 dev = [
     "aiohttp>=3.13.3",
     "mypy>=2.1.0",
+    "psycopg2-binary>=2.9.12",
     "pytest>=8.4.1",
     "pytest-asyncio>=1.0.0",
 ]

--- a/scripts/smoke_moment_reel_pipeline.py
+++ b/scripts/smoke_moment_reel_pipeline.py
@@ -221,8 +221,8 @@ async def main() -> int:
         """
         INSERT INTO coaching_sessions.camera_recordings
             (id, camera_id, team_id, game_session_id, file_name,
-             recording_start, youtube_video_id, upload_status)
-        VALUES (%s, %s, %s, %s, %s, NOW(), %s, 'complete')
+             recording_start, youtube_video_id)
+        VALUES (%s, %s, %s, %s, %s, NOW(), %s)
         """,
         (
             camera_recording_id,
@@ -295,18 +295,21 @@ async def main() -> int:
     # novel pipeline piece.
     banner("5. Simulate Phase A hook output: insert game_video + auto-create reel")
     game_video_id = str(uuid.uuid4())
+    media_video_id = str(uuid.uuid4())
+    db_exec(
+        """
+        INSERT INTO media.videos (id, source_url, source_type)
+        VALUES (%s, %s, 'youtube')
+        """,
+        (media_video_id, f"https://youtu.be/{youtube_video_id}"),
+    )
     db_exec(
         """
         INSERT INTO game_analysis.game_videos
-            (id, game_id, youtube_url, youtube_video_id, video_type, created_at)
-        VALUES (%s, %s, %s, %s, 'full', NOW())
+            (id, game_id, video_id, video_type, created_at)
+        VALUES (%s, %s, %s, 'full', NOW())
         """,
-        (
-            game_video_id,
-            game_id,
-            f"https://youtu.be/{youtube_video_id}",
-            youtube_video_id,
-        ),
+        (game_video_id, game_id, media_video_id),
     )
 
     reel_id = str(uuid.uuid4())
@@ -381,7 +384,6 @@ async def main() -> int:
         config=config,
         ttt_client=ttt_client,
         youtube_uploader=stub_uploader,
-        poll_interval=60,
     )
 
     # Fetch the reel via the polling endpoint (just to confirm the wire)
@@ -405,7 +407,7 @@ async def main() -> int:
     # Run the per-reel processor directly (skip the polling loop noise)
     print("  invoking _process_reel(...)")
     try:
-        await processor._process_reel(reel_payload)
+        await processor._process_reel(ttt_client, reel_payload)
     except Exception as e:
         print(f"  _process_reel RAISED: {e!r}")
         raise

--- a/scripts/smoke_real_service.py
+++ b/scripts/smoke_real_service.py
@@ -431,8 +431,8 @@ def seed_db(recording_dir_name: str, recording_start: datetime) -> dict[str, str
     db_exec(
         "INSERT INTO coaching_sessions.camera_recordings "
         "(id, camera_id, team_id, game_session_id, file_name, recording_start, "
-        "youtube_video_id, upload_status) "
-        "VALUES (%s, %s, %s, %s, %s, %s, %s, 'complete')",
+        "youtube_video_id) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s)",
         (
             cam_rec_id,
             cam_id,

--- a/tests/test_google_drive_upload.py
+++ b/tests/test_google_drive_upload.py
@@ -1,0 +1,54 @@
+"""Tests for GoogleDriveUploader OAuth client-type validation.
+
+The Drive uploader reuses the YouTube OAuth client, which must be a Google
+"Desktop app" client for the interactive loopback consent flow to work. A
+"Web" client fails deep inside the flow with redirect_uri_mismatch; the
+uploader surfaces that up front with an actionable error.
+
+Note: conftest's autouse ``mock_file_system`` patches ``os.path.exists`` to
+True for everything, so each test drives it via a side_effect to control which
+of {client_secret.json, token.json} "exists". The real client_secret.json is
+still written to disk (pathlib), so the uploader's real open()/JSON read works.
+"""
+
+import json
+
+import pytest
+
+from video_grouper.utils.google_drive_upload import GoogleDriveUploader
+
+
+def _write_client_secret(storage, kind: str) -> None:
+    d = storage / "youtube"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "client_secret.json").write_text(
+        json.dumps({kind: {"client_id": "x", "client_secret": "y"}})
+    )
+
+
+def test_web_client_raises_helpful_error(tmp_path, mock_file_system):
+    """A 'web' OAuth client → clear RuntimeError before the browser flow opens."""
+    _write_client_secret(tmp_path, "web")
+    # client_secret.json exists; token.json does not → reach the interactive flow
+    mock_file_system["exists"].side_effect = lambda p: "client_secret" in str(p)
+    uploader = GoogleDriveUploader(str(tmp_path))
+    with pytest.raises(RuntimeError, match="Desktop app"):
+        uploader.authenticate(interactive=True)
+
+
+def test_missing_client_secret_raises_filenotfound(tmp_path, mock_file_system):
+    mock_file_system["exists"].return_value = False
+    uploader = GoogleDriveUploader(str(tmp_path))
+    with pytest.raises(FileNotFoundError):
+        uploader.authenticate(interactive=True)
+
+
+def test_non_interactive_without_token_raises_runtimeerror(tmp_path, mock_file_system):
+    """An 'installed' client but no token + interactive=False → the existing
+    'run with interactive=True' error (the Desktop check is only on the
+    interactive path, so an installed client does not trip it)."""
+    _write_client_secret(tmp_path, "installed")
+    mock_file_system["exists"].side_effect = lambda p: "client_secret" in str(p)
+    uploader = GoogleDriveUploader(str(tmp_path))
+    with pytest.raises(RuntimeError, match="interactive"):
+        uploader.authenticate(interactive=False)

--- a/uv.lock
+++ b/uv.lock
@@ -1750,6 +1750,32 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
+    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f", size = 4579157, upload-time = "2026-04-20T23:35:28.542Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354", size = 4274970, upload-time = "2026-04-20T23:35:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033", size = 5895175, upload-time = "2026-04-20T23:35:33.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e", size = 4110658, upload-time = "2026-04-20T23:35:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5", size = 3656251, upload-time = "2026-04-20T23:35:37.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5", size = 3301810, upload-time = "2026-04-20T23:35:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
+    { url = "https://files.pythonhosted.org/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980", size = 2848762, upload-time = "2026-04-20T23:35:46.421Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2674,6 +2700,7 @@ tray = [
 dev = [
     { name = "aiohttp", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "mypy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "psycopg2-binary", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pytest", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pytest-asyncio", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
@@ -2733,6 +2760,7 @@ provides-extras = ["dev", "metrics", "ml", "render-gpu", "service", "tray"]
 dev = [
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "mypy", specifier = ">=2.1.0" },
+    { name = "psycopg2-binary", specifier = ">=2.9.12" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
 ]

--- a/video_grouper/utils/google_drive_upload.py
+++ b/video_grouper/utils/google_drive_upload.py
@@ -1,5 +1,14 @@
-"""Google Drive file uploader using YouTube OAuth client credentials."""
+"""Google Drive file uploader using YouTube OAuth client credentials.
 
+Reuses the install's YouTube OAuth client (``{storage}/youtube/client_secret.json``).
+That client MUST be a Google Cloud **"Desktop app"** OAuth client: the interactive
+consent flow uses a loopback redirect (``http://localhost:<port>``), which Google
+only allows for Desktop clients. A "Web" client (its redirects are fixed, e.g. a
+Supabase callback) fails the browser flow with ``redirect_uri_mismatch``. See
+``authenticate`` for the pre-flight check that surfaces this clearly.
+"""
+
+import json
 import logging
 import mimetypes
 import os
@@ -37,7 +46,8 @@ class GoogleDriveUploader:
                 If False, raise an error when no valid token is available.
 
         Raises:
-            RuntimeError: If no valid token exists and interactive mode is disabled.
+            RuntimeError: If no valid token exists and interactive mode is disabled,
+                or if the OAuth client is a "Web" (not "Desktop app") client.
             FileNotFoundError: If the client_secret.json file is missing.
         """
         if not os.path.exists(self.client_secret_path):
@@ -74,6 +84,24 @@ class GoogleDriveUploader:
             raise RuntimeError(
                 "No valid Google Drive token available and interactive mode is disabled. "
                 "Run with interactive=True to authenticate via browser."
+            )
+
+        # The browser consent flow (run_local_server) uses a loopback redirect,
+        # which Google only allows for "Desktop app" OAuth clients. A "Web" client
+        # would fail deep inside the flow with a cryptic redirect_uri_mismatch —
+        # surface it here with an actionable message instead.
+        try:
+            with open(self.client_secret_path, encoding="utf-8") as fh:
+                client_type = next(iter(json.load(fh)), None)
+        except (OSError, ValueError, StopIteration):
+            client_type = None
+        if client_type == "web":
+            raise RuntimeError(
+                f"The OAuth client at {self.client_secret_path} is a 'Web' client, "
+                "but interactive Google Drive auth requires a 'Desktop app' client "
+                "(the browser flow's loopback redirect is only allowed for Desktop "
+                "clients). Create an OAuth client of type 'Desktop app' in your "
+                "Google Cloud project and use its client_secret.json."
             )
 
         logger.info("Starting interactive OAuth flow for Google Drive.")


### PR DESCRIPTION
Two integration-plan housekeeping items.

## 1. `smoke_moment_reel_pipeline.py` — un-rot against current schema/API
It no longer ran (drifted from TTT's schema + the HighlightReelProcessor API). Fixed:
- `camera_recordings` INSERT: drop the removed `upload_status` column.
- `game_videos`: `youtube_url`/`youtube_video_id` moved to `media.videos` — insert a `media.videos` row, then `game_videos(video_id FK)`, matching the already-updated `smoke_real_service.py`.
- `HighlightReelProcessor(...)`: drop the removed `poll_interval` kwarg.
- `_process_reel(reel)` → `_process_reel(ttt_client, reel)`.
- Dropped `upload_status` from `smoke_real_service.py`'s `camera_recordings` insert too; added `psycopg2-binary` to **dev** deps (the smokes `import psycopg2`).

**Verified live**: the smoke runs green end-to-end against the local stack — reel `status=ready`, 90.3s mp4, Phase-D `moment_reel_ready` notification. (Re-ran it myself to confirm.)

## 2. Guard Drive auth against a "Web" OAuth client
`GoogleDriveUploader` reuses the YouTube OAuth client, but the interactive loopback consent flow only works with a Google **"Desktop app"** client — a "Web" client fails deep in the flow with `redirect_uri_mismatch` (exactly what bit the Drive-OAuth work this session). Added a pre-flight check that raises an actionable error up front, plus a docstring note and 3 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)