### PR TITLE
firmware docs: correct the claim that telnetd gives a shell on the camera

### DIFF
--- a/reolink-firmware-patching/README.md
+++ b/reolink-firmware-patching/README.md
@@ -194,11 +194,11 @@ After flashing:
   `/mnt/sda/netstate/override` file — daemon yields, you control via UI/API.
 - Update the home-MAC list without re-flashing by writing to
   `/mnt/sda/netstate/home_macs.txt` (one MAC per line). There is **no
-  arbitrary-file web UI** on these cameras — write these files over `telnet`
-  (the patched firmware leaves `telnetd` running, started in `S25_Net`) or by
-  pulling the microSD card and editing it on a PC. For a hands-off setup, prefer
-  baking the home MAC in at build time (the builders already do this) rather
-  than relying on a runtime file.
+  arbitrary-file web UI** on these cameras and **no shell** — `S25_Net` calls
+  `telnetd`, but this firmware's busybox is built without that applet, so port
+  23 never opens. Write these files by pulling the microSD card and editing it
+  on a PC. For a hands-off setup, prefer baking the home MAC in at build time
+  (the builders already do this) rather than relying on a runtime file.
 
 ## Quickstart — comprehensive soccer-cam build (recommended)
 

--- a/reolink-firmware-patching/docs/FIRMWARE_PATCH_NOTES.md
+++ b/reolink-firmware-patching/docs/FIRMWARE_PATCH_NOTES.md
@@ -714,8 +714,14 @@ on the daemon running — but if it fails, recording stays on (the safe directio
 - HTTP `/downloadfile/` is nginx static-serve baked into `device`, so downloads
   work even if `recorder` never starts.
 - There is **no arbitrary-file SD web UI**: runtime files under `/mnt/sda/...`
-  go via `telnet` (`telnetd` is left running by `S25_Net`) or by pulling the
-  card; config is otherwise baked at build time.
+  are placed by **pulling the microSD card**; config is otherwise baked at
+  build time.
+- **There is no shell on the camera.** `S25_Net` ends with a bare `telnetd`
+  line, but the busybox in this firmware is built **without the `telnetd`
+  applet** (327 applets, none named `telnetd`), so that line fails silently and
+  port 23 never opens — verified with a port scan against a running camera.
+  busybox *does* include `tcpsvd`, `inetd` and `sh`, so a shell service can be
+  added in a custom rootfs build if you need one; nothing here ships that.
 
 ### Plan B (deferred, riskier): firmware record-at-home gate — *never writes* the stub
 

--- a/reolink-firmware-patching/docs/PATCHING_GUIDE.md
+++ b/reolink-firmware-patching/docs/PATCHING_GUIDE.md
@@ -346,9 +346,11 @@ self-test in Step 4, option C against any good recording.
 ## Updating the netstate config without re-flashing
 
 The daemon respects two runtime files on the SD card. There is **no
-arbitrary-file web UI** on these cameras — create them over `telnet` (`telnetd`
-is left running by `S25_Net`) or by pulling the microSD card and editing it on a
-PC (any method that places files under `/mnt/sda/` works):
+arbitrary-file web UI** on these cameras, and **no shell** — `S25_Net` calls
+`telnetd`, but this firmware's busybox is built without that applet, so port 23
+never opens (see `FIRMWARE_PATCH_NOTES.md` §5d). Create these files by pulling
+the microSD card and editing it on a PC (any method that places files under
+`/mnt/sda/` works):
 
 | file | purpose |
 |---|---|


### PR DESCRIPTION
## The bug

Three docs tell users to create the netstate runtime files "over `telnet`":

- `README.md` — "write these files over `telnet` (the patched firmware leaves `telnetd` running, started in `S25_Net`)"
- `docs/PATCHING_GUIDE.md` — "create them over `telnet` (`telnetd` is left running by `S25_Net`)"
- `docs/FIRMWARE_PATCH_NOTES.md` §5d — "go via `telnet` (`telnetd` is left running by `S25_Net`)"

**None of that works.** `S25_Net` does end with a bare `telnetd` line, but the busybox shipped in this firmware is built **without the `telnetd` applet** — its applet table has 327 entries and none is `telnetd`. The line fails silently at boot and port 23 never opens.

Confirmed two ways:

1. Applet table extracted from `rootfs_extracted/bin/busybox` — `telnetd` absent (`nanddump`, `nandwrite`, `devmem`, `tcpsvd`, `inetd`, `sh` are all present, so it isn't a stripped-down build generally).
2. Port scan of a running Duo 3 PoE on the current comprehensive build — open ports are 80, 443, 554, 1935, 8000, 9000. **23 is closed.**

Anyone following these instructions to change their home-MAC list or drop an `override` file would have hit a closed port with no explanation.

## The fix

Say what actually works — pulling the microSD card and editing it on a PC, which the docs already listed as the *alternative* and is in fact the only method. Also records the root cause in `FIRMWARE_PATCH_NOTES.md` so it doesn't get re-asserted, and notes that busybox *does* ship `tcpsvd`/`inetd`/`sh` for anyone who wants to add a shell service to their own rootfs build.

Docs only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)