### PR TITLE
fix(ntfy): reconnect the response listener when the stream drops

### DIFF
--- a/tests/test_ntfy_response_reconnect.py
+++ b/tests/test_ntfy_response_reconnect.py
@@ -1,0 +1,110 @@
+"""Regression: the NTFY response listener must survive server disconnects.
+
+ntfy.sh serves the topic as a long-lived chunked stream and closes it
+periodically -- observed every 1.5-3 hours in production. The subscribe
+coroutine was spawned exactly once, and its outer `except` logged the
+error and returned, so the first close ended the task for good. From
+then on the service silently received nothing: game start/end
+confirmations and team-info replies were dropped until someone
+restarted the service.
+
+Observed 2026-08-04: subscribed 01:18, dropped 02:57, dead 25 minutes
+until an unrelated restart at 03:22, dropped again 06:16.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from video_grouper.api_integrations.ntfy_response import NtfyResponseService
+
+
+def _service() -> NtfyResponseService:
+    svc = NtfyResponseService.__new__(NtfyResponseService)
+    svc.topic = "soccer-cam-test"
+    svc.server_url = "https://ntfy.sh"
+    # Keep the test fast; the production values are 5s/300s.
+    svc._RECONNECT_MIN_SECONDS = 0
+    svc._RECONNECT_MAX_SECONDS = 0
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_reconnects_after_peer_closes_the_stream():
+    """The exact production failure: httpx raises when ntfy.sh hangs up."""
+    calls = 0
+
+    async def flaky():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError(
+            "peer closed connection without sending complete message body "
+            "(incomplete chunked read)"
+        )
+
+    svc = _service()
+    with patch.object(svc, "_subscribe_to_real_ntfy", flaky):
+        task = asyncio.create_task(svc._real_ntfy_forever())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert calls > 1, (
+        f"listener resubscribed {calls} time(s); a dropped stream must be "
+        f"retried, not left dead until a service restart"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconnects_after_a_clean_stream_end():
+    """A stream that ends without raising also means 'no longer subscribed'."""
+    calls = 0
+
+    async def ends_cleanly():
+        nonlocal calls
+        calls += 1
+
+    svc = _service()
+    with patch.object(svc, "_subscribe_to_real_ntfy", ends_cleanly):
+        task = asyncio.create_task(svc._real_ntfy_forever())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert calls > 1
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_not_swallowed():
+    """Shutdown must actually stop the loop, not be treated as a drop."""
+
+    async def hang():
+        await asyncio.sleep(3600)
+
+    svc = _service()
+    with patch.object(svc, "_subscribe_to_real_ntfy", hang):
+        task = asyncio.create_task(svc._real_ntfy_forever())
+        await asyncio.sleep(0.01)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert task.cancelled() or task.done()
+
+
+def test_subscribe_propagates_errors_to_the_reconnect_loop():
+    """Static guard: the outer handler must re-raise. Swallowing it is
+    what left the listener dead in the first place."""
+    import inspect
+
+    src = inspect.getsource(NtfyResponseService._subscribe_to_real_ntfy)
+    tail = src[src.rindex("except Exception") :]
+    assert "raise" in tail, (
+        "_subscribe_to_real_ntfy swallows its final exception; "
+        "_real_ntfy_forever can then never distinguish a drop and will "
+        "not reconnect"
+    )

--- a/video_grouper/api_integrations/ntfy_response.py
+++ b/video_grouper/api_integrations/ntfy_response.py
@@ -21,6 +21,13 @@ class NtfyResponseService:
     controlled inputs to simulate user interaction during E2E testing.
     """
 
+    # Reconnect backoff for the long-lived ntfy.sh stream. Starts short
+    # because a server-side close is routine and the topic should be
+    # listened to again almost immediately; caps so a genuine outage
+    # doesn't turn into a hot retry loop.
+    _RECONNECT_MIN_SECONDS = 5
+    _RECONNECT_MAX_SECONDS = 300
+
     def __init__(
         self,
         topic: str,
@@ -86,7 +93,7 @@ class NtfyResponseService:
 
         # Also subscribe to real NTFY topic to respond to real requests
         logger.info(f"Subscribing to real NTFY topic: {self.topic}")
-        self._real_ntfy_task = asyncio.create_task(self._subscribe_to_real_ntfy())
+        self._real_ntfy_task = asyncio.create_task(self._real_ntfy_forever())
 
         logger.info(f"Successfully subscribed to NTFY topic: {self.topic}")
 
@@ -126,8 +133,52 @@ class NtfyResponseService:
         except Exception as e:
             logger.error(f"NTFY response service: Error processing message: {e}")
 
+    async def _real_ntfy_forever(self):
+        """Keep the NTFY subscription alive across server-side disconnects.
+
+        ntfy.sh serves the topic as a long-lived chunked stream and closes
+        it periodically -- observed every 1.5-3 hours in production. The
+        subscribe coroutine used to be spawned exactly once, so the first
+        close ended it ("peer closed connection without sending complete
+        message body") and nothing ever re-created the task. From that
+        moment the service silently stopped receiving responses: game
+        start/end confirmations and team-info replies were dropped until
+        somebody restarted the service. On 2026-08-04 the listener was
+        dead for 25 minutes before an unrelated restart revived it, then
+        died again 3 hours later.
+
+        A disconnect is normal operation, not an error, so reconnect with
+        a short backoff and treat a clean stream end the same as a raised
+        exception -- both mean "no longer subscribed".
+        """
+        backoff = self._RECONNECT_MIN_SECONDS
+        while True:
+            try:
+                await self._subscribe_to_real_ntfy()
+                # Returned without raising: the stream ended cleanly.
+                # Still means we are no longer subscribed.
+                backoff = self._RECONNECT_MIN_SECONDS
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "NTFY response service: subscription dropped (%s); "
+                    "reconnecting in %ss",
+                    exc,
+                    backoff,
+                )
+            try:
+                await asyncio.sleep(backoff)
+            except asyncio.CancelledError:
+                raise
+            backoff = min(backoff * 2, self._RECONNECT_MAX_SECONDS)
+
     async def _subscribe_to_real_ntfy(self):
-        """Subscribe to real NTFY topic and respond to messages."""
+        """Subscribe to real NTFY topic and respond to messages.
+
+        Returns when the stream ends; raises on transport errors. The
+        caller (:meth:`_real_ntfy_forever`) owns reconnection.
+        """
         import json
 
         import httpx
@@ -231,9 +282,12 @@ class NtfyResponseService:
                                 )
 
         except Exception as e:
+            # Do NOT swallow this: _real_ntfy_forever needs it to trigger a
+            # reconnect. Swallowing it here is what left the listener dead.
             logger.error(
                 f"NTFY response service: Error subscribing to real NTFY topic: {e}"
             )
+            raise
 
     def _should_respond_to_message(self, title: str, message: str) -> bool:
         """Determine if we should respond to this message."""


### PR DESCRIPTION
**Not merged deliberately** — opened for review rather than shipped, since three releases already went into production unreviewed overnight.

### The bug
`_subscribe_to_real_ntfy` was spawned once via `create_task`, and its outer `except` logged and **returned**. ntfy.sh closes the long-lived chunked stream every 1.5–3 hours; the first close ended the task for good and nothing re-created it. The service then silently received nothing — game start/end confirmations and team-info replies dropped — until someone restarted it.

Straight from the production log this morning:

```
01:18:32  Successfully subscribed
02:57:37  ERROR peer closed connection ... incomplete chunked read
          <- dead 25 minutes, no retry
03:22:06  (unrelated service restart) -> resubscribed
06:16:06  ERROR peer closed connection <- dead again
```

Neither recovery was self-healing. Both were restarts. This is a plausible contributor to NTFY feeling unreliable.

### The fix
`_real_ntfy_forever()` owns the lifecycle: reconnect with 5 s backoff doubling to a 300 s cap; a clean stream end is treated like a raised error, since both mean "no longer subscribed"; `CancelledError` re-raises so shutdown still works. `_subscribe_to_real_ntfy` now re-raises its final exception — swallowing it is exactly what blinded the loop.

### Verification
`ruff` / `format` / `mypy` clean; **1773** unit tests pass. Four new tests: reconnect after the real `incomplete chunked read` failure, reconnect after a clean end, cancellation not swallowed, and a static guard on the re-raise. Confirmed the guard **fails** against the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)