### PR TITLE
fix(youtube,ntfy): make the upload quota a wait, not a retry storm

### DIFF
--- a/tests/test_youtube_quota_and_task_registry.py
+++ b/tests/test_youtube_quota_and_task_registry.py
@@ -1,0 +1,169 @@
+"""Regressions from the 2026-08-04 overnight batch.
+
+Three defects that together stalled a five-game batch and buried the log
+in 1,800 pointless API calls:
+
+1. The daily upload quota is reported as HTTP 429, but only 400/403 were
+   parsed for a reason -- so YouTubeQuotaError never fired and the queue's
+   quota-deferral path never ran.
+2. That deferral, when it did run, slept until "next midnight Pacific".
+   The limit that actually bites is the project's "Video Uploads per day"
+   metric, which was still rejecting uploads 3h39m AFTER midnight PT. A
+   wake-fail-resleep would have become a 24h+ stall.
+3. GameEndTask never implemented deserialize, so it stayed abstract and
+   TaskRegistry could not construct the probe instance it uses to read
+   task_type -- the class was silently absent from the registry and a
+   persisted end-of-game task could not survive a restart.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _minimal_config():
+    """Config() itself raises -- nine sections are required."""
+    from video_grouper.utils import config as C
+
+    return C.Config(
+        STORAGE=C.StorageConfig(path="."),
+        RECORDING=C.RecordingConfig(),
+        PROCESSING=C.ProcessingConfig(),
+        LOGGING=C.LoggingConfig(),
+        APP=C.AppConfig(),
+        TEAMSNAP=C.TeamSnapConfig(),
+        PLAYMETRICS=C.PlayMetricsConfig(),
+        NTFY=C.NtfyConfig(),
+        YOUTUBE=C.YouTubeConfig(),
+    )
+
+
+def _upload_src():
+    from video_grouper.utils.youtube_upload import YouTubeUploader
+
+    return inspect.getsource(YouTubeUploader.upload_video)
+
+
+class TestQuotaErrorDetection:
+    """A 429 must be recognised as a quota condition."""
+
+    def test_429_is_parsed_for_a_reason(self):
+        src = _upload_src()
+        assert "400, 403, 429" in src, (
+            "429 is the status the API returns for 'Video Uploads per day'; "
+            "if it is not parsed, YouTubeQuotaError never fires and the "
+            "uploader retries every 60s forever"
+        )
+
+    def test_bare_429_still_classified_without_a_parseable_body(self):
+        """The observed 429 body stringifies its details oddly; a 429 from
+        this API is a quota response regardless."""
+        assert "status == 429" in _upload_src()
+
+
+class TestQuotaBackoffIsBounded:
+    """The deferral must poll, not predict the reset."""
+
+    def test_does_not_sleep_until_midnight_pacific(self):
+        from video_grouper.task_processors import base_queue_processor
+
+        src = inspect.getsource(base_queue_processor.QueueProcessor)
+        assert "_quota_retry_seconds" in src
+        assert "US/Pacific" not in src, (
+            "the midnight-Pacific model is contradicted by observation: "
+            "uploads were still rejected 3h39m after midnight PT"
+        )
+
+    def _proc(self, minutes):
+        from video_grouper.task_processors.base_queue_processor import QueueProcessor
+        from video_grouper.task_processors.queue_type import QueueType
+
+        class _Concrete(QueueProcessor):
+            @property
+            def queue_type(self):
+                return QueueType.UPLOAD
+
+            async def process_item(self, item):
+                return None
+
+        cfg = _minimal_config()
+        cfg.youtube.quota_retry_minutes = minutes
+        return _Concrete("/tmp/x", cfg)
+
+    def test_interval_is_configurable(self):
+        assert self._proc(45)._quota_retry_seconds == 45 * 60
+
+    def test_nonsense_interval_is_floored_not_zero(self):
+        """A 0 would restore the hot-retry loop this fix exists to stop."""
+        assert self._proc(0)._quota_retry_seconds >= 60
+
+
+class TestGameEndTaskRegisters:
+    """GameEndTask must be constructible, hence registrable."""
+
+    def test_not_abstract(self):
+        from video_grouper.task_processors.tasks.ntfy.game_end_task import GameEndTask
+
+        assert GameEndTask.__abstractmethods__ == frozenset(), (
+            f"GameEndTask is abstract ({sorted(GameEndTask.__abstractmethods__)}); "
+            f"TaskRegistry cannot build its probe instance and the class is "
+            f"silently left out of the registry"
+        )
+
+    def test_round_trips_through_serialize(self):
+        from video_grouper.task_processors.tasks.ntfy.game_end_task import GameEndTask
+
+        task = GameEndTask(
+            group_dir="D:/games/2026.07.08-18.20.31",
+            config=_minimal_config(),
+            ntfy_service=MagicMock(),
+            combined_video_path="D:/games/2026.07.08-18.20.31/combined.mp4",
+            start_time_offset="00:52",
+            time_offset="01:30",
+            time_seconds=90,
+        )
+        restored = GameEndTask.deserialize(task.serialize())
+        assert restored.group_dir == task.group_dir
+        assert restored.combined_video_path == task.combined_video_path, (
+            "combined_video_path lost in round-trip; serialize() nests fields "
+            "under metadata and deserialize must read them from there"
+        )
+        assert restored.start_time_offset == "00:52"
+
+
+class TestNtfyDeserializersConstruct:
+    """Config() raises (nine required sections), so both deserializers threw
+    before they could return a task."""
+
+    @pytest.mark.parametrize(
+        "mod,cls_name",
+        [
+            ("game_end_task", "GameEndTask"),
+            ("game_start_task", "GameStartTask"),
+        ],
+    )
+    def test_deserialize_does_not_call_bare_config(self, mod, cls_name):
+        import importlib
+
+        m = importlib.import_module(f"video_grouper.task_processors.tasks.ntfy.{mod}")
+        src = inspect.getsource(getattr(m, cls_name).deserialize)
+        assert "Config()" not in src, (
+            f"{cls_name}.deserialize calls Config(), which raises "
+            f"ValidationError for nine missing sections"
+        )
+
+    def test_game_start_round_trips_without_raising(self):
+        from video_grouper.task_processors.tasks.ntfy.game_start_task import (
+            GameStartTask,
+        )
+
+        task = GameStartTask(
+            group_dir="D:/games/g",
+            config=_minimal_config(),
+            ntfy_service=MagicMock(),
+            combined_video_path="D:/games/g/combined.mp4",
+        )
+        GameStartTask.deserialize(task.serialize())

--- a/video_grouper/task_processors/base_queue_processor.py
+++ b/video_grouper/task_processors/base_queue_processor.py
@@ -32,6 +32,20 @@ class QueueProcessor(ABC):
         self.storage_path = storage_path
         self.config = config
 
+        # How long to hold an upload after the API reports the daily quota
+        # is exhausted, before probing again. We can't predict the reset
+        # (see the YouTubeQuotaError branch in _run), so we poll for it.
+        # Read defensively: tests (and some call sites) pass a MagicMock
+        # config, where attribute access yields a Mock that int() rejects.
+        minutes = 30
+        raw = getattr(getattr(config, "youtube", None), "quota_retry_minutes", None)
+        try:
+            if raw is not None:
+                minutes = int(raw)
+        except (TypeError, ValueError):
+            minutes = 30
+        self._quota_retry_seconds = max(60, minutes * 60)
+
         self._queue = None  # Defer creation until start()
         self._queued_items = set()
         self._processor_task = None
@@ -235,28 +249,35 @@ class QueueProcessor(ABC):
                         continue
 
                     if isinstance(e, YouTubeQuotaError):
-                        # Quota errors should not be retried immediately.
-                        # Wait until the quota resets (YouTube daily quotas
-                        # reset at midnight Pacific Time) then retry.
+                        # Quota errors must not be retried immediately, but we
+                        # deliberately do NOT try to predict when the quota
+                        # frees. This used to sleep until "next midnight PT",
+                        # which is wrong for the limit that actually bites:
+                        # the project's "Video Uploads per day" metric. On
+                        # 2026-08-04 uploads were still rejected 3h39m AFTER
+                        # midnight PT, so that model would have woken up,
+                        # failed, and then slept until the FOLLOWING midnight
+                        # -- turning a few-hour wait into a day-plus.
+                        #
+                        # Poll on a bounded interval instead and let the API
+                        # tell us when it has reset. Costs one probe per
+                        # interval (~48/day at the default) versus the 1,440
+                        # of a 60s retry, and recovers within one interval of
+                        # the real reset whenever that happens to be.
                         self._queue.task_done()
                         self._in_progress_item = None
 
-                        # Calculate wait: next midnight PT + 5 min buffer
                         from datetime import datetime, timedelta
 
-                        import pytz
-
-                        now_pt = datetime.now(pytz.timezone("US/Pacific"))
-                        tomorrow_pt = (now_pt + timedelta(days=1)).replace(
-                            hour=0, minute=5, second=0, microsecond=0
-                        )
-                        wait_seconds = (tomorrow_pt - now_pt).total_seconds()
-                        wait_hours = wait_seconds / 3600
+                        wait_seconds = self._quota_retry_seconds
+                        next_try = datetime.now() + timedelta(seconds=wait_seconds)
 
                         logger.warning(
-                            f"{self.__class__.__name__}: YouTube quota exceeded for {item}. "
-                            f"Waiting {wait_hours:.1f}h until quota resets "
-                            f"(~{tomorrow_pt.strftime('%I:%M %p PT')}). [trace_id: {trace_id}]"
+                            f"{self.__class__.__name__}: YouTube upload quota "
+                            f"exhausted for {item}. Holding this upload and "
+                            f"re-probing at {next_try.strftime('%H:%M:%S')} "
+                            f"(every {wait_seconds / 60:.0f} min until the "
+                            f"quota frees). [trace_id: {trace_id}]"
                         )
 
                         # Sleep until quota resets, then requeue

--- a/video_grouper/task_processors/tasks/ntfy/base_ntfy_task.py
+++ b/video_grouper/task_processors/tasks/ntfy/base_ntfy_task.py
@@ -95,6 +95,41 @@ class BaseNtfyTask(BaseTask, ABC):
         """Return the path of the item being processed."""
         return self.group_dir
 
+    @staticmethod
+    def _placeholder_config():
+        """Build a minimal valid Config for a deserialized task.
+
+        ``Config()`` cannot be called bare -- nine sections are required and
+        it raises ValidationError. Both NTFY deserializers did exactly that,
+        so restoring a persisted task threw before it could return. The real
+        config is injected when the task is executed; this only has to be
+        structurally valid.
+        """
+        from video_grouper.utils.config import (
+            AppConfig,
+            Config,
+            LoggingConfig,
+            NtfyConfig,
+            PlayMetricsConfig,
+            ProcessingConfig,
+            RecordingConfig,
+            StorageConfig,
+            TeamSnapConfig,
+            YouTubeConfig,
+        )
+
+        return Config(
+            STORAGE=StorageConfig(path="."),
+            RECORDING=RecordingConfig(),
+            PROCESSING=ProcessingConfig(),
+            LOGGING=LoggingConfig(),
+            APP=AppConfig(),
+            TEAMSNAP=TeamSnapConfig(),
+            PLAYMETRICS=PlayMetricsConfig(),
+            NTFY=NtfyConfig(),
+            YOUTUBE=YouTubeConfig(),
+        )
+
     def serialize(self) -> dict[str, object]:
         """Serialize the task for state persistence."""
         return {

--- a/video_grouper/task_processors/tasks/ntfy/game_end_task.py
+++ b/video_grouper/task_processors/tasks/ntfy/game_end_task.py
@@ -72,6 +72,51 @@ class GameEndTask(BaseNtfyTask):
             self.metadata["time_offset"] = time_offset
             self.metadata["time_seconds"] = time_seconds
 
+    @classmethod
+    def deserialize(cls, data: dict[str, object]) -> "GameEndTask":
+        """Rebuild a GameEndTask from its serialized form.
+
+        Without this the class stays abstract, and TaskRegistry.register_task
+        cannot even construct the throwaway instance it uses to read
+        ``task_type`` -- it logs "could not resolve task_type property" and
+        returns, leaving GameEndTask absent from the registry entirely. A
+        game-end task persisted in the NTFY queue then cannot be restored, so
+        a service restart silently drops it and the end-of-game prompt never
+        arrives. GameStartTask was unaffected only because it is concrete.
+
+        ``BaseNtfyTask.serialize`` nests the fields under ``metadata``; the
+        top-level lookups are a fallback for older state files.
+        """
+        metadata = data.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        def _field(name: str, default: object) -> object:
+            if name in metadata:
+                return metadata[name]
+            return data.get(name, default)
+
+        group_dir = str(data.get("group_dir", ""))
+        combined_video_path = str(_field("combined_video_path", ""))
+        start_time_offset = str(_field("start_time_offset", "00:00"))
+        time_offset = _field("time_offset", None)
+        time_seconds = _field("time_seconds", None)
+
+        from video_grouper.task_processors.services.ntfy_service import NtfyService
+
+        config = cls._placeholder_config()
+        ntfy_service = NtfyService(config.ntfy, group_dir)
+
+        return cls(
+            group_dir=group_dir,
+            config=config,
+            ntfy_service=ntfy_service,
+            combined_video_path=combined_video_path,
+            start_time_offset=start_time_offset,
+            time_offset=time_offset if time_offset is None else str(time_offset),
+            time_seconds=None if time_seconds is None else int(time_seconds),
+        )
+
     def get_task_type(self) -> str:
         """Get the task type identifier."""
         from .enums import NtfyInputType

--- a/video_grouper/task_processors/tasks/ntfy/game_start_task.py
+++ b/video_grouper/task_processors/tasks/ntfy/game_start_task.py
@@ -306,10 +306,9 @@ class GameStartTask(BaseNtfyTask):
         # Create a minimal config and ntfy_service for deserialization
         # These will be properly initialized when the task is executed
         from video_grouper.task_processors.services.ntfy_service import NtfyService
-        from video_grouper.utils.config import Config
 
         # Create minimal config with required fields
-        config = Config()
+        config = cls._placeholder_config()
         ntfy_service = NtfyService(config.ntfy, group_dir)
 
         return cls(

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -375,6 +375,11 @@ class YouTubeConfig(BaseModel):
     # video id without calling the Google API. Must NOT be enabled in
     # production — reels will reference non-existent YouTube videos.
     skip_upload: bool = False
+    # Minutes to hold uploads after the API reports the daily upload quota
+    # is exhausted, before probing whether it has freed. The project-level
+    # "Video Uploads per day" limit does NOT reset at midnight Pacific, so
+    # the reset is discovered by polling rather than predicted.
+    quota_retry_minutes: int = 30
     processed_playlist: YouTubePlaylistConfig | None = None
     raw_playlist: YouTubePlaylistConfig | None = None
     playlist_map: YouTubePlaylistMapConfig | None = None

--- a/video_grouper/utils/youtube_upload.py
+++ b/video_grouper/utils/youtube_upload.py
@@ -526,7 +526,13 @@ class YouTubeUploader:
                         logger.warning("on_progress final callback raised: %s", cb_exc)
             except HttpError as e:
                 reason = ""
-                if e.resp and e.resp.status in (400, 403):
+                # 429 is what the API actually returns when the project's
+                # "Video Uploads per day" limit is hit. It was missing here,
+                # so `reason` stayed empty, YouTubeQuotaError was never
+                # raised, and the queue's quota-deferral path never ran --
+                # the uploader just retried every 60s. Observed 2026-08-04:
+                # 1,800 such calls in six hours, all answered identically.
+                if e.resp and e.resp.status in (400, 403, 429):
                     try:
                         import json
 
@@ -535,6 +541,10 @@ class YouTubeUploader:
                         reason = errors[0].get("reason", "") if errors else ""
                     except Exception:
                         pass
+                # Belt and braces: a 429 from this API is a quota response
+                # whatever the body parses to.
+                if not reason and e.resp and e.resp.status == 429:
+                    reason = "rateLimitExceeded"
                 if reason in (
                     "uploadLimitExceeded",
                     "quotaExceeded",


### PR DESCRIPTION
Builds the daily upload quota into the pipeline so it waits for the reset instead of hammering, plus the `GameEndTask` registration bug.

### 1. The 429 was never recognised
The daily cap is reported as **HTTP 429**, but only 400/403 were parsed for a reason. `reason` stayed empty, `YouTubeQuotaError` was never raised, and the queue's *existing* quota-deferral path never ran. 1,800 identical rejections in six hours.

### 2. The deferral predicted the wrong reset
It slept until "next midnight Pacific". The limit that actually binds is the **project** metric:

```
Quota exceeded for quota metric 'Video Uploads' and limit
'Video Uploads per day' ... consumer 'project_number:554807649482'
```

Uploads were still rejected **3h39m after midnight PT**, so that model would wake, fail, and re-sleep until the *following* midnight — a few-hour wait becoming 24h+.

It now polls a bounded interval (`[YOUTUBE] quota_retry_minutes`, default 30) and lets the API report the reset rather than predicting it: **~48 probes/day instead of 1,440**, recovering within one interval of the real reset under either model.

### 3. GameEndTask was never registered
It never implemented `deserialize`, so it stayed abstract; `TaskRegistry` couldn't build the probe instance it uses to read `task_type`, logged `could not resolve task_type property`, and returned. The class was absent from the registry, so a persisted end-of-game task couldn't be restored and a restart silently dropped the prompt.

**Found while fixing it:** `Config()` cannot be constructed bare (nine required sections) yet **both** NTFY deserializers called it — so restoring either task raised `ValidationError`. Added a shared `_placeholder_config()`. `GameStartTask` still reads top-level keys where `serialize()` nests under `metadata`, silently losing `combined_video_path`; left as a separate change.

### Verification
`ruff` / `format` / `mypy` clean; **1779** unit tests pass. Ten new tests, each confirmed to **fail** against the unfixed code — reverting all three fixes turns 7 of them red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)