### PR TITLE
firmware: reach the encoder ROI through the kernel, not through device

### DIFF
--- a/reolink-firmware-patching/builds/build_roi_qp.sh
+++ b/reolink-firmware-patching/builds/build_roi_qp.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+# Build a patched .pak that makes the encoder's ROI window (per-region QP bias)
+# usable from the camera, and drives it from a per-game config file on the SD
+# card. Everything this build touches is inside the `rootfs` SquashFS:
+#
+#   - kflow_videoenc.ko  : 26-byte in-place format-string fix (see below)  [rootfs]
+#   - /etc/init.d/S37_RoiQp                  the daemon that applies the window
+#   - /etc/soccercam_roi.conf.default        baked-in fallback config
+#
+# `app` is NOT touched, so this layers cleanly on top of any existing build:
+# pass a stock pak for a minimal test image, or pass your comprehensive pak as
+# the base to keep the HTTP unlock / bitrate cap / netstate / recovery.
+#
+# ---------------------------------------------------------------------------
+# What the .ko patch does
+#
+# The kernel's ROI debug command is
+#     echo vdoenc setroi <PathId> <RoiIndex> <Enable> <QP> <QPMode> <X> <Y> <W> <H> \
+#         > /proc/hdal/venc/cmd
+# and its handler (Cmd_VdoEnc_SetROI, kflow_videoenc.ko VMA 0x00111b44) parses
+# those nine numbers with
+#     sscanf_s(s, "%d %d %d %d %d %d %d %d %d", ...)
+# into a 16-byte struct whose fields are NOT all int:
+#     +0x0 u32 enable   +0x4 u16 x   +0x6 u16 y   +0x8 u16 w
+#     +0xa u16 h        +0xc s8  qp  +0xd u8  qp_mode
+# Nine `%d` conversions write nine 4-byte ints, so the writes overlap. The last
+# one (Height, at +0x0a) spills its two high bytes over +0x0c and +0x0d, i.e.
+# over qp and qp_mode. On stock firmware `setroi` therefore always ends up with
+# QP=0 / QPMode=0 — an enabled window that requests no bit reallocation at all.
+#
+# The fix is a length qualifier per field. The replacement format is exactly the
+# same 26 bytes as the original, so no relocation, section size or symbol moves:
+#
+#   before: "%d %d %d %d %d %d %d %d %d"   (26 bytes, file offset 0x36688)
+#   after:  "%d%d%d%hhd%hhd%hd%hd%hd%hd"   (26 bytes)
+#
+# The spaces are droppable because numeric scanf conversions skip leading
+# whitespace (kwrap.ko vsscanf_s @ 0x00109b70 does the _ctype space test before
+# every numeric conversion), and kwrap's vsscanf_s implements both `h` and `hh`
+# (case 0x68 sets short on the first 'h', char on the second).
+#
+# Full evidence: docs/ENCODER_ROI_QP.md.
+#
+# NOTHING HERE HAS BEEN RUN ON HARDWARE. The camera was offline when this was
+# written. Treat a build from this script as staged, not proven.
+# ---------------------------------------------------------------------------
+#
+# No sudo needed (unsquashfs -no-xattrs, mksquashfs -all-root).
+# Usage:
+#   bash build_roi_qp.sh <base.pak> <out.pak> [roi.conf]
+# where [roi.conf] is an optional file baked in as the default window; if
+# omitted, ../runtime/roiqp/roi.conf.example is used.
+#
+# NOTE: <out.pak> MUST be named to the Reolink pattern or the camera rejects it
+# on upload:
+#   IPC_NT15NA416MP.<build>_2505072124.Reolink-Duo-3-PoE.16MP.REOLINK_roiqp.pak
+set -euo pipefail
+
+BASE="${1:?usage: $0 <base.pak> <out.pak> [roi.conf]}"
+OUT="${2:?usage: $0 <base.pak> <out.pak> [roi.conf]}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PAK_DIR="$(cd "$HERE/../pak" && pwd)"
+RT="$HERE/../runtime/roiqp"
+CONF_SRC="${3:-$RT/roi.conf.example}"
+INIT_SRC="$RT/S37_RoiQp"
+KO_REL="lib/modules/5.10.168/hdal/kflow_videoenc/unit/kflow_videoenc.ko"
+
+case "$(basename "$OUT")" in
+  IPC_NT15NA416MP.*_*.Reolink-Duo-3-PoE.16MP.REOLINK*.pak) : ;;
+  *) echo "WARNING: output name '$(basename "$OUT")' does NOT match the Reolink pattern;" >&2
+     echo "         the camera's Local Upgrade will reject it ('Failed to recognize the file format')." >&2
+     echo "         e.g. IPC_NT15NA416MP.4910_2505072124.Reolink-Duo-3-PoE.16MP.REOLINK_roiqp.pak" >&2 ;;
+esac
+
+for x in "$INIT_SRC" "$CONF_SRC"; do
+    [[ -f "$x" ]] || { echo "ERROR: missing $x"; exit 1; }
+done
+
+WORK="$(mktemp -d)"
+trap "rm -rf '$WORK'" EXIT
+cd "$WORK"
+
+echo "==> 1) extract rootfs"
+python3 - "$BASE" <<'PY'
+import struct, sys
+d = open(sys.argv[1], "rb").read()
+b = 0x18 + 5 * 0x48                       # section 5 = rootfs
+off = struct.unpack("<Q", d[b + 0x38:b + 0x40])[0]
+sz = struct.unpack("<Q", d[b + 0x40:b + 0x48])[0]
+open("rootfs_stock.bin", "wb").write(d[off:off + sz])
+PY
+unsquashfs -no-xattrs -d rootfs_unpacked -no-progress rootfs_stock.bin >/dev/null
+
+echo "==> 2) patch kflow_videoenc.ko setroi format string"
+python3 - "$KO_REL" <<'PY'
+import sys
+KO = "rootfs_unpacked/" + sys.argv[1]
+OFF = 0x36688
+OLD = b"%d %d %d %d %d %d %d %d %d"
+NEW = b"%d%d%d%hhd%hhd%hd%hd%hd%hd"
+assert len(NEW) == len(OLD) == 26, "replacement must be the same 26 bytes"
+d = bytearray(open(KO, "rb").read())
+got = bytes(d[OFF:OFF + len(OLD)])
+assert got == OLD, f"{KO}[{hex(OFF)}] mismatch: got {got!r}, expected {OLD!r}. Firmware may have changed; stop."
+assert d[OFF + len(OLD)] == 0, "format string is not NUL-terminated at the expected length; stop."
+# The 9-int format also appears as a substring of longer format strings in this
+# module; only the NUL-delimited whole string is ours, and there must be exactly
+# one of it or we are patching the wrong site.
+whole = b"\x00" + OLD + b"\x00"
+assert bytes(d).count(whole) == 1, f"expected exactly 1 whole-string match, got {bytes(d).count(whole)}"
+d[OFF:OFF + len(NEW)] = NEW
+open(KO, "wb").write(bytes(d))
+print(f"   {OLD.decode()} -> {NEW.decode()}  (26 bytes, in place)")
+PY
+
+echo "==> 3) install S37_RoiQp + default config"
+install -m 0755 "$INIT_SRC" rootfs_unpacked/etc/init.d/S37_RoiQp
+install -m 0644 "$CONF_SRC" rootfs_unpacked/etc/soccercam_roi.conf.default
+echo "   /etc/init.d/S37_RoiQp + /etc/soccercam_roi.conf.default"
+
+echo "==> 4) repack rootfs squashfs"
+mksquashfs rootfs_unpacked rootfs_new.bin \
+    -comp xz -b 262144 -noappend -no-progress \
+    -no-exports -all-root -mkfs-time 0 -all-time 0 \
+    >/dev/null
+
+echo "==> 5) pre-flight: boot-chain sections must be handed through untouched"
+# This runs BEFORE any CRC is computed. It asserts that the only replacement
+# blob we are about to give the repacker is `rootfs`, so loader/fdt/atf/uboot/
+# kernel are, by construction, the base pak's own bytes.
+python3 - <<'PY'
+SWAPS = {"rootfs"}
+BOOT = ["loader", "fdt", "atf", "uboot", "kernel"]
+overlap = SWAPS.intersection(BOOT)
+assert not overlap, f"REFUSING: this build would replace boot sections {sorted(overlap)}"
+print("   swapping only: " + ", ".join(sorted(SWAPS)))
+PY
+
+echo "==> 6) repack pak"
+PYTHONPATH="$PAK_DIR" python3 - "$BASE" "$WORK/out.pak" <<'PY'
+import sys
+from pak_repack import repack
+crc, size, _ = repack(sys.argv[1], sys.argv[2],
+                      swaps={"rootfs": open("rootfs_new.bin", "rb").read()})
+print(f"   built size={size} crc=0x{crc:08x}")
+PY
+
+echo "==> 7) HARD GUARD: loader/fdt/atf/uboot/kernel byte-identical to the base"
+# A pak whose boot chain differs from a known-good base is not recoverable by
+# reflashing over the network. If this check fails the output is deleted, not
+# warned about: a warning in a log nobody reads is not a guard.
+python3 - "$BASE" "$WORK/out.pak" <<'PY'
+import hashlib, struct, sys
+
+BOOT = {"loader", "fdt", "atf", "uboot", "kernel"}
+# `ai` and `app` are not touched by this build either; check them too, so an
+# accidental swap shows up here rather than on the camera.
+ALSO = {"ai", "app"}
+
+
+def sections(path):
+    d = open(path, "rb").read()
+    out = {}
+    for i in range(8):
+        b = 0x18 + i * 0x48
+        name = d[b:b + 0x20].split(b"\x00")[0].decode("ascii", "replace")
+        off = struct.unpack("<Q", d[b + 0x38:b + 0x40])[0]
+        sz = struct.unpack("<Q", d[b + 0x40:b + 0x48])[0]
+        if sz:
+            out[name] = d[off:off + sz]
+    return out
+
+
+base, new = sections(sys.argv[1]), sections(sys.argv[2])
+bad = []
+for name in sorted(BOOT | ALSO):
+    b, n = base.get(name), new.get(name)
+    if b is None or n is None:
+        bad.append(f"{name}: present in base={b is not None} out={n is not None}")
+        continue
+    hb, hn = hashlib.sha256(b).hexdigest(), hashlib.sha256(n).hexdigest()
+    tag = "BOOT" if name in BOOT else "    "
+    if hb == hn:
+        print(f"   {tag} {name:8s} identical  {hb[:16]} ({len(b)} bytes)")
+    else:
+        bad.append(f"{name}: {hb[:16]} != {hn[:16]}")
+if bad:
+    print("\nABORT: sections that must be byte-identical are not:")
+    for m in bad:
+        print("   " + m)
+    sys.exit(1)
+if base["rootfs"] == new["rootfs"]:
+    print("\nABORT: rootfs is unchanged — the patch did not take.")
+    sys.exit(1)
+print("   rootfs  replaced as intended")
+PY
+
+mv "$WORK/out.pak" "$OUT"
+
+echo "==> 8) verify CRC"
+python3 "$PAK_DIR/reolink_crc.py" compute "$OUT"
+
+echo
+echo "====================================================================="
+echo " Build complete: $OUT"
+echo "  - kflow_videoenc.ko setroi format string: fixed (26 B, in place)"
+echo "  - /etc/init.d/S37_RoiQp:                  installed"
+echo "  - /etc/soccercam_roi.conf.default:        $(basename "$CONF_SRC")"
+echo "  - loader/fdt/atf/uboot/kernel/ai/app:     byte-identical to base"
+echo
+echo " NOT VERIFIED ON HARDWARE. First checks after flashing (see"
+echo " docs/ENCODER_ROI_QP.md section 7, 'Prove-out'):"
+echo "   1. cat /proc/hdal/venc/info"
+echo "      -> baseline: out 0 is H265 7680x2160 and the ROI table is EMPTY."
+echo "   2. echo vdoenc setroi 0 0 1 -6 1 0 760 7680 900 > /proc/hdal/venc/cmd"
+echo "      dmesg | grep 'Set ROI Index' | tail -1"
+echo "      -> MUST read back QP = -6, QPMode = 1. If it reads QP = 0,"
+echo "         QPMode = 0 the .ko patch did not take effect."
+echo "   3. cat /proc/hdal/venc/info"
+echo "      -> the ROI table must now have a row for out 0. This is the"
+echo "         driver's own readback, and the strongest single check."
+echo "   4. cat /mnt/sda/soccercam/roi.log  -> what the daemon parsed/applied."
+echo "====================================================================="

--- a/reolink-firmware-patching/docs/APP_REPLACEMENT_DESIGN.md
+++ b/reolink-firmware-patching/docs/APP_REPLACEMENT_DESIGN.md
@@ -213,13 +213,25 @@ and `upgrade` alive and independent of our binary.
 | Stream geometry | Fixed at 7680×2160; four separate patches failed to move it | Arbitrary — we emit the numbers |
 | Frame rate | 21 fps hard ceiling (VTS floor at 2160 rows) | Up to ~63 fps at 720 rows; `fps = 46296/(rows+8)` |
 | Warp / stitch | Factory 257×257 mesh from `CamStitchPara` | Our own LUT; already know the format and the `SET` ioctl |
-| Bit allocation | AQ only; ROI/QP-map present but unexposed | `HD_H26XENC_ROI_WIN` / `USR_QP` driven directly, per-game |
+| Bit allocation | AQ only; ROI/QP-map present but unexposed [1] | `HD_H26XENC_ROI_WIN` / `USR_QP` driven directly, per-game |
 | Crop | `SetCrop` exists but gated by `videoClip: permit 0` | No ability gate |
 | Bitrate | Encoder-validator ceiling ~20.5 Mbps | Our own limits |
 | Pre-stitch frames | Unclear | Direct access to per-sensor buffers |
 
 The recurring theme: **every one of these is currently blocked by a policy or
 constant inside `device`, not by hardware.**
+
+[1] **Bit allocation no longer needs app replacement — see `ENCODER_ROI_QP.md`.**
+"Present but unexposed" is confirmed: `device`'s `hd_videoenc_set` has a working
+`OUT_ROI` (0xc) arm that no call site ever invokes, and no Baichuan/CGI/config
+field reaches it. But driving the HDAL param "directly" turned out to be the
+worst of the available routes — `hd_videoenc_set` case 0xc does not issue an
+ioctl at all; it writes a 284-byte userspace shadow and sets a dirty flag, so an
+outside process cannot replicate it. The encoder ROI is reachable *without*
+touching `device`, through `kflow_videoenc.ko`'s own
+`/proc/hdal/venc/cmd setroi` command plus a 26-byte in-place fix to that
+command's `sscanf` format string. `USR_QP` remains out of reach from userspace
+(it needs a DMA-able QP-map buffer, and has no proc command).
 
 ---
 

--- a/reolink-firmware-patching/docs/ENCODER_ROI_QP.md
+++ b/reolink-firmware-patching/docs/ENCODER_ROI_QP.md
@@ -1,0 +1,699 @@
+# Encoder ROI / QP bias — where the lever actually is
+
+**Status: analysis complete; nothing run on the camera.** The camera was bricked
+and offline for the whole of this work (a faulty `LD_PRELOAD` ioctl shim killed
+`device`; recovery is waiting on a UART cable). Claims below come from
+decompiling the shipped binaries and from one live `/proc/hdal/venc/info` dump
+captured before the brick; each cites its source. Anything that could not be
+settled from those is marked **INFERRED** or **UNVERIFIED** in place.
+
+What *is* verified, off-camera:
+
+- `builds/build_roi_qp.sh` runs clean against the stock
+  `IPC_NT15NA416MP.4867` pak. The output's CRC matches, `loader`, `fdt`, `atf`,
+  `uboot`, `kernel`, `ai` and `app` are byte-identical to the base by SHA-256,
+  and unpacking the result confirms the patched `.ko` (same size, new format
+  string present, old one gone) plus both installed files.
+- The guards fail correctly: a single flipped byte in the `kernel` section trips
+  the identity check, and re-running the build over an already-patched pak
+  aborts at the byte assertion **without creating an output file**.
+- `S37_RoiQp`'s config validator was exercised against 14 fixtures (valid,
+  CRLF, disabled, missing key, unknown key, non-integer, shell-injection
+  attempt, each range violation, absent file). All 14 behave as specified and
+  report a precise reason.
+
+What is **not** verified: everything that requires the camera — whether the
+`.ko` loads, whether `/proc/hdal/venc/cmd` accepts a write, whether the ROI
+reaches the encoder, and what the coordinates mean. §7 is how to find out.
+
+Why we want this: a bitrate study on real footage found ~50–55% of the encoded
+bits going to the treeline and the foreground spectators, and only 8–13% to the
+sky despite it being 44% of the frame. The ball and the players are starved. The
+encoder can bias bits toward a rectangle. Nothing in the stock firmware ever
+asks it to.
+
+`APP_REPLACEMENT_DESIGN.md:216` recorded the lever as "AQ only; ROI/QP-map
+present but unexposed → `HD_H26XENC_ROI_WIN` / `USR_QP` driven directly,
+per-game". The "unexposed" half is **confirmed** — and by direct observation,
+not inference (§1). But the proposed route, driving the HDAL param directly,
+is the *worst* of the ones that exist: it is unreachable from outside `device`
+(§2) and would otherwise mean patching the one process whose death bricks the
+camera. There is a route that touches neither. §4 compares them.
+
+---
+
+## 1. The parameter exists, and userspace never sets it
+
+### Observed on the running camera
+
+The strongest evidence is not static at all. `dumps/probe2/venc_info.txt` is a
+live `cat /proc/hdal/venc/info` taken from this unit on 2026-08-15 while it was
+encoding. Every per-port table in it has a row for outs 0, 1 and 3. The ROI
+table has **no rows at all**:
+
+```
+------------------------- VIDEOENC 0  ROI --------------------------------------
+out   qp_mode  win  qp  rect(x,y,w,h)
+------------------------- VIDEOENC 0  ROW RC -----------------------------------
+out   en  i_qp_rng  i_qp_step  i_qp_min  i_qp_max  p_qp_rng ...
+0     1   2         1          1         51        4        ...
+```
+
+and its neighbours are equally explicit:
+
+| table | out 0 | reading |
+|---|---|---|
+| `ROI` | *(no rows)* | **no ROI window is in effect on any path** |
+| `USER QP` | `en 0  map_addr ........` | QP map off, no buffer ever allocated |
+| `SMART ROI` | `en 0  fg_str[..] .....  mode ....` | the codec's own region picker is off too |
+| `AQ` | `en 1  i_str 3  p_str 3  max_delta 8  min_delta -8` | on |
+| `ROW RC` | `en 1  i_qp_rng 2 … p_qp_rng 4 …` | on |
+| `JND` | `en 1  str 7  level 11  threshold 5` | on |
+
+So the lever is present, wired into the driver's own reporting, and **unused**.
+That is tier-L confirmation of the design note's "present but unexposed", not an
+inference from the existence of a symbol.
+
+Two corrections fall out of the same dump. `APP_REPLACEMENT_DESIGN.md` says bit
+allocation today is "AQ only"; it is actually **AQ + Row RC + JND**, all three
+enabled, none of them regional. And out 0 is `H265 7680x2160`, `CBR`,
+`bitrate 20971520`, `fr 20/1`, with `I(int/min/max) = (35/25/51)` and the same
+for P — see §5 for why that QP floor of **25** bounds what an ROI delta can buy.
+
+### Static confirmation, and why no config path exists
+
+`device` statically links the Novatek HDAL userspace library, so the whole
+`hd_videoenc_*` layer is inside it.
+
+`device FUN_005c11d0` is the param-id → name map (it feeds
+`"HD_VIDEOENC_PARAM_%s: ..."` diagnostics). It gives the complete enum:
+
+| id | name | id | name |
+|---|---|---|---|
+| 0 | `DEVCOUNT` | 0x10 | `OUT_TRIG_SNAPSHOT` |
+| 1 | `SYSCAPS` | 0x11–0x13 | `IN_STAMP_{BUF,IMG,ATTR}` |
+| 2 | `PATH_CONFIG` | 0x14 | `IN_MASK_ATTR` |
+| 3 | `BUFINFO` | 0x15 | `IN_MOSAIC_ATTR` |
+| 4 | `IN` | 0x16 | `IN_PALETTE_TABLE` |
+| 5 | `OUT_ENC_PARAM` | 0x18 | `IN_FRC` |
+| 6 | `OUT_VUI` | 0x1a | `FUNC_CONFIG` |
+| 7 | `OUT_DEBLOCK` | 0x1b | `OUT_ENC_PARAM2` |
+| 8 | `OUT_RATE_CONTROL` | 0x1c | `OUT_RATE_CONTROL2` |
+| **9** | **`OUT_USR_QP`** | 0x1f | `BS_RING` |
+| 0xa | `OUT_SLICE_SPLIT` | 0x20 | `OUT_RATE_CONTROL3` |
+| 0xb | `OUT_ENC_GDR` | 0x23 | `OUT_JPEG_ROI` |
+| **0xc** | **`OUT_ROI`** | | |
+| 0xd | `OUT_ROW_RC` | | |
+| 0xe | `OUT_AQ` | | |
+| 0xf | `OUT_REQUEST_IFRAME` | | |
+
+`device FUN_005cd150` is `hd_videoenc_set` (it prints `"hd_videoenc_set(%s):\n"`
+and passes the literal `"hd_videoenc_set"` to the error reporter). It has a
+working `case 0xc:` — the ROI arm is compiled in and functional.
+
+**But nothing calls it with 0xc.** Enumerating every call site into
+`FUN_005cd150` and recovering the constant in `w1` (the param argument) by
+walking back up to 16 instructions gives 33 sites, and the ids actually driven
+are:
+
+```
+0x02 PATH_CONFIG   0x04 IN            0x05 OUT_ENC_PARAM   0x0a OUT_SLICE_SPLIT
+0x0b OUT_ENC_GDR   0x0f OUT_REQ_IFRM  0x10 OUT_TRIG_SNAP   0x11 IN_STAMP_BUF
+0x12 IN_STAMP_IMG  0x13 IN_STAMP_ATTR 0x14 IN_MASK_ATTR    0x15 IN_MOSAIC_ATTR
+0x1a FUNC_CONFIG   0x1b OUT_ENC_PARAM2 0x1c OUT_RATE_CTL2  0x20 OUT_RATE_CTL3
+```
+
+`0x09 OUT_USR_QP`, `0x0c OUT_ROI`, `0x0d OUT_ROW_RC`, `0x0e OUT_AQ` and
+`0x23 OUT_JPEG_ROI` appear at **no** call site. Every one of the 33 sites
+resolved to a literal, so there is no variable-param site hiding an ROI call.
+*(Caveat: a 16-instruction lookback is a heuristic. It found a constant for all
+33, which is the strong form of the result, but it is not a proof by
+construction.)*
+
+Corroborating: `netserver`, `cgiserver.cgi` and `router` contain **zero**
+occurrences of any `roi`/`qp_map`/`usr_qp` string (byte scan of each binary).
+There is no Baichuan message, no CGI command and no config field anywhere in the
+Reolink layer that reaches the encoder ROI. **There is no existing config path
+to reuse.** The design note's "unexposed" is correct.
+
+The one Reolink-level ROI knob that *does* exist is Smart ROI — `device
+FUN_0059cef0` case 0x2f validates `"invalid smart roi enable (%lu), should be
+0~1"` / `"invalid smart roi mode (%lu), should be 0~1"` and forwards it as
+vendor param `0xf07c`. Smart ROI is the codec's own motion-driven region
+picker, not a region we choose, so it is the wrong lever for "always favour this
+rectangle".
+
+### What `HD_H26XENC_ROI_WIN` looks like
+
+From the validator `device FUN_005c2df0` case 0xc (which range-checks each
+window) plus the `memcpy(dst, src, 0x11c)` and the debug print
+`"  [%2d] en(%u) qp(%d) mode(%d) rect(x,y,w,h)=(%u,%u,%u,%u)\n"` in
+`hd_videoenc_set` case 0xc:
+
+```c
+struct HD_H26XENC_ROI_WIN {        /* 0x11c = 284 bytes */
+    uint32_t  unknown0;            /* u32[0] — not validated, not printed   */
+    struct {                       /* 28 bytes, 10 of them                  */
+        uint32_t enable;           /*   0..1                                */
+        uint32_t x, y, w, h;       /*   NOT range-checked at all            */
+        uint32_t mode;             /*   0..3                                */
+        int32_t  qp;               /*   mode==3: 0..51 ; else -32..31       */
+    } win[10];
+};
+```
+
+284 = 4 + 10 × 28 exactly, and the validated u32 indices are 1+7k … 7+7k for
+k = 0…9, which is where the ten-window count comes from. Error strings that
+pin the ranges: `"HD_H26XENC_ROI_WIN: enable(%d) is out-of-range(0~1)."`,
+`"HD_H26XENC_ROI_WIN: mode(%d) is not supported."`, `"HD_H26XENC_ROI_WIN: when
+mode=%u, qp(%d) is out-of-range(0~51)."`, `"HD_H26XENC_ROI_WIN: when mode=%d,
+qp(%d) is out-of-range(-32~31)."`.
+
+Note `x/y/w/h` get **no** validation — not against the frame, not against
+anything. Whatever a caller passes goes straight through.
+
+---
+
+## 2. Why driving the HDAL param from a helper process does not work
+
+`hd_videoenc_set` does **not** issue an ioctl for ROI. Case 0xc is:
+
+```c
+memcpy(cfg_base + port*0xab8 + 0x15c, p_param, 0x11c);   /* userspace shadow  */
+FUN_005c4d10(0x111, port, 0xf024, 1);                    /* set a dirty flag  */
+```
+
+and `FUN_005c4d10` (`device @ 0x005c4d10`) is nothing but
+
+```c
+*(u32 *)(cfg_base + port*0xab8 + (param_id - 0xf000)*4 + 0x3f8) = value;
+```
+
+— a write into a dirty-flag array indexed by `vendor_param_id - 0xf000`. The
+ROI payload never leaves `device`'s own address space at set time. Compare the
+params that *do* go out immediately, e.g. case 4 (`IN`):
+
+```c
+arg.path_id  = (0x111 << 16) | (n + 0x7f);   /* 0x0111_0080 for n = 1 */
+arg.param_id = 0x1011;  arg.len = 0x10;  arg.ptr = &payload;
+ioctl(isf_fd, 0xc0204905, &arg);
+```
+
+That `+ 0x7f` is worth pausing on: it independently corroborates the corrected
+ISF path-id encoding. Unit `0x0111` is **VideoEnc** — one unit, with every
+encode path as a *port* — ports below `0x80` are **out** ports, `0x80..0xff` are
+**in** ports, `0xffff` is unit ctrl. `HD_VIDEOENC_PARAM_IN` is an input-side
+param, so it lands on `0x01110080` / `0x01110081` / `0x01110083`, while
+out-side params such as `PATH_CONFIG` use the bare out index. The live
+`PATH & BIND` table (`in 0/1/3/7` ↔ `out 0/1/3/7`) matches.
+
+So the established `/dev/isf_flow0` protocol is confirmed, but there is **no
+arithmetic mapping** from HDAL param id to ISF param id — each case expands to
+its own hand-written set of ISF ids (`PATH_CONFIG` → `0xf000, 0xf005, 0xf03a,
+0xf004`; `IN` → `0x1011, 0x1013`). The vendor ids for the bit-allocation family
+are:
+
+| HDAL param | vendor id set by `hd_videoenc_set` |
+|---|---|
+| 6 `OUT_VUI` | `0xf040` |
+| 9 `OUT_USR_QP` | `0xf042` |
+| 0xa `OUT_SLICE_SPLIT` | `0xf041` |
+| 0xb `OUT_ENC_GDR` | `0xf03f` |
+| **0xc `OUT_ROI`** | **`0xf024`** |
+| 0xd `OUT_ROW_RC` | `0xf04a` |
+
+A separate process cannot replicate this: the 284-byte payload lives in
+`device`'s heap-side shadow and only a dirty flag marks it, so an outside helper
+would have to reproduce whatever later flush routine reads that shadow. **Route
+"small helper doing the ioctl directly" is not viable without further runtime
+RE** — and runtime RE is what bricked the camera last time.
+
+`OUT_USR_QP` (the per-CTU QP map) is worse: `device FUN_005cd150` case 9 copies
+16 bytes `{en, ?, map_addr(u64)}` and the validator insists
+`"HD_H26XENC_USR_QP: qp_map_addr is NULL."`. It needs a physically-addressable
+buffer the encoder can DMA. Not reachable from a shell script. **The ROI window
+is the practical lever; the QP map is not.**
+
+---
+
+## 3. The route that is reachable: `/proc/hdal/venc/cmd`
+
+`kflow_videoenc.ko` publishes a debug command node. `isf_vdoenc_proc_init`
+(`@ 0x00100ac4`) does `proc_mkdir("hdal/venc")` then `proc_create` for
+`info`, `cmd`, `help`, `top`, `dbglevel`, and the module's own help text says:
+
+```
+1. 'cat /proc/hdal/venc/info' will show all the videoenc info
+2. 'echo xxx > /proc/hdal/venc/cmd' can input command for some debug purpose
+   echo vdoenc setfixqp 0 1 26 26 > /proc/hdal/venc/cmd
+```
+
+**This is not theoretical — the node exists on this camera.** The live probe run
+of 2026-08-15 captured it (`dumps/probe1/02_hdal_tree.txt`):
+
+```
+/proc/hdal/venc:
+-r-xr-xr-x    1 root     root     0 Aug 15 22:40 cmd
+-r-xr-xr-x    1 root     root     0 Aug 15 22:40 dbglevel
+-r-xr-xr-x    1 root     root     0 Aug 15 22:40 help
+-r-xr-xr-x    1 root     root     0 Aug 15 22:40 info
+-r-xr-xr-x    1 root     root     0 Aug 15 22:40 top
+```
+
+**UNVERIFIED:** the mode is `0555` — no write bit. A write handler *is*
+registered (`isf_vdoenc_proc_cmd_write` is in the symbol table), and root with
+`CAP_DAC_OVERRIDE` can open a mode-less procfs file for writing, so `echo >`
+from an init script should work. Nobody has actually done it on this unit. The
+daemon logs the failure explicitly rather than continuing silently.
+
+`_isf_vdoenc_cmd_vdoenc` (`@ 0x00115820`) walks a 21-entry dispatch table at
+`vdoenc @ 0x0012f408` (`{const char *name; void (*fn)(char *); const char
+*help;}`, stride 0x18). The relevant rows:
+
+| # | name | handler | help |
+|---|---|---|---|
+| 07 | `setaq` | `0x0010fc74` | set AQ |
+| 12 | `setfixqp` | `0x001119d0` | `PathId Enable IFixQP PFixQP` |
+| **13** | **`setroi`** | **`0x00111b44`** | **`PathId RoiIndex Enable QP QPMode Coord_X Coord_Y Width Height`** |
+| 14 | `setsmartroi` | `0x00111d40` | `PathId Enable` |
+
+There is **no** `setusrqp` command — another reason the QP map is out of reach.
+
+### The other proc interface (`/proc/kdrv_vdocdc/`) does not reach ROI
+
+`kdrv_h26x.ko` publishes a second, lower-level proc tree —
+`kdrv_vdocdc_proc_init` creates `/proc/kdrv_vdocdc/{cmd, version, param,
+venc_dbglevel, aq, chn_info, utilization, jpg_*}` — and it does have writable
+nodes (`proc_cmd_write`, `proc_param_write`, `proc_aq_write`). None of them
+reaches ROI:
+
+| node | what it accepts | regional? |
+|---|---|---|
+| `cmd` | one verb, `BrcUpdateMode <n>` | no |
+| `aq` | `echo [mode] [i str1] [p str1] [i str2] [p str2] > /proc/kdrv_vdocdc/aq` | no — global AQ strength |
+| `param` | global codec tunables: `H264/H265RowRCStopFactor`, `RRCNDQPStep`, `RRCNDQPRange`, `RRCSyncRCQPCond`, `ESMVTh`, `MDMode`, `H264YCoefCostTh`, … | no |
+
+Useful adjacent knobs — `aq` in particular is a live, no-flash way to push
+global AQ strength up — but none of them lets us name a rectangle.
+`/proc/hdal/venc/cmd setroi` remains the only ROI route.
+
+### `NMR_VdoEnc_SetROI` (`kflow_videoenc.ko @ 0x00111a84`)
+
+Disassembly, not decompiler output:
+
+```
+00111a94  mov  w19,w0                  ; arg0 = path id (32-bit)
+00111a90  mov  x20,x1                  ; arg1 = pointer to ROI info
+00111a98  bl   NMR_VdoTrig_GetVidEncoder
+00111a9c  cbz  x20,<null path>         ; "[VDOENC][%d] Set ROI Info is NULL"
+00111aac  mov  w0,#0xbe8               ; per-path object stride
+00111ab8  mov  x2,#0xa8                ; <-- 168-byte struct
+00111abc  umaddl x3,w19,w0,x3          ; gNMRVdoEncObj + path*0xbe8
+00111ac0  add  x3,x3,#0x388            ;   + 0x388 = the ROI slot
+00111ac8  bl   memcpy
+00111acc  ldr  x4,[x21, #0x18]         ; encoder object callback
+00111ae0  mov  w0,#0xa                 ; cmd 10 = "ROI changed"
+00111ae4  blr  x4
+```
+
+So: `NMR_VdoEnc_SetROI(u32 path, const void *roi)` copies **168 bytes** into the
+per-path encoder object at `+0x388` and pokes the codec callback with command
+10. No bounds check on the payload, no scaling, no validation.
+
+### The kernel-side ROI struct (16-byte elements, not 28)
+
+`Cmd_VdoEnc_SetROI` (`@ 0x00111b44`) is the `setroi` handler. Its raw
+disassembly pins the layout exactly, because the debug print reads the fields
+back with sized loads:
+
+```
+00111bf4  ubfiz  x8,x2,#0x4,#0x20      ; x8 = RoiIndex * 16   <-- stride 16
+00111c08  ldr    w3,[x19, x8]          ; +0x00  u32  enable
+00111bfc  ldrh   w6,[x24, x8]          ; +0x04  u16  x        (x24 = base+4)
+00111bf8  ldrh   w7,[x25, x8]          ; +0x06  u16  y
+00111c10  ldrh   w8,[x20, x8]          ; +0x08  u16  w
+00111c0c  ldrh   w9,[x21, x8]          ; +0x0a  u16  h
+00111c04  ldrsb  w4,[x22, x8]          ; +0x0c  s8   qp
+00111c00  ldrb   w5,[x23, x8]          ; +0x0d  u8   qp_mode
+                                        ; +0x0e  u16  (unused)
+```
+
+with `x19 = sp+0x80` the struct base, and the frame zeroing `sp+0x80 … sp+0x127`
+covering exactly 0xa8 = 168 bytes — the same 168 the memcpy copies.
+168 = 10 × 16 + 8, i.e. **ten windows plus an 8-byte trailer**, matching HDAL's
+ten. The kernel packs into 16 bytes what HDAL exposes as 28.
+
+| field | offset | width | range |
+|---|---|---|---|
+| `enable` | +0x00 | u32 | 0..1 |
+| `x` | +0x04 | u16 | *(units unconfirmed — see below)* |
+| `y` | +0x06 | u16 | |
+| `w` | +0x08 | u16 | |
+| `h` | +0x0a | u16 | |
+| `qp` | +0x0c | s8 | mode 3: 0..51 absolute; else −32..31 delta |
+| `qp_mode` | +0x0d | u8 | 0..3 |
+| pad | +0x0e | u16 | |
+
+**Coordinate units: UNVERIFIED.** Nothing in `kflow_videoenc.ko` scales the
+rectangle, and the code that programs the hardware
+(`h26XEnc_setRoiCfg`, `h26XEnc_setUsrQPMap`, `h26xEnc_setSmartRoiCfg`) is an
+**undefined external symbol** in `kdrv_h26x.ko` — it lives in a codec blob we do
+not have. u16 fields admit both readings: 7680 needs 16 bits if these are
+pixels, and only 7 bits if they are 64×64 CTUs. `kdrv_h26x.ko` logs
+`"set ROI[%d/%d] , en = %d, win = (%u, %u, %u, %u), qp = (%d, %u), ret = %d"`
+but that string has no resolvable code reference in the module, so it does not
+settle it either. §7 gives the experiment that does.
+
+---
+
+## 4. The `setroi` command is broken on stock firmware
+
+`Cmd_VdoEnc_SetROI` parses its nine arguments with
+
+```
+00111ba8  add x1,x1,#0x648   -> "%d %d %d %d %d %d %d %d %d"
+00111be4  bl  sscanf_s
+```
+
+and the nine destination pointers, read straight off the argument registers, are
+
+| arg | register | address | field |
+|---|---|---|---|
+| PathId | x2 | `sp+0x78` | scratch |
+| RoiIndex | x3 | `sp+0x7c` | scratch |
+| Enable | x4 | `sp+0x80` | `win[0].enable` (u32) |
+| QP | x5 | `sp+0x8c` | `win[0].qp` (**s8**) |
+| QPMode | x6 | `sp+0x8d` | `win[0].qp_mode` (**u8**) |
+| Coord_X | x7 | `sp+0x84` | `win[0].x` (**u16**) |
+| Coord_Y | [sp+0] | `sp+0x86` | `win[0].y` (**u16**) |
+| Width | [sp+8] | `sp+0x88` | `win[0].w` (**u16**) |
+| Height | [sp+0x10] | `sp+0x8a` | `win[0].h` (**u16**) |
+
+Two consequences fall straight out of that table.
+
+**(a) Only window 0 is ever writable.** Every destination is `win[0]`; `RoiIndex`
+scales nothing on the write side (it only indexes the read-back print, via the
+`ubfiz` above). And the handler zeroes the entire 168-byte struct before
+parsing, so each `setroi` call replaces the whole ROI set with *one* window and
+nine disabled ones. One rectangle at a time, by construction.
+
+**(b) `QP` and `QPMode` always come out as 0.** Nine `%d` conversions write nine
+4-byte ints into fields that are 1 and 2 bytes wide, so the writes overlap. In
+format order the last one is Height at `+0x0a`; its four bytes cover `+0x0a`,
+`+0x0b` (the real h) **and `+0x0c`, `+0x0d` — qp and qp_mode**, which receive
+the high half of Height and are therefore 0 for any height below 65536.
+
+`kwrap.ko vsscanf_s @ 0x00109b70` confirms the widths: the no-qualifier arm is
+`*(int *)dst = value` (a 4-byte store), and separate arms exist for `h`
+(`*(short *)`) and `hh` (`*(char *)`), selected at `case 0x68` where the first
+`'h'` sets the short flag and a second `'h'` sets the char flag.
+
+So on stock firmware `echo vdoenc setroi 0 0 1 -6 1 0 760 7680 900` enables a
+window that requests a QP delta of **zero** — an ROI that reallocates nothing.
+The command reaches the encoder; it just can't carry a QP.
+
+### The fix: 26 bytes, in place
+
+Give each conversion the right length qualifier. The replacement is *exactly* the
+same length as the original, so no relocation, section size or symbol moves —
+this is the smallest possible change to a kernel module:
+
+```
+kflow_videoenc.ko  file offset 0x36688  (VMA 0x00136648)
+  before: "%d %d %d %d %d %d %d %d %d"     26 bytes
+  after:  "%d%d%d%hhd%hhd%hd%hd%hd%hd"     26 bytes
+```
+
+The spaces are droppable because numeric scanf conversions skip leading
+whitespace: `vsscanf_s` runs the `_ctype` space test (`(_ctype[c] >> 5) & 1`)
+before every numeric conversion. The NUL-delimited whole string occurs **exactly
+once** in the module (the same 9-int prefix appears inside 13-, 14- and 21-int
+format strings, which is why the build script asserts on the NUL-delimited form
+and the file offset, not on a bare substring).
+
+`kflow_videoenc.ko` carries **no module signature** (no `~Module signature
+appended~` trailer), so a byte patch does not break loading.
+
+### Why this route and not the others
+
+| route | verdict |
+|---|---|
+| **A. `/proc/hdal/venc/cmd setroi` + 26-byte `.ko` fix** | **Recommended.** Touches one string in `rootfs`; `app` untouched, so it layers on any existing build. `device` is never modified — and `device` dying is what bricked this camera. Worst case (module refuses to load) is no video, which reflashing fixes. Costs: one window only, and it needs a way to write to `/proc`. |
+| B. Patch `device` to call `hd_videoenc_set(path, 0xc, …)` | Rejected. There is no existing call to redirect, so it means injecting a code cave that builds a 284-byte struct and calls into HDAL — in the one process whose failure mode is a watchdog reboot loop. Buys 10 windows instead of 1. Not worth it until 1 window is proven insufficient. |
+| C. Standalone helper driving `/dev/isf_flow0` | Rejected on evidence: §2 shows ROI is not delivered by an ioctl at set time. Would require reverse-engineering the shadow-config flush first. |
+| D. Existing config path (Baichuan / CGI / config file) | **Does not exist.** No ROI string in `netserver`, `cgiserver.cgi` or `router`; no `hd_videoenc_set` call with param 0xc in `device`. |
+
+---
+
+## 5. How much a QP delta can actually buy
+
+From the live `RC` table, out 0 runs `CBR`, `bitrate 20971520`, `fr 20/1`, with
+`I(int/min/max) = (35/25/51)` and `P(int/min/max) = (35/25/51)`.
+
+Two consequences for choosing `qp`:
+
+- **The rate controller clamps QP to 25..51.** An ROI delta cannot push the
+  region below QP 25 no matter how negative it is. If the stream is operating
+  near 30, a −6 delta lands around 24 → clamped to 25, and anything beyond −5
+  is wasted. Start small and read the effect rather than reaching for −20.
+  **INFERRED:** that the ROI delta is applied before the RC clamp rather than
+  after it. Nothing we decompiled shows the order; §7.4 will show it as a
+  saturating effect if the clamp wins.
+- **AQ is already spending ±8 QP** (`max_delta 8 / min_delta -8` on out 0) on
+  its own per-block decisions, and JND is on top of that. The ROI delta composes
+  with those, so the *net* QP shift in the window will be smaller than the
+  number you set. This is another reason the first prove-out target should be
+  "is there a rectangle at all", not "is the rectangle exactly −6".
+
+---
+
+## 6. Per-game configuration
+
+The region moves with the field, so it has to be settable per recording without
+reflashing. Same shape as the netstate overrides: a plain file on the writable SD
+card, hot-reloaded by a daemon.
+
+```
+/etc/init.d/S37_RoiQp              runtime/roiqp/S37_RoiQp          (baked in)
+/etc/soccercam_roi.conf.default    runtime/roiqp/roi.conf.example   (baked in)
+/mnt/sda/soccercam/roi.conf        the per-game override            (editable)
+/mnt/sda/soccercam/roi.log         what was parsed, applied, echoed back
+```
+
+Format — flat `key=value`, integers only, `#` comments:
+
+```
+enable=1        # 0 = stock bit allocation
+path=0          # encode path; 0 = the 7680x2160 main stream
+x=0
+y=760
+w=7680
+h=900
+qp=-6           # negative = lower QP inside the window = more bits
+mode=1          # 3 => qp is absolute 0..51; 0/1/2 => delta -32..31
+frame_w=7680
+frame_h=2160
+```
+
+Validation is whole-file and fail-closed. A line that is not
+`^[a-z_]+=-?[0-9]+$`, an unknown key, a missing key, a value outside range, a
+window that does not fit inside `frame_w × frame_h`, or a file over 4 KB rejects
+the **entire** file with the reason logged. Nothing partial is ever applied. If a
+good config had already been applied and the file then goes bad, the daemon
+issues an explicit disable so the encoder returns to stock rather than keeping a
+stale bias.
+
+The daemon re-applies every 300 s as well as on change, because `device` tears
+the encode path down and rebuilds it on any stream-config change (resolution,
+bitrate, day/night), which zeroes the ROI struct. **INFERRED** — the teardown is
+visible in `device`'s path-config handling, but that the ROI is lost across it
+has not been observed.
+
+Every apply logs the kernel's own read-back line
+(`[VDOENC][n] Set ROI Index = …, QP = …, QPMode = …`). Against an unpatched
+module that line reads `QP = 0, QPMode = 0`, so the §4 bug is visible in the log
+rather than silently producing a no-op.
+
+**Open, and honestly unsolved: how the file gets onto the card.** Stock firmware
+has no shell (§5d of `FIRMWARE_PATCH_NOTES.md`) and nginx serves `/mnt/sda`
+read-only, so today the options are the same three the netstate overrides have —
+pull the SD card, use the temporary `tcpsvd` shell from the investigation build,
+or bake the default into the pak and reflash. Baking it in is why the format is
+one short file: switching fields is four numbers.
+
+---
+
+## 7. Prove-out
+
+Nothing below has been run. In order; stop at the first failure.
+
+### 7.0 Preconditions
+
+Camera recovered, `camera.env` filled in, a root shell on the camera (the
+investigation build's `tcpsvd` on 2323, or UART). Lock the exposure first, or
+every A/B comparison measures the weather instead of the encoder:
+
+```bash
+bash runtime/set_exposure.sh manual 110 20
+```
+
+### 7.1 Negative control on the *unpatched* firmware — proves the bug
+
+On stock (or any build without this patch):
+
+```sh
+echo vdoenc setroi 0 0 1 -6 1 0 760 7680 900 > /proc/hdal/venc/cmd
+dmesg | grep 'Set ROI Index' | tail -1
+```
+
+**Expected:** `... Enable = 1, QP = 0, QPMode = 0, Coord_X = 0, Coord_Y = 760,
+Width = 7680, Height = 900`. If QP reads back as −6, §4 is wrong, the stock
+command already works, and the `.ko` patch is unnecessary — say so and drop it.
+
+### 7.2 Baseline the encoder, and confirm the path index
+
+`/proc/hdal/venc/info` is the best instrument we have here: it is the driver's
+own report of the ROI/USER QP/SMART ROI/AQ state, so it answers "did the ROI
+land" directly rather than by inference. Take a baseline:
+
+```sh
+cat /proc/hdal/venc/info > /mnt/sda/soccercam/venc_before.txt
+```
+
+**Expected** (this is what the 2026-08-15 dump already shows, so it is a
+regression check rather than a discovery): `out 0` is `H265 7680x2160` in
+`PATH CONFIG` / `OUT BS`, and the `ROI` table is empty. Note that reading
+`info` also resets the work-status counters ("force reset and wait 1 secnod...")
+— harmless, but don't be surprised by it.
+
+If `out 0` is not the 7680×2160 H265 stream on your build, set `path=` in
+`roi.conf` to whichever index is.
+
+### 7.3 Flash and confirm the patch took
+
+```bash
+bash builds/build_roi_qp.sh \
+    IPC_NT15NA416MP.4906_2505072124.Reolink-Duo-3-PoE.16MP.REOLINK_soccercam_comprehensive.pak \
+    IPC_NT15NA416MP.4910_2505072124.Reolink-Duo-3-PoE.16MP.REOLINK_roiqp.pak
+python flash/flash_pak.py IPC_NT15NA416MP.4910_2505072124.Reolink-Duo-3-PoE.16MP.REOLINK_roiqp.pak
+```
+
+then on the camera:
+
+```sh
+echo vdoenc setroi 0 0 1 -6 1 0 760 7680 900 > /proc/hdal/venc/cmd
+dmesg | grep 'Set ROI Index' | tail -1
+cat /proc/hdal/venc/info | sed -n '/ROI ---/,/ROW RC/p'
+```
+
+**Expected, two independent readbacks:**
+
+1. dmesg echoes `QP = -6, QPMode = 1` with the rect unchanged. This is the
+   decisive check that the 26-byte patch works — on an unpatched module it
+   reads `QP = 0, QPMode = 0` (§7.1).
+2. The `ROI` table in `/proc/hdal/venc/info`, empty in the baseline, now has a
+   row for out 0 giving `qp_mode`, `win`, `qp` and `rect(x,y,w,h)`.
+
+Readback (2) is the one that settles the two things static analysis could not:
+whether `NMR_VdoEnc_SetROI`'s write actually reaches the encoder's live state at
+all, and **what units the driver believes the rectangle is in** — if the table
+reports back `rect(0,760,7680,900)` the driver stores what we sent, and §7.4
+then shows where it lands in the picture.
+
+If the write itself fails (`Permission denied`), the `0555` mode question of §3
+is the cause.
+
+### 7.4 A/B recordings and the QP heatmap
+
+Three recordings of the same static scene, 60 s each, camera untouched:
+
+| clip | config | purpose |
+|---|---|---|
+| `A_off.mp4` | `enable=0` | control |
+| `B_on.mp4` | `enable=1 qp=-6 mode=1` | the treatment |
+| `C_zero.mp4` | `enable=1 qp=0 mode=1` | second control — window present, no bias |
+
+`C` matters: it separates "the ROI window does something" from "enabling a window
+does something". A real effect appears in B-vs-A and is **absent** in C-vs-A.
+
+```bash
+# fetch via the /downloadfile/ unlock, then:
+uv run python reolink-firmware-patching/verify/roi_qp_heatmap.py \
+    A_off.mp4 B_on.mp4 --out roi_B_vs_A.png --frames 120 --expect 0,760,7680,900
+uv run python reolink-firmware-patching/verify/roi_qp_heatmap.py \
+    A_off.mp4 C_zero.mp4 --out roi_C_vs_A.png --frames 120
+```
+
+The tool averages the per-64×64-block mean |Laplacian| over N frames in each
+clip and divides. Lower QP preserves more high-frequency energy, so a working
+ROI is a rectangle of ratio > 1. Read the PNGs.
+
+**Expected:** `roi_B_vs_A.png` shows a band of ratio ≳ 1.05 inside the white
+outline and ≲ 1.0 outside it (bits have to come from somewhere — the sky and
+foreground should get *worse*, which is the point). `roi_C_vs_A.png` is flat
+within noise, and the printed `median` ratio there sets the noise floor that the
+B-vs-A effect has to clear.
+
+**This is also the units test.** If the rectangle in `roi_B_vs_A.png` lands under
+the white outline, `x/y/w/h` are pixels. If it lands in the top-left at roughly
+1/64 the size, they are 64×64 CTUs and every number in `roi.conf` must be
+divided by 64. If it lands nowhere, the ROI is not reaching the hardware.
+
+### 7.5 Confirm the bits actually moved
+
+Re-run the band-bits measurement from the original study on `A_off.mp4` and
+`B_on.mp4` at identical bitrate settings. **Expected:** the near/far-field bands
+gain share and the treeline/foreground bands lose it, with total bitrate
+unchanged (the rate controller is still capped). A rise in *total* bitrate
+instead of a redistribution means the ROI is bypassing rate control — back the
+`qp` delta off.
+
+### 7.6 Soak
+
+Leave a full game recording with `enable=1`. Afterwards check
+`/mnt/sda/soccercam/roi.log` for the periodic re-apply and, in particular, for
+any gap where the encoder path restarted. Confirm the recording is intact
+(`recover_mp4` reports it valid) — an ROI must not cost us the file.
+
+---
+
+## 8. What is still unknown
+
+| question | why it is open |
+|---|---|
+| Coordinate units (pixels vs CTUs) | The programming code is an external symbol in a codec blob. §7.4 settles it empirically. |
+| What `qp_mode` 0, 1 and 2 each mean | HDAL only validates that 3 is absolute and 0/1/2 are deltas. No string or code distinguishes them. |
+| `win[0]` byte `+0x0e..0x0f` and the 8-byte trailer at +0xa0 | Zeroed by the handler, never read anywhere we found. |
+| `HD_H26XENC_ROI_WIN.unknown0` (u32[0]) | Not validated, not printed, not obviously read. |
+| Whether `/proc/hdal/venc/cmd` accepts a write at mode `0555` | Needs the camera. |
+| Whether the ROI survives an encode-path restart | Assumed not; the daemon re-applies defensively. |
+| Whether the ROI delta is applied before or after the RC QP clamp (25..51) | Decides whether deltas beyond ~−5 do anything. §7.4 shows it as saturation. |
+| How the ROI delta composes with AQ (±8) and JND, both enabled | Nothing decompiled orders them. The net shift in the window will be smaller than the configured delta. |
+
+**Resolved by the live `/proc/hdal/venc/info` dump**, previously open: Smart ROI
+(`en 0`) and USER QP (`en 0`, no map) are both **off** in stock firmware, so
+there is no precedence question to settle with Smart ROI and no QP map already
+in play — an ROI window is the only per-region QP state on the encoder.
+
+---
+
+## 9. A correction to the existing notes
+
+`IOCTL_TRACE_FINDINGS.md` states: *"every build in this effort asserts that
+`loader`, `fdt`, `atf`, `uboot`, `kernel`, `ai` and (where unchanged) `app` are
+byte-identical to the base pak before the CRC is written."*
+
+**That is not true of the committed build scripts.** None of
+`build_bitrate_cap.sh`, `build_fps_cap.sh`, `build_soccercam_comprehensive.sh`,
+`build_soccercam_v2.sh`, `build_http_unlock.sh` or `build_netstate.sh` contains
+any such check, and `pak/pak_repack.py` merely copies unreplaced sections through
+without comparing them. The property has held because the repacker only touches
+the sections it is handed — which is a reason to believe it, not a guard that
+enforces it.
+
+`builds/build_roi_qp.sh` implements the guard properly: a pre-flight assertion
+that the swap set does not intersect the boot sections, and a post-build
+byte-for-byte SHA-256 comparison of `loader`, `fdt`, `atf`, `uboot`, `kernel`,
+`ai` and `app` between base and output, which **deletes the output and exits
+non-zero** on any difference. The other builders should be back-filled with the
+same check.

--- a/reolink-firmware-patching/docs/FIRMWARE_PATCH_NOTES.md
+++ b/reolink-firmware-patching/docs/FIRMWARE_PATCH_NOTES.md
@@ -808,10 +808,18 @@ picks these up.
 | `builds/build_netstate.sh` | + auto-toggle recording daemon (v1). `… <kbps> <user> <pass> <home_mac> [more]`. |
 | `builds/build_soccercam_v2.sh` | + free-space reserve (Patch v20 truncation fix) + netstate **v2** (stub cleanup). `… <kbps> <user> <pass> <reserve_gb> <home_mac> [more]`. |
 | `builds/build_soccercam_comprehensive.sh` | + boot-time power-cut recovery (`recover_mp4` + `S35_RecRecover`, video + best-effort AAC). `… <kbps> <user> <pass> <reserve_gb> <home_mac> [more]`. |
+| `builds/build_roi_qp.sh` | Encoder ROI / per-region QP bias, driven per game from a config file on the SD card (§16). `bash builds/build_roi_qp.sh <base.pak> <out.pak> [roi.conf]`. `rootfs`-only, so it layers on any of the above. **Built, not proven on hardware.** |
 | `builds/BUILD_LOG.md` | Artifact tracker: each built `.pak`'s sha256, CRC, and exact contents. |
 
 Each builder `assert`s the stock byte fingerprint at every patch site before
 writing, so a wrong firmware version fails loudly with the offending offset.
+
+Only `build_roi_qp.sh` additionally asserts that `loader`, `fdt`, `atf`,
+`uboot`, `kernel`, `ai` and `app` are byte-identical to the base pak, deleting
+its output on any difference. The other builders rely on `pak_repack.py` only
+touching the sections it is handed, which is a reason to believe the property
+rather than a guard that enforces it — they should be back-filled with the same
+check (see `ENCODER_ROI_QP.md` §8).
 
 The fps-dropdown patch was investigated and rejected as non-functional (it
 only lies in the dropdown — the encoder clamps to 20 fps at 16MP regardless).
@@ -830,6 +838,8 @@ See section 11 for why. No fps patch builder is committed.
 | `runtime/set_exposure.sh <mode> [shutter] [gain]` | Set ISP exposure mode via `SetIsp`. Modes: `auto`, `antismear`, `lownoise`, `manual`. |
 | `runtime/check_isp.sh` | Print current ISP state (exposure/shutter/gain/etc.). Use to confirm persistence after reboot. |
 | `runtime/probe_isp.sh` | Dump full GetIsp action=1 response (state + ranges). Use for discovery. |
+| `runtime/roiqp/S37_RoiQp` | Init fragment (needs the §16 flash): reads `/mnt/sda/soccercam/roi.conf` and applies the encoder ROI window. Fail-closed — a bad config leaves the encoder at stock. |
+| `runtime/roiqp/roi.conf.example` | The per-game ROI config format, commented. |
 
 ### Verification (`verify/`)
 | Script | What it checks |
@@ -839,6 +849,7 @@ See section 11 for why. No fps patch builder is committed.
 | `verify/get_performance.sh` | Poll GetPerformance to watch live codec bitrate, CPU, net throughput. |
 | `verify/fetch_and_analyze.sh [tag]` | Download latest recording via the unlocked HTTP path + ffprobe analysis. **The end-to-end validator** — proves what the encoder actually emits. |
 | `verify/test_recover_mp4.sh <good_recording.mp4> [chop_bytes]` | Build `recover_mp4` + round-trip a recording through clean-orphan and power-cut-orphan recovery; asserts byte-exact tables, bit-identical audio PCM, and clean decode. **The recovery correctness gate** — run before trusting a comprehensive build. |
+| `verify/roi_qp_heatmap.py <before.mp4> <after.mp4>` | Per-64×64-block detail-energy ratio between two recordings, rendered as a PNG. The A/B measurement for the ROI window (§16) — and the test that settles whether its coordinates are pixels or CTUs. |
 
 ### External dependencies
 - **WSL Ubuntu** 24.04 with `squashfs-tools` (`sudo apt install squashfs-tools`).
@@ -1426,6 +1437,33 @@ top -b -n 1 | head -5                                          # confirm CPU is 
 ffprobe -v error -select_streams v:0 -count_frames \
         -show_entries stream=nb_read_frames,duration,r_frame_rate -of default=nw=1 rec.mp4
 ```
+
+---
+
+## 16. Encoder ROI / per-region QP bias (STATIC ANALYSIS ONLY — see `ENCODER_ROI_QP.md`)
+
+Half the encoded bits go to the treeline and the foreground spectators; the ball
+and the players are starved. The encoder has ten ROI windows with per-window QP
+offsets, and **nothing in the stock userspace ever sets them** — `device`'s
+`hd_videoenc_set` (`FUN_005cd150`) has a working `case 0xc` (`OUT_ROI`) arm but
+no call site anywhere passes 0xc, and `netserver` / `cgiserver.cgi` / `router`
+contain no ROI string at all. So there is no config path to reuse.
+
+The reachable lever is the kernel module's own debug command,
+`echo vdoenc setroi <PathId> <RoiIndex> <Enable> <QP> <QPMode> <X> <Y> <W> <H>
+> /proc/hdal/venc/cmd`, which reaches `NMR_VdoEnc_SetROI` directly and bypasses
+`device` and HDAL entirely. That command is **broken on stock firmware**: its
+nine `%d` conversions write 4-byte ints into a struct whose `qp`/`qp_mode` are
+1 byte each, so the final `Height` write always zeroes them and the window
+requests no bit reallocation. `builds/build_roi_qp.sh` fixes it with a 26-byte,
+same-length format-string replacement inside `kflow_videoenc.ko`, and installs
+`S37_RoiQp`, which applies a per-game window from `/mnt/sda/soccercam/roi.conf`.
+
+**None of this has run on hardware** — the camera was bricked and offline
+throughout. `ENCODER_ROI_QP.md` carries the full evidence (structs, offsets,
+decompiled call sites), the route comparison, the open questions (coordinate
+units are *not* established), and the prove-out sequence including its negative
+controls.
 
 ---
 

--- a/reolink-firmware-patching/runtime/roiqp/S37_RoiQp
+++ b/reolink-firmware-patching/runtime/roiqp/S37_RoiQp
@@ -1,0 +1,221 @@
+#!/bin/sh
+# /etc/init.d/S37_RoiQp
+# Apply a per-game encoder ROI window (QP bias) to the main stream.
+#
+# The encoder supports 10 ROI windows with a per-window QP offset. Nothing in
+# the stock userspace ever sets them (see docs/ENCODER_ROI_QP.md); the only
+# reachable control is the kernel debug command
+#
+#     echo vdoenc setroi <PathId> <RoiIndex> <Enable> <QP> <QPMode> <X> <Y> <W> <H> \
+#         > /proc/hdal/venc/cmd
+#
+# which on stock firmware always lands QP=0/QPMode=0 because of an argument-width
+# bug in the kernel module. The pak this script ships in patches that; if you are
+# running it against an unpatched module the dmesg echo will read back
+# "QP = 0, QPMode = 0" and the window will have no effect. The log below records
+# that echo on every apply so the failure is visible rather than silent.
+#
+# Only ROI window 0 is reachable this way: the command's scanf targets are fixed
+# to window 0 and every call re-zeroes the whole 168-byte struct, so RoiIndex is
+# cosmetic and the other nine windows always read back disabled.
+#
+# Config (writable SD card, hot-reloaded):
+#   /mnt/sda/soccercam/roi.conf         - the active window; see roi.conf.example
+#   /mnt/sda/soccercam/roi.log          - what was parsed, applied, and echoed back
+#   /etc/soccercam_roi.conf.default     - baked-in fallback if roi.conf is absent
+#
+# Fail-closed: a missing, unparseable or out-of-range config never reaches the
+# encoder. If a good config had previously been applied, an invalid one disables
+# the window again, so the encoder returns to stock behaviour rather than keeping
+# a stale bias.
+
+CONF_DIR=/mnt/sda/soccercam
+CONF=$CONF_DIR/roi.conf
+DEFAULT=/etc/soccercam_roi.conf.default
+CMD=/proc/hdal/venc/cmd
+LOG=$CONF_DIR/roi.log
+LOG_MAX_BYTES=262144
+
+# Seconds between config checks, and between unconditional re-applies. The
+# re-apply exists because `device` tears the encode path down and rebuilds it
+# whenever the stream config changes (resolution, bitrate, day/night), which
+# drops the ROI struct back to zeros.
+POLL_INTERVAL=30
+REAPPLY_INTERVAL=300
+# How long to wait at boot for the videoenc module to publish its proc node.
+PROC_WAIT=180
+
+mkdir -p "$CONF_DIR" 2>/dev/null
+
+log() {
+    MSG="[$(date '+%F %T')] $*"
+    echo "$MSG"
+    mkdir -p "$CONF_DIR" 2>/dev/null || return 0
+    if [ -f "$LOG" ] && [ "$(wc -c <"$LOG" 2>/dev/null)" -gt $LOG_MAX_BYTES ]; then
+        mv "$LOG" "$LOG.old" 2>/dev/null
+    fi
+    echo "$MSG" >>"$LOG" 2>/dev/null
+}
+
+# --- validation -------------------------------------------------------------
+# Every field is checked before anything is written to /proc. REASON carries the
+# first failure so the log says which line was wrong, not just "invalid".
+
+REASON=""
+
+# in_range <value> <min> <max>  -- integer compare, tolerates a leading '-'
+in_range() {
+    [ "$1" -ge "$2" ] 2>/dev/null && [ "$1" -le "$3" ] 2>/dev/null
+}
+
+parse_conf() {
+    F="$1"
+    REASON=""
+    # defaults
+    C_ENABLE=""; C_PATH=0; C_X=""; C_Y=""; C_W=""; C_H=""; C_QP=""; C_MODE=""
+    C_FRAME_W=7680; C_FRAME_H=2160
+
+    [ -f "$F" ] || { REASON="no config file"; return 1; }
+    # A config bigger than this is not a config.
+    if [ "$(wc -c <"$F" 2>/dev/null)" -gt 4096 ]; then
+        REASON="config larger than 4096 bytes"
+        return 1
+    fi
+
+    while IFS= read -r RAW; do
+        # strip CR (files edited on Windows) and surrounding blanks
+        LINE=$(echo "$RAW" | tr -d '\r' | sed 's/^[ \t]*//; s/[ \t]*$//')
+        [ -z "$LINE" ] && continue
+        case "$LINE" in \#*) continue ;; esac
+        if ! echo "$LINE" | grep -qE '^[a-z_]+=-?[0-9]+$'; then
+            REASON="malformed line: $LINE"
+            return 1
+        fi
+        K=${LINE%%=*}
+        V=${LINE#*=}
+        case "$K" in
+            enable)  C_ENABLE=$V ;;
+            path)    C_PATH=$V ;;
+            x)       C_X=$V ;;
+            y)       C_Y=$V ;;
+            w)       C_W=$V ;;
+            h)       C_H=$V ;;
+            qp)      C_QP=$V ;;
+            mode)    C_MODE=$V ;;
+            frame_w) C_FRAME_W=$V ;;
+            frame_h) C_FRAME_H=$V ;;
+            *)       REASON="unknown key: $K"; return 1 ;;
+        esac
+    done <"$F"
+
+    for N in enable x y w h qp mode; do
+        eval "VAL=\$C_$(echo $N | tr 'a-z' 'A-Z')"
+        [ -n "$VAL" ] || { REASON="missing key: $N"; return 1; }
+    done
+
+    in_range "$C_ENABLE" 0 1     || { REASON="enable out of range (0..1): $C_ENABLE"; return 1; }
+    in_range "$C_PATH"   0 7     || { REASON="path out of range (0..7): $C_PATH"; return 1; }
+    in_range "$C_MODE"   0 3     || { REASON="mode out of range (0..3): $C_MODE"; return 1; }
+    in_range "$C_FRAME_W" 16 65535 || { REASON="frame_w out of range: $C_FRAME_W"; return 1; }
+    in_range "$C_FRAME_H" 16 65535 || { REASON="frame_h out of range: $C_FRAME_H"; return 1; }
+
+    # QP semantics come from the HDAL validator: mode 3 is an absolute QP, the
+    # other modes are a delta. Enforcing both keeps a typo from silently
+    # becoming a legal-but-wrong value.
+    if [ "$C_MODE" -eq 3 ]; then
+        in_range "$C_QP" 0 51 || { REASON="qp out of range for mode=3 (0..51): $C_QP"; return 1; }
+    else
+        in_range "$C_QP" -32 31 || { REASON="qp out of range for mode=$C_MODE (-32..31): $C_QP"; return 1; }
+    fi
+
+    # Geometry. The window must be a real rectangle inside the frame. The kernel
+    # struct stores x/y/w/h as u16, so 65535 is the hard ceiling regardless.
+    in_range "$C_X" 0 65535 || { REASON="x out of range: $C_X"; return 1; }
+    in_range "$C_Y" 0 65535 || { REASON="y out of range: $C_Y"; return 1; }
+    in_range "$C_W" 1 65535 || { REASON="w must be >= 1: $C_W"; return 1; }
+    in_range "$C_H" 1 65535 || { REASON="h must be >= 1: $C_H"; return 1; }
+    if [ $((C_X + C_W)) -gt "$C_FRAME_W" ]; then
+        REASON="x+w ($((C_X + C_W))) exceeds frame_w ($C_FRAME_W)"
+        return 1
+    fi
+    if [ $((C_Y + C_H)) -gt "$C_FRAME_H" ]; then
+        REASON="y+h ($((C_Y + C_H))) exceeds frame_h ($C_FRAME_H)"
+        return 1
+    fi
+    return 0
+}
+
+# --- apply ------------------------------------------------------------------
+
+APPLIED=0
+
+# write_roi <path> <enable> <qp> <mode> <x> <y> <w> <h>
+write_roi() {
+    # RoiIndex (the second argument) is passed as 0: the command only ever
+    # writes window 0 whatever you put here.
+    if printf 'vdoenc setroi %s 0 %s %s %s %s %s %s %s\n' \
+            "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" >"$CMD" 2>/dev/null; then
+        # The kernel prints exactly what it parsed. Echo it into our log so a
+        # mismatch (e.g. running against an unpatched module, where QP and
+        # QPMode always come back 0) is recorded instead of assumed away.
+        ECHOED=$(dmesg 2>/dev/null | grep 'Set ROI Index' | tail -1)
+        log "applied: path=$1 enable=$2 qp=$3 mode=$4 rect=($5,$6 ${7}x${8})"
+        [ -n "$ECHOED" ] && log "  kernel: $ECHOED"
+        return 0
+    fi
+    log "ERROR: write to $CMD failed (is the node writable? are we root?)"
+    return 1
+}
+
+disable_roi() {
+    write_roi "${1:-0}" 0 0 0 0 0 1 1 && APPLIED=0
+}
+
+run() {
+    I=0
+    while [ ! -e "$CMD" ] && [ $I -lt $PROC_WAIT ]; do sleep 1; I=$((I + 1)); done
+    if [ ! -e "$CMD" ]; then
+        log "$CMD never appeared after ${PROC_WAIT}s; giving up (encoder left at stock)"
+        return
+    fi
+    log "===== roi/qp daemon start ====="
+
+    LAST_SIG=""
+    SINCE_APPLY=$REAPPLY_INTERVAL
+    while :; do
+        SRC="$CONF"
+        [ -f "$SRC" ] || SRC="$DEFAULT"
+        SIG=$(md5sum "$SRC" 2>/dev/null | cut -d' ' -f1)
+        [ -z "$SIG" ] && SIG="absent"
+
+        if [ "$SIG" != "$LAST_SIG" ] || [ $SINCE_APPLY -ge $REAPPLY_INTERVAL ]; then
+            if [ "$SIG" != "$LAST_SIG" ]; then
+                log "config $SRC changed (md5 $SIG)"
+            fi
+            if parse_conf "$SRC"; then
+                if [ "$C_ENABLE" -eq 1 ]; then
+                    write_roi "$C_PATH" 1 "$C_QP" "$C_MODE" \
+                              "$C_X" "$C_Y" "$C_W" "$C_H" && APPLIED=1
+                else
+                    log "config disables the window"
+                    disable_roi "$C_PATH"
+                fi
+            else
+                log "REJECTED $SRC: $REASON"
+                if [ $APPLIED -eq 1 ]; then
+                    log "  reverting to stock (disabling previously applied window)"
+                    disable_roi "$C_PATH"
+                fi
+            fi
+            LAST_SIG="$SIG"
+            SINCE_APPLY=0
+        fi
+
+        sleep $POLL_INTERVAL
+        SINCE_APPLY=$((SINCE_APPLY + POLL_INTERVAL))
+    done
+}
+
+( run ) &
+disown 2>/dev/null
+exit 0

--- a/reolink-firmware-patching/runtime/roiqp/roi.conf.example
+++ b/reolink-firmware-patching/runtime/roiqp/roi.conf.example
@@ -1,0 +1,57 @@
+# Encoder ROI window — one region of the 7680x2160 main stream gets a QP bias.
+#
+# Copy to /mnt/sda/soccercam/roi.conf on the camera. S37_RoiQp re-reads it
+# within 30 s of any change; no reboot and no reflash. The same file baked into
+# the pak at /etc/soccercam_roi.conf.default is used when roi.conf is absent.
+#
+# Format: one "key=value" per line, integers only, '#' comments, blank lines OK.
+# ANY malformed line, unknown key, missing key or out-of-range value rejects the
+# WHOLE file — the encoder is left at (or returned to) stock behaviour. Nothing
+# is partially applied.
+#
+# Only ONE window is settable (see docs/ENCODER_ROI_QP.md): the kernel command
+# always writes window 0 and zeroes the other nine.
+#
+# ---------------------------------------------------------------------------
+# enable   0 = no ROI (stock bit allocation), 1 = apply the window below
+# path     encode path index. 0 = main stream (confirmed on this unit: the live
+#          /proc/hdal/venc/info shows out 0 = H265 7680x2160, out 1 = 1536x432,
+#          out 3 = 2560x720, out 7 = JPEG snapshot). Re-check any time the
+#          stream layout changes:
+#            cat /proc/hdal/venc/info
+#          That same file is how you confirm a window actually landed — the ROI
+#          table is empty on stock firmware and gains a row once one is set.
+# x,y,w,h  the window. UNITS ARE NOT YET CONFIRMED ON HARDWARE — the kernel
+#          struct stores them as u16, which admits either pixels or CTUs. The
+#          values below assume PIXELS. The prove-out in docs/ENCODER_ROI_QP.md
+#          settles it: if the effect shows up at 1/64 the requested size in the
+#          top-left corner, the units are 64x64 CTUs and every number here must
+#          be divided by 64.
+# qp       QP bias. Negative = lower QP inside the window = MORE bits = the
+#          thing we want over the pitch. Range depends on mode (below).
+#          Keep it small. The live encoder state (dumps/probe2/venc_info.txt)
+#          shows the main stream running CBR with I/P QP clamped to 25..51, and
+#          AQ already spending +/-8 QP of its own with JND on top. A delta much
+#          past -5 is likely to saturate against the RC floor and buy nothing.
+# mode     0..3. Mode 3 makes qp an ABSOLUTE QP (0..51). Modes 0/1/2 make it a
+#          DELTA (-32..31); the difference between 0, 1 and 2 is not documented
+#          in anything we have decompiled. Start with mode=1 and a small delta.
+# frame_w  frame size used for the "window must fit inside the frame" check.
+# frame_h  Defaults 7680x2160; change only if the stream geometry changes.
+# ---------------------------------------------------------------------------
+#
+# The band below is the playing surface on the Spencerport framing: the pitch
+# occupies roughly y=760..1660 across the full width, with sky above and the
+# spectator foreground below. Re-measure per field — the camera is aimed
+# differently at each one, which is the whole reason this is a config file.
+
+enable=1
+path=0
+x=0
+y=760
+w=7680
+h=900
+qp=-6
+mode=1
+frame_w=7680
+frame_h=2160

--- a/reolink-firmware-patching/verify/roi_qp_heatmap.py
+++ b/reolink-firmware-patching/verify/roi_qp_heatmap.py
@@ -1,0 +1,140 @@
+"""Per-block detail-energy heatmap for A/B-testing the encoder ROI window.
+
+The camera gives us no per-CTU QP readout, and no HEVC tool we have decodes one
+either. What a QP change does leave behind is a change in preserved detail: a
+block coded at a lower QP keeps more high-frequency energy. So instead of
+reading QP, measure it — decode two recordings of the *same static scene*
+(ROI off, then ROI on), compute the mean absolute Laplacian per block, and
+divide. A working ROI window shows up as a rectangle in the ratio map.
+
+This is also how the units question gets settled. If the rectangle lands where
+the config asked for it, x/y/w/h are pixels. If it lands in the top-left at
+1/64 the requested size, they are 64x64 CTUs.
+
+Both clips must be shot with the scene and the exposure locked, or the ratio map
+measures the weather. Use runtime/set_exposure.sh manual before recording.
+
+Usage:
+    python roi_qp_heatmap.py before.mp4 after.mp4 --out heatmap.png
+    python roi_qp_heatmap.py before.mp4 after.mp4 --out heatmap.png \\
+        --frames 120 --block 64 --expect 0,760,7680,900
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import av
+import numpy as np
+from PIL import Image, ImageDraw
+
+# 4-neighbour Laplacian. Absolute response averaged over a block is a cheap,
+# reference-free stand-in for "how much detail survived quantisation".
+_KERNEL_OFFSETS = ((-1, 0), (1, 0), (0, -1), (0, 1))
+
+
+def block_detail(gray: np.ndarray, block: int) -> np.ndarray:
+    """Mean |Laplacian| per block x block tile of a single-channel frame."""
+    lap = -4.0 * gray
+    for dy, dx in _KERNEL_OFFSETS:
+        lap += np.roll(np.roll(gray, dy, axis=0), dx, axis=1)
+    energy = np.abs(lap)
+    # Drop the 1px wrap-around border so np.roll's edge artefacts stay out.
+    energy[0, :] = energy[-1, :] = energy[:, 0] = energy[:, -1] = 0.0
+    h, w = energy.shape
+    bh, bw = h // block, w // block
+    trimmed = energy[: bh * block, : bw * block]
+    return trimmed.reshape(bh, block, bw, block).mean(axis=(1, 3))
+
+
+def accumulate(path: str, frames: int, block: int) -> tuple[np.ndarray, int]:
+    """Average the per-block detail map over the first `frames` decoded frames."""
+    total: np.ndarray | None = None
+    count = 0
+    with av.open(path) as container:
+        stream = container.streams.video[0]
+        stream.thread_type = "AUTO"
+        for frame in container.decode(stream):
+            gray = frame.to_ndarray(format="gray").astype(np.float32)
+            tile = block_detail(gray, block)
+            total = tile if total is None else total + tile
+            count += 1
+            if count >= frames:
+                break
+    if total is None or count == 0:
+        raise SystemExit(f"no frames decoded from {path}")
+    return total / count, count
+
+
+def render(ratio: np.ndarray, block: int, out: str, expect: str | None) -> None:
+    """Write the ratio map as a PNG, red = more detail after, blue = less."""
+    # Centre the colour scale on 1.0 and clip at +/-25%, which is a large effect
+    # for a handful of QP steps; anything beyond that saturates.
+    span = 0.25
+    norm = np.clip((ratio - 1.0) / span, -1.0, 1.0)
+    rgb = np.zeros((*norm.shape, 3), dtype=np.uint8)
+    pos, neg = np.clip(norm, 0, 1), np.clip(-norm, 0, 1)
+    base = 40.0
+    rgb[..., 0] = (base + pos * (255 - base)).astype(np.uint8)
+    rgb[..., 2] = (base + neg * (255 - base)).astype(np.uint8)
+    rgb[..., 1] = base
+
+    img = Image.fromarray(rgb).resize(
+        (norm.shape[1] * 4, norm.shape[0] * 4), Image.NEAREST
+    )
+    if expect:
+        try:
+            ex, ey, ew, eh = (int(v) for v in expect.split(","))
+        except ValueError:
+            raise SystemExit("--expect wants x,y,w,h in pixels") from None
+        scale = 4.0 / block
+        draw = ImageDraw.Draw(img)
+        draw.rectangle(
+            [ex * scale, ey * scale, (ex + ew) * scale - 1, (ey + eh) * scale - 1],
+            outline=(255, 255, 255),
+            width=2,
+        )
+    img.save(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("before", help="recording with the ROI disabled (control)")
+    ap.add_argument("after", help="recording with the ROI enabled")
+    ap.add_argument("--out", default="roi_heatmap.png", help="output PNG")
+    ap.add_argument("--frames", type=int, default=120, help="frames to average")
+    ap.add_argument("--block", type=int, default=64, help="block size in pixels")
+    ap.add_argument(
+        "--expect",
+        default=None,
+        help="x,y,w,h in pixels — drawn as a white outline for comparison",
+    )
+    args = ap.parse_args()
+
+    a, na = accumulate(args.before, args.frames, args.block)
+    b, nb = accumulate(args.after, args.frames, args.block)
+    if a.shape != b.shape:
+        raise SystemExit(f"geometry differs: {a.shape} vs {b.shape}")
+
+    # Guard against divide-by-zero on flat blocks (clipped sky at night).
+    floor = max(float(np.median(a)) * 1e-3, 1e-6)
+    ratio = b / np.maximum(a, floor)
+
+    render(ratio, args.block, args.out, args.expect)
+
+    rows = ratio.mean(axis=1)
+    print(f"decoded {na} + {nb} frames, blocks {ratio.shape[0]}x{ratio.shape[1]}")
+    print(
+        f"ratio: min {ratio.min():.3f}  median {np.median(ratio):.3f}  max {ratio.max():.3f}"
+    )
+    print("per-row-band mean ratio (row = y // block):")
+    for i in range(0, len(rows), max(1, len(rows) // 16)):
+        y = i * args.block
+        print(f"  y={y:5d}  {rows[i]:.3f}")
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stacked on #126.

A bitrate study on real footage found ~50–55% of encoded bits go to the treeline and foreground spectators, while sky takes 8–13% despite 44% of the frame. The ball and players are starved. This makes bit allocation steerable per game.

## The route the design note proposed does not exist

`APP_REPLACEMENT_DESIGN.md:216` assumed we'd drive `HD_H26XENC_ROI_WIN` from `device`. `device` does have a working ROI arm at `case 0xc` (`FUN_005cd150`) — but all 33 call sites were enumerated and the param constant recovered at every one: **nothing ever passes 0xc**. The arm issues no ioctl at all; it memcpys into a userspace shadow and sets a dirty flag, which no outside process can replicate. `netserver`, `cgiserver.cgi` and `router` contain zero ROI strings. There is no config path.

## What is reachable — with a 26-byte fix

`/proc/hdal/venc/cmd setroi` in `kflow_videoenc.ko`, which is **broken as shipped**. Its `vsscanf_s` format string is nine `%d` — nine 4-byte writes into a struct of `u16 x/y/w/h`, `s8 qp`, `u8 mode`. The final `Height` write at `+0x0a` spills over `qp` and `qp_mode`, so the command physically cannot carry a QP value.

Same-length format-string swap at file offset `0x36688`:
`"%d %d %d %d %d %d %d %d %d"` → `"%d%d%d%hhd%hhd%hd%hd%hd%hd"`

Spaces are droppable because `vsscanf_s` runs the ctype space skip before every numeric conversion (`kwrap.ko vsscanf_s @ 0x00109b70`). Module carries no signature. **`device` is never touched.**

## Live evidence upgraded this from inference to observation

`/proc/hdal/venc/info` captured from the running camera: empty ROI table, `USER QP en=0`, `SMART ROI en=0`, while `AQ`, `ROW RC` and `JND` are all on. Two consequences: "AQ only" in the design note is really **AQ + Row RC + JND**, and the RC table's QP floor is **25**, so deltas beyond about −5 saturate. Both are documented and the floor is a config comment.

## Verified vs not

Off-camera: clean build on stock 4867, CRC matches, all seven non-rootfs sections SHA-identical, repacked `.ko` patched at unchanged size, a flipped kernel byte trips the guard, re-patching an already-patched pak aborts with no output file, validator exercised on 14 fixtures including a shell-injection attempt.

**Not verified — anything needing the camera.** Whether the `.ko` loads, whether the `0555` proc node accepts a write, whether the ROI reaches the encoder, and **what the coordinates mean** (pixels vs CTUs is genuinely unresolved; the programming code is an external symbol in a codec blob). §7 is the prove-out.

Also: only one window is settable — the scanf targets are fixed to `win[0]`.

## Process finding

`IOCTL_TRACE_FINDINGS.md` claimed every builder asserts the boot chain is byte-identical. **None of the six committed builders does**, and `pak_repack.py` doesn't compare either. `build_roi_qp.sh` is the first to implement it; §9 recommends back-filling the others. (The chain did survive — separately verified by SHA-256 across all five paks — but by luck, not by a guard.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRurxvFA57JEacBJ2qbdoK