### PR TITLE
firmware: script the pak flash instead of driving the web UI by hand

### DIFF
--- a/reolink-firmware-patching/README.md
+++ b/reolink-firmware-patching/README.md
@@ -69,6 +69,8 @@ reolink-firmware-patching/
 │   ├── build_soccercam_v2.sh        # + free-space reserve + netstate v2 (stub cleanup)
 │   ├── build_soccercam_comprehensive.sh  # + power-cut recovery (video+audio)
 │   └── BUILD_LOG.md                 # artifact tracker (sha256 / CRC / contents)
+├── flash/                           # flash a built pak without the web UI
+│   └── flash_pak.py                 # chunked HTTP upload + local CRC pre-check
 ├── recover/                         # power-cut recovery (compiled into the comprehensive build)
 │   ├── recover_mp4.c                # static aarch64 reindexer (rebuilds a moov-less mdat)
 │   └── helix/                       # AAC audio recovery (Helix decoder, fetched locally)
@@ -143,7 +145,11 @@ sudo bash builds/build_bitrate_cap.sh \
     /path/to/patched_out.pak \
     20480
 
-# 3. Flash via the camera's web UI:
+# 3. Flash it -- either scripted (verifies the CRC before uploading, then
+#    waits for the reboot):
+python flash/flash_pak.py /path/to/patched_out.pak
+
+#    ...or via the camera's web UI:
 #    Settings -> Maintenance -> Local Upgrade -> select patched_out.pak
 #    Wait for reboot (1-3 min).
 

--- a/reolink-firmware-patching/docs/PATCHING_GUIDE.md
+++ b/reolink-firmware-patching/docs/PATCHING_GUIDE.md
@@ -236,6 +236,22 @@ bit-for-bit). It must end in `PASS`.
 
 ## Step 5 — Flash the patched .pak
 
+### Option A — scripted (recommended when iterating)
+
+```bash
+python flash/flash_pak.py /path/to/output_patched.pak
+```
+
+This verifies the pak's Reolink CRC **locally before uploading anything**, then
+performs the same chunked upload the web UI does and waits for the camera to
+come back. It always passes `restoreCfg: 0`, i.e. it never resets your config.
+
+Note you cannot simply POST the whole pak: the camera's nginx sets
+`client_max_body_size 512k`, so a single ~25 MB request returns **HTTP 413**.
+The script slices the upload into the same ~38 KB parts the web UI uses.
+
+### Option B — web UI
+
 1. Open the camera's web UI in your browser: `http://<CAMERA_IP>`.
 2. Log in as admin.
 3. Navigate to: **Settings → Maintenance → Local Upgrade**.

--- a/reolink-firmware-patching/flash/flash_pak.py
+++ b/reolink-firmware-patching/flash/flash_pak.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Flash a .pak to the camera over HTTP, without the web UI.
+
+Why this exists
+---------------
+Every flash in this tooling used to be a manual trip through
+Settings -> Maintenance -> Local Upgrade. That is fine once; it is miserable
+when you are iterating on a build. It also gives you no pre-flight check: the
+web UI happily uploads a pak whose CRC is wrong and lets the camera reject it
+several minutes later.
+
+A naive scripted upload fails, which is probably why this wasn't automated
+before: the camera's nginx sets ``client_max_body_size 512k`` in its ``http{}``
+block, so POSTing a ~25 MB pak in one request returns **413 Request Entity Too
+Large**. The web UI never hits that because it slices the file into ~38 KB
+parts. This script reimplements that same chunked protocol.
+
+The protocol (from the camera's own ``www/js/accountLogin.*.js``)
+----------------------------------------------------------------
+1. ``UpgradePrepare`` with ``{"restoreCfg": 0, "fileName": "<pak basename>"}``.
+   ``restoreCfg: 0`` keeps your existing settings -- this is the scripted
+   equivalent of *not* ticking "Reset Configuration".
+2. For each ``bytesPerPiece = 38912`` slice, POST multipart/form-data to
+   ``cgi-bin/api.cgi?cmd=Upgrade&file=upgrade-package`` with field name
+   ``upgrade-package`` and a composite filename::
+
+       <pak basename>&<uuid4>&<part index>&<total size>
+
+   The uuid groups the parts of one upload; the camera reassembles into
+   ``/mnt/tmp/img`` and tracks ``current recved data len:%d/%d``.
+3. The camera verifies the Reolink CRC over the assembled pak before writing
+   anything, so a truncated or corrupt upload is rejected rather than flashed.
+
+Safety
+------
+* The pak's CRC is verified locally *before* a single byte is uploaded.
+* The camera's own CRC check is the second gate.
+* Only ``app`` / ``rootfs`` are ever touched by this tooling's builders, so the
+  boot chain stays intact and a bad flash is recoverable through the same path.
+
+Keep a stock pak around regardless -- see ``docs/PATCHING_GUIDE.md``.
+
+Usage
+-----
+    python flash/flash_pak.py <path/to.pak>
+    python flash/flash_pak.py <path/to.pak> --env ../camera.env
+    python flash/flash_pak.py <path/to.pak> --no-wait
+
+Reads ``CAMERA_IP`` / ``CAMERA_USER`` / ``CAMERA_PASS`` from ``camera.env``
+next to this tooling's root (same file ``_camera_env.sh`` uses).
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import sys
+import time
+import uuid
+
+# The web UI's own slice size. Anything above nginx's 512k client_max_body_size
+# is rejected with HTTP 413, so this must stay well under it.
+BYTES_PER_PIECE = 38912
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+
+
+def load_env(path: str) -> dict[str, str]:
+    """Parse the shell-style camera.env that _camera_env.sh also sources."""
+    env: dict[str, str] = {}
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            env[key.strip()] = value.strip().strip("'\"")
+    for required in ("CAMERA_IP", "CAMERA_USER", "CAMERA_PASS"):
+        if not env.get(required):
+            sys.exit(f"ERROR: {required} missing from {path}")
+    return env
+
+
+def verify_crc_locally(pak: str) -> None:
+    """Refuse to upload a pak the camera would reject anyway."""
+    sys.path.insert(0, os.path.join(ROOT, "pak"))
+    try:
+        from reolink_crc import CRC_FIELD_OFFSET, compute  # noqa: PLC0415
+    except ImportError:
+        print("WARNING: pak/reolink_crc.py not importable; skipping local CRC check")
+        return
+    with open(pak, "rb") as fh:
+        data = fh.read()
+    stored = int.from_bytes(data[CRC_FIELD_OFFSET : CRC_FIELD_OFFSET + 4], "little")
+    computed = compute(data)
+    if stored != computed:
+        sys.exit(
+            f"ERROR: CRC mismatch in {os.path.basename(pak)} "
+            f"(stored 0x{stored:08x}, computed 0x{computed:08x}). "
+            "The camera would reject this. Rebuild it."
+        )
+    print(f"local CRC ok: 0x{computed:08x}")
+
+
+def api(conn: http.client.HTTPConnection, path: str, payload: list) -> dict:
+    body = json.dumps(payload).encode()
+    conn.request(
+        "POST",
+        path,
+        body,
+        {"Content-Type": "application/json", "Content-Length": str(len(body))},
+    )
+    raw = conn.getresponse().read()
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        return {"_raw": raw[:400].decode(errors="replace")}
+    return parsed[0] if isinstance(parsed, list) and parsed else parsed
+
+
+def login(conn: http.client.HTTPConnection, env: dict[str, str]) -> str:
+    rsp = api(
+        conn,
+        "/cgi-bin/api.cgi?cmd=Login",
+        [
+            {
+                "cmd": "Login",
+                "action": 0,
+                "param": {
+                    "User": {
+                        "userName": env["CAMERA_USER"],
+                        "password": env["CAMERA_PASS"],
+                    }
+                },
+            }
+        ],
+    )
+    try:
+        return rsp["value"]["Token"]["name"]
+    except (KeyError, TypeError):
+        sys.exit(f"ERROR: login failed: {rsp}")
+
+
+def prepare(
+    conn: http.client.HTTPConnection, token: str, name: str, attempts: int = 12
+) -> None:
+    """Open an upgrade session, waiting out a stale one if necessary.
+
+    A previously aborted upload holds the session and answers "busy" until it
+    times out, so retry rather than failing immediately.
+    """
+    for attempt in range(1, attempts + 1):
+        rsp = api(
+            conn,
+            f"/cgi-bin/api.cgi?cmd=UpgradePrepare&token={token}",
+            [
+                {
+                    "cmd": "UpgradePrepare",
+                    "action": 0,
+                    "param": {"restoreCfg": 0, "fileName": name},
+                }
+            ],
+        )
+        if rsp.get("code") == 0:
+            print(f"UpgradePrepare ok ({rsp.get('value')})")
+            return
+        detail = rsp.get("error", {}).get("detail", rsp)
+        print(f"  prepare {attempt}/{attempts}: {detail}; retrying in 15s")
+        time.sleep(15)
+    sys.exit(
+        "ERROR: could not open an upgrade session (still busy). Reboot the camera and retry."
+    )
+
+
+def upload(
+    conn: http.client.HTTPConnection, env: dict[str, str], token: str, pak: str
+) -> None:
+    name = os.path.basename(pak)
+    total = os.path.getsize(pak)
+    group = str(uuid.uuid4())
+    parts = (total + BYTES_PER_PIECE - 1) // BYTES_PER_PIECE
+    print(f"uploading {name}: {total} bytes in {parts} parts")
+
+    started = time.time()
+    text = ""
+    with open(pak, "rb") as fh:
+        for index in range(parts):
+            piece = fh.read(BYTES_PER_PIECE)
+            filename = f"{name}&{group}&{index}&{total}"
+            boundary = uuid.uuid4().hex
+            body = (
+                (
+                    f"--{boundary}\r\n"
+                    f'Content-Disposition: form-data; name="upgrade-package"; '
+                    f'filename="{filename}"\r\n'
+                    f"Content-Type: application/octet-stream\r\n\r\n"
+                ).encode()
+                + piece
+                + f"\r\n--{boundary}--\r\n".encode()
+            )
+
+            for _ in range(3):
+                try:
+                    conn.request(
+                        "POST",
+                        f"/cgi-bin/api.cgi?token={token}&cmd=Upgrade&file=upgrade-package",
+                        body,
+                        {
+                            "Content-Type": f"multipart/form-data; boundary={boundary}",
+                            "Content-Length": str(len(body)),
+                        },
+                    )
+                    response = conn.getresponse()
+                    text = response.read().decode(errors="replace")
+                    break
+                except OSError as exc:
+                    print(f"\n  part {index}: {exc}; reconnecting")
+                    conn.close()
+                    conn = http.client.HTTPConnection(env["CAMERA_IP"], 80, timeout=60)
+                    time.sleep(1)
+            else:
+                sys.exit(f"ERROR: part {index} failed after 3 attempts")
+
+            if response.status != 200:
+                sys.exit(
+                    f"ERROR: part {index}/{parts} HTTP {response.status}: {text[:300]}"
+                )
+
+            if index % 50 == 0 or index == parts - 1:
+                pct = 100.0 * (index + 1) / parts
+                print(
+                    f"  {index + 1}/{parts} ({pct:5.1f}%)  {time.time() - started:5.1f}s",
+                    flush=True,
+                )
+
+    print(f"upload complete in {time.time() - started:.1f}s")
+    print(f"camera response: {text.strip()[:200]}")
+
+
+def wait_for_reboot(env: dict[str, str], timeout: int = 420) -> None:
+    """The camera drops off while it flashes; report when it is back."""
+    print("waiting for the camera to flash and reboot...")
+    started = time.time()
+    went_down = False
+    while time.time() - started < timeout:
+        alive = True
+        try:
+            conn = http.client.HTTPConnection(env["CAMERA_IP"], 80, timeout=5)
+            conn.request("GET", "/")
+            conn.getresponse().read()
+            conn.close()
+        except OSError:
+            alive = False
+        elapsed = int(time.time() - started)
+        if not alive and not went_down:
+            print(f"  [{elapsed:3d}s] camera went down (flashing)")
+            went_down = True
+        elif alive and went_down:
+            print(f"  [{elapsed:3d}s] camera is back up")
+            return
+        time.sleep(3)
+    print("WARNING: timed out waiting for the camera to come back; check it manually")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Flash a .pak to a Reolink camera over HTTP."
+    )
+    parser.add_argument("pak", help="path to the .pak to flash")
+    parser.add_argument(
+        "--env", default=os.path.join(ROOT, "camera.env"), help="camera.env path"
+    )
+    parser.add_argument(
+        "--no-wait", action="store_true", help="don't wait for the reboot to complete"
+    )
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.pak):
+        sys.exit(f"ERROR: no such file: {args.pak}")
+
+    name = os.path.basename(args.pak)
+    if not (name.startswith("IPC_") and name.endswith(".pak")):
+        # The camera validates the filename and rejects anything that doesn't
+        # look like a stock release name -- catch it before a long upload.
+        print(
+            f"WARNING: '{name}' does not look like a stock pak name; the camera may reject it"
+        )
+
+    env = load_env(args.env)
+    verify_crc_locally(args.pak)
+
+    conn = http.client.HTTPConnection(env["CAMERA_IP"], 80, timeout=60)
+    token = login(conn, env)
+    print(f"logged in to {env['CAMERA_IP']}")
+    prepare(conn, token, name)
+    upload(conn, env, token, args.pak)
+    conn.close()
+
+    if not args.no_wait:
+        wait_for_reboot(env)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

Flashing a patched pak meant a manual trip through **Settings → Maintenance → Local Upgrade** every single time. Fine once; tedious when iterating on a build. It also gave no pre-flight check — the web UI happily uploads a pak whose CRC is wrong and lets the camera reject it minutes later.

## Why it wasn't already scripted

A naive `curl -F` of the pak returns **HTTP 413 Request Entity Too Large**. The camera's nginx sets `client_max_body_size 512k` in its `http{}` block, which applies to every location — so a ~25 MB single-request upload can never work.

The web UI never hits that limit because it slices the file. Recovered the protocol from the camera's own `www/js/accountLogin.*.js`:

```js
bytesPerPiece = 38912
filename = file.name + "&" + uuidFolder + "&" + index + "&" + size
FormData.append("upgrade-package", blob, filename)
POST cgi-bin/api.cgi?token=..&cmd=Upgrade&file=upgrade-package
```

The uuid groups the parts of one upload; the camera reassembles into `/mnt/tmp/img`, tracking `current recved data len:%d/%d`, and verifies the Reolink CRC over the whole pak before writing anything.

## What this adds

`reolink-firmware-patching/flash/flash_pak.py`:

- **Verifies the pak's CRC locally before uploading a single byte** (reuses `pak/reolink_crc.py`). The web UI has no equivalent.
- Always sends `restoreCfg: 0`, the scripted equivalent of not ticking "Reset Configuration".
- Retries `UpgradePrepare` while a stale session reports `busy` (an aborted upload holds it until it times out).
- Reconnects and retries individual parts on transport errors.
- Waits for the camera to drop off and come back, so the script exits when the flash is actually done.

Reads the same `camera.env` that `_camera_env.sh` sources.

## Verification

Flashed end-to-end against the Duo 3 PoE (`IPC_NT15NA416MP`):

```
local CRC ok: 0xfabda72c
UpgradePrepare ok ({'rspCode': 200})
uploading ...stitchprobe.pak: 25841376 bytes in 665 parts
  665/665 (100.0%)   46.2s
upload complete in 46.2s
camera response: {"cmd":"Upgrade","code":0,"value":{"rspCode":200}}
  [  2s] camera went down (flashing)
  [ 43s] camera is back up
```

Camera came back on the new build with config intact. The local CRC gate was checked against both a patched build and the stock 4867 pak (`0x23b254c5`, matching the value documented in `FIRMWARE_PATCH_NOTES.md` §3).

`ruff check` and `ruff format --check` pass; pre-commit hooks ran clean on commit.

The web-UI route is kept documented as Option B — nothing is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)