### PR TITLE
fix(detector): CLI --sigma wins over store summary; hard-fail dynamic-sigma without depth

### DIFF
--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -1,8 +1,11 @@
 """Unit tests for the v4 heatmap detector + target generation."""
 
+import json
+
 import pytest
 
-from training.data_prep.heatmap_dataset import gaussian_heatmap
+from training.data_prep.heatmap_dataset import HeatmapCropDataset, gaussian_heatmap
+from training.train_v4_heatmap import require_positive_depth
 
 
 def test_gaussian_heatmap_peak_at_center():
@@ -27,3 +30,49 @@ def test_heatmapnet_forward_and_peak():
     px, py, score = peak_xy(hm)
     assert (px, py) == (34, 12)
     assert score > 0.99
+
+
+def _mk_store(tmp_path, summary):
+    (tmp_path / "crops").mkdir()
+    index = {
+        "summary": summary,
+        "items": [{"file": "a.npy", "x": 10.0, "y": 12.0, "split": "train"}],
+    }
+    (tmp_path / "index.json").write_text(json.dumps(index))
+    return tmp_path
+
+
+def test_sigma_explicit_cli_wins_over_store_summary(tmp_path):
+    # The footgun this guards against: a σ=4 store summary silently overriding a
+    # --sigma 3 run into an exact σ=4 replica.
+    store = _mk_store(tmp_path, {"crop": 64, "sigma": 4.0})
+    assert HeatmapCropDataset(store, "train", sigma=3.0).sigma == 3.0
+
+
+def test_sigma_none_defers_to_store_summary(tmp_path):
+    store = _mk_store(tmp_path, {"crop": 64, "sigma": 6.0})
+    assert HeatmapCropDataset(store, "train").sigma == 6.0
+
+
+def test_sigma_none_without_summary_defaults_to_4(tmp_path):
+    store = _mk_store(tmp_path, {"crop": 64})
+    assert HeatmapCropDataset(store, "train").sigma == 4.0
+
+
+def test_require_positive_depth_rejects_partial_store():
+    # Partial coverage is the dangerous case: the store LOOKS depth-ready.
+    items = [
+        {"file": "a.npy", "x": 1.0, "y": 2.0, "split": "train", "depth": 0.3},
+        {"file": "b.npy", "x": 3.0, "y": 4.0, "split": "train"},
+        {"file": "c.npy", "x": None, "y": None, "split": "train"},
+    ]
+    with pytest.raises(SystemExit, match="1/2 positive"):
+        require_positive_depth(items, "store", "--dynamic-sigma")
+
+
+def test_require_positive_depth_accepts_full_coverage():
+    items = [
+        {"file": "a.npy", "x": 1.0, "y": 2.0, "split": "train", "depth": 0.3},
+        {"file": "c.npy", "x": None, "y": None, "split": "train"},  # negatives exempt
+    ]
+    require_positive_depth(items, "store", "--dynamic-sigma")

--- a/training/data_prep/heatmap_dataset.py
+++ b/training/data_prep/heatmap_dataset.py
@@ -260,13 +260,20 @@ class HeatmapCropDataset:
         root,
         split: str = "train",
         crop: int = 256,
-        sigma: float = 4.0,
+        sigma: float | None = None,
         augment: bool | None = None,
     ):
         self.root = Path(root)
         data = json.loads((self.root / "index.json").read_text())
         self.crop = data.get("summary", {}).get("crop", crop)
-        self.sigma = data.get("summary", {}).get("sigma", sigma)
+        # σ precedence: an EXPLICIT sigma wins; None defers to the store summary
+        # (the build-time σ). Targets are built at load time, so overriding σ on a
+        # prebuilt store is valid — the old summary-always-wins rule silently turned
+        # a `--sigma 3` run on a σ=4 store into an exact σ=4 replica.
+        if sigma is None:
+            self.sigma = data.get("summary", {}).get("sigma", 4.0)
+        else:
+            self.sigma = float(sigma)
         self.items = [r for r in data["items"] if r["split"] == split]
         # Horizontal-flip augmentation (train only): a mirrored field strip is a valid, different
         # soccer scene, so it adds real variety — cheaper diversity than pure oversampling.

--- a/training/docs/EXPERIMENTS.md
+++ b/training/docs/EXPERIMENTS.md
@@ -4,6 +4,38 @@ Each experiment has: hypothesis, method, result, conclusion. Failures are as val
 
 ---
 
+## EXP-DIST-50: the σ sweep is VOID — a CLI-σ precedence footgun trained hm_sig30 at σ=4; fixed (2026-07-15)
+
+**Trigger:** pre-flight verification of the "in-flight σ sweep" (EXP-DIST-49's `sigma_exp` task) before
+reading its results.
+
+**Finding — the footgun:** `HeatmapCropDataset.__init__` did
+`self.sigma = data.get("summary", {}).get("sigma", sigma)` — the store summary **always** won over the
+constructor/CLI σ, so `train_v4_heatmap --sigma X` on a prebuilt store silently trained at the store's
+build-time σ. Verified against the actual sweep launcher (`G:\ballresearch\selector\sigma_exp.ps1`): it
+ran `training.train_v4_heatmap --out G:/ballresearch/distill/crops_reolink --sigma 3.0` with **no
+rebuild**, and `crops_reolink`'s summary records `"sigma": 4.0`.
+
+**Verdict on the sweep:**
+- **`hm_sig30` trained at σ=4.0, not 3.0 — it is an hn4-recipe replica** (val-crop recall ~0.39 matches
+  the hn4 family) and says nothing about target sharpness. Do not read `cands_spc_sig30` as a σ=3 result.
+- The sweep never completed anyway: `sigma_exp.status` stuck at "dump sig30" since 07-14 17:41, the σ=2.5
+  arm never started, no `sigma_exp.done`.
+
+**Second footgun in the same family (fixed together):** `_DynSigmaDataset`/`_DepthDataset` silently
+substituted a mid-field default for a missing per-item `depth` (`r.get("depth", 0.5)` / `0.0`), so
+`--dynamic-sigma` on a depth-less store would have trained EVERY positive at one constant σ≈3.25 without
+erroring. The live risk is real: `crops_reolink_dyn` is **partially** depth-recorded (21,133 of 45,164
+positives) — it looks depth-ready and isn't.
+
+**Fix (this commit):** (1) σ precedence — `--sigma`/constructor σ default is now a `None` sentinel; an
+explicit value WINS over the store summary, `None` defers to it (fresh builds default 4.0); (2)
+`require_positive_depth()` hard-fails `--dynamic-sigma`/`--far-weight` when any positive lacks `depth`,
+and the datasets read `r["depth"]` strictly. Unit tests cover both.
+
+**Next:** re-run the sweep corrected (σ=3, σ=2.5 + dynamic-σ after completing `crops_reolink_dyn` depth
+coverage) — scheduled after the current multi-game hn2/4/5 dump batch drains the GPU.
+
 ## EXP-DIST-49 [CORRECTED 2026-07-14]: dynamic-σ WAS wrongly dismissed — ball size DOES vary ~4→17px with depth; my "constant size" was a flawed measurement (2026-07-13/14)
 
 **CORRECTION (2026-07-14, after Mark challenged the constant-size claim — he was right):** the

--- a/training/train_v4_heatmap.py
+++ b/training/train_v4_heatmap.py
@@ -112,6 +112,24 @@ def assemble_games(
     return games
 
 
+def require_positive_depth(items: list[dict], store, flag: str) -> None:
+    """Hard-fail when a depth-consuming flag runs on a store whose positives lack depth.
+
+    The depth datasets used to substitute a silent mid-field default for a missing
+    ``depth`` key, so ``--dynamic-sigma`` on a depth-less (or PARTIALLY recorded)
+    store trained those positives at one constant σ without erroring. Partial
+    stores are the dangerous case — they look depth-ready but aren't.
+    """
+    pos = [r for r in items if r.get("x") is not None]
+    missing = sum(1 for r in pos if "depth" not in r)
+    if missing:
+        raise SystemExit(
+            f"{flag}: {missing}/{len(pos)} positive crops in {store} have no 'depth' "
+            "field. Rebuild with record_depth=True or backfill depth first — a "
+            "partial store would silently train those positives at a default depth."
+        )
+
+
 def center_distance_eval(model, ds, device, radius=20, thr=0.5):
     """Recall/precision by peak-vs-target center distance on a crop dataset."""
     import torch
@@ -156,7 +174,15 @@ def main():
         help="DataLoader workers; raise to feed a data-starved GPU (was hardcoded 4)",
     )
     ap.add_argument("--crop", type=int, default=256)
-    ap.add_argument("--sigma", type=float, default=4.0)
+    ap.add_argument(
+        "--sigma",
+        type=float,
+        default=None,
+        help="target gaussian sigma. Default None = the store's build-time σ (index "
+        "summary; 4.0 on a fresh build). An EXPLICIT value wins over the store "
+        "summary — previously the summary silently overrode this flag, so a "
+        "--sigma 3 run on a σ=4 store trained at σ=4.",
+    )
     ap.add_argument("--lr", type=float, default=1e-3)
     ap.add_argument("--rebuild", action="store_true", help="re-render crops")
     ap.add_argument(
@@ -236,7 +262,7 @@ def main():
             games,
             out,
             crop=args.crop,
-            sigma=args.sigma,
+            sigma=4.0 if args.sigma is None else args.sigma,
             val_game_ids=val_ids,
             record_depth=far_on or dyn_on,
         )
@@ -264,7 +290,9 @@ def main():
                 far = 0.0
             else:
                 tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], self.sigma)
-                far = float(1.0 - r.get("depth", 0.0))  # far touchline -> 1.0
+                # depth is guaranteed by require_positive_depth() at startup; a
+                # KeyError here means the guard was bypassed — fail loudly.
+                far = float(1.0 - r["depth"])  # far touchline -> 1.0
             if self.augment and random.random() < 0.5:
                 stack = _np.ascontiguousarray(stack[:, :, ::-1])
                 tgt = _np.ascontiguousarray(tgt[:, ::-1])
@@ -294,7 +322,9 @@ def main():
             if r["x"] is None:
                 tgt = _np.zeros((self.crop, self.crop), _np.float32)
             else:
-                depth = float(r.get("depth", 0.5))
+                # depth is guaranteed by require_positive_depth() at startup; a
+                # KeyError here means the guard was bypassed — fail loudly.
+                depth = float(r["depth"])
                 sig = self.sigma_far + (self.sigma_near - self.sigma_far) * depth
                 tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], sig)
             if self.augment and random.random() < 0.5:
@@ -309,6 +339,10 @@ def main():
     else:
         ds_cls = HeatmapCropDataset
     tr = ds_cls(out, "train", args.crop, args.sigma)
+    if dyn_on or far_on:
+        require_positive_depth(
+            tr.items, out, "--dynamic-sigma" if dyn_on else "--far-weight"
+        )
     if dyn_on:
         tr.sigma_far = args.sigma_far
         tr.sigma_near = args.sigma_near


### PR DESCRIPTION
## What

Two silent-footgun fixes in the v4 heatmap trainer, documented as **EXP-DIST-50**:

1. **σ precedence** — `HeatmapCropDataset` let the store summary's σ override an explicit `--sigma`, so `train_v4_heatmap --sigma 3` on the σ=4 `crops_reolink` store silently trained at σ=4. σ is now a `None` sentinel: an explicit CLI value wins, `None` defers to the store's build-time σ (fresh builds default 4.0).
2. **Depth guard** — `--dynamic-sigma` / `--far-weight` on a store whose positives lack `depth` silently trained on a mid-field default (0.5 / 0.0). `require_positive_depth()` now hard-fails at startup (partially-recorded stores are the dangerous case — `crops_reolink_dyn` has depth on only 21,133 of 45,164 positives), and the depth datasets read `r["depth"]` strictly.

## Why now

Pre-flight verification of the in-flight σ sweep found it was **void**: `sigma_exp.ps1` ran `--sigma 3.0` against `crops_reolink` (summary σ=4.0) with no rebuild → `hm_sig30` is an hn4-recipe replica (val recall ~0.39 matches). The σ=2.5 arm never started. Verified against the launcher, the store summary, and the server repo copy. The corrected sweep re-runs after the current multi-game dump batch drains the GPU.

## Verification

- New unit tests: σ explicit-wins / None-defers / no-summary-default, depth guard partial-store rejection + full-coverage pass
- Full unit suite: **1557 passed, 4 skipped, 1 xfailed**; ruff + format clean (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)