### PR TITLE
firmware: hard-fail any pak that would record on the home network

### DIFF
--- a/reolink-firmware-patching/runtime/camsh.py
+++ b/reolink-firmware-patching/runtime/camsh.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Run commands on the camera's probe shell, with destructive ones refused.
+
+The investigation builds start `tcpsvd -vE 0.0.0.0 2323 /bin/sh`, which gives
+an unauthenticated root shell that survives `device` dying. That is the reason
+recovery from the 2026-08-16 outage took minutes instead of waiting on a UART
+cable, and it is also a loaded gun: the same shell has write access to
+`/mnt/sda`, which is where every recording lives.
+
+On 2026-08-16 a cleanup step ran `rm -f /mnt/sda/Mp4Record/*/*.mp4` intending to
+remove one test clip. The glob matched everything -- 236.7 GB across 20 date
+directories. The footage turned out to be archived on the server, so nothing was
+ultimately lost, but that was luck, not design.
+
+This module is the only sanctioned way to drive that shell. It refuses the
+class of command that caused the incident *before* anything reaches the camera,
+because a rule that nothing enforces is a comment. Cleanup is expected to name
+exact paths; if that is inconvenient, leave the files.
+
+Usage as a library:
+
+    from camsh import sh, CameraCommandRefused
+    print(sh("cat /proc/uptime"))
+
+Usage as a CLI:
+
+    python camsh.py 192.168.86.24 "cat /proc/uptime; ls /mnt/sda"
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+import sys
+
+DEFAULT_HOST = "192.168.86.24"
+DEFAULT_PORT = 2323
+
+# Paths that hold the only on-camera copy of anything we care about. Nothing
+# this tool sends may delete, move, truncate or reformat inside them.
+PROTECTED = (
+    "/mnt/sda/Mp4Record",
+    "/mnt/para",
+    "/dev/mtd",
+    "/dev/mmcblk",
+    "/dev/hd/sda",
+)
+
+# (regex, why) -- checked against the whole command string.
+REFUSALS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"\brm\b[^\n]*[*?\[]"),
+        "rm with a wildcard. This is the exact command that wiped 236.7 GB of "
+        "recordings on 2026-08-16. Delete by exact full path or not at all.",
+    ),
+    (
+        re.compile(r"\brm\b[^\n]*(-[a-zA-Z]*r|--recursive)"),
+        "recursive rm. Remove individual files by exact path instead.",
+    ),
+    (
+        re.compile(r"\b(mkfs|fdisk|parted|flash_erase|nandwrite|dd)\b"),
+        "a command that writes raw block or flash devices. Flashing goes "
+        "through flash/flash_pak.py, which verifies a CRC first.",
+    ),
+    (
+        re.compile(r"\b(reboot|halt|poweroff|shutdown)\b"),
+        "a reboot. Reboot deliberately and explicitly, not as a side effect of "
+        "a command batch -- the camera boots recording-enabled and writes a "
+        "~200 MB stub before the netstate daemon disables it.",
+    ),
+    (
+        re.compile(r">\s*/dev/(mtd|mmcblk|hd/sda)"),
+        "a redirect onto a raw device node.",
+    ),
+    (
+        re.compile(r"\b(mv|cp)\b[^\n]*/mnt/sda/Mp4Record"),
+        "moving or overwriting inside Mp4Record.",
+    ),
+    (
+        re.compile(r"\btouch\b[^\n]*/mnt/sda/netstate/override"),
+        "asserting the netstate override. That flag makes the daemon yield and "
+        "leaves the camera recording at home; see "
+        "verify/check_recording_default.sh.",
+    ),
+)
+
+
+class CameraCommandRefused(RuntimeError):
+    """Raised instead of sending a command that could destroy data."""
+
+
+def check(cmd: str) -> None:
+    """Raise CameraCommandRefused if `cmd` is in the forbidden class."""
+    for pattern, why in REFUSALS:
+        if pattern.search(cmd):
+            raise CameraCommandRefused(
+                f"refusing to send {why}\n  command: {cmd.strip()[:200]}"
+            )
+
+    # A destructive verb aimed at a protected path, even without a wildcard.
+    if re.search(r"\b(rm|mv|truncate|shred)\b", cmd):
+        for path in PROTECTED:
+            if path in cmd:
+                raise CameraCommandRefused(
+                    f"refusing to send a destructive command touching {path}\n"
+                    f"  command: {cmd.strip()[:200]}"
+                )
+
+
+def sh(
+    cmd: str, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, timeout: int = 40
+) -> str:
+    """Send one command set to the probe shell and return its combined output.
+
+    The listener runs `sh` per connection: it reads stdin to EOF, executes, and
+    exits. So one call is one batch, and state does not carry between calls.
+    """
+    check(cmd)
+    s = socket.create_connection((host, port), timeout=timeout)
+    try:
+        s.sendall((cmd + "\n").encode())
+        s.shutdown(socket.SHUT_WR)
+        chunks = []
+        try:
+            while True:
+                buf = s.recv(65536)
+                if not buf:
+                    break
+                chunks.append(buf)
+        except TimeoutError:
+            pass
+    finally:
+        s.close()
+    return b"".join(chunks).decode(errors="replace")
+
+
+def _selftest() -> int:
+    blocked = [
+        "rm -f /mnt/sda/Mp4Record/*/*.mp4",
+        "rm -rf /mnt/sda/stitchprobe",
+        "rm /mnt/sda/Mp4Record/2026-08-16/clip.mp4",
+        "dd if=/dev/zero of=/dev/mtd5",
+        "reboot",
+        "touch /mnt/sda/netstate/override",
+        "cat /proc/uptime; rm -f /tmp/*.bin",
+    ]
+    allowed = [
+        "cat /proc/uptime",
+        "rm -f /tmp/dev.log",
+        "ls -la /mnt/sda/Mp4Record",
+        "cat /proc/hdal/venc/top",
+        "md5sum /etc/init.d/start_app",
+    ]
+    fails = 0
+    for c in blocked:
+        try:
+            check(c)
+            print(f"  [FAIL] should have been refused: {c}")
+            fails += 1
+        except CameraCommandRefused:
+            print(f"  [ok]   refused: {c}")
+    for c in allowed:
+        try:
+            check(c)
+            print(f"  [ok]   allowed: {c}")
+        except CameraCommandRefused as e:
+            print(f"  [FAIL] should have been allowed: {c}  ({e})")
+            fails += 1
+    print(
+        f"\n{len(blocked) + len(allowed) - fails}/{len(blocked) + len(allowed)} gates passed"
+    )
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] == "selftest":
+        sys.exit(_selftest())
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(2)
+    try:
+        print(sh(sys.argv[2], host=sys.argv[1]))
+    except CameraCommandRefused as exc:
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        sys.exit(3)

--- a/reolink-firmware-patching/verify/check_recording_default.sh
+++ b/reolink-firmware-patching/verify/check_recording_default.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# check_recording_default.sh -- refuse any pak that would record at home.
+#
+# The camera must idle on the home network and record everywhere else. That is
+# S99_NetState's job: it polls the default-gateway MAC and disables recording on
+# a confirmed home MAC. The daemon has one kill switch --
+# /mnt/sda/netstate/override -- whose presence makes it yield entirely, handing
+# recording control back to whatever the stored config says.
+#
+# That kill switch is fine as an operator action. It is NOT fine baked into a
+# build. A build that asserts the override at boot silently defeats home
+# detection on every power-on, and the failure is invisible: recording simply
+# stays on at home and fills the card with footage of a garage.
+#
+# That is exactly what happened. The 2026-08-16 investigation builds carried an
+# init script (S36_StitchProbe) that ran `touch /mnt/sda/netstate/override`
+# twice during boot. Every boot from 13:31 onward logged
+# "override present -- daemon yields", and the camera recorded at home until it
+# was noticed by hand. 34 stub files had accumulated by the time the flag was
+# removed.
+#
+# This runs against a BUILT pak, before flashing, and exits non-zero on any
+# violation. It is a gate, not a warning -- per the project rule that in an
+# automated chain a warning that nothing reads is not a guard.
+#
+# Usage:
+#   verify/check_recording_default.sh <path/to.pak>
+#
+# Requires: unsquashfs (mtd-utils/squashfs-tools). On Windows run it under WSL.
+
+set -euo pipefail
+
+PAK="${1:-}"
+if [ -z "$PAK" ] || [ ! -f "$PAK" ]; then
+    echo "usage: $0 <path/to.pak>" >&2
+    exit 2
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> extracting rootfs from $(basename "$PAK")"
+python3 - "$PAK" "$WORK/rootfs.bin" <<'PY'
+import sys
+sys.path.insert(0, __import__("os").path.join(__import__("os").path.dirname(sys.argv[0]) or ".", ".."))
+from pak import pak  # reolink-firmware-patching/pak/pak.py
+data = open(sys.argv[1], "rb").read()
+for s in pak.parse(data):
+    if s["name"] == "rootfs" and s["size"]:
+        open(sys.argv[2], "wb").write(data[s["offset"]: s["offset"] + s["size"]])
+        break
+else:
+    raise SystemExit("no rootfs section in pak")
+PY
+
+unsquashfs -d "$WORK/rfs" "$WORK/rootfs.bin" > /dev/null
+INIT="$WORK/rfs/etc/init.d"
+FAIL=0
+
+echo "==> 1) the netstate daemon must be present"
+if ls "$INIT" | grep -q '^S99_NetState$'; then
+    echo "    ok: S99_NetState installed"
+else
+    echo "    FAIL: no S99_NetState -- nothing would ever disable recording at home"
+    FAIL=1
+fi
+
+echo "==> 2) no init script may assert the override kill switch"
+HITS="$(grep -rln 'netstate/override' "$INIT" 2>/dev/null || true)"
+if [ -z "$HITS" ]; then
+    echo "    ok: no init script references the override flag"
+else
+    # Referencing it to *read* it is the daemon's own job; asserting it is not.
+    for f in $HITS; do
+        if grep -qE '^[^#]*(touch|>|cp|echo).*netstate/override' "$f"; then
+            echo "    FAIL: $(basename "$f") asserts /mnt/sda/netstate/override"
+            grep -nE '^[^#]*(touch|>|cp|echo).*netstate/override' "$f" | sed 's/^/           /'
+            FAIL=1
+        else
+            echo "    ok: $(basename "$f") only reads the flag"
+        fi
+    done
+fi
+
+echo "==> 3) the daemon must carry a home MAC list"
+NS="$INIT/S99_NetState"
+if [ -f "$NS" ]; then
+    MACS="$(grep -E '^HOME_MACS_DEFAULT=' "$NS" | head -1 | cut -d'"' -f2 || true)"
+    if [ -n "$MACS" ]; then
+        echo "    ok: HOME_MACS_DEFAULT=\"$MACS\""
+    else
+        echo "    FAIL: HOME_MACS_DEFAULT is empty -- every network looks like away"
+        FAIL=1
+    fi
+fi
+
+echo
+if [ "$FAIL" -ne 0 ]; then
+    echo "REFUSING: this pak would record on the home network."
+    exit 1
+fi
+echo "PASS: recording defaults to disabled at home."


### PR DESCRIPTION
Stacked on #128.

The camera is supposed to idle at home and record everywhere else. `S99_NetState` does that by polling the default-gateway MAC every 30 s. It has one kill switch — `/mnt/sda/netstate/override` — whose presence makes the daemon yield entirely.

That's fine as an operator action. It is not fine baked into a build. The 2026-08-16 investigation builds carried an init script that ran `touch /mnt/sda/netstate/override` **twice** during boot, so every boot from 13:31 onward logged `override present -- daemon yields` and the camera recorded at home until Mark noticed by hand. 34 stub files had accumulated.

Nothing detected it because nothing was looking, and a doc note wouldn't have helped — the offending script was never in the repo, only in ad-hoc build scripts.

So: a gate that runs against a **built pak** before flashing and exits non-zero, per the project rule that in an automated chain a warning nothing reads is not a guard.

Checks:
1. `S99_NetState` is present — without it nothing ever disables recording at home.
2. No init script *asserts* the override flag. Reading it, as the daemon does, is fine; `touch`/`>`/`cp`/`echo` onto it is not.
3. `HOME_MACS_DEFAULT` is non-empty — an empty list makes every network look like away.

Verified both directions:

```
4909 -> FAIL: S36_StitchProbe asserts /mnt/sda/netstate/override
           20:touch /mnt/sda/netstate/override 2>/dev/null
           34:    touch /mnt/sda/netstate/override 2>/dev/null
        REFUSING: this pak would record on the home network.

4906 -> PASS: recording defaults to disabled at home.
```

Live fix already applied to the camera: override removed, daemon resumed control, confirmed home MAC `60:b7:6e:ac:8d:34`, recording disabled, and it cleaned up 34 of 34 boot stubs from the current boot only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRurxvFA57JEacBJ2qbdoK