### PR TITLE
fix(update): stop the reinstall loop and unblock the tray's Install button

### DIFF
--- a/tests/test_queue_status_in_progress.py
+++ b/tests/test_queue_status_in_progress.py
@@ -139,6 +139,9 @@ class TestQueueStatusSummary:
         app.highlight_reel_processor = None
         app.ttt_job_processor = None
         app.clip_processor = None
+        # Real __init__ always sets this (None when no pipeline is
+        # configured); the summary reads it directly.
+        app.pipeline_processor = None
         return app
 
     def test_all_idle_shows_zero_queues_and_none_in_progress(self):
@@ -195,6 +198,7 @@ class TestQueueStatusSummary:
         app.highlight_reel_processor = None
         app.ttt_job_processor = None
         app.clip_processor = None
+        app.pipeline_processor = None
 
         s = app.get_queue_status_summary()
         assert s["download"]["queued"] == 2  # 0 + 2 across cameras
@@ -227,6 +231,7 @@ class TestLogQueueStatusFormat:
         app.highlight_reel_processor = None
         app.ttt_job_processor = None
         app.clip_processor = None
+        app.pipeline_processor = None
 
         with caplog.at_level(logging.INFO, logger="video_grouper.video_grouper_app"):
             app._log_queue_status()
@@ -260,6 +265,7 @@ class TestGetQueueSizesBackwardCompat:
         app.clip_request_processor = None
         app.ttt_job_processor = None
         app.clip_processor = None
+        app.pipeline_processor = None
 
         sizes = app.get_queue_sizes()
         assert sizes["video"] == 0
@@ -273,3 +279,65 @@ class TestGetQueueSizesBackwardCompat:
         # filter in the StopService deferral path.
         for v in sizes.values():
             assert isinstance(v, int)
+
+
+class TestUpgradeQuiescence:
+    """``_update_quiescence_check`` gates the auto-upgrade. It must
+    treat a dequeued-but-running task as BUSY.
+
+    Regression (2026-08-03): it read ``get_queue_sizes()``, which
+    documents itself as excluding the in-progress item. A YouTube
+    upload that had already been dequeued therefore reported queue=0,
+    the gate said "idle", and the upgrade stopped the service on top
+    of the running upload -- killing it at 2%.
+    """
+
+    def _make_app(self, **kwargs):
+        app = TestQueueStatusSummary()._make_app(**kwargs)
+        # _has_active_download() probes this attribute directly; a bare
+        # MagicMock attribute would read as truthy and mask everything.
+        for dp in app.download_processors.values():
+            dp._in_progress_item = None
+        return app
+
+    @pytest.mark.asyncio
+    async def test_idle_when_nothing_queued_or_running(self):
+        app = self._make_app()
+        is_idle, reason = await app._update_quiescence_check()
+        assert is_idle is True
+        assert reason is None
+
+    @pytest.mark.asyncio
+    async def test_busy_when_upload_is_in_flight_with_empty_queue(self):
+        """The exact failure: queue=0, upload running."""
+        app = self._make_app(
+            youtube_qsize=0,
+            youtube_busy="YoutubeUploadTask(2026.07.06-17.50.05)",
+        )
+        is_idle, reason = await app._update_quiescence_check()
+        assert is_idle is False, "an in-flight upload must block the upgrade"
+        assert "youtube" in reason
+
+    @pytest.mark.asyncio
+    async def test_busy_when_autocam_render_is_in_flight(self):
+        """The pipeline processor runs the longest task in the app and
+        was missing from the summary entirely, so a render in progress
+        was invisible to the gate."""
+        app = self._make_app()
+        proc = MagicMock()
+        proc.get_queue_size = MagicMock(return_value=0)
+        proc.get_in_progress_summary = MagicMock(
+            return_value="PipelineTask(2026.07.08-18.20.31)"
+        )
+        app.pipeline_processor = proc
+
+        is_idle, reason = await app._update_quiescence_check()
+        assert is_idle is False, "an in-flight AutoCam render must block the upgrade"
+        assert "pipeline" in reason
+
+    @pytest.mark.asyncio
+    async def test_busy_when_work_is_merely_queued(self):
+        app = self._make_app(video_qsize=2)
+        is_idle, reason = await app._update_quiescence_check()
+        assert is_idle is False
+        assert "video=2" in reason

--- a/tests/test_tray.py
+++ b/tests/test_tray.py
@@ -109,3 +109,47 @@ def test_restart_service_success(mock_restart_service):
         tray_icon.showMessage.assert_called_once_with(
             "Service", "Service restarted successfully"
         )
+
+
+def test_apply_pending_update_sends_same_origin_header():
+    """Regression (2026-08-03): the service's rebinding/CSRF middleware
+    rejects any state-changing request without Origin/Referer, and
+    ``urllib.request`` sends neither -- so every Install Update click
+    came back 403 "Missing Origin/Referer on state-changing request"
+    and the manual upgrade path never worked. The tray must supply its
+    own base URL as the Origin.
+    """
+    import json
+
+    captured = {}
+
+    class _Resp:
+        def __enter__(self_inner):
+            return self_inner
+
+        def __exit__(self_inner, *exc):
+            return False
+
+        def read(self_inner):
+            return json.dumps({"status": "spawned"}).encode("utf-8")
+
+    def _fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.header_items())
+        captured["method"] = req.get_method()
+        return _Resp()
+
+    with patch("video_grouper.tray.main.SystemTrayIcon.__init__", lambda x: None):
+        tray_icon = SystemTrayIcon()
+        tray_icon.config = None  # falls back to the default 8765
+        tray_icon.showMessage = MagicMock()
+        with patch("urllib.request.urlopen", _fake_urlopen):
+            tray_icon.apply_pending_update()
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://localhost:8765/api/update/apply"
+    # urllib title-cases header keys.
+    origin = {k.lower(): v for k, v in captured["headers"].items()}["origin"]
+    assert origin == "http://localhost:8765"
+    tray_icon.showMessage.assert_called_once()
+    assert "spawned" in tray_icon.showMessage.call_args[0][1]

--- a/tests/web/test_auth_server.py
+++ b/tests/web/test_auth_server.py
@@ -1273,3 +1273,47 @@ def test_receive_token_completes_when_auto_claim_raises(storage, client):
     # Token still persisted.
     saved = json.loads((storage / "ttt" / "tokens.json").read_text(encoding="utf-8"))
     assert saved["access_token"] == jwt
+
+
+# ---------------------------------------------------------------------------
+# CSRF guard vs. the tray's own POST (regression: 2026-08-03)
+# ---------------------------------------------------------------------------
+
+
+class _StubUpdateProcessor:
+    """Minimal stand-in for UpdateCheckProcessor's HTTP surface."""
+
+    storage_path = "."
+    _pending_version = "9.9.9"
+
+    def build_status(self):
+        from video_grouper.task_processors.update_check_processor import UpdateStatus
+
+        return UpdateStatus(current_version="0.0.1", auto_update=True)
+
+    async def apply_pending(self):
+        return True, "spawned"
+
+
+def test_update_apply_403s_without_origin_but_accepts_the_trays_own(storage):
+    """The tray drives Install Update with ``urllib.request``, which
+    sends neither Origin nor Referer -- so the rebinding/CSRF guard
+    answered every click with 403 and the manual upgrade path was
+    dead. The guard must stay on for headerless callers while the
+    tray's same-origin POST gets through.
+
+    These tests previously mounted ``build_router`` on a bare FastAPI
+    app, which is why the middleware never ran and the bug shipped.
+    """
+    app = create_app(
+        _ttt_config(), str(storage), update_processor=_StubUpdateProcessor()
+    )
+    with TestClient(app, base_url="http://localhost:8765") as c:
+        headerless = c.post("/api/update/apply")
+        assert headerless.status_code == 403
+        assert "Missing Origin/Referer" in headerless.text
+
+        # Exactly what video_grouper.tray.main.apply_pending_update sends.
+        with_origin = c.post("/api/update/apply", headers=_SAME_ORIGIN)
+        assert with_origin.status_code == 202
+        assert with_origin.json()["status"] == "spawned"

--- a/video_grouper/installer/installer.nsi
+++ b/video_grouper/installer/installer.nsi
@@ -118,6 +118,86 @@ FunctionEnd
     Pop $0
 !macroend
 
+; Block until VideoGrouperService actually reaches STOPPED.
+;
+; `sc.exe stop` is ASYNCHRONOUS -- it returns as soon as the SCM
+; accepts the stop control, NOT when the process has exited. The
+; previous code slept 1500ms and started overwriting, which raced a
+; service that was still shutting down. Windows refuses to overwrite
+; a mapped image, so `File /r` failed on the locked exe and on
+; _internal\*.pyd -- and because nothing checked the error flag, the
+; script wrote "files-copied" .. "complete" regardless. The service
+; then restarted on the OLD code, reported the OLD version, saw the
+; new release again and reinstalled. Observed 2026-08-03: two full
+; 395 MB download+install cycles 35s apart, both reporting 0.5.7,
+; ~15 service restarts in 10 minutes.
+;
+; Timing out here is a HARD FAIL by design: leaving the previous
+; version running and retrying on the next check is strictly better
+; than overwriting a live install.
+!macro WaitForServiceStopped Ticks
+    Push $0
+    Push $1
+    Push $2
+    StrCpy $1 0
+    ${Do}
+        ; Non-zero (typically 1060) means the service isn't registered
+        ; at all -- a fresh install has nothing to wait for.
+        nsExec::ExecToStack 'sc.exe query VideoGrouperService'
+        Pop $0
+        Pop $2
+        ${If} $0 != "0"
+            ${ExitDo}
+        ${EndIf}
+        ; `find` exits 0 only when the STATE line reads STOPPED.
+        nsExec::ExecToStack 'cmd.exe /c "sc query VideoGrouperService | find $\"STOPPED$\" > nul"'
+        Pop $0
+        Pop $2
+        ${If} $0 == "0"
+            ${ExitDo}
+        ${EndIf}
+        Sleep 500
+        IntOp $1 $1 + 1
+        ${If} $1 >= ${Ticks}
+            !insertmacro WritePhase "service-stop-timeout"
+            SetErrorLevel 2
+            Abort
+        ${EndIf}
+    ${Loop}
+    Pop $2
+    Pop $1
+    Pop $0
+!macroend
+
+; Same idea for the tray: taskkill /F returns before Windows has
+; necessarily torn the process down, and the tray shares
+; $INSTDIR\_internal with the service, so a surviving tray locks the
+; payload just as effectively.
+!macro WaitForProcessGone ExeName Ticks
+    Push $0
+    Push $1
+    Push $2
+    StrCpy $1 0
+    ${Do}
+        nsExec::ExecToStack 'cmd.exe /c "tasklist /FI $\"IMAGENAME eq ${ExeName}$\" | find /I $\"${ExeName}$\" > nul"'
+        Pop $0
+        Pop $2
+        ${If} $0 != "0"
+            ${ExitDo}
+        ${EndIf}
+        Sleep 500
+        IntOp $1 $1 + 1
+        ${If} $1 >= ${Ticks}
+            !insertmacro WritePhase "process-kill-timeout"
+            SetErrorLevel 2
+            Abort
+        ${EndIf}
+    ${Loop}
+    Pop $2
+    Pop $1
+    Pop $0
+!macroend
+
 Section "Install" SecInstall
     ; Use 64-bit registry view so the 64-bit service can find the keys
     SetRegView 64
@@ -143,22 +223,40 @@ Section "Install" SecInstall
     ; v0.3.8 upgrade testing (LastTaskResult 0x80071420 on the
     ; post-upgrade /Run because of the lock conflict).
     ;
-    ; sc.exe stop is best-effort: a clean upgrade has the service
-    ; already gone, and a fresh install has nothing to stop. The
-    ; 0 exit code means stopped; non-zero is benign here.
+    ; Request the stop, then WAIT for it. Neither command below is
+    ; synchronous, so both are followed by an explicit poll (see the
+    ; WaitFor* macros above for the reinstall-loop this prevents).
     nsExec::ExecToLog 'sc.exe stop VideoGrouperService'
     nsExec::ExecToLog 'taskkill /F /IM VideoGrouperTray.exe'
-    ; Brief delay so Windows actually releases handles on the
-    ; killed binaries before File /r tries to overwrite them.
-    Sleep 1500
+
+    ; 60 x 500ms = 30s for the service (it has async processors to
+    ; unwind), 20 x 500ms = 10s for the force-killed tray.
+    !insertmacro WaitForServiceStopped 60
+    !insertmacro WaitForProcessGone "VideoGrouperTray.exe" 20
+
+    ; Windows can hold the image section a moment past process exit.
+    Sleep 500
 
     ; Copy the merged onedir output (service + tray + shared _internal/).
     ; The multi-target spec at video_grouper/installer/VideoGrouper.spec
     ; builds both exes against one dependency tree, so service and tray
     ; live side-by-side under $INSTDIR with a single _internal/ folder.
     SetOutPath "$INSTDIR"
+    ; SetOverwrite `on` (the default) reacts to a locked target with a
+    ; modal Abort/Retry/Ignore that /S suppresses -- which is how a
+    ; skipped payload still reached "complete". `try` sets the error
+    ; flag instead, and we hard-fail on it: a partial copy must never
+    ; be reported as a successful install.
+    ClearErrors
+    SetOverwrite try
     File "..\icon.ico"
     File /r "..\dist\VideoGrouper\*"
+    SetOverwrite on
+    ${If} ${Errors}
+        !insertmacro WritePhase "files-copy-failed"
+        SetErrorLevel 2
+        Abort
+    ${EndIf}
 
     !insertmacro WritePhase "files-copied"
 
@@ -234,15 +332,12 @@ Section "Install" SecInstall
     ; CI runs stay headless. (Silent installs also happen during
     ; auto-upgrade: the service spawns us with /S and exits; we
     ; come up cleanly when the service's StartService below fires.)
-    ${IfNot} ${Silent}
-        nsExec::ExecToLog 'sc.exe start VideoGrouperService'
-    ${Else}
-        ; Auto-upgrade re-runs us silently. The previous service
-        ; will have exited cleanly before we got here; start the
-        ; freshly-installed binary so the dashboard comes back up
-        ; without waiting for the recovery actions.
-        nsExec::ExecToLog 'sc.exe start VideoGrouperService'
-    ${EndIf}
+    ; Both branches do the same thing -- WaitForServiceStopped above
+    ; guarantees the old service is gone and the payload landed, so
+    ; there is nothing left to distinguish. (The prior comment here
+    ; claimed the auto-upgrade path had "exited cleanly before we got
+    ; here"; it hadn't, which is what the wait now enforces.)
+    nsExec::ExecToLog 'sc.exe start VideoGrouperService'
 
     !insertmacro WritePhase "service-started"
 

--- a/video_grouper/tray/main.py
+++ b/video_grouper/tray/main.py
@@ -704,11 +704,10 @@ class SystemTrayIcon(QSystemTrayIcon):
     def apply_pending_update(self) -> None:
         """POST /api/update/apply when the user clicks Install Update.
 
-        Phase 1 boundary: the service returns 503 with a "Phase 2"
-        explanation. We surface that string verbatim so the user
-        understands why nothing happens; once Phase 2 lands the same
-        click drives the real installer spawn with no client-side
-        change needed.
+        The service answers 202 on a successful installer spawn, 409
+        when nothing is staged, and 503 while the pipeline is busy. We
+        surface the returned reason verbatim so the user can tell
+        "nothing to install" apart from "still rendering".
         """
         import json
         import urllib.error
@@ -716,7 +715,21 @@ class SystemTrayIcon(QSystemTrayIcon):
 
         url = self._web_url("/api/update/apply")
         try:
-            req = urllib.request.Request(url, method="POST", data=b"")
+            # The service's CSRF guard (auth_server.host_and_origin_check)
+            # rejects every state-changing request that arrives without an
+            # Origin/Referer -- browsers always send one, urllib never does.
+            # Without this header the tray's own Install Update click came
+            # back 403 "Missing Origin/Referer on state-changing request",
+            # so the manual upgrade path was dead on arrival. Send our own
+            # base URL as the Origin: it is same-origin by construction and
+            # keeps the rebinding/CSRF defense intact for real browsers
+            # (which cannot forge this header).
+            req = urllib.request.Request(
+                url,
+                method="POST",
+                data=b"",
+                headers={"Origin": self._web_url("")},
+            )
             with urllib.request.urlopen(req, timeout=10) as resp:
                 body = json.loads(resp.read().decode("utf-8"))
             self.showMessage(

--- a/video_grouper/update/nsis_marker.py
+++ b/video_grouper/update/nsis_marker.py
@@ -13,6 +13,13 @@ Phases (defined in ``installer.nsi``):
   scheduled-task-registered -> service-started ->
   tray-launched -> complete
 
+Plus three terminal failure phases, each written immediately before
+the installer aborts rather than overwrite a live install:
+
+  service-stop-timeout   the service never reached STOPPED
+  process-kill-timeout   the tray survived taskkill /F
+  files-copy-failed      File /r could not write some of the payload
+
 If the file reads ``complete``, the install ran to the end. Anything
 else is the failure-furthest point reached. Missing file means no
 install has run since the last journal sync (we delete the file

--- a/video_grouper/video_grouper_app.py
+++ b/video_grouper/video_grouper_app.py
@@ -1003,11 +1003,11 @@ class VideoGrouperApp:
     async def _update_quiescence_check(self) -> tuple[bool, str | None]:
         """Tell the auto-upgrade poller whether it's safe to apply.
 
-        Returns ``(is_idle, busy_reason)``. Idle means: no pipeline
-        processor has queued work AND no download is mid-flight. Busy
-        means: at least one processor would be interrupted by a
-        StopService -- name the loudest one so the dashboard can
-        explain the deferral.
+        Returns ``(is_idle, busy_reason)``. Idle means: no processor
+        has queued work, none has a task in hand, and no download is
+        mid-flight. Busy means: at least one processor would be
+        interrupted by a StopService -- name every one of them so the
+        dashboard can explain the deferral.
 
         The same callable the processor uses for its `deferred`
         journal entries -- keep the reason string short and
@@ -1015,12 +1015,25 @@ class VideoGrouperApp:
         """
         if self._has_active_download():
             return False, "download in progress"
-        # `get_queue_sizes()` reports -1 for processors that are
-        # disabled in this config; treat that as 0, not busy.
-        sizes = {k: v for k, v in self.get_queue_sizes().items() if v > 0}
-        if sizes:
-            top = ", ".join(f"{k}={v}" for k, v in sizes.items())
-            return False, top
+        # Use the in-progress-aware summary, NOT get_queue_sizes():
+        # that one deliberately excludes the task a processor has
+        # already dequeued, so a YouTube upload or an AutoCam render
+        # mid-flight reported queue=0 and read as "idle". An upgrade
+        # then stopped the service on top of the running task -- which
+        # is exactly how a 07.06 upload got killed at 2%. A busy
+        # processor is busy whether the work is queued or in hand.
+        busy: list[str] = []
+        for name, entry in self.get_queue_status_summary().items():
+            if not entry:
+                continue
+            queued = entry.get("queued") or 0
+            in_progress = entry.get("in_progress")
+            if queued > 0:
+                busy.append(f"{name}={queued}")
+            if in_progress:
+                busy.append(f"{name} in progress")
+        if busy:
+            return False, ", ".join(busy)
         return True, None
 
     async def _watch_config_for_restart(self) -> None:
@@ -1329,6 +1342,12 @@ class VideoGrouperApp:
                 getattr(self, "reprocess_request_processor", None),
             ),
             ("clips", self.clip_processor),
+            # The config-driven pipeline (AutoCam render) runs the
+            # longest task in the whole app -- tens of minutes per
+            # game. It was missing here, so the upgrade quiescence
+            # gate could not see a render in flight and would happily
+            # stop the service on top of one.
+            ("pipeline", self.pipeline_processor),
         ):
             entry = _summary(proc)
             if entry is not None:


### PR DESCRIPTION
Three defects in the auto-upgrade path, found while investigating the v0.5.7 → v0.5.8 upgrade that reinstalled itself in a loop on 2026-08-03.

### 1. The installer raced the running service (root cause of the loop)
`sc.exe stop` is asynchronous — it returns when the SCM *accepts* the control, not when the process exits — and `installer.nsi` waited a flat `Sleep 1500` before `File /r`. Windows refuses to overwrite a mapped image, so the copy failed on the locked exe and `_internal\*.pyd`. Nothing checked the error flag, so the script wrote `files-copied` … `complete` anyway.

The service then restarted on the **old** code, reported the **old** version, re-detected the release, and reinstalled. The journal recorded two full 395 MB download+install cycles 35 s apart, both `from_version 0.5.7`, alongside ~15 service restarts in 10 minutes.

Now: poll until the service actually reports `STOPPED` (30 s) and until the tray process is gone (10 s), then hard-fail rather than overwrite a live install. `SetOverwrite try` + an explicit `${If} ${Errors}` turns a partial copy into an abort instead of a false `complete`.

### 2. The tray's Install Update button always returned 403
The rebinding/CSRF middleware rejects state-changing requests without `Origin`/`Referer`; `urllib.request` sends neither. Every click got `403 Missing Origin/Referer on state-changing request`, so the manual upgrade path never worked. The tray now sends its own base URL as `Origin` — browsers cannot forge that header, so the defense is unchanged.

This shipped because the update-API tests mounted the router on a bare `FastAPI()` app, where the middleware never runs. The new test goes through the real `create_app`.

### 3. Quiescence ignored in-flight work
It read `get_queue_sizes()`, which documents itself as excluding the in-progress item — so an already-dequeued YouTube upload reported `queue=0`, read as "idle", and the upgrade stopped the service on top of it (killed a real upload at 2%). It now uses the in-progress-aware summary, which was also missing the pipeline processor entirely — an AutoCam render, the longest task in the app, was invisible to the gate.

### Verification
- `ruff check` / `ruff format` / `mypy` clean (pre-commit)
- 1749 unit tests pass; 155 update-path tests pass including integration/e2e
- `makensis` compiles `installer.nsi` with the same flags CI uses
- Each regression test was confirmed to **fail** against the unfixed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)