### PR TITLE
fix(autocam): never reattach to an idle AutoCam window

### DIFF
--- a/tests/test_autocam_automation.py
+++ b/tests/test_autocam_automation.py
@@ -837,3 +837,65 @@ class TestStatusVocabulary311:
         # mirrors the production condition
         is_error = "failed" in lowered or ("error" in lowered and "eta:" not in lowered)
         assert not is_error
+
+
+import video_grouper.tray.autocam_automation as mod  # noqa: E402
+
+
+class TestStatusClassification311:
+    """``_autocam_is_processing`` must not read the idle start screen as
+    a running render (regression: 2026-08-03).
+
+    3.1.1 has no Notification control, so the status read is a walk of
+    every Text descendant -- which includes the buttons "Processing
+    Setup" and "Start Processing". The old ``"processing" in text``
+    check matched those on a completely idle window.
+    """
+
+    # Verbatim from D:\soccer-cam-storage\logs\video_grouper_tray.log.
+    IDLE = (
+        "c588e0da50fb | Source: | Browse files | None selected | "
+        "Destination: | Browse file | None selected | Processing Setup | "
+        "Add Logo | Start Processing"
+    )
+    RUNNING = (
+        "c588e0da50fb | Source: | Browse files | Selected 1 videos | "
+        "Destination: | Browse file | D:/out.mp4 | Processing Setup | "
+        "Add Logo | Start Processing | Status: | Running | Processed: | "
+        "3874 | Dropped: | 0 | FPS: | 29.5 | Elapsed: | 00:02:20 | "
+        "ETA: | 00:45:24 | 4.6%"
+    )
+    INITIALIZING = (
+        "c588e0da50fb | Source: | Browse files | Selected 1 videos | "
+        "Destination: | Browse file | D:/out.mp4 | Processing Setup | "
+        "Add Logo | Start Processing | Status: | Initializing | "
+        "Processed: | 0 | Dropped: | 0 | FPS: | N/A | Elapsed: | "
+        "00:00:00 | ETA: | N/A | N/A"
+    )
+    SUCCEEDED = IDLE + " | Status: | Succeeded | Processed: | 81000"
+
+    def test_idle_start_screen_is_not_processing(self):
+        """The exact string that wedged the queue for ~50 minutes."""
+        assert mod._autocam_is_processing(self.IDLE) is False
+
+    def test_running_panel_is_processing(self):
+        assert mod._autocam_is_processing(self.RUNNING) is True
+
+    def test_initializing_panel_is_processing(self):
+        assert mod._autocam_is_processing(self.INITIALIZING) is True
+
+    def test_succeeded_is_not_reported_as_still_processing(self):
+        assert mod._autocam_is_processing(self.SUCCEEDED) is False
+
+    def test_legacy_30x_notification_still_recognised(self):
+        """3.0.x had a free-text Notification control and no Status row;
+        that vocabulary must keep working."""
+        assert mod._autocam_is_processing("processing") is True
+        assert mod._autocam_is_processing("finished processing") is True
+
+    def test_fields_parse_label_value_pairs(self):
+        fields = mod._autocam_status_fields(self.RUNNING)
+        assert fields["status"] == "Running"
+        assert fields["processed"] == "3874"
+        assert fields["fps"] == "29.5"
+        assert fields["eta"] == "00:45:24"

--- a/tests/test_autocam_resume.py
+++ b/tests/test_autocam_resume.py
@@ -183,6 +183,17 @@ class TestParseWmiDatetime:
         assert _parse_wmi_datetime("20260529182708.xxxxxx-300") is None
 
 
+# Verbatim AutoCam 3.1.1 status blobs (see video_grouper_tray.log). The
+# idle one is what the reattach path used to mistake for a live render:
+# its "Processing Setup" / "Start Processing" buttons contain the word
+# "processing" even though nothing is running.
+_IDLE_STATUS = (
+    "c588e0da50fb | Source: | Browse files | None selected | Destination: | "
+    "Browse file | None selected | Processing Setup | Add Logo | Start Processing"
+)
+_RUNNING_STATUS = _IDLE_STATUS + " | Status: | Running | Processed: | 3874"
+
+
 class TestResumeBranch:
     """Patch DirectoryState + win32 + psutil + pywinauto to verify the
     resume vs fresh-launch branching in _execute_autocam_gui_automation."""
@@ -211,7 +222,13 @@ class TestResumeBranch:
             # real desktop; without patching it, the fresh-launch test
             # spins for the full 15s "wait for SettingsWindow" deadline.
             patch("video_grouper.tray.autocam_automation.win32gui") as wg,
+            # The resume branch now refuses to reattach to an idle window,
+            # so these tests must say what the GUI is actually showing.
+            patch(
+                "video_grouper.tray.autocam_automation._read_autocam_status"
+            ) as read_status,
         ):
+            read_status.return_value = _RUNNING_STATUS
             wg.EnumWindows = MagicMock()
             wg.IsWindowVisible = MagicMock(return_value=False)
             # Default desktop().window() returns a usable mock window.
@@ -226,8 +243,45 @@ class TestResumeBranch:
                 "live_pids": live_pids,
                 "wait_complete": wait_complete,
                 "window": window,
+                "read_status": read_status,
                 "group_dir": group_dir,
             }
+
+    def test_resume_refuses_idle_window_and_relaunches(self, patches):
+        """Regression (2026-08-03): live PIDs + a live window are not
+        proof of a render. A run that died during setup left an idle,
+        unconfigured GUI; the resume branch attached to it and polled a
+        render that never existed until the game hit pipeline_failed.
+        An idle status must force the full kill+launch+setup path."""
+        gd = patches["group_dir"]
+        state = DirectoryState(gd)
+        input_p = Path(gd) / "video" / "in-raw.mp4"
+        input_p.parent.mkdir(parents=True, exist_ok=True)
+        input_p.touch()
+        input_path = str(input_p)
+        state.set_autocam_run(
+            {
+                "launcher_pid": 1234,
+                "gui_pids": [1234, 5678],
+                "input_path": os.path.abspath(input_path),
+                "output_path": os.path.join(gd, "video", "out.mp4"),
+                "started_at": "2026-05-09T20:00:00Z",
+            }
+        )
+        patches["live_pids"].return_value = [5678]
+        patches["find_hwnd"].return_value = 0xCAFE
+        patches["read_status"].return_value = _IDLE_STATUS
+
+        _execute_autocam_gui_automation(
+            "fake.exe",
+            input_path,
+            os.path.join(gd, "video", "out.mp4"),
+            group_dir=gd,
+        )
+
+        # Full relaunch, not a reattach: the idle window is torn down and
+        # AutoCam is started fresh so setup actually runs.
+        patches["sub"].Popen.assert_called_once()
 
     def test_resume_skips_launch_when_marker_and_processes_alive(self, patches):
         """When state.json has a marker AND PIDs are alive AND window is

--- a/video_grouper/tray/autocam_automation.py
+++ b/video_grouper/tray/autocam_automation.py
@@ -180,6 +180,63 @@ def _autocam_still_writing(state: DirectoryState | None, input_path: str) -> boo
     return bool(live)
 
 
+# Values 3.1.1 shows in its "Status:" row while a render is in flight.
+_ACTIVE_STATUS_VALUES = ("running", "initializing", "processing")
+
+# Window chrome that only shows up when we are reading the whole window
+# (the 3.1.1 descendants walk) rather than 3.0.x's single Notification
+# string. "Start Processing" and "Processing Setup" are *buttons* -- they
+# are present whether or not anything is running.
+_CONFIG_SCREEN_MARKERS = ("start processing", "browse files", "processing setup")
+
+
+def _autocam_status_fields(raw: str) -> dict[str, str]:
+    """Split a ``' | '``-joined status blob into ``label -> value``.
+
+    3.1.1's panel renders as alternating label/value Text controls
+    (``Status: | Running | Processed: | 3874 | ...``), so the value for
+    a row is simply the segment following its ``Label:`` segment.
+    """
+    parts = [p.strip() for p in raw.split("|")]
+    fields: dict[str, str] = {}
+    for label, value in zip(parts, parts[1:], strict=False):
+        if label.endswith(":"):
+            fields[label[:-1].strip().lower()] = value
+    return fields
+
+
+def _autocam_is_processing(raw: str) -> bool:
+    """True only when AutoCam is genuinely mid-render.
+
+    3.1.1 has no dedicated notification control, so
+    :func:`_read_autocam_status` returns a walk of every Text
+    descendant -- including the button labels "Processing Setup" and
+    "Start Processing". A plain ``"processing" in text`` check therefore
+    fires on the completely *idle* start screen.
+
+    That is exactly what wedged the queue on 2026-08-03: a run died
+    during setup, the next attempt reattached to the leftover
+    unconfigured GUI, read ``Source: ... None selected`` as "Processing
+    started", and polled a render that did not exist until the task
+    timed out -- three times, until the game was marked pipeline_failed.
+
+    So: when the panel exposes a ``Status:`` row, trust only that row.
+    When we can see window chrome but no ``Status:`` row has appeared,
+    nothing has started yet. Otherwise fall back to the 3.0.x
+    free-text notification vocabulary.
+    """
+    lowered = raw.lower()
+    status = _autocam_status_fields(raw).get("status")
+    if status is not None:
+        return status.strip().lower() in _ACTIVE_STATUS_VALUES
+    if any(marker in lowered for marker in _CONFIG_SCREEN_MARKERS):
+        return False
+    return any(
+        token in lowered
+        for token in ("processing", "processed", "running", "initializing")
+    )
+
+
 def _read_autocam_status(main_window) -> str:
     """Best-effort read of AutoCam's status text, across UI versions.
 
@@ -757,13 +814,7 @@ def _wait_for_completion_and_cleanup(
                         except OSError:
                             pass
                     break
-                elif (
-                    "processing" in notification_text
-                    or "processed" in notification_text
-                    # 3.1.1 status values before completion
-                    or "running" in notification_text
-                    or "initializing" in notification_text
-                ):
+                elif _autocam_is_processing(raw_notification):
                     if not processing_started:
                         processing_started = True
                         logger.info("Processing started: %r", raw_notification)
@@ -998,13 +1049,34 @@ def _execute_autocam_gui_automation(
                         e,
                     )
                 else:
-                    return _wait_for_completion_and_cleanup(
-                        main_window,
-                        state,
-                        output_path=existing.get("output_path", abs_output_path),
-                        tracked_pids=live,
-                        input_path=existing.get("input_path", abs_input_path),
+                    # Belt and braces alongside the deferred marker write:
+                    # a live process + a live window still isn't proof the
+                    # GUI is rendering. It may have been reset to the idle
+                    # start screen (AutoCam relaunched by hand, a finished
+                    # run dismissed). Reattaching to an idle window means
+                    # polling a render that will never appear, so require
+                    # either an active Status: row or the completion text
+                    # before skipping setup.
+                    resume_status = _read_autocam_status(main_window)
+                    resumable = _autocam_is_processing(resume_status) or any(
+                        token in resume_status.lower()
+                        for token in ("finished processing", "succeeded")
                     )
+                    if not resumable:
+                        logger.warning(
+                            "Reattach candidate is idle, not rendering (%r); "
+                            "clearing marker and doing a full relaunch",
+                            resume_status,
+                        )
+                        state.clear_autocam_run()
+                    else:
+                        return _wait_for_completion_and_cleanup(
+                            main_window,
+                            state,
+                            output_path=existing.get("output_path", abs_output_path),
+                            tracked_pids=live,
+                            input_path=existing.get("input_path", abs_input_path),
+                        )
             else:
                 logger.info(
                     "Stale autocam_run marker (live_pids=%s, hwnd=%s); clearing and relaunching",
@@ -1043,29 +1115,17 @@ def _execute_autocam_gui_automation(
         if hwnd is None:
             raise TimeoutError("Once Autocam window not found within 35 seconds")
 
-        # Persist PIDs to state.json so a tray crash mid-pass can reattach
-        # on restart. Get the window-owning PID via win32process (instant,
-        # no subprocess spawn) — this is the child GUI.exe that actually
-        # owns the AutoCam window, not just the launcher which may exit.
+        # Collect the PIDs now (the window-owning PID via win32process is
+        # instant and needs no subprocess) but DON'T write the reattach
+        # marker yet -- see the deferred write after "Start Processing"
+        # below. This is the child GUI.exe that actually owns the AutoCam
+        # window, not just the launcher, which may exit.
         import win32process
 
         _, window_pid = win32process.GetWindowThreadProcessId(hwnd)
-        if state is not None:
-            gui_pids = list({launcher.pid, window_pid})
-            state.set_autocam_run(
-                {
-                    "launcher_pid": launcher.pid,
-                    "gui_pids": gui_pids,
-                    "input_path": abs_input_path,
-                    "output_path": abs_output_path,
-                    "started_at": datetime.datetime.now(datetime.UTC).isoformat(),
-                }
-            )
-            logger.info(
-                "Recorded autocam_run marker: launcher_pid=%s gui_pids=%s",
-                launcher.pid,
-                gui_pids,
-            )
+        pending_gui_pids = (
+            list({launcher.pid, window_pid}) if state is not None else None
+        )
 
         # Wrap the hwnd in a pywinauto window wrapper for interaction
         main_window = desktop.window(handle=hwnd)
@@ -1234,6 +1294,30 @@ def _execute_autocam_gui_automation(
             control_type="Button",
         ).click()
         time.sleep(2)
+
+        # Only NOW record the reattach marker. Writing it at launch time
+        # meant a run that died anywhere during setup (source select,
+        # destination select, field auto-marking) still left a marker
+        # claiming a render was live. The next attempt took the resume
+        # path, skipped kill+launch+setup, and polled an idle
+        # never-configured GUI until it timed out -- which is how the
+        # 2026-08-03 batch wedged and marked a game pipeline_failed.
+        # A marker written here means processing was actually started.
+        if state is not None and pending_gui_pids is not None:
+            state.set_autocam_run(
+                {
+                    "launcher_pid": launcher.pid,
+                    "gui_pids": pending_gui_pids,
+                    "input_path": abs_input_path,
+                    "output_path": abs_output_path,
+                    "started_at": datetime.datetime.now(datetime.UTC).isoformat(),
+                }
+            )
+            logger.info(
+                "Recorded autocam_run marker after start: launcher_pid=%s gui_pids=%s",
+                launcher.pid,
+                pending_gui_pids,
+            )
 
         # Track both the launcher and the window-owning PID for exit
         # detection. No subprocess spawning — window_pid was already


### PR DESCRIPTION
A render that dies during setup wedged the entire queue. On 2026-08-03 a run failed right after launch (`Could not focus main window`), leaving AutoCam open but never configured — no source, no destination. Every retry took the resume path, logged `skipping kill+launch+setup`, and polled that idle window until the task timed out. Three times, until the game was marked `pipeline_failed` and discovery stopped offering it. The batch sat still for ~50 minutes.

### Root cause: the marker meant the wrong thing
`autocam_run` was written as soon as the window appeared — before source select, destination select, and field auto-marking. So it recorded "AutoCam is open", not "a render is running". It's now written after **Start Processing** is clicked.

### Safety net: verify before reattaching
Live PIDs + a live hwnd aren't proof of a render (AutoCam may have been relaunched by hand, or reset after a finished run). The resume path now reads the window's status and falls through to a full kill+launch+setup unless it sees an active render or a completion message.

### Why the idle screen looked busy
`processing_started` was decided by substring-matching the whole status blob. 3.1.1 has no `Notification` control, so that blob is a walk of every Text descendant — including the **buttons** `Processing Setup` and `Start Processing`:

```
c588e0da50fb | Source: | Browse files | None selected | Destination: |
Browse file | None selected | Processing Setup | Add Logo | Start Processing
```

`"processing" in text` → `True`, on a completely idle window. Status is now parsed into label/value pairs and only the `Status:` row is trusted. The 3.0.x free-text vocabulary still works where no such row exists.

### Verification
- `ruff` / `format` / `mypy` clean; 1756 unit tests pass
- Tests use the **verbatim** status strings from `video_grouper_tray.log`, including the idle blob that caused the wedge
- Confirmed directly: old predicate returns `True` on that blob, new one returns `False`, and `True` on a real `Status: | Running` panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)