### PR TITLE
fix(update): a quota-parked processor is not busy

### DIFF
--- a/tests/test_quiescence_quota_parked.py
+++ b/tests/test_quiescence_quota_parked.py
@@ -1,0 +1,143 @@
+"""Regression: a quota-parked processor must not block the auto-upgrade.
+
+On 2026-08-04 the upload queue was parked on YouTube's daily "Video Uploads
+per day" limit. Nothing was in flight and nothing could start -- the worker
+loop was asleep -- yet quiescence reported "youtube=2, youtube in progress"
+and the upgrade deferred.
+
+It deferred on EVERY hourly check, not occasionally, because the update
+check and StateAuditor's re-queue run on aligned ~60s cadences: the check
+landed inside the same ~2s churn window every time. Meanwhile QUEUE_STATUS
+sampled queued=0/in_progress=None at every 5-minute mark. The net effect was
+that v0.5.12 -- the release that stops the retry storm -- could not install
+because of the storm.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_file_system():
+    yield None
+
+
+@pytest.fixture(autouse=True)
+def mock_ffmpeg():
+    yield None
+
+
+def _app(youtube_queued=0, youtube_busy=None, quota_blocked=False):
+    from video_grouper.video_grouper_app import VideoGrouperApp
+
+    app = VideoGrouperApp.__new__(VideoGrouperApp)
+
+    def _proc(qsize=0, busy=None, blocked=False):
+        p = MagicMock()
+        p.get_queue_size = MagicMock(return_value=qsize)
+        p.get_in_progress_summary = MagicMock(return_value=busy)
+        p.is_quota_blocked = MagicMock(return_value=blocked)
+        p._in_progress_item = None
+        return p
+
+    app.video_processor = _proc()
+    app.upload_processor = _proc(youtube_queued, youtube_busy, quota_blocked)
+    app.ntfy_processor = None
+    app.download_processors = {"cam": _proc()}
+    app.clip_request_processor = None
+    app.highlight_reel_processor = None
+    app.ttt_job_processor = None
+    app.clip_processor = None
+    app.pipeline_processor = None
+    return app
+
+
+class TestQuotaParkedIsNotBusy:
+    @pytest.mark.asyncio
+    async def test_parked_uploads_do_not_block_the_upgrade(self):
+        """The exact production state: 2 queued, one momentarily in hand,
+        but the processor is parked on quota and cannot act."""
+        app = _app(
+            youtube_queued=2,
+            youtube_busy="YoutubeUploadTask(2026.07.08-18.20.31)",
+            quota_blocked=True,
+        )
+        is_idle, reason = await app._update_quiescence_check()
+        assert is_idle is True, (
+            f"quota-parked uploads reported the pipeline busy ({reason}); the "
+            f"upgrade then defers for as long as the external limit lasts"
+        )
+        assert reason is None
+
+    @pytest.mark.asyncio
+    async def test_real_upload_still_blocks_the_upgrade(self):
+        """The guard must keep working for genuine in-flight uploads --
+        stopping the service mid-upload is what killed one at 2%."""
+        app = _app(
+            youtube_queued=0,
+            youtube_busy="YoutubeUploadTask(2026.07.06-17.50.05)",
+            quota_blocked=False,
+        )
+        is_idle, reason = await app._update_quiescence_check()
+        assert is_idle is False
+        assert "youtube" in reason
+
+    @pytest.mark.asyncio
+    async def test_queued_work_still_blocks_when_not_parked(self):
+        app = _app(youtube_queued=3, quota_blocked=False)
+        is_idle, reason = await app._update_quiescence_check()
+        assert is_idle is False
+        assert "youtube=3" in reason
+
+
+class TestQuotaBlockedFlag:
+    def _proc(self, minutes=30):
+        from video_grouper.task_processors.base_queue_processor import QueueProcessor
+        from video_grouper.task_processors.queue_type import QueueType
+        from video_grouper.utils import config as C
+
+        class _Concrete(QueueProcessor):
+            @property
+            def queue_type(self):
+                return QueueType.UPLOAD
+
+            async def process_item(self, item):
+                return None
+
+        cfg = C.Config(
+            STORAGE=C.StorageConfig(path="."),
+            RECORDING=C.RecordingConfig(),
+            PROCESSING=C.ProcessingConfig(),
+            LOGGING=C.LoggingConfig(),
+            APP=C.AppConfig(),
+            TEAMSNAP=C.TeamSnapConfig(),
+            PLAYMETRICS=C.PlayMetricsConfig(),
+            NTFY=C.NtfyConfig(),
+            YOUTUBE=C.YouTubeConfig(),
+        )
+        cfg.youtube.quota_retry_minutes = minutes
+        return _Concrete("/tmp/x", cfg)
+
+    def test_defaults_to_not_blocked(self):
+        assert self._proc().is_quota_blocked() is False
+
+    def test_blocked_while_parked_then_expires(self):
+        p = self._proc()
+        p._quota_blocked_until = time.time() + 60
+        assert p.is_quota_blocked() is True
+        p._quota_blocked_until = time.time() - 1
+        assert p.is_quota_blocked() is False, "a lapsed park must not linger"
+
+    def test_success_clears_the_park(self):
+        """Set on quota error, cleared the moment anything succeeds."""
+        import inspect
+
+        from video_grouper.task_processors import base_queue_processor
+
+        src = inspect.getsource(base_queue_processor.QueueProcessor)
+        assert "self._quota_blocked_until = time.time() + wait_seconds" in src
+        assert "self._quota_blocked_until = 0.0" in src

--- a/video_grouper/task_processors/base_queue_processor.py
+++ b/video_grouper/task_processors/base_queue_processor.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from abc import ABC, abstractmethod
 
 from video_grouper.task_processors.tasks.base_task import BaseTask
@@ -45,6 +46,11 @@ class QueueProcessor(ABC):
         except (TypeError, ValueError):
             minutes = 30
         self._quota_retry_seconds = max(60, minutes * 60)
+        # Epoch seconds until which this processor is parked on an external
+        # quota. While parked it is NOT doing work and cannot start any, so
+        # the upgrade quiescence gate must not read it as busy -- see
+        # is_quota_blocked().
+        self._quota_blocked_until = 0.0
 
         self._queue = None  # Defer creation until start()
         self._queued_items = set()
@@ -211,6 +217,7 @@ class QueueProcessor(ABC):
                     self._retry_counts.pop(
                         item_key, None
                     )  # Clear retry count on success
+                    self._quota_blocked_until = 0.0
                     self._in_progress_item = None
                     queue_size = self._queue.qsize()
                     await self.save_state()
@@ -271,6 +278,7 @@ class QueueProcessor(ABC):
 
                         wait_seconds = self._quota_retry_seconds
                         next_try = datetime.now() + timedelta(seconds=wait_seconds)
+                        self._quota_blocked_until = time.time() + wait_seconds
 
                         logger.warning(
                             f"{self.__class__.__name__}: YouTube upload quota "
@@ -472,6 +480,22 @@ class QueueProcessor(ABC):
 
         except Exception as e:
             logger.error(f"{self.__class__.__name__}: Error loading state: {e}")
+
+    def is_quota_blocked(self) -> bool:
+        """True while this processor is parked waiting on an external quota.
+
+        A parked processor holds items it *cannot* act on: the worker loop is
+        sleeping until the quota is probed again, so nothing is in flight and
+        nothing can start. Reporting it as busy blocks the auto-upgrade for as
+        long as the external limit lasts -- and because the update check and
+        the StateAuditor re-queue run on aligned ~60s cadences, the check
+        landed inside the churn window on EVERY attempt rather than
+        occasionally. Observed 2026-08-04: two consecutive hourly checks both
+        deferred with "youtube=2, youtube in progress" while the queue read
+        idle at every 5-minute sample, leaving the very release that stops the
+        retry storm unable to install because of the storm.
+        """
+        return time.time() < self._quota_blocked_until
 
     def get_queue_size(self) -> int:
         """Get the current pending queue size.

--- a/video_grouper/video_grouper_app.py
+++ b/video_grouper/video_grouper_app.py
@@ -1022,9 +1022,37 @@ class VideoGrouperApp:
         # then stopped the service on top of the running task -- which
         # is exactly how a 07.06 upload got killed at 2%. A busy
         # processor is busy whether the work is queued or in hand.
+        # A processor parked on an external quota is NOT busy: its worker
+        # loop is asleep until the quota is re-probed, so nothing is in
+        # flight and nothing can start. Counting it as busy deferred the
+        # auto-upgrade indefinitely on 2026-08-04 -- and because the update
+        # check and StateAuditor's re-queue run on aligned ~60s cadences, the
+        # check hit the churn window every time rather than occasionally, so
+        # the release that stops the retry storm could not install.
+        parked = {
+            name
+            for name, proc in (
+                ("youtube", getattr(self, "upload_processor", None)),
+                ("video", getattr(self, "video_processor", None)),
+                ("pipeline", getattr(self, "pipeline_processor", None)),
+            )
+            if proc is not None
+            and callable(getattr(proc, "is_quota_blocked", None))
+            # `is True`, not truthiness: a MagicMock processor returns a Mock
+            # here, which is truthy, and would silently mark every processor
+            # parked -- reporting the pipeline idle while real work runs.
+            and proc.is_quota_blocked() is True
+        }
+
         busy: list[str] = []
         for name, entry in self.get_queue_status_summary().items():
             if not entry:
+                continue
+            if name in parked:
+                logger.debug(
+                    "quiescence: ignoring %s -- parked on quota, not working",
+                    name,
+                )
                 continue
             queued = entry.get("queued") or 0
             in_progress = entry.get("in_progress")


### PR DESCRIPTION
The auto-upgrade deferred **indefinitely** while the upload queue sat parked on YouTube's daily `Video Uploads per day` limit. Nothing was in flight and nothing could start — the worker loop sleeps until the quota is re-probed — yet quiescence reported `youtube=2, youtube in progress`.

### Why it never cleared
It deferred on *every* hourly check, not occasionally:

```
07:52:37  deferred  youtube=2, youtube in progress
08:52:37  deferred  youtube=2, youtube in progress
```

The update check and StateAuditor's re-queue run on aligned ~60 s cadences, so the check lands inside the same ~2 s churn window every time — while `QUEUE_STATUS` sampled `queued=0, in_progress=None` at every 5-minute mark. The result: **the release that stops the retry storm could not install because of the storm.**

### Fix
`QueueProcessor` records `_quota_blocked_until` when it parks on a quota error, clears it the moment anything succeeds, and exposes `is_quota_blocked()`. The quiescence gate skips parked processors.

### The strict `is True` matters
Most tests and several call sites pass a `MagicMock`, where `proc.is_quota_blocked()` returns a **truthy Mock**. Without `is True`, every processor reads as parked and the gate reports idle *while real work runs* — the mirror image of the bug this gate exists to prevent. That broke three existing tests on the first run here, which is how it was caught.

Genuine in-flight work still blocks the upgrade; only a provably-parked processor is ignored.

### Verification
`ruff` / `format` / `mypy` clean; **1789** unit tests pass. Six new tests cover parked-vs-busy, a real upload still blocking, merely-queued work still blocking, and the flag's set/clear/expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)