### PR TITLE
feat(config): add AutoCam licence key to the config screen

### DIFF
--- a/tests/test_autocam_automation.py
+++ b/tests/test_autocam_automation.py
@@ -1,6 +1,9 @@
 """Tests for the autocam automation function."""
 
 import datetime
+import logging
+import os
+import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -899,3 +902,81 @@ class TestStatusClassification311:
         assert fields["processed"] == "3874"
         assert fields["fps"] == "29.5"
         assert fields["eta"] == "00:45:24"
+
+
+class TestEnsureAutocamLicence:
+    r"""``ensure_autocam_licence`` activates the *current* Windows profile.
+
+    AutoCam keeps activation in %LOCALAPPDATA%\Once\licence.txt, which is
+    per-profile. A render driven by a different account (e.g. the
+    LocalSystem service) is therefore unlicensed -- and silently
+    watermarked -- even when the desktop user holds a valid licence.
+    """
+
+    def _paths(self, tmp_path):
+        exe_dir = tmp_path / "Once.Autocam"
+        exe_dir.mkdir()
+        (exe_dir / "AutocamCLI.exe").write_text("stub", encoding="utf-8")
+        return str(exe_dir / "AutocamGUI.exe"), str(exe_dir / "AutocamCLI.exe")
+
+    def test_no_key_configured_is_a_noop(self, tmp_path):
+        """Hand-activated installs must keep working untouched."""
+        gui, _ = self._paths(tmp_path)
+        with patch("subprocess.run") as run:
+            assert mod.ensure_autocam_licence(gui, "") is True
+        run.assert_not_called()
+
+    def test_already_licensed_profile_does_not_reactivate(self, tmp_path):
+        gui, _ = self._paths(tmp_path)
+        licence = tmp_path / "local" / "Once" / "licence.txt"
+        licence.parent.mkdir(parents=True)
+        licence.write_text("blob", encoding="utf-8")
+        with (
+            patch.dict(os.environ, {"LOCALAPPDATA": str(tmp_path / "local")}),
+            patch("subprocess.run") as run,
+        ):
+            assert mod.ensure_autocam_licence(gui, "KEY-123") is True
+        run.assert_not_called()
+
+    def test_activates_when_profile_has_no_licence(self, tmp_path):
+        gui, cli = self._paths(tmp_path)
+        local = tmp_path / "local"
+        licence = local / "Once" / "licence.txt"
+
+        def _fake_run(cmd, **kwargs):
+            # The vendor writes licence.txt on a successful activate.
+            licence.parent.mkdir(parents=True, exist_ok=True)
+            licence.write_text("blob", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        with (
+            patch.dict(os.environ, {"LOCALAPPDATA": str(local)}),
+            patch("subprocess.run", side_effect=_fake_run) as run,
+        ):
+            assert mod.ensure_autocam_licence(gui, "KEY-123") is True
+        run.assert_called_once()
+        assert run.call_args[0][0] == [cli, "activate", "KEY-123"]
+
+    def test_failed_activation_reports_false_and_hides_the_key(self, tmp_path, caplog):
+        gui, _ = self._paths(tmp_path)
+        local = tmp_path / "local"
+        result = subprocess.CompletedProcess(
+            [], 1, stdout="Invalid LicenceToken for KEY-123", stderr=""
+        )
+        with (
+            patch.dict(os.environ, {"LOCALAPPDATA": str(local)}),
+            patch("subprocess.run", return_value=result),
+            caplog.at_level(logging.ERROR),
+        ):
+            assert mod.ensure_autocam_licence(gui, "KEY-123") is False
+        assert "KEY-123" not in caplog.text, "licence key must not reach the logs"
+        assert "watermarked" in caplog.text
+
+    def test_missing_cli_is_reported_not_crashed(self, tmp_path):
+        exe_dir = tmp_path / "Once.Autocam"
+        exe_dir.mkdir()  # no AutocamCLI.exe alongside
+        with patch.dict(os.environ, {"LOCALAPPDATA": str(tmp_path / "local")}):
+            assert (
+                mod.ensure_autocam_licence(str(exe_dir / "AutocamGUI.exe"), "KEY-123")
+                is False
+            )

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -369,3 +369,66 @@ def test_load_no_ball_tracking_no_pipeline_stays_disabled(tmp_path):
     cfg = load_config(_write(tmp_path, _REQUIRED_SECTIONS))
     assert cfg.pipeline.is_active() is False
     assert cfg.pipeline.ordered_steps() == []
+
+
+_AUTOCAM_SECTION = """\
+[AUTOCAM]
+executable = C:/once/AutocamGUI.exe
+license_key = KEY-FROM-CONFIG-SCREEN
+"""
+
+
+def test_autocam_section_feeds_the_autocam_step(tmp_path):
+    """[AUTOCAM] is the operator-facing home for installation settings.
+
+    It exists because the /config editor only renders scalar fields of
+    top-level sections — pipeline step specs are nested and never appear.
+    The values have to reach the step that actually runs AutoCam.
+    """
+    cfg = load_config(
+        _write(
+            tmp_path,
+            _REQUIRED_SECTIONS + _AUTOCAM_SECTION + _BALL_TRACKING_AUTOCAM_ONLY,
+        )
+    )
+    step = cfg.pipeline.ordered_steps()[0]
+    assert step.type == "autocam"
+    assert step.config["license_key"] == "KEY-FROM-CONFIG-SCREEN"
+
+
+def test_step_spec_value_wins_over_autocam_section(tmp_path):
+    """A step that names its own executable keeps it — the section only
+    fills gaps, so an explicit per-step choice is never overwritten."""
+    ini = (
+        _REQUIRED_SECTIONS
+        + _AUTOCAM_SECTION
+        + textwrap.dedent(
+            """\
+        [PIPELINE]
+        enabled = true
+        steps = autocam
+        [PIPELINE.autocam]
+        type = autocam
+        executable = D:/other/AutocamGUI.exe
+        """
+        )
+    )
+    step = load_config(_write(tmp_path, ini)).pipeline.ordered_steps()[0]
+    assert step.config["executable"] == "D:/other/AutocamGUI.exe"
+    # ...but the licence key it didn't specify still comes through.
+    assert step.config["license_key"] == "KEY-FROM-CONFIG-SCREEN"
+
+
+def test_no_autocam_section_changes_nothing(tmp_path):
+    cfg = load_config(
+        _write(tmp_path, _REQUIRED_SECTIONS + _BALL_TRACKING_AUTOCAM_ONLY)
+    )
+    assert "license_key" not in cfg.pipeline.ordered_steps()[0].config
+
+
+def test_autocam_section_survives_save_round_trip(tmp_path):
+    path = _write(tmp_path, _REQUIRED_SECTIONS + _AUTOCAM_SECTION)
+    cfg = load_config(path)
+    assert cfg.autocam.license_key == "KEY-FROM-CONFIG-SCREEN"
+    save_config(cfg, path)
+    assert load_config(path).autocam.license_key == "KEY-FROM-CONFIG-SCREEN"

--- a/tests/web/test_config_editor.py
+++ b/tests/web/test_config_editor.py
@@ -291,3 +291,38 @@ def test_post_config_preserves_pipeline_section(pipeline_client, pipeline_config
     by_id = {s.step_id: s for s in ordered}
     assert by_id["stitch"].config["stitch_profile_path"] == "/calib/flash.json"
     assert by_id["ball_detect"].config["model_path"] == "/m/model.onnx"
+
+
+def test_autocam_license_key_is_editable_and_masked(client, config_path):
+    """The AutoCam licence key must be settable from /config, and must
+    behave like every other credential: never rendered back, and left
+    alone when the operator saves the form without retyping it.
+
+    It exists because AutoCam activation is per Windows profile, so the
+    account that renders has to be the account that activated — which
+    otherwise means logging in as the service account by hand.
+    """
+    page = client.get("/config").text
+    assert "AUTOCAM.license_key" in page, "licence key must appear on the config screen"
+    # Rendered as a credential input, not plain text.
+    field = page[page.index("AUTOCAM.license_key") - 200 :]
+    assert 'type="password"' in field[:600]
+
+    resp = client.post(
+        "/config",
+        data={"AUTOCAM.license_key": "SECRET-KEY-1", "LOGGING.level": "INFO"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert load_config(config_path).autocam.license_key == "SECRET-KEY-1"
+
+    # Never echoed back to the browser.
+    assert "SECRET-KEY-1" not in client.get("/config").text
+
+    # Saving an unrelated field with the key left blank keeps the stored value.
+    client.post(
+        "/config",
+        data={"AUTOCAM.license_key": "", "LOGGING.level": "DEBUG"},
+        follow_redirects=False,
+    )
+    assert load_config(config_path).autocam.license_key == "SECRET-KEY-1"

--- a/video_grouper/pipeline/steps/autocam.py
+++ b/video_grouper/pipeline/steps/autocam.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 
 class AutocamStepConfig(BaseModel):
     executable: str | None = None
+    # See AutocamConfig.license_key: AutoCam activation is per Windows
+    # profile, so the account that renders must be the account that
+    # activated. Blank leaves any hand-activated install alone.
+    license_key: str = ""
 
 
 def _invoke_autocam(
@@ -32,6 +36,7 @@ def _invoke_autocam(
     input_path: str,
     output_path: str,
     group_dir: str | None = None,
+    license_key: str = "",
 ) -> bool:
     """Lazy-import the GUI driver and run AutoCam on a single file.
 
@@ -42,7 +47,9 @@ def _invoke_autocam(
     from video_grouper.tray.autocam_automation import run_autocam_on_file
     from video_grouper.utils.config import AutocamConfig
 
-    legacy_cfg = AutocamConfig(enabled=True, executable=executable)
+    legacy_cfg = AutocamConfig(
+        enabled=True, executable=executable, license_key=license_key
+    )
     return run_autocam_on_file(legacy_cfg, input_path, output_path, group_dir=group_dir)
 
 
@@ -69,6 +76,7 @@ class AutocamStep(PipelineStep[AutocamStepConfig]):
                 input_path,
                 output_path,
                 str(ctx.group_dir),
+                self.config.license_key,
             )
         except Exception:
             logger.exception(

--- a/video_grouper/tray/autocam_automation.py
+++ b/video_grouper/tray/autocam_automation.py
@@ -29,6 +29,85 @@ _AUTOCAM_PROCESS_NAME = _AUTOCAM_PROCESS_NAMES[0]
 # container/header but reached within the first minute of a real render.
 _OUTPUT_PROGRESS_MIN_BYTES = 5 * 1024 * 1024
 
+# AutoCam's activation lives per Windows profile, not per machine.
+_LICENCE_FILENAME = "licence.txt"  # vendor's spelling
+_ACTIVATE_TIMEOUT_SECONDS = 120
+
+
+def _profile_licence_path() -> str:
+    """Where AutoCam keeps this profile's activation."""
+    local_app_data = os.environ.get("LOCALAPPDATA") or os.path.expanduser(
+        r"~\AppData\Local"
+    )
+    return os.path.join(local_app_data, "Once", _LICENCE_FILENAME)
+
+
+def _autocam_cli_path(executable: str | None) -> str | None:
+    """Locate AutocamCLI.exe next to the configured front-end.
+
+    Activation is a CLI verb, so it works regardless of whether the render
+    itself is driven through the GUI or the CLI.
+    """
+    if not executable:
+        return None
+    candidate = os.path.join(os.path.dirname(executable), "AutocamCLI.exe")
+    return candidate if os.path.isfile(candidate) else None
+
+
+def ensure_autocam_licence(executable: str | None, license_key: str) -> bool:
+    """Activate AutoCam for the *current* Windows profile if it isn't already.
+
+    Returns True when the profile ends up licensed (or was already), False
+    when activation was needed, attempted and failed.
+
+    Deliberately a no-op when no key is configured: existing installs where
+    the operator activated AutoCam by hand keep working untouched. The
+    reason this exists at all is that ``licence.txt`` is per-profile, so the
+    account that renders has to be the account that activated -- which is
+    invisible and surprising when the renderer is a service account rather
+    than the desktop user who bought the licence.
+    """
+    if not license_key:
+        return True
+    licence_path = _profile_licence_path()
+    if os.path.isfile(licence_path):
+        logger.debug("AutoCam already activated for this profile (%s)", licence_path)
+        return True
+    cli = _autocam_cli_path(executable)
+    if cli is None:
+        logger.error(
+            "AutoCam licence key is configured but AutocamCLI.exe was not found "
+            "next to %r; cannot activate this profile.",
+            executable,
+        )
+        return False
+    logger.info("Activating AutoCam for this profile using the configured key")
+    try:
+        result = subprocess.run(
+            [cli, "activate", license_key],
+            capture_output=True,
+            text=True,
+            timeout=_ACTIVATE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.error("AutoCam activation could not be run: %s", exc)
+        return False
+    # Never log the key itself; the vendor echoes it in some messages.
+    stdout = (result.stdout or "").replace(license_key, "***")
+    stderr = (result.stderr or "").replace(license_key, "***")
+    if result.returncode == 0 and os.path.isfile(licence_path):
+        logger.info("AutoCam activated for this profile: %s", licence_path)
+        return True
+    logger.error(
+        "AutoCam activation failed (exit=%s). Renders from this account will "
+        "be watermarked. stdout=%r stderr=%r",
+        result.returncode,
+        stdout.strip(),
+        stderr.strip(),
+    )
+    return False
+
+
 # Suppress the console flash on every tasklist/wmic poll -- the tray is
 # a GUI app and these run on a 30s discovery loop.
 _NO_WINDOW = 0x08000000
@@ -1363,6 +1442,12 @@ def run_autocam_on_file(
         # Validate inputs
         if not _validate_autocam_inputs(autocam_config, input_path, output_path):
             return False
+
+        # Activate this profile if a key is configured and it isn't already.
+        # Non-fatal: an unlicensed render still produces usable video, just
+        # watermarked, and failing the whole game over it would be worse
+        # than the watermark. The error log above is the loud part.
+        ensure_autocam_licence(autocam_config.executable, autocam_config.license_key)
 
         # Execute GUI automation
         return _execute_autocam_gui_automation(

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -217,6 +217,18 @@ class NtfyConfig(BaseModel):
 class AutocamConfig(BaseModel):
     enabled: bool = True
     executable: str | None = None
+    # AutoCam licence key, as sold by the vendor (their own spelling is
+    # "licence"; we use the US spelling for our config surface). Entirely
+    # user-supplied — we never ship a key.
+    #
+    # AutoCam stores its activation per Windows profile, under
+    # %LOCALAPPDATA%\Once\licence.txt. That makes the licence invisible to
+    # any other account: a render driven from a different user (notably the
+    # LocalSystem service) is unlicensed and comes out watermarked even
+    # though the desktop user is fully licensed. Setting this lets the
+    # pipeline activate the profile it actually renders under, instead of
+    # asking the operator to log in as that account and activate by hand.
+    license_key: str = ""
 
 
 class CloudSyncConfig(BaseModel):
@@ -400,6 +412,12 @@ class Config(BaseModel):
     )
     setup: SetupConfig = Field(alias="SETUP", default_factory=SetupConfig)
     node: NodeConfig = Field(alias="NODE", default_factory=NodeConfig)
+    # Installation-level AutoCam settings (where the vendor's app lives and
+    # the operator's licence key), as opposed to per-run rendering options,
+    # which belong to the pipeline step. Kept a top-level section so it is
+    # editable from /config: the editor only renders scalar fields of
+    # top-level sections, and pipeline step specs are nested.
+    autocam: AutocamConfig = Field(alias="AUTOCAM", default_factory=AutocamConfig)
     pipeline: PipelineConfig = Field(alias="PIPELINE", default_factory=PipelineConfig)
 
     model_config = {"validate_by_name": True}
@@ -536,7 +554,37 @@ def load_config(config_path: Path) -> Config:
     # into [PIPELINE].
     config_dict.pop("BALL_TRACKING", None)
 
+    # Installation-level AutoCam settings live in [AUTOCAM] so they're
+    # editable from /config. Fold them into the AutoCam step spec, which is
+    # what actually runs, unless that spec sets its own value. Same shape as
+    # the legacy migration above: one operator-facing place, resolved here
+    # rather than by giving steps access to the whole Config.
+    _merge_autocam_section(config_dict)
+
     return Config.model_validate(config_dict)
+
+
+# Step types that consume installation-level AutoCam settings.
+_AUTOCAM_STEP_TYPES = ("autocam", "autocam_cli")
+
+
+def _merge_autocam_section(config_dict: dict) -> None:
+    """Push ``[AUTOCAM]`` values down into AutoCam pipeline step specs."""
+    autocam_section = config_dict.get("AUTOCAM") or {}
+    shared = {
+        key: value
+        for key in ("executable", "license_key")
+        if (value := autocam_section.get(key))
+    }
+    if not shared:
+        return
+    specs = (config_dict.get("PIPELINE") or {}).get("step_specs") or {}
+    for spec in specs.values():
+        if not isinstance(spec, dict) or spec.get("type") not in _AUTOCAM_STEP_TYPES:
+            continue
+        step_cfg = spec.setdefault("config", {})
+        for key, value in shared.items():
+            step_cfg.setdefault(key, value)
 
 
 def save_config(config: Config, config_path: Path):

--- a/video_grouper/web/config_editor.py
+++ b/video_grouper/web/config_editor.py
@@ -45,6 +45,7 @@ _SENSITIVE_FIELDS = frozenset(
         "plugin_signing_key",
         "access_token",
         "refresh_token",
+        "license_key",
     }
 )
 


### PR DESCRIPTION
AutoCam stores activation **per Windows profile**, in `%LOCALAPPDATA%\Once\licence.txt`. Verified on the GPU box:

```
C:\Users\jared\AppData\Local\Once\licence.txt                   ← exists
C:\Windows\System32\config\systemprofile\...\Once\licence.txt   ← absent
```

So a licence is invisible to every other account. A render driven by a different user — notably the `LocalSystem` service — is unlicensed and comes out watermarked even though the desktop user is fully licensed. Today the only fix is to log in as the rendering account and activate by hand.

### Why a top-level `[AUTOCAM]` section
The `/config` editor walks **scalar fields of top-level sections only** (`_render_section` skips nested models, and pipeline step specs are nested dicts). A key added to `AutocamStepConfig` would never be reachable from the UI. So installation-level settings — where AutoCam lives, and the operator's key — get their own section, and `load_config` folds them down into `autocam` / `autocam_cli` step specs with `setdefault`. An explicit per-step value still wins. Same shape as the existing legacy `BALL_TRACKING` migration: resolved at load time rather than by handing steps the whole `Config` (`StepContext` deliberately has no config access).

### Activation
`ensure_autocam_licence()` runs `AutocamCLI.exe activate <key>` when a key is set **and** the profile has no `licence.txt`. No key configured → no behaviour change, so hand-activated installs are untouched. Failure is logged loudly but isn't fatal: an unlicensed render still produces usable video, just watermarked, and failing the whole game over it would be worse than the watermark.

### Secret handling
Added to `_SENSITIVE_FIELDS`: password input, never echoed back, blank-on-save keeps the stored value. The key is also scrubbed from activation stdout/stderr before logging — the vendor echoes it in some messages, and a test asserts it never reaches the log.

### Verification
`ruff` / `format` / `mypy` clean; **1766** unit tests pass. New tests cover the config screen round-trip (renders, masked, saves, not echoed, blank preserves), the section→step-spec merge including per-step precedence, and all five activation paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)