### PR TITLE
firmware: write the VPE warp mesh directly instead of via the camera model

### DIFF
--- a/reolink-firmware-patching/vpe/README.md
+++ b/reolink-firmware-patching/vpe/README.md
@@ -1,0 +1,107 @@
+# VPE 2-D warp mesh
+
+The Duo 3's Video Processing Engine warps each sensor image through a coarse
+control-point mesh (the DCE's "2-D LUT") before the stitcher composes the
+panorama. The mesh decides where every source pixel lands, so it is the only
+place where an *exactly specified* geometric mapping can be imposed.
+
+| file | what |
+|---|---|
+| `lut2d.py` | decode / edit / rebuild a mesh off-camera; `selftest` gates the parser |
+| `lut2d_ioctl.c` | read and write the live mesh on the camera via `/dev/nvt_vpe` |
+
+## Why write the mesh rather than the camera model
+
+The firmware can regenerate a mesh from its stored calibration
+(`Na_calc_2dlut_data`), and that path is available — `stitch_para.py` decodes and
+rebuilds the calibration blob byte-identically. But `Na_calc_2dlut_data` is an
+**iterative optimiser**, not a projection: it searches for a working angle in
+0.1-degree steps, applies an angle-dependent shear to both homographies, and
+finishes with a power-law x-warp whose barrel term is not Brown-Conrady. Hand it
+a modified camera model and you get *a* valid mesh, not the one you asked for.
+
+That is not a guess. A fully free 16-parameter cylindrical+Brown fit to the real
+66 049-point mesh stalls at 26.8 px RMS / 133 px max — a free fit that cannot get
+below 27 px means the model *family* is wrong. Two parameter-free checks agree:
+undistorting the mesh never straightens its rows or columns (best over all 120
+coefficient permutations: 87 px, versus 62/102 px for doing nothing), and the
+mesh bulges outward horizontally but inward vertically, which no radially
+symmetric map can do.
+
+So: the parametric route is fine for small nudges, and writing the mesh directly
+is the route that guarantees the mapping.
+
+## Format
+
+Confirmed against a live dump from firmware v3.0.0.4867_2505072124:
+
+```
+header   2 or 3 u32   {id, reserved, n} on the wire; some dumps saved from +4
+table    n rows x align4(n) u32
+n        257 on this unit (vpe_2dlut_size)
+stride   260; entries n..stride-1 are padding and read zero
+entry    (y << 16) | x, each half unsigned Q14.2
+```
+
+Each entry is the **source** pixel that a destination control point samples,
+in quarter-pixels, so coordinates run 0 .. 16383.75 and every decodable value is
+a multiple of 0.25.
+
+`lut2d.py` does not assume a header size — it locates the table by testing which
+offset makes every row's padded tail read zero *and* the total size come out
+exact, then preserves the header bytes verbatim so a round-trip is byte-identical
+by construction.
+
+## Off-camera use
+
+```
+python lut2d.py info     lut_vpe0.bin
+python lut2d.py dump     lut_vpe0.bin 128
+python lut2d.py selftest lut_vpe0.bin
+```
+
+`selftest` runs nine synthetic gates that need no fixture (round-trip,
+quantisation error, monotonicity, targeted-edit byte count, range rejection) and
+eight more against a real dump (header detection, size, byte-identical
+round-trip, zero padding, coordinate bounds, row/column monotonicity,
+quarter-pixel exactness). Against the factory mesh from this camera all 17 pass:
+
+```
+n=257 header=8B stride=260
+source x 4.50..3398.00   y 17.50..2154.75
+monotonic  rows 100.0%   cols 100.0%
+```
+
+Building a new mesh is a mapping function from normalised destination
+coordinates to source pixels:
+
+```python
+lut = Lut2D.from_mapping(257, lambda u, v: (u * 3839, v * 2159))
+open("flat.bin", "wb").write(lut.to_bytes())
+```
+
+Factory dumps live in `F:\archive\duo3_stitch\dumps\` — they are calibration data
+for one physical camera, not source, so they are not tracked here.
+
+## On-camera use
+
+```
+lut2d_ioctl get 0 /mnt/sda/lut_vpe0.bin
+lut2d_ioctl set 0 /mnt/sda/lut_new.bin --i-have-a-recovery-path
+```
+
+**`get` is proven on hardware. `set` is not** — it was written after the camera
+went offline and has never run. The write path therefore:
+
+- refuses to run at all without the explicit `--i-have-a-recovery-path` flag;
+- checks the mesh structure locally before handing anything to the driver;
+- reads the mesh back afterwards and diffs it, because a `SET` that silently
+  does nothing is indistinguishable from one that worked unless you check.
+
+Before trusting it, dump the factory mesh, write that same mesh back, and confirm
+the read-back is byte-identical and the image is unchanged. Only then write a
+mesh you generated.
+
+A bad mesh tears the image; it does not brick the camera. The mesh is runtime
+state — the DCE is reprogrammed from stored calibration on every boot, so a power
+cycle undoes anything written here.

--- a/reolink-firmware-patching/vpe/lut2d.py
+++ b/reolink-firmware-patching/vpe/lut2d.py
@@ -1,0 +1,360 @@
+"""Read, edit and rebuild the Duo 3's DCE 2-D geometric warp mesh.
+
+The VPE's Distortion Correction Engine warps each sensor image through a
+coarse control-point mesh before the stitcher composes the panorama. The mesh
+is what actually decides where every source pixel lands, so writing it directly
+is the only route that gives an exactly-specified mapping — the firmware's own
+`Na_calc_2dlut_data` is an iterative optimiser that reinterprets whatever camera
+model you hand it (see docs/FIRMWARE_PATCH_NOTES.md).
+
+Format, as confirmed against a live dump from `/dev/nvt_vpe`
+(`VPE_IOC_GET_2DLUT = 0xc008760d`) on firmware v3.0.0.4867_2505072124:
+
+    header      2 or 3 u32 (see `_find_table_offset`) — preserved verbatim
+    table       n rows of `stride` u32, stride = align4(n)
+    n           mesh dimension, 257 on this unit (`vpe_2dlut_size`)
+    stride      260 for n=257; entries n..stride-1 are padding and read zero
+    entry       (y << 16) | x, each half unsigned Q14.2
+
+Each entry is the *source* pixel the destination control point samples from,
+in quarter-pixel units, so the representable range is 0 .. 16383.75 and every
+decodable coordinate is a multiple of 0.25.
+
+CLI:
+    python lut2d.py info     <lut.bin>
+    python lut2d.py dump     <lut.bin> [row]
+    python lut2d.py selftest [lut.bin]      # fixture optional; synthetic gates always run
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from collections.abc import Callable
+
+# Quarter-pixel fixed point: 14 integer bits, 2 fractional.
+FRAC_BITS = 2
+FRAC_SCALE = 1 << FRAC_BITS
+COORD_MAX = (1 << 16) - 1
+COORD_MAX_PX = COORD_MAX / FRAC_SCALE
+
+# Header layouts seen in the wild. The kernel's own ioctl buffer is
+# {id, reserved, n} (12 bytes, per vpe_uti_calc_2dlut_ioctl_size); some dumps
+# were saved from +4 and so start at {reserved, n}.
+HEADER_SIZES = (8, 12)
+
+
+def align4(n: int) -> int:
+    """Row stride in entries — the driver pads each row up to a multiple of 4."""
+    return (n + 3) & ~3
+
+
+class Lut2DError(Exception):
+    """Raised when a blob does not match the documented mesh layout."""
+
+
+class Lut2D:
+    """A 2-D warp mesh, held as raw quarter-pixel integers.
+
+    Coordinates are kept in their on-wire integer form so that a decode/encode
+    round-trip is byte-identical by construction rather than by luck. Use
+    `get`/`set` for pixel floats and `raw`/`set_raw` for the underlying ints.
+    """
+
+    def __init__(
+        self, n: int, entries: list[int], header: bytes, stride: int | None = None
+    ):
+        self.n = n
+        self.stride = align4(n) if stride is None else stride
+        self.header = header
+        if len(entries) != self.n * self.stride:
+            raise Lut2DError(
+                f"expected {self.n * self.stride} entries, got {len(entries)}"
+            )
+        self.entries = entries
+
+    # -- construction ----------------------------------------------------
+
+    @classmethod
+    def from_bytes(cls, blob: bytes) -> Lut2D:
+        n, off = _find_table_offset(blob)
+        stride = align4(n)
+        want = n * stride
+        body = blob[off : off + want * 4]
+        if len(body) != want * 4:
+            raise Lut2DError(
+                f"table truncated: need {want * 4} bytes at +{off}, have {len(body)}"
+            )
+        entries = list(struct.unpack(f"<{want}I", body))
+        return cls(n, entries, blob[:off], stride)
+
+    @classmethod
+    def from_mapping(
+        cls,
+        n: int,
+        fn: Callable[[float, float], tuple[float, float]],
+        header: bytes = b"\x00\x00\x00\x00\x01\x01\x00\x00",
+    ) -> Lut2D:
+        """Build a mesh by sampling `fn(u, v) -> (src_x, src_y)` on an n x n grid.
+
+        `u` and `v` run 0.0 .. 1.0 across the destination frame. Coordinates are
+        quantised to quarter-pixels, so expect up to 0.125 px of rounding error.
+        """
+        stride = align4(n)
+        entries = [0] * (n * stride)
+        last = n - 1
+        for row in range(n):
+            v = row / last
+            base = row * stride
+            for col in range(n):
+                x, y = fn(col / last, v)
+                entries[base + col] = _pack(x, y)
+        # header carries n; keep the caller's bytes but make n consistent
+        hdr = bytearray(header)
+        struct.pack_into("<I", hdr, len(hdr) - 4, n)
+        return cls(n, entries, bytes(hdr), stride)
+
+    @classmethod
+    def identity(cls, n: int, width: float, height: float) -> Lut2D:
+        """A pass-through mesh spanning `width` x `height` source pixels."""
+        return cls.from_mapping(n, lambda u, v: (u * (width - 1), v * (height - 1)))
+
+    # -- serialisation ---------------------------------------------------
+
+    def to_bytes(self) -> bytes:
+        return self.header + struct.pack(f"<{len(self.entries)}I", *self.entries)
+
+    # -- accessors -------------------------------------------------------
+
+    def raw(self, row: int, col: int) -> int:
+        return self.entries[row * self.stride + col]
+
+    def set_raw(self, row: int, col: int, value: int) -> None:
+        self.entries[row * self.stride + col] = value & 0xFFFFFFFF
+
+    def get(self, row: int, col: int) -> tuple[float, float]:
+        return _unpack(self.raw(row, col))
+
+    def set(self, row: int, col: int, x: float, y: float) -> None:
+        self.set_raw(row, col, _pack(x, y))
+
+    def padding(self) -> list[int]:
+        """Every entry in the padded tail of every row."""
+        return [
+            self.entries[r * self.stride + c]
+            for r in range(self.n)
+            for c in range(self.n, self.stride)
+        ]
+
+    def bounds(self) -> tuple[float, float, float, float]:
+        """(min_x, min_y, max_x, max_y) over the live n x n control points."""
+        xs_min = ys_min = float("inf")
+        xs_max = ys_max = float("-inf")
+        for r in range(self.n):
+            base = r * self.stride
+            for c in range(self.n):
+                x, y = _unpack(self.entries[base + c])
+                xs_min = min(xs_min, x)
+                xs_max = max(xs_max, x)
+                ys_min = min(ys_min, y)
+                ys_max = max(ys_max, y)
+        return xs_min, ys_min, xs_max, ys_max
+
+    def monotonic_fraction(self) -> tuple[float, float]:
+        """Fraction of steps where x increases along rows / y increases down columns.
+
+        A sane warp is close to 1.0 for both. A low value means the mesh folds,
+        which the DCE will render as a torn image.
+        """
+        ok_x = tot_x = ok_y = tot_y = 0
+        for r in range(self.n):
+            base = r * self.stride
+            for c in range(self.n - 1):
+                tot_x += 1
+                if (
+                    _unpack(self.entries[base + c + 1])[0]
+                    >= _unpack(self.entries[base + c])[0]
+                ):
+                    ok_x += 1
+        for c in range(self.n):
+            for r in range(self.n - 1):
+                tot_y += 1
+                a = _unpack(self.entries[r * self.stride + c])[1]
+                b = _unpack(self.entries[(r + 1) * self.stride + c])[1]
+                if b >= a:
+                    ok_y += 1
+        return ok_x / tot_x, ok_y / tot_y
+
+
+# -- helpers -------------------------------------------------------------
+
+
+def _pack(x: float, y: float) -> int:
+    xi = int(round(x * FRAC_SCALE))
+    yi = int(round(y * FRAC_SCALE))
+    if not (0 <= xi <= COORD_MAX) or not (0 <= yi <= COORD_MAX):
+        raise Lut2DError(f"({x}, {y}) outside representable range 0..{COORD_MAX_PX}")
+    return (yi << 16) | xi
+
+
+def _unpack(v: int) -> tuple[float, float]:
+    return (v & 0xFFFF) / FRAC_SCALE, (v >> 16) / FRAC_SCALE
+
+
+def _find_table_offset(blob: bytes) -> tuple[int, int]:
+    """Locate the table by testing the padding invariant, not by assuming a header.
+
+    Dumps exist with both a 2-word and a 3-word header, so pick whichever offset
+    makes every row's padded tail read zero and the size come out exact.
+    """
+    for off in HEADER_SIZES:
+        if len(blob) < off:
+            continue
+        n = struct.unpack_from("<I", blob, off - 4)[0]
+        if not (3 <= n <= 1025):
+            continue
+        stride = align4(n)
+        if len(blob) != off + n * stride * 4:
+            continue
+        entries = struct.unpack_from(f"<{n * stride}I", blob, off)
+        tail = [entries[r * stride + c] for r in range(n) for c in range(n, stride)]
+        if any(tail):
+            continue
+        return n, off
+    raise Lut2DError(
+        f"no header size in {HEADER_SIZES} explains a {len(blob)}-byte blob "
+        "with a zero-padded n x align4(n) table"
+    )
+
+
+# -- self-test -----------------------------------------------------------
+
+
+class _Gates:
+    def __init__(self) -> None:
+        self.failed = 0
+        self.n = 0
+
+    def check(self, label: str, ok: bool, detail: str = "") -> None:
+        self.n += 1
+        mark = "PASS" if ok else "FAIL"
+        if not ok:
+            self.failed += 1
+        print(f"  [{mark}] G{self.n:<2} {label}{('  — ' + detail) if detail else ''}")
+
+
+def selftest(fixture: str | None = None) -> int:
+    g = _Gates()
+
+    print("synthetic gates (no fixture needed)")
+    ident = Lut2D.identity(65, 3840, 2160)
+    g.check("identity mesh has n*align4(n) entries", len(ident.entries) == 65 * 68)
+    g.check("identity mesh pads with zeros", not any(ident.padding()))
+    g.check(
+        "identity mesh round-trips byte-identically",
+        Lut2D.from_bytes(ident.to_bytes()).to_bytes() == ident.to_bytes(),
+    )
+
+    err = 0.0
+    for r in range(0, 65, 8):
+        for c in range(0, 65, 8):
+            x, y = ident.get(r, c)
+            err = max(err, abs(x - c / 64 * 3839), abs(y - r / 64 * 2159))
+    g.check("identity quantisation <= 0.125 px", err <= 0.125, f"max {err:.3f} px")
+
+    warp = Lut2D.from_mapping(
+        33, lambda u, v: (100 + u * 3000, 50 + v * 2000 + 40 * (u - 0.5) ** 2)
+    )
+    g.check(
+        "analytic warp round-trips byte-identically",
+        Lut2D.from_bytes(warp.to_bytes()).to_bytes() == warp.to_bytes(),
+    )
+    mx, my = warp.monotonic_fraction()
+    g.check(
+        "analytic warp is monotonic", mx == 1.0 and my == 1.0, f"x {mx:.3f} y {my:.3f}"
+    )
+
+    before = warp.to_bytes()
+    warp.set(5, 7, 123.25, 456.75)
+    after = warp.to_bytes()
+    diff = sum(1 for a, b in zip(before, after, strict=True) if a != b)
+    g.check("editing one point changes at most 4 bytes", diff <= 4, f"{diff} bytes")
+    g.check("edited point reads back exactly", warp.get(5, 7) == (123.25, 456.75))
+
+    try:
+        Lut2D.from_mapping(9, lambda u, v: (-1.0, 0.0))
+    except Lut2DError:
+        g.check("out-of-range coordinate is rejected", True)
+    else:
+        g.check("out-of-range coordinate is rejected", False)
+
+    if not fixture:
+        print("\nno fixture given — factory-mesh gates skipped")
+        print(f"\n{g.n - g.failed}/{g.n} gates passed")
+        return 1 if g.failed else 0
+
+    print(f"\nfactory mesh gates ({fixture})")
+    blob = open(fixture, "rb").read()
+    lut = Lut2D.from_bytes(blob)
+    g.check(
+        "header located by padding invariant",
+        True,
+        f"n={lut.n} header={len(lut.header)}B stride={lut.stride}",
+    )
+    g.check(
+        "size is exactly header + n*stride*4",
+        len(blob) == len(lut.header) + lut.n * lut.stride * 4,
+    )
+    g.check("round-trip is byte-identical", lut.to_bytes() == blob)
+    g.check("all padding entries are zero", not any(lut.padding()))
+
+    x0, y0, x1, y1 = lut.bounds()
+    g.check(
+        "source coordinates inside one 4096x2304 sensor frame",
+        0 <= x0 and x1 < 4096 and 0 <= y0 and y1 < 2304,
+        f"x {x0:.2f}..{x1:.2f}  y {y0:.2f}..{y1:.2f}",
+    )
+    mx, my = lut.monotonic_fraction()
+    g.check("rows advance in x for >= 95% of steps", mx >= 0.95, f"{mx * 100:.1f}%")
+    g.check("columns advance in y for >= 95% of steps", my >= 0.95, f"{my * 100:.1f}%")
+    g.check(
+        "every coordinate is a whole quarter-pixel",
+        all(
+            _unpack(v)[0] * 4 % 1 == 0 and _unpack(v)[1] * 4 % 1 == 0
+            for v in lut.entries
+        ),
+    )
+
+    print(f"\n{g.n - g.failed}/{g.n} gates passed")
+    return 1 if g.failed else 0
+
+
+# -- CLI -----------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__)
+        return 2
+    cmd = argv[1]
+    if cmd == "selftest":
+        return selftest(argv[2] if len(argv) > 2 else None)
+    if cmd in ("info", "dump"):
+        lut = Lut2D.from_bytes(open(argv[2], "rb").read())
+        x0, y0, x1, y1 = lut.bounds()
+        mx, my = lut.monotonic_fraction()
+        print(f"n={lut.n} stride={lut.stride} header={lut.header.hex(' ')}")
+        print(f"source x {x0:.2f}..{x1:.2f}   y {y0:.2f}..{y1:.2f}")
+        print(f"monotonic  rows {mx * 100:.1f}%   cols {my * 100:.1f}%")
+        if cmd == "dump":
+            row = int(argv[3]) if len(argv) > 3 else 0
+            for c in range(lut.n):
+                x, y = lut.get(row, c)
+                print(f"  [{row:3d},{c:3d}] = {x:9.2f}, {y:9.2f}")
+        return 0
+    print(f"unknown command: {cmd}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/reolink-firmware-patching/vpe/lut2d_ioctl.c
+++ b/reolink-firmware-patching/vpe/lut2d_ioctl.c
@@ -1,0 +1,202 @@
+/* lut2d_ioctl - read and write the live DCE 2-D warp mesh on the camera.
+ *
+ * Cross-compile for the camera:
+ *   aarch64-linux-gnu-gcc -O2 -static -o lut2d_ioctl lut2d_ioctl.c
+ *
+ * Protocol, from RE of app/device and hdal/vpe/nvt_vpe.ko on
+ * v3.0.0.4867_2505072124:
+ *
+ *   VPE_IOC_GET_2DLUT = _IOWR('v', 13, 8) = 0xc008760d   (device @ VA 0x599c1c)
+ *   VPE_IOC_SET_2DLUT = _IOW ('v', 13, 8) = 0x4008760d
+ *   buffer            = {u32 id, u32 reserved, u32 n} followed by the table
+ *   size              = 12 + align4(n)*n*4              (vpe_uti_calc_2dlut_ioctl_size)
+ *                       n = vpe_2dlut_size = 257 -> 267292
+ *   entry             = (y<<16)|x, each half unsigned Q14.2
+ *
+ * The ioctl's declared size field is 8, but the driver reads the whole buffer;
+ * passing the buffer itself as the argument is the convention that returns 0
+ * and yields a table matching what procfs reports (`get_2dlut_param`).
+ *
+ * GET is proven on hardware. SET is NOT — it was written after the camera went
+ * offline and has never run. Hence: `set` always reads the mesh back and diffs
+ * it, and refuses to proceed at all unless --i-have-a-recovery-path is given.
+ * Writing a folded or out-of-range mesh produces a torn image, not a brick, but
+ * verify against a known-good dump before trusting it.
+ */
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#define GET_2DLUT 0xc008760dUL
+#define SET_2DLUT 0x4008760dUL
+#define DEV "/dev/nvt_vpe"
+
+#define N 257
+#define ALIGN4(x) (((x) + 3) & ~3)
+#define STRIDE ALIGN4(N)
+#define HDR_WORDS 3
+#define HDR_BYTES (HDR_WORDS * 4)
+#define TABLE_BYTES (STRIDE * N * 4)
+#define BUFSZ (HDR_BYTES + TABLE_BYTES)
+
+/* Reject a mesh that would tear the image before handing it to the hardware:
+ * the padded tail of every row must be zero, and no control point may fall
+ * outside the Q14.2 range the DCE can represent. */
+static int table_looks_sane(const unsigned int *t)
+{
+    int r, c, bad = 0;
+    for (r = 0; r < N; r++) {
+        for (c = N; c < STRIDE; c++) {
+            if (t[r * STRIDE + c]) {
+                fprintf(stderr, "  row %d pad[%d] = 0x%08x, expected 0\n", r, c, t[r * STRIDE + c]);
+                if (++bad > 8) return 0;
+            }
+        }
+    }
+    return bad == 0;
+}
+
+static unsigned char *read_file(const char *path, long *out_len)
+{
+    FILE *f = fopen(path, "rb");
+    unsigned char *buf;
+    long len;
+    if (!f) { perror(path); return NULL; }
+    fseek(f, 0, SEEK_END);
+    len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    buf = malloc(len);
+    if (!buf || fread(buf, 1, len, f) != (size_t)len) {
+        fprintf(stderr, "%s: short read\n", path);
+        free(buf);
+        fclose(f);
+        return NULL;
+    }
+    fclose(f);
+    *out_len = len;
+    return buf;
+}
+
+static int do_get(int fd, int id, const char *path)
+{
+    unsigned char *buf = calloc(1, BUFSZ);
+    unsigned int *h = (unsigned int *)buf;
+    FILE *f;
+    int r;
+
+    h[0] = id; h[1] = 0; h[2] = N;
+    r = ioctl(fd, GET_2DLUT, buf);
+    printf("GET id=%d -> %d  hdr={%u,%u,%u}\n", id, r, h[0], h[1], h[2]);
+    if (r != 0) { free(buf); return 1; }
+
+    f = fopen(path, "wb");
+    if (!f) { perror(path); free(buf); return 1; }
+    fwrite(buf, 1, BUFSZ, f);
+    fclose(f);
+    printf("  wrote %s (%d bytes)\n", path, BUFSZ);
+    free(buf);
+    return 0;
+}
+
+static int do_set(int fd, int id, const char *path, int armed)
+{
+    unsigned char *in;
+    unsigned char *buf, *back;
+    unsigned int *h;
+    long len;
+    int r, off;
+
+    in = read_file(path, &len);
+    if (!in) return 1;
+
+    /* Accept a dump saved with either a 2-word or 3-word header. */
+    if (len == BUFSZ) off = HDR_BYTES;
+    else if (len == BUFSZ - 4) off = HDR_BYTES - 4;
+    else {
+        fprintf(stderr, "%s: %ld bytes, expected %d or %d\n", path, len, BUFSZ, BUFSZ - 4);
+        free(in);
+        return 1;
+    }
+
+    buf = calloc(1, BUFSZ);
+    h = (unsigned int *)buf;
+    h[0] = id; h[1] = 0; h[2] = N;
+    memcpy(buf + HDR_BYTES, in + off, TABLE_BYTES);
+    free(in);
+
+    if (!table_looks_sane((unsigned int *)(buf + HDR_BYTES))) {
+        fprintf(stderr, "refusing to write: table failed the structure check\n");
+        free(buf);
+        return 1;
+    }
+    printf("mesh from %s passes the structure check\n", path);
+
+    if (!armed) {
+        printf("dry run — pass --i-have-a-recovery-path to actually write\n");
+        free(buf);
+        return 0;
+    }
+
+    r = ioctl(fd, SET_2DLUT, buf);
+    printf("SET id=%d -> %d\n", id, r);
+    if (r != 0) { free(buf); return 1; }
+
+    /* Read back and diff. A SET that silently does nothing looks identical to
+     * one that worked unless you check. */
+    back = calloc(1, BUFSZ);
+    h = (unsigned int *)back;
+    h[0] = id; h[1] = 0; h[2] = N;
+    r = ioctl(fd, GET_2DLUT, back);
+    if (r != 0) {
+        printf("  read-back failed (%d) — cannot confirm the write\n", r);
+        free(buf); free(back);
+        return 1;
+    }
+    if (memcmp(buf + HDR_BYTES, back + HDR_BYTES, TABLE_BYTES) == 0) {
+        printf("  read-back matches: the mesh is live\n");
+        free(buf); free(back);
+        return 0;
+    }
+    {
+        int i, diff = 0;
+        unsigned int *a = (unsigned int *)(buf + HDR_BYTES);
+        unsigned int *b = (unsigned int *)(back + HDR_BYTES);
+        for (i = 0; i < STRIDE * N; i++) if (a[i] != b[i]) diff++;
+        printf("  read-back DIFFERS in %d of %d entries — the write did not take\n",
+               diff, STRIDE * N);
+    }
+    free(buf); free(back);
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    int fd, rc, id, armed = 0, i;
+    const char *cmd, *path;
+
+    if (argc < 4) {
+        fprintf(stderr,
+                "usage: %s get <vpe_id> <out.bin>\n"
+                "       %s set <vpe_id> <in.bin> [--i-have-a-recovery-path]\n",
+                argv[0], argv[0]);
+        return 2;
+    }
+    cmd = argv[1];
+    id = atoi(argv[2]);
+    path = argv[3];
+    for (i = 4; i < argc; i++)
+        if (!strcmp(argv[i], "--i-have-a-recovery-path")) armed = 1;
+
+    fd = open(DEV, O_RDWR);
+    if (fd < 0) { perror("open " DEV); return 1; }
+
+    if (!strcmp(cmd, "get")) rc = do_get(fd, id, path);
+    else if (!strcmp(cmd, "set")) rc = do_set(fd, id, path, armed);
+    else { fprintf(stderr, "unknown command: %s\n", cmd); rc = 2; }
+
+    close(fd);
+    return rc;
+}


### PR DESCRIPTION
Stacked on #125.

The stitch geometry is decided by the DCE's 257×257 control-point mesh. The firmware can regenerate that mesh from stored calibration, but `Na_calc_2dlut_data` is an **iterative optimiser**, not a projection — it searches for a working angle in 0.1° steps, shears both homographies by it, and finishes with a power-law x-warp whose barrel term is not Brown-Conrady. Feed it a modified camera model and you get *a* valid mesh, not the one you specified.

Numerically: a fully free 16-parameter cylindrical+Brown fit to the real 66,049-point mesh stalls at **26.8 px RMS / 133 px max**, and undistorting the mesh never straightens its rows or columns (best over all 120 coefficient permutations: 87 px, against 62/102 px for doing nothing). The model *family* is wrong, so no parameter choice recovers it.

Independent corroboration found while writing this: the stored Brown-Conrady radial map **folds at r_d = 0.7576**, while the image corners sit at r_d = 0.85–0.91. The coefficients are undefined past the middle of the frame edge — you cannot derive true field of view from them.

## What's here

- `vpe/lut2d.py` — mesh codec. Holds coordinates as their on-wire quarter-pixel integers so a decode/encode round-trip is byte-identical **by construction**, and locates the table by testing which header offset makes every row's padded tail read zero rather than assuming a header size (dumps exist with both 2-word and 3-word headers, so assuming would have been wrong).
- `vpe/lut2d_ioctl.c` — on-camera client. Cross-compiles clean under `aarch64-linux-gnu-gcc -Wall -Wextra`.

## Verification

`selftest` runs 9 fixture-free gates plus 8 against a real dump. All 17 pass against the factory mesh from this camera:

```
n=257 header=8B stride=260
source x 4.50..3398.00   y 17.50..2154.75
monotonic  rows 100.0%   cols 100.0%
17/17 gates passed
```

## Honest limit

`get` is proven on hardware. **`set` is not** — it was written after the camera went offline and has never run. It therefore refuses to run without an explicit flag, checks mesh structure before touching the driver, and diffs a read-back afterwards, because a `SET` that silently does nothing is otherwise indistinguishable from one that worked.

Factory dumps stay on F: — they're calibration data for one physical camera, not source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRurxvFA57JEacBJ2qbdoK