### PR TITLE
ttt: adopt roster contract from TTT PR #126 (player_id + optional user_id)

### DIFF
--- a/tests/integration/ttt/test_ttt_integration.py
+++ b/tests/integration/ttt/test_ttt_integration.py
@@ -757,9 +757,19 @@ class TestScheduleAndGames:
         assert isinstance(result, list)
 
     def test_get_roster(self, ttt_client):
-        """Get team roster."""
+        """Get team roster.
+
+        Post-PR #126 contract: player_id is the stable identity and
+        full_name is the display name; user_id is optional (None for
+        accountless youth players).
+        """
         result = ttt_client.get_roster(TEAM_ID)
         assert isinstance(result, list)
+        for entry in result:
+            assert "player_id" in entry
+            assert "full_name" in entry
+            # user_id may be absent/None; must not be assumed present.
+            assert entry.get("user_id") is None or isinstance(entry["user_id"], str)
 
     def test_auto_match_video_no_match(self, ttt_client):
         """Auto-match with time far from any game returns no match."""

--- a/tests/test_ttt_api.py
+++ b/tests/test_ttt_api.py
@@ -219,10 +219,27 @@ class TestTTTApiClient(unittest.TestCase):
         self.assertEqual(params, {"team_id": "team-1"})
 
     def test_get_roster(self):
-        data = [{"user_id": "u1", "display_name": "Player One", "role": "player"}]
+        # player_id is the stable identity; user_id is optional (null for
+        # accountless youth players, present for login-backed staff).
+        data = [
+            {
+                "player_id": "p1",
+                "user_id": None,
+                "full_name": "Player One",
+                "role": "player",
+            },
+            {
+                "player_id": "p2",
+                "user_id": "u2",
+                "full_name": "Coach Smith",
+                "role": "coach",
+            },
+        ]
         self.client._http.request = Mock(return_value=_mock_response(200, data))
         result = self.client.get_roster("team-1")
         self.assertEqual(result, data)
+        # Passthrough must not choke on user_id=None entries.
+        self.assertIsNone(result[0]["user_id"])
         call_args = self.client._http.request.call_args
         self.assertEqual(call_args[1]["params"]["team_id"], "team-1")
 

--- a/video_grouper/api_integrations/mock_ttt_api.py
+++ b/video_grouper/api_integrations/mock_ttt_api.py
@@ -51,22 +51,29 @@ class MockTTTApiClient:
             },
         ]
 
+        # player_id is the stable identity for every row; user_id is only
+        # present for login-backed staff (coaches/managers) — accountless
+        # youth players have user_id=None. Mirrors TTT's roster contract
+        # (device-link/roster) post-PR #126.
         self._roster = [
             {
+                "player_id": str(uuid.uuid4()),
                 "user_id": MOCK_USER_ID,
-                "display_name": "Coach Smith",
+                "full_name": "Coach Smith",
                 "role": "coach",
                 "jersey_number": None,
             },
             {
-                "user_id": str(uuid.uuid4()),
-                "display_name": "Player One",
+                "player_id": str(uuid.uuid4()),
+                "user_id": None,
+                "full_name": "Player One",
                 "role": "player",
                 "jersey_number": 10,
             },
             {
-                "user_id": str(uuid.uuid4()),
-                "display_name": "Player Two",
+                "player_id": str(uuid.uuid4()),
+                "user_id": None,
+                "full_name": "Player Two",
                 "role": "player",
                 "jersey_number": 7,
             },

--- a/video_grouper/api_integrations/ttt_api.py
+++ b/video_grouper/api_integrations/ttt_api.py
@@ -606,6 +606,14 @@ class TTTApiClient:
         """Get team roster.
 
         GET {api_base_url}/api/internal/device-link/roster
+
+        Each entry's stable identity is ``player_id`` (a ``team_members`` row),
+        plus a display ``full_name``. ``user_id`` is OPTIONAL — accountless
+        youth players have ``user_id: null`` and only login-backed staff rows
+        (coaches/managers) carry one. Callers must key entries on
+        ``player_id``, falling back to ``user_id`` only when ``player_id`` is
+        absent (older/degenerate rows), and must not assume ``user_id`` is
+        present.
         """
         url = f"{self.api_base_url}/api/internal/device-link/roster"
         params = {"team_id": team_id}


### PR DESCRIPTION
## Summary
- TTT's `GET /api/internal/device-link/roster` (TTT PR #126, already merged) now returns entries keyed on `player_id` + `full_name`, with `user_id` OPTIONAL — accountless youth players have `user_id: null`; only login-backed staff (coach/manager) rows carry one.
- `TTTApiClient.get_roster()` is a thin JSON passthrough (`video_grouper/api_integrations/ttt_api.py`) with **no production call site yet** (confirmed via repo-wide grep — only unit tests, an integration test, and `MockTTTApiClient`'s in-memory fixture reference it). Since it already returns raw dicts, the passthrough itself doesn't break on the new shape — it just needed to document the contract for whoever wires it up next.
- Scope is therefore minimal / correctness-in-advance:
  - `ttt_api.py`: documented the new response contract on `get_roster()` — key on `player_id` (fall back to `user_id` only if `player_id` is absent), use `full_name`, don't assume `user_id` is present.
  - `mock_ttt_api.py`: updated the in-memory `_roster` E2E fixture to the new shape (`player_id`, `full_name`, `user_id: null` for the two player rows, present for the coach row).
  - `tests/test_ttt_api.py::test_get_roster`: updated mock response data to the new shape, added an assertion that the passthrough doesn't choke on `user_id: None`.
  - `tests/integration/ttt/test_ttt_integration.py::test_get_roster`: strengthened the live-backend assertions to check `player_id`/`full_name` presence and that `user_id` is either `None` or a string.

## Test plan
- [x] `uv run ruff check` — all checks passed (repo-wide)
- [x] `uv run ruff format --check` — no reformatting needed
- [x] `uv run pytest tests/test_ttt_api.py -v` — 44/44 passed
- [x] `uv run pytest -m "not integration and not e2e"` — 1508 passed, 1 pre-existing skip, 110 deselected (integration/e2e)
- [x] pre-commit hooks (ruff check, ruff format, mypy) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dx2yMTNXjbfNDWUbfBFxDj