### PR TITLE
detector: experiment infra — store versioning, sigma/spawn fixes, encoding prelude, patience, person head (+EXP-DIST-50..55)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,24 @@
+import importlib.machinery
 import sys
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 # pytest-qt (loaded at plugin discovery) imports PyQt6, whose DLLs collide
 # with onnxruntime-gpu's DLL load on Windows. Stub onnxruntime before any
 # test module tries to import it — unit tests already mock InferenceSession.
-sys.modules.setdefault("onnxruntime", MagicMock())
+# The stub needs a real __spec__: importlib.util.find_spec("onnxruntime")
+# raises ValueError on a spec-less sys.modules entry.
+_ort_stub = MagicMock()
+_ort_stub.__spec__ = importlib.machinery.ModuleSpec("onnxruntime", loader=None)
+sys.modules.setdefault("onnxruntime", _ort_stub)
+
+# torch's first import probes DLL directories via os.path.exists; the autouse
+# mock_file_system fixture patches os.path.exists globally, so a torch import
+# that first happens INSIDE a test crashes (add_dll_directory on phantom
+# paths). Import it here, while the real filesystem is still visible.
+try:
+    import torch  # noqa: F401
+except ImportError:  # torch is an optional extra; tests skip without it
+    pass
 
 import asyncio  # noqa: E402
 import configparser  # noqa: E402

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -213,3 +213,21 @@ def test_heatmapnet_out_ch2_forward_and_loader(tmp_path):
     with torch.no_grad():
         out = model(x)
     assert tuple(out.shape) == (1, 2, 32, 32)
+
+
+def test_dataset_variants_are_picklable(tmp_path):
+    # Windows DataLoader workers spawn + pickle the dataset: a class defined
+    # inside main() dies with "Can't get local object". Guard module-level-ness.
+    import pickle
+
+    from training.train_v4_heatmap import (
+        _DepthDataset,
+        _DynSigmaDataset,
+        _PersonDataset,
+    )
+
+    store = _mk_store(tmp_path, {"crop": 64, "sigma": 4.0})
+    for cls in (_DepthDataset, _DynSigmaDataset, _PersonDataset):
+        ds = cls(store, "train")
+        blob = pickle.dumps(ds)
+        assert pickle.loads(blob).crop == 64

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -7,6 +7,16 @@ import pytest
 from training.data_prep.heatmap_dataset import HeatmapCropDataset, gaussian_heatmap
 from training.train_v4_heatmap import require_positive_depth
 
+# torch MUST be imported at collection time: conftest's autouse mock_file_system
+# patches os.path.exists globally, and torch's Windows DLL-path setup calls it
+# during first import — importing torch inside a test therefore crashes.
+try:
+    import torch
+except ImportError:
+    torch = None
+
+needs_torch = pytest.mark.skipif(torch is None, reason="torch not installed")
+
 
 def test_gaussian_heatmap_peak_at_center():
     g = gaussian_heatmap(64, 64, 30, 20, sigma=4.0)
@@ -16,8 +26,8 @@ def test_gaussian_heatmap_peak_at_center():
     assert g[0, 0] < 0.01  # far corner ~0
 
 
+@needs_torch
 def test_heatmapnet_forward_and_peak():
-    torch = pytest.importorskip("torch")
     from training.models.heatmap_net import HeatmapNet, peak_xy
 
     net = HeatmapNet(in_frames=3, in_ch_per_frame=1, base=8).eval()
@@ -76,3 +86,84 @@ def test_require_positive_depth_accepts_full_coverage():
         {"file": "c.npy", "x": None, "y": None, "split": "train"},  # negatives exempt
     ]
     require_positive_depth(items, "store", "--dynamic-sigma")
+
+
+@needs_torch
+def test_encoding_prelude_gray3_is_identity():
+    from training.models.heatmap_net import EncodingPrelude
+
+    x = torch.rand(2, 3, 16, 16)
+    out = EncodingPrelude("gray3")(x)
+    assert out is x  # exact identity — the byte-identical default path
+
+
+@needs_torch
+def test_encoding_prelude_diff3_math():
+    from training.models.heatmap_net import EncodingPrelude
+
+    x = torch.rand(2, 3, 16, 16)
+    g0, g1, g2 = x[:, 0:1], x[:, 1:2], x[:, 2:3]
+    out = EncodingPrelude("diff3")(x)
+    assert torch.equal(out[:, 0:1], g2)  # appearance = frame t
+    assert torch.equal(out[:, 1:2], g1 - g0)
+    assert torch.equal(out[:, 2:3], g2 - g1)
+
+
+@needs_torch
+def test_encoding_prelude_rejects_unknown():
+    from training.models.heatmap_net import EncodingPrelude
+
+    with pytest.raises(ValueError, match="unknown encoding"):
+        EncodingPrelude("rgb9")
+
+
+@needs_torch
+def test_default_encoding_byte_identical_to_bare_net():
+    from training.models.heatmap_net import (
+        DetectorWithEncoding,
+        EncodingPrelude,
+        HeatmapNet,
+    )
+
+    net = HeatmapNet(in_frames=3, in_ch_per_frame=1, base=8).eval()
+    x = torch.rand(1, 3, 32, 32)
+    with torch.no_grad():
+        assert torch.equal(
+            DetectorWithEncoding(EncodingPrelude("gray3"), net)(x), net(x)
+        )
+
+
+@needs_torch
+def test_load_detector_checkpoint_roundtrip(tmp_path):
+    from training.models.heatmap_net import HeatmapNet, load_detector_checkpoint
+
+    net = HeatmapNet(in_frames=3, in_ch_per_frame=1, base=8).eval()
+    ck = tmp_path / "best.pt"
+    torch.save(
+        {
+            "model": net.state_dict(),
+            "epoch": 3,
+            "encoding": "diff3",
+            "base": 8,
+            "out_ch": 1,
+        },
+        ck,
+    )
+    model, meta = load_detector_checkpoint(ck)
+    assert meta == {"encoding": "diff3", "base": 8, "out_ch": 1}
+    x = torch.rand(1, 3, 32, 32)
+    with torch.no_grad():
+        # composed model = net(prelude(x)), on raw frames
+        assert torch.equal(model(x), net(model.prelude(x)))
+
+    # legacy checkpoint (bare state dict, no metadata) -> gray3
+    ck2 = tmp_path / "legacy.pt"
+    torch.save(net.state_dict(), ck2)
+    model2, meta2 = load_detector_checkpoint(ck2)
+    assert meta2["encoding"] == "gray3"
+    with torch.no_grad():
+        assert torch.equal(model2(x), net(x))
+
+    # explicit base contradicting the state dict is a hard error
+    with pytest.raises(ValueError, match="base=8"):
+        load_detector_checkpoint(ck, base=24)

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -1,8 +1,11 @@
 """Unit tests for the v4 heatmap detector + target generation."""
 
+import json
+
 import pytest
 
-from training.data_prep.heatmap_dataset import gaussian_heatmap
+from training.data_prep.heatmap_dataset import HeatmapCropDataset, gaussian_heatmap
+from training.train_v4_heatmap import require_positive_depth
 
 
 def test_gaussian_heatmap_peak_at_center():
@@ -27,3 +30,49 @@ def test_heatmapnet_forward_and_peak():
     px, py, score = peak_xy(hm)
     assert (px, py) == (34, 12)
     assert score > 0.99
+
+
+def _mk_store(tmp_path, summary):
+    (tmp_path / "crops").mkdir()
+    index = {
+        "summary": summary,
+        "items": [{"file": "a.npy", "x": 10.0, "y": 12.0, "split": "train"}],
+    }
+    (tmp_path / "index.json").write_text(json.dumps(index))
+    return tmp_path
+
+
+def test_sigma_explicit_cli_wins_over_store_summary(tmp_path):
+    # The footgun this guards against: a σ=4 store summary silently overriding a
+    # --sigma 3 run into an exact σ=4 replica.
+    store = _mk_store(tmp_path, {"crop": 64, "sigma": 4.0})
+    assert HeatmapCropDataset(store, "train", sigma=3.0).sigma == 3.0
+
+
+def test_sigma_none_defers_to_store_summary(tmp_path):
+    store = _mk_store(tmp_path, {"crop": 64, "sigma": 6.0})
+    assert HeatmapCropDataset(store, "train").sigma == 6.0
+
+
+def test_sigma_none_without_summary_defaults_to_4(tmp_path):
+    store = _mk_store(tmp_path, {"crop": 64})
+    assert HeatmapCropDataset(store, "train").sigma == 4.0
+
+
+def test_require_positive_depth_rejects_partial_store():
+    # Partial coverage is the dangerous case: the store LOOKS depth-ready.
+    items = [
+        {"file": "a.npy", "x": 1.0, "y": 2.0, "split": "train", "depth": 0.3},
+        {"file": "b.npy", "x": 3.0, "y": 4.0, "split": "train"},
+        {"file": "c.npy", "x": None, "y": None, "split": "train"},
+    ]
+    with pytest.raises(SystemExit, match="1/2 positive"):
+        require_positive_depth(items, "store", "--dynamic-sigma")
+
+
+def test_require_positive_depth_accepts_full_coverage():
+    items = [
+        {"file": "a.npy", "x": 1.0, "y": 2.0, "split": "train", "depth": 0.3},
+        {"file": "c.npy", "x": None, "y": None, "split": "train"},  # negatives exempt
+    ]
+    require_positive_depth(items, "store", "--dynamic-sigma")

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -2,6 +2,7 @@
 
 import json
 
+import numpy as np
 import pytest
 
 from training.data_prep.heatmap_dataset import HeatmapCropDataset, gaussian_heatmap
@@ -167,3 +168,48 @@ def test_load_detector_checkpoint_roundtrip(tmp_path):
     # explicit base contradicting the state dict is a hard error
     with pytest.raises(ValueError, match="base=8"):
         load_detector_checkpoint(ck, base=24)
+
+
+def test_person_center_heatmap():
+    from training.data_prep.heatmap_dataset import person_center_heatmap
+
+    # empty -> zeros
+    assert person_center_heatmap(64, 64, []).max() == 0.0
+    # one 40px-tall box -> peak 1.0 at its center, sigma = 40/8 = 5
+    hm = person_center_heatmap(64, 64, [[20.0, 10.0, 40.0, 50.0, 0.9]])
+    assert hm[30, 30] == pytest.approx(1.0, abs=1e-5)  # center (30, 30) = (y, x)
+    g = gaussian_heatmap(64, 64, 30, 30, 5.0)
+    assert np.allclose(hm, g, atol=1e-6)
+    # two boxes max-composite: both peaks are 1.0
+    hm2 = person_center_heatmap(64, 64, [[0, 0, 10, 16, 0.5], [40, 40, 60, 62, 0.8]])
+    assert hm2[8, 5] == pytest.approx(1.0, abs=1e-5)
+    assert hm2[51, 50] == pytest.approx(1.0, abs=1e-5)
+    # tiny box: sigma clamps at 4; huge box clamps at 12
+    tiny = person_center_heatmap(64, 64, [[0, 0, 8, 8, 0.5]])
+    assert np.allclose(tiny, gaussian_heatmap(64, 64, 4, 4, 4.0), atol=1e-6)
+
+
+@needs_torch
+def test_heatmapnet_out_ch2_forward_and_loader(tmp_path):
+    from training.models.heatmap_net import HeatmapNet, load_detector_checkpoint
+
+    net = HeatmapNet(in_frames=3, in_ch_per_frame=1, base=8, out_ch=2).eval()
+    x = torch.rand(1, 3, 32, 32)
+    assert tuple(net(x).shape) == (1, 2, 32, 32)
+
+    ck = tmp_path / "ph.pt"
+    torch.save(
+        {
+            "model": net.state_dict(),
+            "epoch": 1,
+            "encoding": "diff3",
+            "base": 8,
+            "out_ch": 2,
+        },
+        ck,
+    )
+    model, meta = load_detector_checkpoint(ck)
+    assert meta["out_ch"] == 2
+    with torch.no_grad():
+        out = model(x)
+    assert tuple(out.shape) == (1, 2, 32, 32)

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -231,3 +231,53 @@ def test_dataset_variants_are_picklable(tmp_path):
         ds = cls(store, "train")
         blob = pickle.dumps(ds)
         assert pickle.loads(blob).crop == 64
+
+
+def test_store_versioning_freeze_and_resolve(tmp_path):
+    import json as _json
+
+    from training.data_prep.store_versions import (
+        canonical_sha,
+        freeze_index,
+        resolve_index,
+    )
+
+    # sha is key-order independent
+    assert canonical_sha({"a": 1, "b": 2}) == canonical_sha({"b": 2, "a": 1})
+
+    store = _mk_store(tmp_path, {"crop": 64, "sigma": 4.0})
+    v1, s1 = freeze_index(store)
+    assert v1 == 1
+    # idempotent: same content -> same version
+    assert freeze_index(store) == (v1, s1)
+
+    # mutate the store in place (the EXP-DIST-55 hazard) -> next freeze = v2
+    d = _json.loads((store / "index.json").read_text())
+    d["items"].append({"file": "b.npy", "x": None, "y": None, "split": "train"})
+    (store / "index.json").write_text(_json.dumps(d))
+    v2, s2 = freeze_index(store)
+    assert v2 == 2 and s2 != s1
+
+    # v1 is immutable and still resolvable to the PRE-mutation content
+    old, ver, sha = resolve_index(store, version=1)
+    assert ver == 1 and sha == s1
+    assert len(old["items"]) == 1
+
+
+def test_dataset_records_and_honors_index_version(tmp_path):
+    import json as _json
+
+    store = _mk_store(tmp_path, {"crop": 64, "sigma": 4.0})
+    ds = HeatmapCropDataset(store, "train")
+    assert ds.index_version == 1 and len(ds.index_sha) == 16
+    assert len(ds.items) == 1
+
+    # mutate the store; a pinned-version dataset must still see the OLD data
+    d = _json.loads((store / "index.json").read_text())
+    d["items"].append({"file": "c.npy", "x": None, "y": None, "split": "train"})
+    (store / "index.json").write_text(_json.dumps(d))
+
+    ds_new = HeatmapCropDataset(store, "train")  # current -> v2, sees 2 items
+    assert ds_new.index_version == 2 and len(ds_new.items) == 2
+    ds_pinned = HeatmapCropDataset(store, "train", index_version=1)
+    assert ds_pinned.index_version == 1 and len(ds_pinned.items) == 1

--- a/training/cli/build_human_crops.py
+++ b/training/cli/build_human_crops.py
@@ -191,12 +191,17 @@ def main() -> None:
             continue
         print(f"  {sd.name}: +{n} crops (raw-segment)", flush=True)
 
+    from training.data_prep.store_versions import freeze_index
+
+    v0, s0 = freeze_index(out)
     idx_obj["items"] = items
     idx_obj.setdefault("summary", {})
     idx_obj["summary"]["samples"] = len(items)
     idx_obj["summary"]["human_pos"] = totals["pos"]
     idx_obj["summary"]["human_neg"] = totals["neg"]
     (out / "index.json").write_text(json.dumps(idx_obj))
+    v1, s1 = freeze_index(out)
+    print(f"STORE VERSIONED: pre=v{v0}({s0}) -> post=v{v1}({s1})", flush=True)
     print(
         f"\nHUMAN CROPS appended: +{totals['pos']} positives, +{totals['neg']} negatives "
         f"(store now {len(items)} crops) -> {out}",

--- a/training/cli/dump_game_candidates.py
+++ b/training/cli/dump_game_candidates.py
@@ -60,7 +60,12 @@ def main() -> None:
     ap.add_argument("--ckpt", required=True)
     ap.add_argument("--game-dir", required=True)
     ap.add_argument("--out", required=True)
-    ap.add_argument("--base", type=int, default=24)
+    ap.add_argument(
+        "--base",
+        type=int,
+        default=None,
+        help="expected base width; inferred from the checkpoint, mismatch = error",
+    )
     ap.add_argument("--stride", type=int, default=4)
     ap.add_argument("--chunk", type=int, default=1500)
     ap.add_argument("--top-k", type=int, default=24)
@@ -109,7 +114,7 @@ def main() -> None:
     )
     from training.data_prep.segment_decode import iter_frames_from_segments
     from training.data_prep.warped_dataset import resolve_video_rotation
-    from training.models.heatmap_net import HeatmapNet
+    from training.models.heatmap_net import load_detector_checkpoint
     from training.world_model.eval import extract_peaks
     from video_grouper.inference.iso_warp import expand_polygon
 
@@ -135,10 +140,9 @@ def main() -> None:
     )
 
     dev = "cuda" if torch.cuda.is_available() else "cpu"
-    model = HeatmapNet(in_frames=3, in_ch_per_frame=1, base=args.base).to(dev)
-    ck = torch.load(args.ckpt, map_location=dev)
-    model.load_state_dict(ck["model"] if "model" in ck else ck)
-    model.eval()
+    # prelude + net (raw frames in, logits out); geometry inferred from the ckpt,
+    # encoding from its metadata — an explicit --base mismatch is a hard error.
+    model, _meta = load_detector_checkpoint(args.ckpt, base=args.base, device=dev)
 
     clip = gj.get("combined_video") or "combined.mp4"
     vrot = resolve_video_rotation(str(gd / clip), gj.get("video_rotation"))

--- a/training/cli/eval_detector.py
+++ b/training/cli/eval_detector.py
@@ -96,7 +96,12 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--ckpt", required=True)
     ap.add_argument("--game-dir", required=True)
-    ap.add_argument("--base", type=int, default=24)
+    ap.add_argument(
+        "--base",
+        type=int,
+        default=None,
+        help="expected base width; inferred from the checkpoint, mismatch = error",
+    )
     ap.add_argument(
         "--stride",
         type=int,
@@ -167,7 +172,7 @@ def main() -> None:
     from training.data_prep.warped_dataset import (
         resolve_video_rotation,
     )
-    from training.models.heatmap_net import HeatmapNet
+    from training.models.heatmap_net import load_detector_checkpoint
     from training.world_model.eval import extract_peaks
     from training.world_model.geometry import build_field_geometry
     from training.world_model.reranker import track_ball
@@ -210,10 +215,9 @@ def main() -> None:
     )
 
     dev = "cuda" if torch.cuda.is_available() else "cpu"
-    model = HeatmapNet(in_frames=3, in_ch_per_frame=1, base=args.base).to(dev)
-    ck = torch.load(args.ckpt, map_location=dev)
-    model.load_state_dict(ck["model"] if "model" in ck else ck)
-    model.eval()
+    # prelude + net (raw frames in, logits out); geometry inferred from the ckpt,
+    # encoding from its metadata — an explicit --base mismatch is a hard error.
+    model, _meta = load_detector_checkpoint(args.ckpt, base=args.base, device=dev)
 
     vrot = resolve_video_rotation(video, gj.get("video_rotation"))
     from training.data_prep.segment_decode import iter_frames_from_segments

--- a/training/cli/export_ball_detector.py
+++ b/training/cli/export_ball_detector.py
@@ -20,19 +20,24 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--ckpt", required=True)
     ap.add_argument("--out", required=True)
-    ap.add_argument("--base", type=int, default=24)
+    ap.add_argument(
+        "--base",
+        type=int,
+        default=None,
+        help="expected base width; inferred from the checkpoint, mismatch = error",
+    )
     ap.add_argument("--opset", type=int, default=17)
     args = ap.parse_args()
 
     import numpy as np
     import torch
 
-    from training.models.heatmap_net import HeatmapNet
+    from training.models.heatmap_net import load_detector_checkpoint
 
-    model = HeatmapNet(in_frames=3, in_ch_per_frame=1, base=args.base)
-    ck = torch.load(args.ckpt, map_location="cpu")
-    model.load_state_dict(ck["model"] if "model" in ck else ck)
-    model.eval()
+    # model = prelude + net (raw frames in, logits out). The prelude's encoding
+    # math is traced INTO the graph, so the ONNX input contract stays raw gray
+    # frames for every encoding and the runtime needs no encoding knowledge.
+    model, meta = load_detector_checkpoint(args.ckpt, base=args.base)
 
     class _WithSigmoid(torch.nn.Module):
         def __init__(self, net: torch.nn.Module):
@@ -66,7 +71,25 @@ def main() -> None:
     err = float(np.abs(ref - got).max())
     if err > 1e-4:
         raise RuntimeError(f"ONNX export parity FAILED: max |dh| = {err:g}")
-    print(f"exported {args.out} (parity max |dh| = {err:.2e})")
+
+    # Stamp provenance into the graph so a model file is self-describing.
+    import onnx
+
+    m = onnx.load(args.out)
+    for k, v in (
+        ("encoding", meta["encoding"]),
+        ("base", meta["base"]),
+        (
+            "out_ch",
+            meta["out_ch"],
+        ),
+    ):
+        p = m.metadata_props.add()
+        p.key, p.value = k, str(v)
+    onnx.save(m, args.out)
+    print(
+        f"exported {args.out} (encoding={meta['encoding']}, parity max |dh| = {err:.2e})"
+    )
 
 
 if __name__ == "__main__":

--- a/training/cli/mine_hard_negatives.py
+++ b/training/cli/mine_hard_negatives.py
@@ -45,7 +45,14 @@ def load_index(out: Path) -> tuple[list, dict | None]:
 
 
 def save_index(out: Path, items: list, wrapper: dict | None) -> None:
-    """Write the index back in the SAME form it was read (updating summary counts)."""
+    """Write the index back in the SAME form it was read (updating summary counts).
+
+    EXP-DIST-55: the store is pinned BEFORE and AFTER the write, so both the
+    pre-mining and post-mining states are immutable, recoverable versions —
+    in-place mutation cost a full experiment batch its baseline."""
+    from training.data_prep.store_versions import freeze_index
+
+    v0, s0 = freeze_index(out)
     if wrapper is not None:
         wrapper["items"] = items
         summary = wrapper.get("summary")
@@ -54,6 +61,8 @@ def save_index(out: Path, items: list, wrapper: dict | None) -> None:
         (out / "index.json").write_text(json.dumps(wrapper))
     else:
         (out / "index.json").write_text(json.dumps(items))
+    v1, s1 = freeze_index(out)
+    print(f"STORE VERSIONED: pre=v{v0}({s0}) -> post=v{v1}({s1})", flush=True)
 
 
 def main() -> None:

--- a/training/cli/mine_hard_negatives.py
+++ b/training/cli/mine_hard_negatives.py
@@ -68,7 +68,12 @@ def main() -> None:
     ap.add_argument("--camera", default="reolink")
     ap.add_argument("--holdout", nargs="*", default=[])
     ap.add_argument("--val", nargs="*", default=[])
-    ap.add_argument("--base", type=int, default=24)
+    ap.add_argument(
+        "--base",
+        type=int,
+        default=None,
+        help="expected base width; inferred from the checkpoint, mismatch = error",
+    )
     ap.add_argument("--base-stride", type=int, default=1)
     ap.add_argument(
         "--sample-stride",
@@ -125,7 +130,7 @@ def main() -> None:
     )
     from training.data_prep.segment_decode import iter_frames_from_segments
     from training.data_prep.warped_dataset import resolve_video_rotation
-    from training.models.heatmap_net import HeatmapNet
+    from training.models.heatmap_net import load_detector_checkpoint
     from training.world_model.eval import extract_peaks
     from training.world_model.geometry import build_field_geometry
 
@@ -146,10 +151,9 @@ def main() -> None:
     games = dd.build_distill_games(cfgs, base_stride=args.base_stride, report=False)
 
     dev = "cuda" if torch.cuda.is_available() else "cpu"
-    model = HeatmapNet(in_frames=3, in_ch_per_frame=1, base=args.base).to(dev)
-    ck = torch.load(args.ckpt, map_location=dev)
-    model.load_state_dict(ck["model"] if "model" in ck else ck)
-    model.eval()
+    # prelude + net (raw frames in, logits out); geometry inferred from the ckpt,
+    # encoding from its metadata — an explicit --base mismatch is a hard error.
+    model, _meta = load_detector_checkpoint(args.ckpt, base=args.base, device=dev)
 
     half = args.crop // 2
     total = 0

--- a/training/data_prep/heatmap_dataset.py
+++ b/training/data_prep/heatmap_dataset.py
@@ -260,13 +260,20 @@ class HeatmapCropDataset:
         root,
         split: str = "train",
         crop: int = 256,
-        sigma: float = 4.0,
+        sigma: float | None = None,
         augment: bool | None = None,
     ):
         self.root = Path(root)
         data = json.loads((self.root / "index.json").read_text())
         self.crop = data.get("summary", {}).get("crop", crop)
-        self.sigma = data.get("summary", {}).get("sigma", sigma)
+        # σ precedence: an EXPLICIT sigma wins; None defers to the store summary
+        # (the build-time σ). Targets are built at load time, so overriding σ on a
+        # prebuilt store is valid — the old summary-always-wins rule silently turned
+        # a `--sigma 3` run on a σ=4 store into an exact σ=4 replica.
+        if sigma is None:
+            self.sigma = data.get("summary", {}).get("sigma", 4.0)
+        else:
+            self.sigma = float(sigma)
         self.items = [r for r in data["items"] if r["split"] == split]
         # Horizontal-flip augmentation (train only): a mirrored field strip is a valid, different
         # soccer scene, so it adds real variety — cheaper diversity than pure oversampling.

--- a/training/data_prep/heatmap_dataset.py
+++ b/training/data_prep/heatmap_dataset.py
@@ -271,6 +271,10 @@ def build_heatmap_crops(
     (out_dir / "index.json").write_text(
         json.dumps({"summary": summary, "items": index})
     )
+    from training.data_prep.store_versions import freeze_index
+
+    v, sha = freeze_index(out_dir)
+    print(f"STORE VERSIONED: created as v{v} ({sha})", flush=True)
     return summary
 
 
@@ -284,9 +288,17 @@ class HeatmapCropDataset:
         crop: int = 256,
         sigma: float | None = None,
         augment: bool | None = None,
+        index_version: int | None = None,
     ):
+        from training.data_prep.store_versions import resolve_index
+
         self.root = Path(root)
-        data = json.loads((self.root / "index.json").read_text())
+        # Provenance is pinned on EVERY construction (EXP-DIST-55: the store was
+        # silently mutated between runs). None = freeze + use the current index;
+        # an explicit version trains on that exact immutable snapshot.
+        data, self.index_version, self.index_sha = resolve_index(
+            self.root, index_version
+        )
         self.crop = data.get("summary", {}).get("crop", crop)
         # σ precedence: an EXPLICIT sigma wins; None defers to the store summary
         # (the build-time σ). Targets are built at load time, so overriding σ on a

--- a/training/data_prep/heatmap_dataset.py
+++ b/training/data_prep/heatmap_dataset.py
@@ -48,6 +48,28 @@ def gaussian_heatmap(h: int, w: int, cx: float, cy: float, sigma: float) -> np.n
     return g.astype(np.float32)
 
 
+def person_center_heatmap(
+    h: int,
+    w: int,
+    boxes: list,
+    sigma_div: float = 8.0,
+    sigma_min: float = 4.0,
+    sigma_max: float = 12.0,
+) -> np.ndarray:
+    """Max-composited person-center Gaussians from ``[x1, y1, x2, y2, conf]`` boxes.
+
+    σ scales with the person's box height (persons are 30–150 px, unlike the
+    ball, so one fixed σ would mis-size most of them). Boxes partly outside the
+    crop still contribute their in-crop mass.
+    """
+    hm = np.zeros((h, w), np.float32)
+    for x1, y1, x2, y2, *_ in boxes:
+        cx, cy = (x1 + x2) / 2.0, (y1 + y2) / 2.0
+        sig = float(np.clip((y2 - y1) / sigma_div, sigma_min, sigma_max))
+        np.maximum(hm, gaussian_heatmap(h, w, cx, cy, sig), out=hm)
+    return hm
+
+
 # The band/dewarp geometry is PRODUCT code now (video_grouper.inference.iso_warp,
 # Mark 2026-07-10: single homegrown path). Underscore aliases kept for the
 # existing training callers.

--- a/training/data_prep/store_versions.py
+++ b/training/data_prep/store_versions.py
@@ -1,0 +1,82 @@
+"""Immutable, versioned crop-store indexes — every dataset state is reproducible.
+
+Why (EXP-DIST-55): ``crops_reolink`` was mutated IN PLACE by successive mining
+rounds, so "the store" silently changed identity between runs — an entire
+experiment batch trained on hn5's data while believing it was hn4's, and the
+only recovery path was an ad-hoc backup file the miner happened to write.
+
+Rules enforced here:
+
+- ``index_vN.json`` files are IMMUTABLE snapshots. Freezing identical content
+  twice returns the same version (content-addressed by sha, not by count).
+- ``index.json`` stays the CURRENT alias — every existing reader keeps working —
+  but mutators MUST pin the store before and after an edit
+  (:func:`freeze_index` both sides), so both states are recoverable forever.
+- Consumers (datasets → trainers → checkpoints) record ``(version, sha)`` so
+  every artifact knows exactly which data produced it.
+- Crop ``.npy`` files are never deleted; ``index_vN.json`` files are never
+  edited.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+
+def canonical_sha(obj) -> str:
+    """Content hash of an index (key-order independent, 16 hex chars)."""
+    blob = json.dumps(obj, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(blob).hexdigest()[:16]
+
+
+def _versions(store: Path) -> dict[int, Path]:
+    out: dict[int, Path] = {}
+    for p in store.glob("index_v*.json"):
+        m = re.fullmatch(r"index_v(\d+)\.json", p.name)
+        if m:
+            out[int(m.group(1))] = p
+    return out
+
+
+def freeze_index(store) -> tuple[int, str]:
+    """Pin the store's current ``index.json`` as an immutable ``index_vN.json``.
+
+    Idempotent: if the current content already matches a pinned version, that
+    version is returned. Returns ``(version, sha)``; on an unwritable store the
+    version is 0 (= "unpinned") so read-only consumers still work — callers
+    surface that in their logs.
+    """
+    store = Path(store)
+    cur = json.loads((store / "index.json").read_text())
+    sha = canonical_sha(cur)
+    vers = _versions(store)
+    for n in sorted(vers):
+        if canonical_sha(json.loads(vers[n].read_text())) == sha:
+            return n, sha
+    n = max(vers, default=0) + 1
+    try:
+        tmp = store / f"index_v{n}.json.tmp"
+        tmp.write_text(json.dumps(cur))
+        tmp.replace(store / f"index_v{n}.json")
+    except OSError:
+        return 0, sha
+    return n, sha
+
+
+def resolve_index(store, version: int | None = None) -> tuple[dict | list, int, str]:
+    """Load a pinned index: ``(data, version, sha)``.
+
+    ``version=None`` freezes and uses the CURRENT ``index.json`` — the default
+    path automatically pins provenance for every run. An explicit ``version``
+    loads that exact immutable snapshot regardless of later mutations.
+    """
+    store = Path(store)
+    if version is None:
+        n, sha = freeze_index(store)
+        return json.loads((store / "index.json").read_text()), n, sha
+    p = store / f"index_v{version}.json"
+    data = json.loads(p.read_text())
+    return data, version, canonical_sha(data)

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -4,6 +4,28 @@ Append-only. Never delete entries — if a decision is reversed, add a new entry
 
 ---
 
+## 2026-07-17: Two-box compute policy — server is the reliable/data-local queue, FORTNITE-OP harvests its own idle windows
+
+**Context:** two GPU boxes with opposite profiles — the server (GTX 1060: slow, always on,
+data-local to F:/G:) and FORTNITE-OP (RTX 3060 Ti: ~2.5x faster, sporadically available — it is a
+family gaming PC and games preempt everything, incl. one crash under combined load).
+
+**Policy:**
+- **Training runs → FORTNITE-OP job queue** (`\server	raining\deploy\queue\{pending,running,done}`,
+  FIFO json job specs `{desc, cmd, resume_cmd}`). The `Ph1GameGuard` scheduled task (runs as the
+  `training` user, at-startup, auto-restart) polls every 20 s: any GPU-heavy game (worker
+  `idle_games` list + Epic/Steam/Riot-path processes >500 MB) → training procs KILLED immediately
+  (suspend would pin VRAM and starve the game) and the job returns to `pending` in its resume form;
+  5 game-free minutes → oldest pending job dispatched. Interruption cost ≈ epochs since last
+  checkpoint; the box turns school hours and overnights into training time unattended.
+- **Precision runs (controls, protocol-exact experiments) + all data-touching work (dumps, sweeps,
+  store builds, mining) → server**: deterministic timing, no preemption, F:/G: local.
+- Cross-box data identity is verifiable via the store index shas (see the versioned-store decision
+  above): a FORTNITE-OP job must state the same index sha as its server-side comparators.
+- Roblox measured at only 37% GPU / 1.2 GB but STAYS a yield trigger: the criterion is "a kid is
+  interactively using the machine", not raw wattage (contention stutters the game; the box already
+  crashed once under combined load).
+
 ## 2026-07-17: Crop-store indexes are IMMUTABLE and VERSIONED — no in-place mutation, every run records its data (Mark: blocking, before all further experiments)
 
 **Trigger:** EXP-DIST-55 — the hn5 chain mutated `crops_reolink/index.json` in place (−480

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -4,6 +4,33 @@ Append-only. Never delete entries — if a decision is reversed, add a new entry
 
 ---
 
+## 2026-07-17: Crop-store indexes are IMMUTABLE and VERSIONED — no in-place mutation, every run records its data (Mark: blocking, before all further experiments)
+
+**Trigger:** EXP-DIST-55 — the hn5 chain mutated `crops_reolink/index.json` in place (−480
+GT-guarded negatives, +782 corroboration negatives), so an entire three-lever experiment batch
+(EXP-DIST-51/52/53) silently trained on hn5's data while comparing itself against hn4's baseline.
+~3 GPU-days of results voided; recovery was only possible because the miner happened to leave an
+ad-hoc backup (`index.prehn5.json`).
+
+**Decision (mechanism in `training/data_prep/store_versions.py`):**
+- `index_vN.json` snapshots are IMMUTABLE and content-addressed (16-hex sha of the canonical
+  JSON); freezing identical content twice returns the same version. Never edited, never deleted.
+- `index.json` remains the CURRENT alias (all existing readers keep working), but every mutator
+  (`mine_hard_negatives`, `build_human_crops`) pins the store BEFORE and AFTER its write, and
+  `build_heatmap_crops` freezes v1 at creation — both sides of any change are recoverable forever.
+- Every consumer pins provenance automatically: `HeatmapCropDataset` freezes+records
+  `(index_version, index_sha)` on construction; `train_v4_heatmap` prints a `DATA:` line at startup
+  and writes `{store, index_version, index_sha}` into every checkpoint; `--index-version N` trains
+  on an exact historical snapshot regardless of later mutations.
+- Crop `.npy` files are never deleted (de-indexing is the only removal mechanism — which is what
+  made the hn4-era restore possible).
+- Live stores retro-versioned on the server: `crops_reolink` v1=pre-hn4-mining, v2=hn4-era
+  (=`index.prehn5.json`, the control's data), v3=current/hn5-era; `crops_reolink_hn4era` and
+  `crops_reolink_dyn` pinned v1. (Shas recorded in the retro-freeze output attached to EXP-DIST-55.)
+
+**Rule going forward:** an experiment that cannot state its store + index version + sha did not
+happen. Comparisons across runs must compare index shas first.
+
 ## 2026-07-12: Indoor/dome venues (blue turf) ARE in scope for the ball detector
 
 Mark confirmed indoor games are in scope, so the grass-trained detector cannot simply exclude

--- a/training/docs/EXPERIMENTS.md
+++ b/training/docs/EXPERIMENTS.md
@@ -4,6 +4,38 @@ Each experiment has: hypothesis, method, result, conclusion. Failures are as val
 
 ---
 
+## EXP-DIST-50: the σ sweep is VOID — a CLI-σ precedence footgun trained hm_sig30 at σ=4; fixed (2026-07-15)
+
+**Trigger:** pre-flight verification of the "in-flight σ sweep" (EXP-DIST-49's `sigma_exp` task) before
+reading its results.
+
+**Finding — the footgun:** `HeatmapCropDataset.__init__` did
+`self.sigma = data.get("summary", {}).get("sigma", sigma)` — the store summary **always** won over the
+constructor/CLI σ, so `train_v4_heatmap --sigma X` on a prebuilt store silently trained at the store's
+build-time σ. Verified against the actual sweep launcher (`G:\ballresearch\selector\sigma_exp.ps1`): it
+ran `training.train_v4_heatmap --out G:/ballresearch/distill/crops_reolink --sigma 3.0` with **no
+rebuild**, and `crops_reolink`'s summary records `"sigma": 4.0`.
+
+**Verdict on the sweep:**
+- **`hm_sig30` trained at σ=4.0, not 3.0 — it is an hn4-recipe replica** (val-crop recall ~0.39 matches
+  the hn4 family) and says nothing about target sharpness. Do not read `cands_spc_sig30` as a σ=3 result.
+- The sweep never completed anyway: `sigma_exp.status` stuck at "dump sig30" since 07-14 17:41, the σ=2.5
+  arm never started, no `sigma_exp.done`.
+
+**Second footgun in the same family (fixed together):** `_DynSigmaDataset`/`_DepthDataset` silently
+substituted a mid-field default for a missing per-item `depth` (`r.get("depth", 0.5)` / `0.0`), so
+`--dynamic-sigma` on a depth-less store would have trained EVERY positive at one constant σ≈3.25 without
+erroring. The live risk is real: `crops_reolink_dyn` is **partially** depth-recorded (21,133 of 45,164
+positives) — it looks depth-ready and isn't.
+
+**Fix (this commit):** (1) σ precedence — `--sigma`/constructor σ default is now a `None` sentinel; an
+explicit value WINS over the store summary, `None` defers to it (fresh builds default 4.0); (2)
+`require_positive_depth()` hard-fails `--dynamic-sigma`/`--far-weight` when any positive lacks `depth`,
+and the datasets read `r["depth"]` strictly. Unit tests cover both.
+
+**Next:** re-run the sweep corrected (σ=3, σ=2.5 + dynamic-σ after completing `crops_reolink_dyn` depth
+coverage) — scheduled after the current multi-game hn2/4/5 dump batch drains the GPU.
+
 ## EXP-DIST-49 [CORRECTED 2026-07-14]: dynamic-σ WAS wrongly dismissed — ball size DOES vary ~4→17px with depth; my "constant size" was a flawed measurement (2026-07-13/14)
 
 **CORRECTION (2026-07-14, after Mark challenged the constant-size claim — he was right):** the

--- a/training/docs/EXPERIMENTS.md
+++ b/training/docs/EXPERIMENTS.md
@@ -4,6 +4,42 @@ Each experiment has: hypothesis, method, result, conclusion. Failures are as val
 
 ---
 
+## EXP-DIST-51: df3 signed-diff encoding — G1 FAIL; far discrimination REGRESSES vs hn4 (2026-07-16)
+
+**Hypothesis (external brief + Jmot re-analysis):** replacing the two redundant gray history frames
+with signed differences `(g_t, g_{t-1}-g_{t-2}, g_t-g_{t-1})` hands layer 1 a pixel-level,
+direction-preserving motion signature (a ball moving > its diameter/frame leaves a clean ± lobe
+pair), un-stranding the temporal signal and improving ball-vs-distractor discrimination — the thing
+hn2/hn4/hn5 hard negatives have been patching.
+
+**Method:** `hm_df3` = from-scratch hn4 recipe (crops_reolink + GT-guarded negs, base 24, 40 ep,
+σ=4) + `--input-encoding diff3` (EncodingPrelude, in-graph — see the exp/detector-diff-encoding
+branch). Val-crop peak 0.403 @ep17 (best in family on the weak proxy; new bests at eps 1,2,3,4,8,17
+— gaps 1,1,1,4,9 — then 23 dry epochs; loss still falling = crop memorization). Dump + sweep on the
+held-out Spencerport clip (134 GT: 115 far / 19 near), frame-aligned with the hn4 protocol.
+
+**Result (R15m) vs hn4 (EXP-DIST-46):**
+
+| metric | df3 | hn4 | verdict |
+|---|---|---|---|
+| ceiling ALL / FAR / NEAR | 0.948 / 0.939 / 1.0 | 0.970 / 0.965 / 1.0 | FAIL (bar: far ≥ .955) |
+| score-argmax ALL / FAR / NEAR | 0.291 / **0.209** / 0.789 | 0.418 / **0.339** / 0.895 | FAIL (bar: far ≥ .32) |
+| far rank: r1 / P(≤3) / med-rank / absent | 0.15 / 0.26 / 7 / 0.06 | (hn4 better across) | — |
+
+**Conclusion: NEGATIVE, both gates failed.** The encoding didn't just fail to move far-argmax — it
+regressed it ~40% relative (0.339→0.209), with near-argmax also down (0.895→0.789) and ceiling-far
+slightly down. The val-crop proxy (0.403, family-best) was again anti-correlated with held-out
+quality — third confirmation of the EXP-DIST-46 lesson. Plausible mechanism for the regression:
+collapsing appearance to ONE gray frame costs more far-band discrimination than the diff channels
+return (far balls are slow in most GT frames → weak diff signature; compression flicker lives at
+ball scale → noisy diffs; and the GT-guarded hard negatives were mined against gray3 models'
+confusions). **Per the plan gate: the motion/color thesis is re-examined before any superstore /
+chroma build — the 55 GB store is NOT justified on this evidence.** A softer variant (replace only
+one history frame, keep two appearance frames) is a possible cheap follow-up but is NOT queued.
+The diff3 machinery stays (default-off, byte-identical, tested) — the negative result is the value.
+Data: `G:\ballresearch\distill\cands_spc_df3.pkl`, `G:\ballresearch\encoding\{train_df3.log,
+sweep_encoding.log}`; checkpoint `runs/hm_df3/best.pt` (ep17).
+
 ## EXP-DIST-50: the σ sweep is VOID — a CLI-σ precedence footgun trained hm_sig30 at σ=4; fixed (2026-07-15)
 
 **Trigger:** pre-flight verification of the "in-flight σ sweep" (EXP-DIST-49's `sigma_exp` task) before

--- a/training/docs/EXPERIMENTS.md
+++ b/training/docs/EXPERIMENTS.md
@@ -4,6 +4,43 @@ Each experiment has: hypothesis, method, result, conclusion. Failures are as val
 
 ---
 
+## EXP-DIST-53: ph1 person head (out_ch=2, yolo26n sidecar) — G1 FAIL on far; near preserved; val proxy now fully discredited (2026-07-17)
+
+**Hypothesis (EXP-DIST-47 Phase-4 / external brief):** a 22 cm ball ≡ a 22 cm head, so a person-center
+channel on the shared backbone is the only context that can separate them; ball channel should stop
+firing on heads.
+
+**Method:** person supervision WITHOUT a store rebuild — yolo26n over the STORED gray crops
+(vision-calibrated recipe: never upscale + two-scale union @ thr 0.20; naive 1280-letterbox upscaling
+detected NOTHING), annotated on FORTNITE-OP's 3060 Ti (79,183 crops, 100% of train covered, 1.85 h).
+`--person-sidecar` + masked person loss (λ=0.5), out_ch=2. Two legs: `hm_ph1` (crashed at ep26 when
+the box was game-loaded — peak ep20 rescued) and `hm_ph1b` (resumed overnight from ep20, early-stopped
+ep25, val 0.410 @ep15 — the family's highest-ever proxy). Both dumped + swept, same protocol.
+
+**Result (R15m, 115 far / 19 near) — the full batch:**
+
+| run | ceiling FAR | argmax FAR | argmax NEAR | val-proxy peak |
+|---|---|---|---|---|
+| **hn4 (champion)** | **0.965** | **0.339** | 0.895 | 0.368 |
+| df3 (EXP-51) | 0.939 | 0.209 | 0.789 | 0.403 |
+| sig30b (EXP-52) | 0.93 | 0.235 | 0.842 | 0.379 |
+| ph1 (ep20) | 0.93 | 0.226 | **0.895** | 0.397 |
+| ph1b (resumed) | 0.93 | 0.270 | 0.684 | 0.410 |
+
+**Conclusion: FAIL on the far gate; the least-bad of the batch.** ph1 ties hn4 on near-argmax (the
+person head costs nothing near) and posts the batch-best far ranking (P(rank≤3) 0.42); ph1b's far
+argmax 0.270 is the batch best but its near collapsed (0.684) — the extra proxy-val epochs traded
+near ranking away. **The val-crop proxy is now fully discredited for model selection:** its ordering
+across this batch (0.410 > 0.403 > 0.397 > 0.379 > hn4's 0.368) has NO relationship to held-out
+quality (hn4 best, df3 worst). Person-channel value likely lives at the SELECTOR (centroids/size
+gate — the original EXP-DIST-47 Phase-4 plan), not in the ball channel itself.
+
+**Open question the whole batch raises — RUN VARIANCE:** every new run (three different single
+levers) landed ceiling-far 0.93–0.939, below even hn2's 0.948. Either all three levers coincidentally
+cost ceiling, or hn4's 0.965 is partly a favorable unseeded draw. **Next: a seeded/plain hn4-recipe
+CONTROL re-run under patience (~6 h) to size run-to-run variance before interpreting any of these
+gaps as real** — and before spending on the next lever.
+
 ## EXP-DIST-52: sig30b (fixed σ=3, CORRECTED sweep) — G1 FAIL; σ=4 stays champion (2026-07-17)
 
 **Hypothesis (EXP-DIST-49 follow-up):** the ball is ~4–17 px but σ=4 paints a ~16 px target blob;

--- a/training/docs/EXPERIMENTS.md
+++ b/training/docs/EXPERIMENTS.md
@@ -4,6 +4,36 @@ Each experiment has: hypothesis, method, result, conclusion. Failures are as val
 
 ---
 
+## EXP-DIST-52: sig30b (fixed σ=3, CORRECTED sweep) — G1 FAIL; σ=4 stays champion (2026-07-17)
+
+**Hypothesis (EXP-DIST-49 follow-up):** the ball is ~4–17 px but σ=4 paints a ~16 px target blob;
+a sharper fixed σ=3 should stop training the net to fire on head-sized blobs (a "half-measure"
+toward dynamic-σ). This redoes the run the σ-precedence footgun voided (EXP-DIST-50) — the first
+training where `--sigma` actually took effect.
+
+**Method:** `hm_sig30b` = from-scratch hn4 recipe + `--sigma 3.0` + `--patience 10` (new flag; run
+early-stopped at ep33, peak val 0.379 @ep23 — patience saved ~4 h). Same held-out dump + sweep
+protocol as df3/hn4.
+
+**Result (R15m, 134 GT: 115 far / 19 near) vs hn4:**
+
+| metric | sig30b | df3 (51) | hn4 | verdict |
+|---|---|---|---|---|
+| ceiling ALL / FAR | 0.94 / 0.93 | 0.948 / 0.939 | 0.970 / 0.965 | FAIL (far bar .955) |
+| score-argmax ALL / FAR / NEAR | 0.321 / **0.235** / 0.842 | 0.291 / 0.209 / 0.789 | 0.418 / **0.339** / 0.895 | FAIL (far bar .32) |
+| far rank r1 / P(≤3) / med / absent | 0.18 / 0.35 / 6 / 0.07 | 0.15 / 0.26 / 7 / 0.06 | (hn4 better) | — |
+
+**Conclusion: NEGATIVE.** σ=3 regressed far argmax ~30% relative vs σ=4 (0.339→0.235) and shaved
+the ceiling too — sharper targets did NOT sharpen far discrimination; they cost recall across the
+board (a 3–4 px far ball may simply need the broader supervisory blob to accumulate gradient).
+Both of the brief-driven levers (diff encoding, target sharpness) have now failed the same gate in
+the same direction; **the hn4 recipe (gray3, σ=4, GT-guarded hard negatives) remains champion.**
+Depth-scaled dynamic-σ (σ≈ball radius: ~1.5 far / ~5 near) is a DIFFERENT claim than fixed σ=3 and
+remains runnable after `crops_reolink_dyn` depth completion — but two same-family failures argue
+for letting the ph1 person-head result (and its held-out eval, running now) pick the direction
+before more σ spend. Data: `cands_spc_sig30b.pkl`, `G:\ballresearch\encoding\{train_sig30b.log,
+sweep_encoding.log}` (incl. same-protocol hn4 baseline rows appended by the chain).
+
 ## EXP-DIST-51: df3 signed-diff encoding — G1 FAIL; far discrimination REGRESSES vs hn4 (2026-07-16)
 
 **Hypothesis (external brief + Jmot re-analysis):** replacing the two redundant gray history frames

--- a/training/docs/EXPERIMENTS.md
+++ b/training/docs/EXPERIMENTS.md
@@ -4,6 +4,58 @@ Each experiment has: hypothesis, method, result, conclusion. Failures are as val
 
 ---
 
+## EXP-DIST-55: the batch's confound FOUND — crops_reolink was MUTATED IN PLACE by the hn5 chain; df3/sig30b/ph1 all trained on hn5's data, not hn4's; CONTROL running (2026-07-17)
+
+**Trigger (Mark):** three unrelated levers landing within 0.009 of each other and below BOTH
+baselines is systematic, not scatter — design the control to DISCRIMINATE. Candidate 1 (hn4 was
+warm-started) is ELIMINATED: `train_hn4.ps1` shows from-scratch, full 40 ep, no `--resume` (the
+external brief's "warm-start lineage" description was wrong). Candidate 2 (patience undertraining)
+cannot explain df3, which ran the full 40. Digging further found candidate 3:
+
+**The store hn4 trained on is NOT the store the batch trained on.** `crops_reolink` index snapshots:
+- `index.prehn5.json` (hn4's store): 83,459 items, train **77,916** (= hn4's training log exactly),
+  480 GT-guarded negs present, **0 corroboration negs**.
+- `index.json` (current — what df3/sig30b/ph1/ph1b ALL trained on): the hn5 chain **removed the 480
+  GT-guarded negatives and added 782 corroboration negatives in place** → train 78,218. That is
+  hn5's data configuration — the negative set EXP-DIST-46 proved over-suppresses far balls (hn5
+  far-argmax 0.148, family worst). Every batch run inherited it silently.
+
+**CONTROL (running, `hm_ctrl`):** exact hn4 protocol — from-scratch, FULL 40 epochs, NO patience,
+default σ/encoding, same box/venv, our branch code (default path proven byte-identical) — on a
+restored hn4-era store VIEW (`crops_reolink_hn4era`: prehn5 index + junction to the shared crops
+dir; all 83,459 files verified present; train=77,916 confirmed at startup). Readout ~07:00 07-18.
+Interpretation: ceiling-far ≈0.965 → code path clean, store mutation was the confound, **the whole
+lever batch (51/52/53) is VOID** and levers re-run on the hn4-era view; ≈0.93 → confound is
+elsewhere (seed/code) — investigate before any re-run.
+
+**Durable fix this mandates (queued):** stores must stop being mutated in place — mining writes a
+NEW index version (`index_vN.json`) + the trainer takes an explicit index/version argument, so every
+run records which data it saw. The silent-mutation hazard cost this batch ~3 GPU-days.
+
+## EXP-DIST-54: the val-crop proxy INVERTS on this batch — worse than no metric (2026-07-17)
+
+**Finding (Mark: worth its own entry):** across the five-run batch, val-crop recall ordering has NO
+positive relationship to held-out quality — it inverts at the extremes:
+
+| run | val proxy | held-out far argmax |
+|---|---|---|
+| ph1b | **0.410** (best) | 0.270 |
+| df3 | 0.403 | **0.209** (worst) |
+| ph1 | 0.397 | 0.226 |
+| sig30b | 0.379 | 0.235 |
+| hn4 | 0.368 (worst) | **0.339** (best) |
+
+This is the third and decisive confirmation of the EXP-DIST-46 lesson ("val-crop recall ≠ held-out
+quality") — now with a full anti-correlated table. **Implication: the proxy has been steering
+`best.pt` checkpoint selection, the new `--patience` early-stop, and possibly earlier decisions —
+an inverted metric is worse than no metric.** (The EXP-DIST-55 store confound may explain part of
+this batch's inversion — the proxy val split lives in the same mutated store — but hn4-vs-hn2 era
+data already showed the same sign.) Mitigations until a better selector exists: (a) treat val-crop
+recall as a TRAINING-HEALTH signal only; (b) patience stays acceptable for wall-clock but
+checkpoint SELECTION should prefer late/multiple candidates dumped against held-out (e.g.
+`--save-every` + a cheap held-out mini-dump per candidate — queued); (c) never promote on proxy
+numbers — G1/G2 only.
+
 ## EXP-DIST-53: ph1 person head (out_ch=2, yolo26n sidecar) — G1 FAIL on far; near preserved; val proxy now fully discredited (2026-07-17)
 
 **Hypothesis (EXP-DIST-47 Phase-4 / external brief):** a 22 cm ball ≡ a 22 cm head, so a person-center

--- a/training/docs/STATUS.md
+++ b/training/docs/STATUS.md
@@ -1,6 +1,27 @@
 # Current Status
 
-*Last updated: 2026-07-15*
+*Last updated: 2026-07-17*
+
+## 2026-07-16/17 — brief-lever batch COMPLETE: df3 / sig30b / ph1 ALL fail G1; hn4 stays champion
+
+Three single-lever experiments off the external brief, all trained + held-out-swept in ~36 h
+(EXP-DIST-51/52/53, full table in 53): **diff3 encoding** (far argmax 0.339→0.209), **fixed σ=3**
+(→0.235), **ph1 person head** (→0.226 ep20 / 0.270 resumed; near preserved at 0.895). None beats
+hn4; the val-crop proxy is now fully discredited (its ordering anti-correlates with held-out).
+Every new run's ceiling (0.93–0.939) sits below hn2's 0.948 → **next: a plain hn4-recipe CONTROL
+re-run to size unseeded run-variance before interpreting lever costs or funding the next lever.**
+
+Infrastructure landed on `exp/detector-diff-encoding` (PR #111, ready to merge): σ-precedence fix +
+depth guard (EXP-DIST-50: the old σ sweep was void), EncodingPrelude (in-graph, ONNX contract
+unchanged — 0.0-delta parity vs shipped hn2 on real frames), `load_detector_checkpoint` everywhere,
+`--patience` (saved ~4 h on its first run), `--person-sidecar` masked multi-task loss, module-level
+dataset variants (Windows spawn pickling — would have killed dyn-σ too), conftest torch/ort import
+fixes (2 latent failures). ph1 sidecar built WITHOUT a store rebuild (yolo26n on stored gray crops,
+never-upscale + two-scale recipe, vision-calibrated; 100% train coverage; D:\ph1 on FORTNITE-OP +
+staged copies). FORTNITE-OP recommissioned as a second trainer (3060 Ti, ~12 min/epoch; crashed once
+under kid-gaming load — WinRM listener rebuilt via SMB service trick; idle-gated night training
+works). Customer-iGPU floor measured (Iris Xe, DirectML, native band): **75 h/game = 3.1× OVER the
+24 h budget** — FP16 is the first lever when speed work resumes (per Mark: after accuracy).
 
 ## 2026-07-15 — σ-footgun fix (PR #110), σ sweep VOID, diff3 encoding landed + POC-verified
 

--- a/training/docs/STATUS.md
+++ b/training/docs/STATUS.md
@@ -1,8 +1,19 @@
 # Current Status
 
-*Last updated: 2026-07-17*
+*Last updated: 2026-07-17 (control running)*
 
-## 2026-07-16/17 — brief-lever batch COMPLETE: df3 / sig30b / ph1 ALL fail G1; hn4 stays champion
+## 2026-07-17 — CONFOUND FOUND: the batch trained on hn5-mutated data; CONTROL running (EXP-DIST-55)
+
+Mark flagged the 0.93-cluster as systematic, not scatter. Root cause: the hn5 chain MUTATED
+crops_reolink IN PLACE (-480 GT-guarded negs, +782 corroboration negs) — df3/sig30b/ph1 all trained
+on hn5-poisoned data, not hn4 recipe data. Control (hm_ctrl) now training: exact hn4 protocol on the
+restored hn4-era store view (train=77,916 verified = hn4 log). ~0.965 far ceiling => batch VOID,
+re-run levers on clean store; ~0.93 => investigate seed/code. Readout ~07:00 07-18. Also EXP-DIST-54:
+the val-crop proxy fully INVERTS on this batch (0.410 proxy = mid held-out; 0.368 = best) — demoted
+to training-health signal only; never select/promote on it. Durable fix queued: versioned store
+indexes, no in-place mutation.
+
+## 2026-07-16/17 — brief-lever batch (results PENDING control validation, see EXP-DIST-55): df3 / sig30b / ph1 all below hn4
 
 Three single-lever experiments off the external brief, all trained + held-out-swept in ~36 h
 (EXP-DIST-51/52/53, full table in 53): **diff3 encoding** (far argmax 0.339→0.209), **fixed σ=3**

--- a/training/docs/STATUS.md
+++ b/training/docs/STATUS.md
@@ -1,6 +1,37 @@
 # Current Status
 
-*Last updated: 2026-07-10*
+*Last updated: 2026-07-15*
+
+## 2026-07-15 — σ-footgun fix (PR #110), σ sweep VOID, diff3 encoding landed + POC-verified
+
+External optimization brief (archived to F:) reviewed against the repo; accuracy items adopted,
+speed items dropped per Mark (offline batch product; capacity cuts rejected — recall is the problem).
+
+- **PR #110 (`fix/sigma-cli-precedence` → `fix/selector-planner-review`):** CLI `--sigma` now WINS over
+  the store summary (was silently overridden — EXP-DIST-50); `--dynamic-sigma`/`--far-weight` hard-fail
+  on stores whose positives lack `depth` (`crops_reolink_dyn` is only partially depth-recorded:
+  21,133/45,164). **The σ sweep is VOID:** `hm_sig30` trained at σ=4 (an hn4 replica); σ=2.5 never ran.
+  Re-run corrected after the multi-game hn2/4/5 dump batch drains the GPU.
+- **diff3 input encoding landed on `exp/detector-diff-encoding`** (stacked on the σ-fix branch):
+  `EncodingPrelude` computes `(g_t, g_{t-1}-g_{t-2}, g_t-g_{t-1})` IN-GRAPH — the ONNX contract stays
+  raw gray frames, `ball_detector.py` untouched; `load_detector_checkpoint()` (geometry inferred from
+  the state dict, encoding from ckpt metadata, `--base` mismatch = hard error) now used by trainer
+  resume, export, eval_detector, dump_game_candidates, mine_hard_negatives. `--input-encoding
+  {gray3,diff3}`, default byte-identical (tested: gray3 prelude is the literal identity).
+- **POCs (laptop, real Spencerport footage):** (1) export CLI round-trip of a diff3 ckpt — parity
+  5.96e-08, Sub/Concat ops in-graph, input still `frames (1,3,h,w)` dynamic, metadata_props stamped;
+  (2) vision-checked diff panel at f553 seg-2 (struck ball, ~45 px/frame vs the tree line): ball nearly
+  invisible in gray_t, isolated high-contrast ± blobs in both diff channels
+  (`C:\Users\markb\Videos\soccer-cam-eval\spencerport\poc_diff3_f553.png`). Jmot is NOT re-trodden:
+  it was |Δ|(polarity-blind) ADDED as a 4th channel and ignored (≈J); diff3 is signed and REPLACES the
+  redundant frames. Motion is informative at ball scale (MOG2: ball in 89% of unlearned motion blobs).
+- **Customer-iGPU floor measured (Iris Xe i7-1270P, DirectML, native 1552×7680 band, shipped hn2):**
+  ~7-8.5 s/inference, ~10 s end-to-end per inferred frame → **75 h per 90-min game vs the 24 h budget
+  (3.1× OVER)**. Decode is fine (106 ms/src-frame). Speed levers (FP16 first) queued AFTER the accuracy
+  waves per Mark; target-tier question open.
+- **Next:** train df3 from scratch on the hn4 recipe when a GPU frees (multi_dump running) → G1
+  (Spc-clip ceiling/argmax vs cached cand_hn4, frame-aligned grid). Then ph1 (person head via sidecar
+  annotations on stored crops — no store rebuild; supervision from yolo26n on crop patches, masked loss).
 
 ## 2026-07-10 (evening) — side-pan STRETCH root-caused and fixed (crop truncation)
 

--- a/training/models/heatmap_net.py
+++ b/training/models/heatmap_net.py
@@ -88,6 +88,88 @@ class HeatmapNet(nn.Module):
         return self.head(y)  # logits
 
 
+class EncodingPrelude(nn.Module):
+    """Parameter-free input encoding applied IN FRONT of the net (and baked into
+    the ONNX graph at export), so the external input contract stays raw stacked
+    grayscale frames ``[g_{t-2}, g_{t-1}, g_t]`` everywhere — training, eval
+    CLIs, and the product runtime never diverge on the encoding math.
+
+    Encodings:
+      - ``gray3``: identity — the legacy contract (3 raw gray frames).
+      - ``diff3``: ``(g_t, g_{t-1}-g_{t-2}, g_t-g_{t-1})`` — SIGNED frame
+        differences replacing the two redundant history frames. A ball moving
+        farther than its own diameter per frame leaves a direction-preserving
+        ± lobe pair at its CURRENT position in the diff channels — a pixel-level
+        motion signature no receptive field has to assemble. Signed (not |Δ|,
+        which is polarity-blind and failed as an additive 4th channel — Jmot),
+        and REPLACING the raw history so the temporal signal is load-bearing.
+        Appearance stays frame t: labels and runtime candidates are keyed to t.
+    """
+
+    ENCODINGS = ("gray3", "diff3")
+
+    def __init__(self, encoding: str = "gray3"):
+        super().__init__()
+        if encoding not in self.ENCODINGS:
+            raise ValueError(f"unknown encoding {encoding!r} (want {self.ENCODINGS})")
+        self.encoding = encoding
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.encoding == "gray3":
+            return x
+        g0, g1, g2 = x[:, 0:1], x[:, 1:2], x[:, 2:3]
+        return torch.cat([g2, g1 - g0, g2 - g1], dim=1)
+
+
+class DetectorWithEncoding(nn.Module):
+    """``net(prelude(x))`` — raw frames in, logits out (drop-in for a bare net)."""
+
+    def __init__(self, prelude: EncodingPrelude, net: HeatmapNet):
+        super().__init__()
+        self.prelude = prelude
+        self.net = net
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(self.prelude(x))
+
+
+def load_detector_checkpoint(
+    ckpt_path,
+    base: int | None = None,
+    device: str = "cpu",
+) -> tuple[DetectorWithEncoding, dict]:
+    """Load a detector checkpoint -> ``(model, meta)``; model takes RAW frames.
+
+    Geometry (base width, out_ch, input channels) is inferred from the state
+    dict itself; checkpoint metadata supplies the input ``encoding`` (legacy
+    checkpoints without metadata are ``gray3``). An explicit ``base`` that
+    contradicts the state dict is a hard error — the silent alternative is a
+    mis-built net that loads nothing or the wrong shapes.
+    """
+    ck = torch.load(ckpt_path, map_location=device)
+    state = ck["model"] if isinstance(ck, dict) and "model" in ck else ck
+    inferred_base = state["d1.net.0.weight"].shape[0]
+    in_ch = state["d1.net.0.weight"].shape[1]
+    out_ch = state["head.weight"].shape[0]
+    if base is not None and base != inferred_base:
+        raise ValueError(
+            f"checkpoint {ckpt_path} was trained at base={inferred_base}, "
+            f"but base={base} was requested"
+        )
+    encoding = (
+        ck.get("encoding", "gray3")
+        if isinstance(ck, dict) and "model" in ck
+        else "gray3"
+    )
+    net = HeatmapNet(
+        in_frames=in_ch, in_ch_per_frame=1, base=inferred_base, out_ch=out_ch
+    )
+    net.load_state_dict(state)
+    model = DetectorWithEncoding(EncodingPrelude(encoding), net).to(device).eval()
+    meta = {"encoding": encoding, "base": int(inferred_base), "out_ch": int(out_ch)}
+    return model, meta
+
+
 def peak_xy(heatmap: torch.Tensor) -> tuple[int, int, float]:
     """Argmax peak of a single ``(H, W)`` heatmap (logits or probs) -> (x, y, score).
 

--- a/training/train_v4_heatmap.py
+++ b/training/train_v4_heatmap.py
@@ -333,6 +333,14 @@ def main():
         "on top of best.pt) instead of training from scratch.",
     )
     ap.add_argument(
+        "--patience",
+        type=int,
+        default=None,
+        help="early-stop after N epochs without a val-recall improvement (default off). "
+        "best.pt is checkpointed at the peak either way, so this only saves wall-clock "
+        "— df3 spent 23 of 40 epochs past its ep-17 peak; hn4 peaked at ep 5.",
+    )
+    ap.add_argument(
         "--dynamic-sigma",
         action="store_true",
         help="Experiment A (dynamic ball size): per-sample target gaussian sigma scales with the "
@@ -482,6 +490,7 @@ def main():
     runs = Path(args.runs) if args.runs else (out / "runs")
     runs.mkdir(parents=True, exist_ok=True)
     best = -1.0
+    best_ep = -1
     for ep in range(args.epochs):
         model.train()
         tot = 0.0
@@ -532,6 +541,7 @@ def main():
         )
         if metrics["recall"] >= best:
             best = metrics["recall"]
+            best_ep = ep
             torch.save(
                 {
                     "model": model.state_dict(),
@@ -542,6 +552,13 @@ def main():
                 },
                 runs / "best.pt",
             )
+        elif args.patience is not None and ep - best_ep >= args.patience:
+            print(
+                f"EARLY STOP at epoch {ep + 1}: no val improvement in "
+                f"{args.patience} epochs (best {best} @ epoch {best_ep + 1})",
+                flush=True,
+            )
+            break
     print(f"DONE best_val_recall={best}", flush=True)
 
 

--- a/training/train_v4_heatmap.py
+++ b/training/train_v4_heatmap.py
@@ -333,6 +333,14 @@ def main():
         "on top of best.pt) instead of training from scratch.",
     )
     ap.add_argument(
+        "--index-version",
+        type=int,
+        default=None,
+        help="train on this exact immutable index_vN.json snapshot of the store "
+        "(default None = pin + use the CURRENT index.json). EXP-DIST-55: stores "
+        "were mutated in place between runs; every run now records its data.",
+    )
+    ap.add_argument(
         "--patience",
         type=int,
         default=None,
@@ -429,7 +437,7 @@ def main():
         ds_cls = _PersonDataset
     else:
         ds_cls = HeatmapCropDataset
-    tr = ds_cls(out, "train", args.crop, args.sigma)
+    tr = ds_cls(out, "train", args.crop, args.sigma, index_version=args.index_version)
     if dyn_on or far_on:
         require_positive_depth(
             tr.items, out, "--dynamic-sigma" if dyn_on else "--far-weight"
@@ -446,9 +454,16 @@ def main():
             f"({n_annot}/{len(tr.items)} of train; rest masked)",
             flush=True,
         )
-    va = HeatmapCropDataset(out, "val", args.crop, args.sigma)
+    va = HeatmapCropDataset(
+        out, "val", args.crop, args.sigma, index_version=args.index_version
+    )
     print(
         f"train crops={len(tr)} val crops={len(va)} far_weight={args.far_weight}",
+        flush=True,
+    )
+    print(
+        f"DATA: store={out} index_v{tr.index_version} sha={tr.index_sha}"
+        + (" (UNPINNED - store not writable)" if tr.index_version == 0 else ""),
         flush=True,
     )
     if len(tr) == 0:
@@ -549,6 +564,9 @@ def main():
                     "encoding": args.input_encoding,
                     "base": args.base,
                     "out_ch": 2 if person_on else 1,
+                    "store": str(out),
+                    "index_version": tr.index_version,
+                    "index_sha": tr.index_sha,
                 },
                 runs / "best.pt",
             )

--- a/training/train_v4_heatmap.py
+++ b/training/train_v4_heatmap.py
@@ -247,6 +247,22 @@ def main():
         "identity (legacy, byte-identical). diff3 = (g_t, g_{t-1}-g_{t-2}, "
         "g_t-g_{t-1}) signed frame differences — see EncodingPrelude.",
     )
+    ap.add_argument(
+        "--person-sidecar",
+        default=None,
+        help="ph1: JSON sidecar {crop_file: [[x1,y1,x2,y2,conf], ...]} of yolo26n "
+        "person boxes on the stored crops (no store rebuild). Enables the out_ch=2 "
+        "ball+person multi-task head: channel 1 learns person centers so shared "
+        "features separate a 22cm ball from a 22cm head (EXP-DIST-47). Crops "
+        "absent from the sidecar are MASKED out of the person loss; the ball "
+        "channel/loss is unchanged. Runtime slices channel 0 — no product change.",
+    )
+    ap.add_argument(
+        "--person-weight",
+        type=float,
+        default=0.5,
+        help="λ on the person-channel loss (only with --person-sidecar)",
+    )
     args = ap.parse_args()
 
     import torch
@@ -341,10 +357,57 @@ def main():
                 tgt = _np.ascontiguousarray(tgt[:, ::-1])
             return torch.from_numpy(stack), torch.from_numpy(tgt[None])
 
+    class _PersonDataset(HeatmapCropDataset):
+        """ph1: adds a person-center target channel from the yolo26n sidecar.
+
+        Returns ``(stack, tgt_2ch, person_valid)``: channel 0 = the unchanged ball
+        Gaussian, channel 1 = max-composited person Gaussians (σ from box height).
+        ``person_valid`` is 1.0 for crops PRESENT in the sidecar (an annotated
+        empty crop is a real "no person" label) and 0.0 for absent crops, which
+        the loss masks out — partial sidecars train cleanly."""
+
+        persons: dict = {}
+
+        def __getitem__(self, i):
+            import random
+
+            import numpy as _np
+
+            from training.data_prep.heatmap_dataset import person_center_heatmap
+
+            r = self.items[i]
+            stack = (
+                _np.load(self.root / "crops" / r["file"]).astype(_np.float32) / 255.0
+            )
+            if r["x"] is None:
+                tgt = _np.zeros((self.crop, self.crop), _np.float32)
+            else:
+                tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], self.sigma)
+            boxes = self.persons.get(r["file"])
+            pvalid = 0.0 if boxes is None else 1.0
+            ptgt = person_center_heatmap(self.crop, self.crop, boxes or [])
+            if self.augment and random.random() < 0.5:
+                stack = _np.ascontiguousarray(stack[:, :, ::-1])
+                tgt = _np.ascontiguousarray(tgt[:, ::-1])
+                ptgt = _np.ascontiguousarray(ptgt[:, ::-1])
+            return (
+                torch.from_numpy(stack),
+                torch.from_numpy(_np.stack([tgt, ptgt], 0)),
+                torch.tensor(pvalid, dtype=torch.float32),
+            )
+
+    person_on = args.person_sidecar is not None
+    if person_on and (dyn_on or far_on):
+        raise SystemExit(
+            "--person-sidecar cannot combine with --dynamic-sigma/--far-weight yet "
+            "(dataset variants are not composed); run them as separate experiments."
+        )
     if dyn_on:
         ds_cls: type = _DynSigmaDataset
     elif far_on:
         ds_cls = _DepthDataset
+    elif person_on:
+        ds_cls = _PersonDataset
     else:
         ds_cls = HeatmapCropDataset
     tr = ds_cls(out, "train", args.crop, args.sigma)
@@ -355,6 +418,15 @@ def main():
     if dyn_on:
         tr.sigma_far = args.sigma_far
         tr.sigma_near = args.sigma_near
+    if person_on:
+        sidecar = json.loads(Path(args.person_sidecar).read_text())
+        tr.persons = sidecar
+        n_annot = sum(1 for r in tr.items if r["file"] in sidecar)
+        print(
+            f"person sidecar: {len(sidecar)} annotated crops "
+            f"({n_annot}/{len(tr.items)} of train; rest masked)",
+            flush=True,
+        )
     va = HeatmapCropDataset(out, "val", args.crop, args.sigma)
     print(
         f"train crops={len(tr)} val crops={len(va)} far_weight={args.far_weight}",
@@ -376,7 +448,9 @@ def main():
     )
     from training.models.heatmap_net import DetectorWithEncoding, EncodingPrelude
 
-    model = HeatmapNet(in_frames=3, in_ch_per_frame=1, base=args.base).to(dev)
+    model = HeatmapNet(
+        in_frames=3, in_ch_per_frame=1, base=args.base, out_ch=2 if person_on else 1
+    ).to(dev)
     # gray3 prelude is the identity, so the default path is byte-identical to the
     # pre-encoding trainer (guarded by test). The prelude runs in front of the net
     # here AND inside the exported ONNX graph — one module, no train/infer skew.
@@ -401,22 +475,38 @@ def main():
         model.train()
         tot = 0.0
         for batch in dl:
+            pv = None
             if far_on:
                 x, tgt, far = batch
                 far = far.to(dev).view(-1, 1, 1, 1)
+            elif person_on:
+                x, tgt, pv = batch
+                pv = pv.to(dev).view(-1, 1, 1, 1)
             else:
                 x, tgt = batch
             x, tgt = x.to(dev), tgt.to(dev)
             pred = torch.sigmoid(model(prelude(x)))
-            # emphasize the (rare) ball pixels: weighted MSE.
-            w = 1.0 + 30.0 * tgt
-            if far_on:
-                # Far-band up-weighting: scale ONLY the positive (ball-pixel) weight
-                # by (1 + K*far_factor) so far balls dominate the loss. tgt acts as
-                # the positive mask, so background weight (the leading 1.0) is
-                # untouched. K=0 collapses this to exactly w=1+30*tgt.
-                w = 1.0 + 30.0 * tgt * (1.0 + args.far_weight * far)
-            loss = (w * (pred - tgt) ** 2).mean()
+            if person_on:
+                # ball channel: the unchanged weighted MSE. person channel: same
+                # form, masked to sidecar-annotated samples (pv), scaled by λ —
+                # unannotated crops contribute NOTHING to channel 1.
+                bt, pt = tgt[:, 0:1], tgt[:, 1:2]
+                loss = ((1.0 + 30.0 * bt) * (pred[:, 0:1] - bt) ** 2).mean()
+                loss = (
+                    loss
+                    + args.person_weight
+                    * (pv * (1.0 + 30.0 * pt) * (pred[:, 1:2] - pt) ** 2).mean()
+                )
+            else:
+                # emphasize the (rare) ball pixels: weighted MSE.
+                w = 1.0 + 30.0 * tgt
+                if far_on:
+                    # Far-band up-weighting: scale ONLY the positive (ball-pixel)
+                    # weight by (1 + K*far_factor) so far balls dominate the loss.
+                    # tgt acts as the positive mask, so background weight (the
+                    # leading 1.0) is untouched. K=0 collapses to exactly w=1+30*tgt.
+                    w = 1.0 + 30.0 * tgt * (1.0 + args.far_weight * far)
+                loss = (w * (pred - tgt) ** 2).mean()
             opt.zero_grad()
             loss.backward()
             opt.step()
@@ -437,7 +527,7 @@ def main():
                     "epoch": ep,
                     "encoding": args.input_encoding,
                     "base": args.base,
-                    "out_ch": 1,
+                    "out_ch": 2 if person_on else 1,
                 },
                 runs / "best.pt",
             )

--- a/training/train_v4_heatmap.py
+++ b/training/train_v4_heatmap.py
@@ -112,6 +112,24 @@ def assemble_games(
     return games
 
 
+def require_positive_depth(items: list[dict], store, flag: str) -> None:
+    """Hard-fail when a depth-consuming flag runs on a store whose positives lack depth.
+
+    The depth datasets used to substitute a silent mid-field default for a missing
+    ``depth`` key, so ``--dynamic-sigma`` on a depth-less (or PARTIALLY recorded)
+    store trained those positives at one constant σ without erroring. Partial
+    stores are the dangerous case — they look depth-ready but aren't.
+    """
+    pos = [r for r in items if r.get("x") is not None]
+    missing = sum(1 for r in pos if "depth" not in r)
+    if missing:
+        raise SystemExit(
+            f"{flag}: {missing}/{len(pos)} positive crops in {store} have no 'depth' "
+            "field. Rebuild with record_depth=True or backfill depth first — a "
+            "partial store would silently train those positives at a default depth."
+        )
+
+
 def center_distance_eval(model, ds, device, radius=20, thr=0.5):
     """Recall/precision by peak-vs-target center distance on a crop dataset."""
     import torch
@@ -156,7 +174,15 @@ def main():
         help="DataLoader workers; raise to feed a data-starved GPU (was hardcoded 4)",
     )
     ap.add_argument("--crop", type=int, default=256)
-    ap.add_argument("--sigma", type=float, default=4.0)
+    ap.add_argument(
+        "--sigma",
+        type=float,
+        default=None,
+        help="target gaussian sigma. Default None = the store's build-time σ (index "
+        "summary; 4.0 on a fresh build). An EXPLICIT value wins over the store "
+        "summary — previously the summary silently overrode this flag, so a "
+        "--sigma 3 run on a σ=4 store trained at σ=4.",
+    )
     ap.add_argument("--lr", type=float, default=1e-3)
     ap.add_argument("--rebuild", action="store_true", help="re-render crops")
     ap.add_argument(
@@ -236,7 +262,7 @@ def main():
             games,
             out,
             crop=args.crop,
-            sigma=args.sigma,
+            sigma=4.0 if args.sigma is None else args.sigma,
             val_game_ids=val_ids,
             record_depth=far_on or dyn_on,
         )
@@ -264,7 +290,9 @@ def main():
                 far = 0.0
             else:
                 tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], self.sigma)
-                far = float(1.0 - r.get("depth", 0.0))  # far touchline -> 1.0
+                # depth is guaranteed by require_positive_depth() at startup; a
+                # KeyError here means the guard was bypassed — fail loudly.
+                far = float(1.0 - r["depth"])  # far touchline -> 1.0
             if self.augment and random.random() < 0.5:
                 stack = _np.ascontiguousarray(stack[:, :, ::-1])
                 tgt = _np.ascontiguousarray(tgt[:, ::-1])
@@ -294,7 +322,9 @@ def main():
             if r["x"] is None:
                 tgt = _np.zeros((self.crop, self.crop), _np.float32)
             else:
-                depth = float(r.get("depth", 0.5))
+                # depth is guaranteed by require_positive_depth() at startup; a
+                # KeyError here means the guard was bypassed — fail loudly.
+                depth = float(r["depth"])
                 sig = self.sigma_far + (self.sigma_near - self.sigma_far) * depth
                 tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], sig)
             if self.augment and random.random() < 0.5:
@@ -309,6 +339,10 @@ def main():
     else:
         ds_cls = HeatmapCropDataset
     tr = ds_cls(out, "train", args.crop, args.sigma)
+    if dyn_on or far_on:
+        require_positive_depth(
+            tr.items, out, "--dynamic-sigma" if dyn_on else "--far-weight"
+        )
     if dyn_on:
         tr.sigma_far = args.sigma_far
         tr.sigma_near = args.sigma_near

--- a/training/train_v4_heatmap.py
+++ b/training/train_v4_heatmap.py
@@ -20,6 +20,8 @@ import argparse
 import json
 from pathlib import Path
 
+from training.data_prep.heatmap_dataset import HeatmapCropDataset
+
 # 05-27 sets share the (human-corrected) autocam-keypoint polygon; Irondequoit
 # has its own. Override via --polygon-* if these move.
 DEFAULT_POLY_0527 = "D:/detect_work/field_polygon_autocam.json"
@@ -127,6 +129,119 @@ def require_positive_depth(items: list[dict], store, flag: str) -> None:
             f"{flag}: {missing}/{len(pos)} positive crops in {store} have no 'depth' "
             "field. Rebuild with record_depth=True or backfill depth first — a "
             "partial store would silently train those positives at a default depth."
+        )
+
+
+# Dataset variants live at MODULE level: Windows DataLoader workers use spawn,
+# which pickles the dataset by qualified name — a class defined inside main()
+# dies with "Can't get local object" the moment num_workers > 0.
+class _DepthDataset(HeatmapCropDataset):
+    """Adds per-sample field depth (positives) so the loss can far-band weight.
+
+    Returns ``(stack, tgt, far_factor)`` where ``far_factor = 1-depth`` for
+    positives (1 at the far touchline, 0 near) and 0 for negatives. Only used
+    when ``--far-weight > 0``; the default path uses the unchanged
+    ``HeatmapCropDataset`` (byte-identical to the curve)."""
+
+    def __getitem__(self, i):
+        import random
+
+        import numpy as _np
+        import torch
+
+        from training.data_prep.heatmap_dataset import gaussian_heatmap
+
+        r = self.items[i]
+        stack = _np.load(self.root / "crops" / r["file"]).astype(_np.float32) / 255.0
+        if r["x"] is None:
+            tgt = _np.zeros((self.crop, self.crop), _np.float32)
+            far = 0.0
+        else:
+            tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], self.sigma)
+            # depth is guaranteed by require_positive_depth() at startup; a
+            # KeyError here means the guard was bypassed — fail loudly.
+            far = float(1.0 - r["depth"])  # far touchline -> 1.0
+        if self.augment and random.random() < 0.5:
+            stack = _np.ascontiguousarray(stack[:, :, ::-1])
+            tgt = _np.ascontiguousarray(tgt[:, ::-1])
+        return (
+            torch.from_numpy(stack),
+            torch.from_numpy(tgt[None]),
+            torch.tensor(far, dtype=torch.float32),
+        )
+
+
+class _DynSigmaDataset(HeatmapCropDataset):
+    """Experiment A: per-sample target sigma = sigma_far + (sigma_near - sigma_far) * depth
+    (depth 0=far -> tight gaussian; 1=near -> broad) so the target encodes the ball's
+    location-dependent apparent size. Negatives stay all-zero. Returns (stack, tgt)."""
+
+    sigma_far: float = 2.0
+    sigma_near: float = 8.0
+
+    def __getitem__(self, i):
+        import random
+
+        import numpy as _np
+        import torch
+
+        from training.data_prep.heatmap_dataset import gaussian_heatmap
+
+        r = self.items[i]
+        stack = _np.load(self.root / "crops" / r["file"]).astype(_np.float32) / 255.0
+        if r["x"] is None:
+            tgt = _np.zeros((self.crop, self.crop), _np.float32)
+        else:
+            # depth is guaranteed by require_positive_depth() at startup; a
+            # KeyError here means the guard was bypassed — fail loudly.
+            depth = float(r["depth"])
+            sig = self.sigma_far + (self.sigma_near - self.sigma_far) * depth
+            tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], sig)
+        if self.augment and random.random() < 0.5:
+            stack = _np.ascontiguousarray(stack[:, :, ::-1])
+            tgt = _np.ascontiguousarray(tgt[:, ::-1])
+        return torch.from_numpy(stack), torch.from_numpy(tgt[None])
+
+
+class _PersonDataset(HeatmapCropDataset):
+    """ph1: adds a person-center target channel from the yolo26n sidecar.
+
+    Returns ``(stack, tgt_2ch, person_valid)``: channel 0 = the unchanged ball
+    Gaussian, channel 1 = max-composited person Gaussians (σ from box height).
+    ``person_valid`` is 1.0 for crops PRESENT in the sidecar (an annotated
+    empty crop is a real "no person" label) and 0.0 for absent crops, which
+    the loss masks out — partial sidecars train cleanly."""
+
+    persons: dict = {}
+
+    def __getitem__(self, i):
+        import random
+
+        import numpy as _np
+        import torch
+
+        from training.data_prep.heatmap_dataset import (
+            gaussian_heatmap,
+            person_center_heatmap,
+        )
+
+        r = self.items[i]
+        stack = _np.load(self.root / "crops" / r["file"]).astype(_np.float32) / 255.0
+        if r["x"] is None:
+            tgt = _np.zeros((self.crop, self.crop), _np.float32)
+        else:
+            tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], self.sigma)
+        boxes = self.persons.get(r["file"])
+        pvalid = 0.0 if boxes is None else 1.0
+        ptgt = person_center_heatmap(self.crop, self.crop, boxes or [])
+        if self.augment and random.random() < 0.5:
+            stack = _np.ascontiguousarray(stack[:, :, ::-1])
+            tgt = _np.ascontiguousarray(tgt[:, ::-1])
+            ptgt = _np.ascontiguousarray(ptgt[:, ::-1])
+        return (
+            torch.from_numpy(stack),
+            torch.from_numpy(_np.stack([tgt, ptgt], 0)),
+            torch.tensor(pvalid, dtype=torch.float32),
         )
 
 
@@ -271,7 +386,6 @@ def main():
     from training.data_prep.heatmap_dataset import (
         HeatmapCropDataset,
         build_heatmap_crops,
-        gaussian_heatmap,
     )
     from training.models.heatmap_net import HeatmapNet
 
@@ -292,109 +406,6 @@ def main():
             record_depth=far_on or dyn_on,
         )
         print("dataset:", summary, flush=True)
-
-    class _DepthDataset(HeatmapCropDataset):
-        """Adds per-sample field depth (positives) so the loss can far-band weight.
-
-        Returns ``(stack, tgt, far_factor)`` where ``far_factor = 1-depth`` for
-        positives (1 at the far touchline, 0 near) and 0 for negatives. Only used
-        when ``--far-weight > 0``; the default path uses the unchanged
-        ``HeatmapCropDataset`` (byte-identical to the curve)."""
-
-        def __getitem__(self, i):
-            import random
-
-            import numpy as _np
-
-            r = self.items[i]
-            stack = (
-                _np.load(self.root / "crops" / r["file"]).astype(_np.float32) / 255.0
-            )
-            if r["x"] is None:
-                tgt = _np.zeros((self.crop, self.crop), _np.float32)
-                far = 0.0
-            else:
-                tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], self.sigma)
-                # depth is guaranteed by require_positive_depth() at startup; a
-                # KeyError here means the guard was bypassed — fail loudly.
-                far = float(1.0 - r["depth"])  # far touchline -> 1.0
-            if self.augment and random.random() < 0.5:
-                stack = _np.ascontiguousarray(stack[:, :, ::-1])
-                tgt = _np.ascontiguousarray(tgt[:, ::-1])
-            return (
-                torch.from_numpy(stack),
-                torch.from_numpy(tgt[None]),
-                torch.tensor(far, dtype=torch.float32),
-            )
-
-    class _DynSigmaDataset(HeatmapCropDataset):
-        """Experiment A: per-sample target sigma = sigma_far + (sigma_near - sigma_far) * depth
-        (depth 0=far -> tight gaussian; 1=near -> broad) so the target encodes the ball's
-        location-dependent apparent size. Negatives stay all-zero. Returns (stack, tgt)."""
-
-        sigma_far: float = 2.0
-        sigma_near: float = 8.0
-
-        def __getitem__(self, i):
-            import random
-
-            import numpy as _np
-
-            r = self.items[i]
-            stack = (
-                _np.load(self.root / "crops" / r["file"]).astype(_np.float32) / 255.0
-            )
-            if r["x"] is None:
-                tgt = _np.zeros((self.crop, self.crop), _np.float32)
-            else:
-                # depth is guaranteed by require_positive_depth() at startup; a
-                # KeyError here means the guard was bypassed — fail loudly.
-                depth = float(r["depth"])
-                sig = self.sigma_far + (self.sigma_near - self.sigma_far) * depth
-                tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], sig)
-            if self.augment and random.random() < 0.5:
-                stack = _np.ascontiguousarray(stack[:, :, ::-1])
-                tgt = _np.ascontiguousarray(tgt[:, ::-1])
-            return torch.from_numpy(stack), torch.from_numpy(tgt[None])
-
-    class _PersonDataset(HeatmapCropDataset):
-        """ph1: adds a person-center target channel from the yolo26n sidecar.
-
-        Returns ``(stack, tgt_2ch, person_valid)``: channel 0 = the unchanged ball
-        Gaussian, channel 1 = max-composited person Gaussians (σ from box height).
-        ``person_valid`` is 1.0 for crops PRESENT in the sidecar (an annotated
-        empty crop is a real "no person" label) and 0.0 for absent crops, which
-        the loss masks out — partial sidecars train cleanly."""
-
-        persons: dict = {}
-
-        def __getitem__(self, i):
-            import random
-
-            import numpy as _np
-
-            from training.data_prep.heatmap_dataset import person_center_heatmap
-
-            r = self.items[i]
-            stack = (
-                _np.load(self.root / "crops" / r["file"]).astype(_np.float32) / 255.0
-            )
-            if r["x"] is None:
-                tgt = _np.zeros((self.crop, self.crop), _np.float32)
-            else:
-                tgt = gaussian_heatmap(self.crop, self.crop, r["x"], r["y"], self.sigma)
-            boxes = self.persons.get(r["file"])
-            pvalid = 0.0 if boxes is None else 1.0
-            ptgt = person_center_heatmap(self.crop, self.crop, boxes or [])
-            if self.augment and random.random() < 0.5:
-                stack = _np.ascontiguousarray(stack[:, :, ::-1])
-                tgt = _np.ascontiguousarray(tgt[:, ::-1])
-                ptgt = _np.ascontiguousarray(ptgt[:, ::-1])
-            return (
-                torch.from_numpy(stack),
-                torch.from_numpy(_np.stack([tgt, ptgt], 0)),
-                torch.tensor(pvalid, dtype=torch.float32),
-            )
 
     person_on = args.person_sidecar is not None
     if person_on and (dyn_on or far_on):

--- a/training/train_v4_heatmap.py
+++ b/training/train_v4_heatmap.py
@@ -238,6 +238,15 @@ def main():
         default=5.0,
         help="target sigma at depth=1 (near touchline, ~17px ball) when --dynamic-sigma",
     )
+    ap.add_argument(
+        "--input-encoding",
+        choices=("gray3", "diff3"),
+        default="gray3",
+        help="input encoding applied in front of the net (and baked into the ONNX "
+        "graph at export — the external contract stays raw gray frames). gray3 = "
+        "identity (legacy, byte-identical). diff3 = (g_t, g_{t-1}-g_{t-2}, "
+        "g_t-g_{t-1}) signed frame differences — see EncodingPrelude.",
+    )
     args = ap.parse_args()
 
     import torch
@@ -365,9 +374,23 @@ def main():
         prefetch_factor=4 if args.workers > 0 else None,
         pin_memory=True,
     )
+    from training.models.heatmap_net import DetectorWithEncoding, EncodingPrelude
+
     model = HeatmapNet(in_frames=3, in_ch_per_frame=1, base=args.base).to(dev)
+    # gray3 prelude is the identity, so the default path is byte-identical to the
+    # pre-encoding trainer (guarded by test). The prelude runs in front of the net
+    # here AND inside the exported ONNX graph — one module, no train/infer skew.
+    prelude = EncodingPrelude(args.input_encoding).to(dev)
+    eval_model = DetectorWithEncoding(prelude, model)
     if args.resume:
         rck = torch.load(args.resume, map_location=dev)
+        rck_enc = rck.get("encoding", "gray3") if "model" in rck else "gray3"
+        if rck_enc != args.input_encoding:
+            raise SystemExit(
+                f"--resume checkpoint was trained with encoding={rck_enc!r} but this "
+                f"run is --input-encoding {args.input_encoding!r} — warm-starting "
+                "across encodings silently mismatches what layer 1 learned."
+            )
         model.load_state_dict(rck["model"] if "model" in rck else rck)
         print(f"resumed (warm-start) from {args.resume}", flush=True)
     opt = torch.optim.Adam(model.parameters(), lr=args.lr)
@@ -384,7 +407,7 @@ def main():
             else:
                 x, tgt = batch
             x, tgt = x.to(dev), tgt.to(dev)
-            pred = torch.sigmoid(model(x))
+            pred = torch.sigmoid(model(prelude(x)))
             # emphasize the (rare) ball pixels: weighted MSE.
             w = 1.0 + 30.0 * tgt
             if far_on:
@@ -398,7 +421,9 @@ def main():
             loss.backward()
             opt.step()
             tot += float(loss)
-        metrics = center_distance_eval(model, va, dev) if len(va) else {"recall": 0.0}
+        metrics = (
+            center_distance_eval(eval_model, va, dev) if len(va) else {"recall": 0.0}
+        )
         print(
             f"epoch {ep + 1}/{args.epochs} loss={tot / max(len(dl), 1):.4f} "
             f"val={metrics}",
@@ -406,7 +431,16 @@ def main():
         )
         if metrics["recall"] >= best:
             best = metrics["recall"]
-            torch.save({"model": model.state_dict(), "epoch": ep}, runs / "best.pt")
+            torch.save(
+                {
+                    "model": model.state_dict(),
+                    "epoch": ep,
+                    "encoding": args.input_encoding,
+                    "base": args.base,
+                    "out_ch": 1,
+                },
+                runs / "best.pt",
+            )
     print(f"DONE best_val_recall={best}", flush=True)
 
 


### PR DESCRIPTION
## What this became

Started as the σ-precedence fix + diff3 encoding; grew into the full detector-experiment infrastructure branch (11 commits). All behavior changes are opt-in flags with **byte-identical defaults** (tested, and proven 0.0-delta against the shipped hn2 ONNX on real video).

### Bug fixes
1. **σ precedence** — CLI `--sigma` silently overridden by the store summary; voided the original σ sweep (EXP-DIST-50). Explicit value now wins; depth-consuming flags hard-fail on stores lacking per-crop depth.
2. **Windows spawn pickling** — dataset variant classes hoisted to module level (`Can't get local object` killed any `num_workers>0` run of the variants on Windows).
3. **Test-infra latents** — conftest `onnxruntime` stub gains a real ModuleSpec; torch imported before the autouse `os.path.exists` mock poisons its DLL probing.

### Infrastructure
4. **Immutable versioned store indexes** (`store_versions.py`) — content-addressed `index_vN.json`; mutators (`mine_hard_negatives`, `build_human_crops`) pin the store before AND after every write; datasets/trainers/checkpoints record `{store, index_version, index_sha}`; `--index-version N` trains on exact historical data. Root-cause fix for EXP-DIST-55 (the hn5 chain mutated `crops_reolink` in place — a 3-run experiment batch silently trained on the wrong data).
5. **`EncodingPrelude` + `load_detector_checkpoint`** — input-encoding math computed in-graph (ONNX contract stays raw gray frames; runtime untouched); net geometry inferred from checkpoints; replaces 4 hand-rolled load sites.
6. **`--patience N`** early stop (wall-clock only — `best.pt` is peak-checkpointed either way).
7. **`--person-sidecar` multi-task trainer** — out_ch=2 ball+person head supervised from a yolo26n sidecar over stored crops (no store rebuild), masked loss for partial coverage.

### Experiment record (docs)
EXP-DIST-50–55: the voided σ sweep; three single-lever results (diff3, σ=3, person head — all G1 fails, later found confounded by the in-place store mutation); the val-proxy inversion finding; the confound analysis + control-run design. DECISIONS: immutable stores mandate; two-box compute policy (server = precision/data-local, FORTNITE-OP = preemptible idle-window job queue).

## Verification
Suite **1576 passed** / 1 skipped / 1 xfailed; ruff clean; ONNX export parity ≤1e-4; candidate-exact parity (0.0 px / 0.0 score across real frames) between shipped hn2 and the new code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)