### PR TITLE
fix(youtube): don't re-upload a video that already landed

### DIFF
--- a/tests/test_youtube_upload_resume.py
+++ b/tests/test_youtube_upload_resume.py
@@ -1,0 +1,116 @@
+"""Regression: YoutubeUploadTask must not re-upload a video that already landed.
+
+The task uploads processed + raw and marks the group ``complete`` only
+when BOTH succeed. So any failure of the second upload re-ran the first
+on the next attempt: a duplicate video on YouTube, and 1,600 wasted
+quota units out of a daily allowance of exactly six uploads.
+
+Observed live 2026-08-03: 07.06's processed video went up twice
+(YgErRwoODek, then _DahHq3Q3VQ after a mid-raw-upload service restart),
+and that wasted unit is what pushed the last raw upload of the night
+past the quota with two games still unuploaded.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_grouper.models import DirectoryState
+from video_grouper.task_processors.tasks.upload.youtube_upload_task import (
+    YoutubeUploadTask,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_file_system():
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def mock_ffmpeg():
+    yield None
+
+
+def _make_group(tmp_path):
+    storage = tmp_path
+    group = storage / "2026.07.11-10.56.44"
+    videos = group / "2026.07.11 - Team vs Opp (Venue)"
+    videos.mkdir(parents=True)
+    (videos / "g-raw.mp4").write_bytes(b"x" * 16)
+    (videos / "g.mp4").write_bytes(b"x" * 16)
+    (group / "match_info.ini").write_text(
+        "[MATCH]\nmy_team_name = Team\nopponent_team_name = Opp\n"
+        "location = Venue\nstart_time_offset = 00:00\ntotal_duration = \n",
+        encoding="utf-8",
+    )
+    # get_youtube_paths(storage) expects a credentials file to exist.
+    (storage / "client_secret.json").write_text("{}", encoding="utf-8")
+    return storage, group
+
+
+async def _run(tmp_path, already):
+    storage, group = _make_group(tmp_path)
+    if already:
+        st = DirectoryState(str(group), str(storage))
+        for kind, vid in already.items():
+            st.record_uploaded_video(kind, vid)
+
+    uploaded: list[str] = []
+
+    def fake_upload(path, title, description, privacy_status=None, playlist_id=None):
+        uploaded.append(os.path.basename(path))
+        return "NEWID-" + os.path.basename(path)
+
+    cfg = MagicMock()
+    cfg.privacy_status = "unlisted"
+
+    with (
+        patch(
+            "video_grouper.utils.youtube_upload.get_youtube_paths",
+            return_value=(
+                str(storage / "client_secret.json"),
+                str(storage / "tok.json"),
+            ),
+        ),
+        patch("video_grouper.utils.youtube_upload.YouTubeUploader") as uploader_cls,
+        patch.object(
+            YoutubeUploadTask,
+            "_get_playlist_names",
+            return_value=("Processed PL", "Raw PL"),
+        ),
+    ):
+        uploader_cls.return_value.upload_video = fake_upload
+        uploader_cls.return_value.get_or_create_playlist = lambda *a, **k: "PLID"
+        task = YoutubeUploadTask(group_dir=str(group))
+        ok = await task.execute(youtube_config=cfg, storage_path=str(storage))
+    return ok, uploaded, DirectoryState(str(group), str(storage)).get_uploaded_videos()
+
+
+@pytest.mark.asyncio
+async def test_first_run_uploads_both_and_records_ids(tmp_path):
+    ok, uploaded, recorded = await _run(tmp_path, already=None)
+    assert ok is True
+    assert sorted(uploaded) == ["g-raw.mp4", "g.mp4"]
+    assert recorded["processed"] == "NEWID-g.mp4"
+    assert recorded["raw"] == "NEWID-g-raw.mp4"
+
+
+@pytest.mark.asyncio
+async def test_retry_skips_the_processed_video_already_on_youtube(tmp_path):
+    """The exact 2026-08-03 case: processed landed, raw failed on quota."""
+    ok, uploaded, _ = await _run(tmp_path, already={"processed": "ALREADY"})
+    assert uploaded == ["g-raw.mp4"], (
+        "processed video was re-uploaded despite already being on YouTube -- "
+        "that is a duplicate video and 1/6th of the daily quota"
+    )
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_retry_with_both_recorded_uploads_nothing(tmp_path):
+    ok, uploaded, _ = await _run(tmp_path, already={"processed": "A", "raw": "B"})
+    assert uploaded == []
+    assert ok is True

--- a/video_grouper/models/directory_state.py
+++ b/video_grouper/models/directory_state.py
@@ -416,6 +416,37 @@ class DirectoryState:
         """Remove the autocam_run marker (run finished successfully or failed)."""
         self._update_state_field("autocam_run", None)
 
+    def get_uploaded_videos(self) -> dict:
+        """Map of ``kind`` -> YouTube video id already uploaded for this group.
+
+        Kinds are ``"processed"`` and ``"raw"``. Absent key means not yet
+        uploaded. Used to make YoutubeUploadTask resumable per file: the
+        task uploads both videos and only marks the group complete when
+        BOTH succeed, so any failure of the second one re-ran the first
+        on the next attempt. That cost a duplicate video on YouTube and
+        1,600 quota units -- a sixth of the daily allowance, which is
+        only six uploads/day (2026-08-03: 07.06's processed video went
+        up twice, and the wasted unit is what pushed the last raw upload
+        past the quota).
+        """
+        try:
+            with FileLock(self.state_file_path):
+                if os.path.exists(self.state_file_path):
+                    with open(self.state_file_path) as f:
+                        state_data = json.load(f)
+                    value = state_data.get("uploaded_videos")
+                    if isinstance(value, dict):
+                        return value
+        except (json.JSONDecodeError, FileNotFoundError, TimeoutError):
+            pass
+        return {}
+
+    def record_uploaded_video(self, kind: str, video_id: str) -> None:
+        """Remember that *kind* is already on YouTube as *video_id*."""
+        existing = self.get_uploaded_videos()
+        existing[kind] = video_id
+        self._update_state_field("uploaded_videos", existing)
+
     def get_autocam_run(self) -> dict | None:
         """Read the autocam_run marker, or None if no run is recorded."""
         try:

--- a/video_grouper/task_processors/tasks/upload/youtube_upload_task.py
+++ b/video_grouper/task_processors/tasks/upload/youtube_upload_task.py
@@ -158,6 +158,17 @@ class YoutubeUploadTask(BaseUploadTask):
                 )
                 return False
 
+            # Which of the two videos are already on YouTube? This task
+            # uploads processed + raw and only marks the group complete
+            # when BOTH land, so without this check a failure on the
+            # second one re-uploads the first on every retry -- a
+            # duplicate video and 1,600 wasted quota units out of a
+            # daily allowance of six uploads.
+            from video_grouper.models import DirectoryState as _DirState
+
+            _state = _DirState(str(resolved_group_dir), storage_path)
+            already = _state.get_uploaded_videos()
+
             # googleapiclient is sync; without asyncio.to_thread the
             # 60-90 minute resumable upload would block this event loop,
             # which the auth server, tray status poller, and other queue
@@ -165,7 +176,14 @@ class YoutubeUploadTask(BaseUploadTask):
             # "update status poll unexpected error: timed out" every
             # 60s in the tray log throughout the upload window.
             # Upload processed (trimmed) video
-            if processed_video_path and os.path.exists(processed_video_path):
+            if already.get("processed"):
+                logger.info(
+                    "Skipping processed video for %s: already uploaded as %s",
+                    self.group_dir,
+                    already["processed"],
+                )
+                self.youtube_video_id = already["processed"]
+            elif processed_video_path and os.path.exists(processed_video_path):
                 logger.info(f"Uploading processed video: {processed_video_path}")
                 title = match_info.get_youtube_title("processed")
                 description = match_info.get_youtube_description("processed")
@@ -195,9 +213,16 @@ class YoutubeUploadTask(BaseUploadTask):
                 else:
                     # Expose for UploadProcessor → TTT step artifact reporting
                     self.youtube_video_id = video_id
+                    _state.record_uploaded_video("processed", video_id)
 
             # Upload raw (untrimmed) video
-            if raw_video_path and os.path.exists(raw_video_path):
+            if already.get("raw"):
+                logger.info(
+                    "Skipping raw video for %s: already uploaded as %s",
+                    self.group_dir,
+                    already["raw"],
+                )
+            elif raw_video_path and os.path.exists(raw_video_path):
                 logger.info(f"Uploading raw video: {raw_video_path}")
                 title = match_info.get_youtube_title("raw")
                 description = match_info.get_youtube_description("raw")
@@ -222,6 +247,8 @@ class YoutubeUploadTask(BaseUploadTask):
                 if not video_id:
                     logger.error(f"Failed to upload raw video: {raw_video_path}")
                     success = False
+                else:
+                    _state.record_uploaded_video("raw", video_id)
 
             if success:
                 logger.info(


### PR DESCRIPTION
`YoutubeUploadTask` uploads processed → raw and marks the group `complete` only when **both** succeed. Nothing recorded which had already gone up, so a failure of the second re-ran the first on the next attempt.

That's expensive, not cosmetic: the YouTube Data API gives **10,000 quota units/day** and a video insert costs **1,600** — exactly **six uploads a day**. A duplicate burns a sixth of the budget.

### Both costs were paid live tonight
A service restart landed mid-raw-upload for 07.06, so its processed video went up **twice** — `YgErRwoODek`, then `_DahHq3Q3VQ`. Six uploads succeeded on 08-03 and the seventh hit `uploadLimitExceeded`, leaving West Seneca's raw plus two whole games unuploaded. The retry loop was poised to duplicate a *second* processed video (West Seneca's `xsTrN_ZyPqo`) the moment quota reset.

### Fix
`DirectoryState` records `uploaded_videos` as `{kind: video_id}` in `state.json`, written immediately after each successful upload; the task skips any kind already recorded. A retry after a partial upload resumes instead of restarting — one quota unit instead of two, and no duplicate possible.

Per-kind **ids** rather than booleans, so the stored value also answers "which YouTube video is this file" — which the TTT artifact path already wants.

### Verification
`ruff` / `format` / `mypy` clean; **1769** unit tests pass. Three new tests drive the real `execute()` path (first run uploads both and records ids; retry with processed recorded uploads only the raw; retry with both recorded uploads nothing). Confirmed they **fail** against the unfixed code with exactly the duplicate symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)