### PR TITLE
fix(stitch): stop the seam correction degrading the panorama it repairs

### DIFF
--- a/tests/test_stitch_remap.py
+++ b/tests/test_stitch_remap.py
@@ -1,20 +1,39 @@
-"""Unit tests for video_grouper.utils.stitch_remap."""
+"""Unit tests for video_grouper.utils.stitch_remap (and the step that uses it)."""
 
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
+from fractions import Fraction
 from pathlib import Path
+from typing import Any
 
 import numpy as np
+import pytest
 
 from video_grouper.utils.stitch_remap import (
     StitchProfile,
     apply_shift_to_frame_nv12,
     apply_shift_to_frame_rgb,
     build_dx_lookup,
+    chroma_aligned_dx,
     load_profile,
+    shift_no_wrap,
     write_profile,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_ffmpeg():
+    """Override conftest's autouse PyAV mock for this module.
+
+    ``test_add_output_stream_applies_spec_to_a_real_container`` needs the real
+    ``av.open`` to prove PyAV accepts every attribute the spec sets; nothing
+    here encodes a frame, so real PyAV is cheap. Same override pattern as
+    tests/test_audio_padding.py.
+    """
+    yield
+
 
 SAMPLE_PROFILE = StitchProfile(
     source_width=7680,
@@ -84,7 +103,7 @@ def test_apply_shift_nv12_skips_zero_rows() -> None:
 
 
 def test_apply_shift_nv12_shifts_right_half_only() -> None:
-    """Left half (x < seam_x) must be unchanged; right half gets rolled."""
+    """Left half (x < seam_x) must be unchanged; right half gets shifted."""
     h, w = 10, 20
     seam_x = 10
     y = np.zeros((h, w), dtype=np.uint8)
@@ -92,15 +111,16 @@ def test_apply_shift_nv12_shifts_right_half_only() -> None:
     y[:, seam_x:] = np.arange(w - seam_x, dtype=np.uint8)  # 0..9 in right half
 
     uv = np.zeros((h // 2, w), dtype=np.uint8)
-    dx = np.full(h, -2, dtype=np.int32)  # roll right half by -2
+    dx = np.full(h, -2, dtype=np.int32)  # shift right half by -2
 
     apply_shift_to_frame_nv12(y, uv, dx, seam_x)
 
     # Left half unchanged
     assert (y[:, :seam_x] == 1).all()
-    # Right half: np.roll(arange(10), -2) → [2,3,4,5,6,7,8,9,0,1]
+    # Right half shifted left by 2, outer edge replicated (NOT wrapped: the old
+    # np.roll put the seam's 0,1 back at the panorama's far right edge)
     np.testing.assert_array_equal(
-        y[0, seam_x:], np.array([2, 3, 4, 5, 6, 7, 8, 9, 0, 1])
+        y[0, seam_x:], np.array([2, 3, 4, 5, 6, 7, 8, 9, 9, 9])
     )
 
 
@@ -117,6 +137,279 @@ def test_apply_shift_rgb_shifts_right_half_only() -> None:
 
     # Left half unchanged
     assert (out[:, :seam_x] == frame[:, :seam_x]).all()
-    # Right-half pixel at x=seam_x originally held (0, 10, 20); after roll -3 the pixel
-    # now at x=seam_x came from x=seam_x+3, i.e. (3, 13, 23)
+    # Right-half pixel at x=seam_x originally held (0, 10, 20); after shifting -3 the
+    # pixel now at x=seam_x came from x=seam_x+3, i.e. (3, 13, 23)
     np.testing.assert_array_equal(out[0, seam_x], [3, 13, 23])
+
+
+# --- Defect 2: the shift must not wrap content into the seam ----------------
+
+
+def test_shift_no_wrap_positive_replicates_head() -> None:
+    seg = np.arange(8, dtype=np.uint8)
+    out = shift_no_wrap(seg, 3)
+    # np.roll would have given [5,6,7,0,1,2,3,4] — the tail landing at the head.
+    np.testing.assert_array_equal(out, [0, 0, 0, 0, 1, 2, 3, 4])
+
+
+def test_shift_no_wrap_negative_replicates_tail() -> None:
+    seg = np.arange(8, dtype=np.uint8)
+    out = shift_no_wrap(seg, -3)
+    np.testing.assert_array_equal(out, [3, 4, 5, 6, 7, 7, 7, 7])
+
+
+def test_shift_no_wrap_zero_is_identity() -> None:
+    seg = np.arange(8, dtype=np.uint8)
+    np.testing.assert_array_equal(shift_no_wrap(seg, 0), seg)
+
+
+def test_shift_no_wrap_beyond_segment_width() -> None:
+    """|dx| >= width: everything shifts out, the surviving edge fills the row."""
+    seg = np.arange(4, dtype=np.uint8)
+    np.testing.assert_array_equal(shift_no_wrap(seg, 9), [0, 0, 0, 0])
+    np.testing.assert_array_equal(shift_no_wrap(seg, -9), [3, 3, 3, 3])
+    np.testing.assert_array_equal(shift_no_wrap(np.empty(0, dtype=np.uint8), 3), [])
+
+
+def test_apply_shift_rgb_never_wraps_far_edge_into_seam() -> None:
+    """dx>0 must not roll the panorama's far right edge into the seam columns."""
+    h, w = 4, 16
+    seam_x = 8
+    dx = 3
+    frame = np.zeros((h, w, 3), dtype=np.uint8)
+    frame[:, :seam_x] = [1, 1, 1]
+    frame[:, seam_x:] = [2, 2, 2]
+    # A marker only at the far right edge of the panorama — exactly what np.roll
+    # would have wrapped into the seam.
+    frame[:, w - dx :] = [255, 0, 0]
+
+    out = apply_shift_to_frame_rgb(frame, np.full(h, dx, dtype=np.int32), seam_x)
+
+    seam_cols = out[:, seam_x : seam_x + dx]
+    assert not (seam_cols == [255, 0, 0]).all(axis=-1).any(), (
+        "far-edge content wrapped into the seam columns"
+    )
+    # Replicate: the seam columns hold a copy of what was the first right-half pixel
+    assert (seam_cols == [2, 2, 2]).all()
+
+
+def test_apply_shift_nv12_never_wraps_far_edge_into_seam() -> None:
+    h, w = 4, 16
+    seam_x = 8
+    dx = 3
+    y = np.full((h, w), 2, dtype=np.uint8)
+    y[:, :seam_x] = 1
+    y[:, w - dx :] = 255  # far-edge marker
+    uv = np.zeros((h // 2, w), dtype=np.uint8)
+
+    apply_shift_to_frame_nv12(y, uv, np.full(h, dx, dtype=np.int32), seam_x)
+
+    # dx=3 rounds to 2 for chroma alignment, so 2 seam columns are vacated.
+    assert not (y[:, seam_x : seam_x + 2] == 255).any()
+    assert (y[:, seam_x : seam_x + 2] == 2).all()
+
+
+# --- Defect 3: luma and chroma must agree ----------------------------------
+
+
+def test_chroma_aligned_dx_rounds_toward_zero_symmetrically() -> None:
+    assert chroma_aligned_dx(0) == 0
+    assert chroma_aligned_dx(2) == 2
+    assert chroma_aligned_dx(-2) == -2
+    # Odd values round toward zero, and the sign flip is symmetric — the old
+    # `(dx // 2) * 2` gave -36 for -35 and +34 for +35, a leftward bias.
+    assert chroma_aligned_dx(35) == 34
+    assert chroma_aligned_dx(-35) == -34
+    assert chroma_aligned_dx(1) == 0
+    assert chroma_aligned_dx(-1) == 0
+    for dx in range(-40, 41):
+        assert chroma_aligned_dx(dx) == -chroma_aligned_dx(-dx)
+        assert chroma_aligned_dx(dx) % 2 == 0
+        assert abs(chroma_aligned_dx(dx)) <= abs(dx)
+
+
+def _edge_column_luma(row: np.ndarray, marker: int) -> int:
+    """First column of `row` holding `marker`."""
+    hits = np.nonzero(row == marker)[0]
+    assert hits.size, "marker not found"
+    return int(hits[0])
+
+
+def test_apply_shift_nv12_luma_and_chroma_land_on_the_same_column() -> None:
+    """An odd dx must not leave luma and chroma disagreeing at the seam."""
+    h, w = 4, 32
+    seam_x = 8
+    edge_x = 16  # a vertical edge at luma column 16 (chroma sample 8)
+
+    for dx in (3, -3, 5, -5):
+        y = np.zeros((h, w), dtype=np.uint8)
+        y[:, edge_x:] = 200
+        uv = np.zeros((h // 2, w), dtype=np.uint8)
+        # Byte index in the interleaved UV row == luma column (chroma sample c
+        # sits at bytes 2c, 2c+1 and covers luma columns 2c, 2c+1).
+        uv[:, edge_x::2] = 200  # U of every chroma sample right of the edge
+        uv[:, edge_x + 1 :: 2] = 100  # its V
+
+        apply_shift_to_frame_nv12(y, uv, np.full(h, dx, dtype=np.int32), seam_x)
+
+        luma_edge = _edge_column_luma(y[0], 200)
+        chroma_edge = _edge_column_luma(uv[0], 200)
+        assert luma_edge == chroma_edge, (
+            f"dx={dx}: luma edge at {luma_edge}, chroma edge at {chroma_edge}"
+        )
+        # ...and both landed on the chroma-aligned shift, not the raw dx.
+        assert luma_edge == edge_x + chroma_aligned_dx(dx)
+
+
+def test_apply_shift_nv12_replicates_whole_chroma_pairs() -> None:
+    """The vacated chroma strip must hold (U, V) pairs, not one smeared byte."""
+    h, w = 2, 16
+    seam_x = 4
+    y = np.zeros((h, w), dtype=np.uint8)
+    uv = np.zeros((h // 2, w), dtype=np.uint8)
+    uv[0, ::2] = 20  # U
+    uv[0, 1::2] = 90  # V
+    uv[0, -2:] = [21, 91]  # distinct final pair
+
+    apply_shift_to_frame_nv12(y, uv, np.full(h, -4, dtype=np.int32), seam_x)
+
+    # 4 luma px = 2 chroma samples vacated at the outer edge; both are copies of
+    # the final (U, V) pair, so U stays U and V stays V.
+    np.testing.assert_array_equal(uv[0, -4:], [21, 91, 21, 91])
+
+
+# --- Defect 1: the correction must not silently downgrade the encode -------
+
+
+@dataclass
+class _FakeCodecContext:
+    name: str = "hevc"
+    pix_fmt: str = "yuv420p"
+    color_range: int = 1
+    colorspace: int = 5
+    color_primaries: int = 1
+    color_trc: int = 1
+
+
+@dataclass
+class _FakeVideoStream:
+    """Duck-typed stand-in for av.video.stream.VideoStream."""
+
+    codec_context: Any
+    width: int = 7680
+    height: int = 2160
+    average_rate: Any = Fraction(20, 1)
+    bit_rate: int | None = 20_480_000
+    time_base: Any = Fraction(1, 10240)
+
+
+def _fake_encoder_lookup(name: str) -> tuple[str, frozenset[str]]:
+    return name, frozenset({"yuv420p", "yuv420p10le"})
+
+
+def test_output_stream_spec_carries_source_encode_settings() -> None:
+    """The camera's 7680x2160 HEVC @ 20480 kbps must survive the correction."""
+    from video_grouper.pipeline.steps.stitch_correct import _output_stream_spec
+
+    stream = _FakeVideoStream(codec_context=_FakeCodecContext())
+    spec = _output_stream_spec(stream, encoder_lookup=_fake_encoder_lookup)
+
+    assert spec.codec_name == "hevc"  # not the hardcoded "h264"
+    assert spec.bit_rate == 20_480_000  # not PyAV's ~1 Mbps default
+    assert spec.pix_fmt == "yuv420p"
+    assert spec.rate == Fraction(20, 1)
+    assert spec.time_base == Fraction(1, 10240)
+    assert spec.width == 7680
+    assert spec.height == 2160
+    # Colour metadata carried so the copy is interpreted as the source was
+    assert spec.color_range == 1
+    assert spec.colorspace == 5
+    assert spec.color_primaries == 1
+    assert spec.color_trc == 1
+
+
+def test_output_stream_spec_carries_10bit_pix_fmt() -> None:
+    from video_grouper.pipeline.steps.stitch_correct import _output_stream_spec
+
+    stream = _FakeVideoStream(codec_context=_FakeCodecContext(pix_fmt="yuv420p10le"))
+    spec = _output_stream_spec(stream, encoder_lookup=_fake_encoder_lookup)
+    assert spec.pix_fmt == "yuv420p10le"
+
+
+def test_output_stream_spec_downgrades_pix_fmt_the_encoder_cannot_take() -> None:
+    from video_grouper.pipeline.steps.stitch_correct import _output_stream_spec
+
+    stream = _FakeVideoStream(codec_context=_FakeCodecContext(pix_fmt="yuv444p12le"))
+    spec = _output_stream_spec(stream, encoder_lookup=_fake_encoder_lookup)
+    assert spec.pix_fmt == "yuv420p"
+
+
+def test_output_stream_spec_falls_back_to_container_bitrate() -> None:
+    from video_grouper.pipeline.steps.stitch_correct import _output_stream_spec
+
+    stream = _FakeVideoStream(codec_context=_FakeCodecContext(), bit_rate=None)
+    spec = _output_stream_spec(
+        stream, container_bit_rate=20_600_000, encoder_lookup=_fake_encoder_lookup
+    )
+    assert spec.bit_rate == 20_600_000
+
+
+def test_output_stream_spec_bitrate_fallback_matches_the_camera() -> None:
+    """No declared bitrate anywhere: derive it from the camera's own bpp."""
+    from video_grouper.pipeline.steps.stitch_correct import _output_stream_spec
+
+    stream = _FakeVideoStream(codec_context=_FakeCodecContext(), bit_rate=0)
+    spec = _output_stream_spec(
+        stream, container_bit_rate=0, encoder_lookup=_fake_encoder_lookup
+    )
+    # 7680x2160 @ 20 fps is exactly the encode the constant was derived from
+    assert spec.bit_rate == 20_480_000
+    # Half the frame area at the same rate ⇒ half the budget
+    half = _FakeVideoStream(
+        codec_context=_FakeCodecContext(), bit_rate=0, width=3840, height=2160
+    )
+    half_spec = _output_stream_spec(
+        half, container_bit_rate=None, encoder_lookup=_fake_encoder_lookup
+    )
+    assert half_spec.bit_rate == 10_240_000
+
+
+def test_resolve_encoder_keeps_hevc_and_falls_back_for_unknown() -> None:
+    """Against real PyAV: no encode, just codec lookup."""
+    from video_grouper.pipeline.steps.stitch_correct import _resolve_encoder
+
+    name, pix_fmts = _resolve_encoder("hevc")
+    assert name == "hevc"
+    assert "yuv420p" in pix_fmts
+
+    name, _ = _resolve_encoder("no_such_codec")
+    assert name == "h264"
+
+
+def test_add_output_stream_applies_spec_to_a_real_container(tmp_path: Path) -> None:
+    """PyAV must accept every attribute the spec sets (no frames encoded)."""
+    import av
+
+    from video_grouper.pipeline.steps.stitch_correct import (
+        _add_output_stream,
+        _output_stream_spec,
+    )
+
+    stream = _FakeVideoStream(
+        codec_context=_FakeCodecContext(), width=64, height=48, bit_rate=1_234_000
+    )
+    spec = _output_stream_spec(stream, encoder_lookup=_fake_encoder_lookup)
+
+    container = av.open(str(tmp_path / "out.mp4"), mode="w")
+    try:
+        out_stream = _add_output_stream(container, spec)
+        # The encoder for "hevc" is libx265 — same codec id, so the corrected
+        # copy is still H.265 rather than the old hardcoded H.264.
+        assert out_stream.codec_context.codec.id == av.Codec("hevc", "r").id
+        assert out_stream.codec_context.bit_rate == 1_234_000
+        assert out_stream.codec_context.pix_fmt == "yuv420p"
+        assert out_stream.codec_context.time_base == Fraction(1, 10240)
+        assert out_stream.width == 64
+        assert out_stream.height == 48
+    finally:
+        container.close()

--- a/video_grouper/pipeline/steps/stitch_correct.py
+++ b/video_grouper/pipeline/steps/stitch_correct.py
@@ -3,7 +3,9 @@
 Reads the panoramic ``input_path``, applies
 :func:`video_grouper.utils.stitch_remap.apply_shift_to_frame_rgb` per frame
 using the configured calibration profile, writes a corrected mp4 alongside, and
-rebinds ``input_path`` so downstream steps consume the corrected video.
+rebinds ``input_path`` so downstream steps consume the corrected video. The
+re-encode mirrors the source stream's codec, bitrate, pixel format, frame rate
+and colour metadata — see ``_output_stream_spec``.
 
 Pass-through (no work, no error) when the profile path isn't configured or the
 file isn't loadable — stitch correction is an opt-in calibration.
@@ -13,8 +15,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import BaseModel
 
@@ -22,11 +26,173 @@ from video_grouper.pipeline import register_step
 from video_grouper.pipeline.base import PipelineStep, StepContext
 from video_grouper.pipeline.manifest import PipelineManifest
 
+if TYPE_CHECKING:
+    # Type-only: av is imported lazily inside the helpers below so this module
+    # stays importable where av isn't installed.
+    from av.container import OutputContainer
+    from av.video.stream import VideoStream
+
 logger = logging.getLogger(__name__)
+
+# This step is FIRST in the homegrown preset chain (see pipeline/presets.py), so
+# whatever it throws away is thrown away for the detector, tracker and renderer
+# too. The camera's daily-driver encode is 7680x2160 H.265 at 20 fps / 20480
+# kbps — its hardware ceiling (reolink-firmware-patching/docs/PATCHING_GUIDE.md
+# step 7). Re-encoding to h264 with no bit_rate set hands the whole panorama to
+# PyAV's default rate control (~1 Mbps at any resolution), an order-of-magnitude
+# cut that would cost more than the seam repair gains. So: carry the source's
+# codec, bitrate, pixel format, frame rate, time base and colour metadata.
+_FALLBACK_CODEC = "h264"
+
+# Bits per pixel per frame, used ONLY when neither the stream nor the container
+# declares a usable bitrate. Derived from the camera's own ceiling encode:
+# 20_480_000 bps / (7680 * 2160 px * 20 fps) = 0.0617 bpp. Scaling that by the
+# real frame size and rate reproduces the source's own quality target at any
+# resolution — a number we can point at, rather than PyAV's silent default.
+_FALLBACK_BITS_PER_PIXEL = 20_480_000 / (7680 * 2160 * 20)
+
+# Only reached if the source reports no frame rate either. 20 fps is the Duo 3's
+# real hardware ceiling (reolink-firmware-patching/docs/FIRMWARE_PATCH_NOTES.md).
+_FALLBACK_FPS = 20.0
 
 
 class StitchCorrectStepConfig(BaseModel):
     stitch_profile_path: str | None = None
+
+
+@dataclass(frozen=True)
+class _OutputStreamSpec:
+    """Encoder settings for the corrected copy, taken from the source stream."""
+
+    codec_name: str
+    width: int
+    height: int
+    pix_fmt: str
+    bit_rate: int
+    # PyAV-typed passthroughs: Fraction rate/time_base and the colour enums.
+    rate: Any = None
+    time_base: Any = None
+    color_range: Any = None
+    colorspace: Any = None
+    color_primaries: Any = None
+    color_trc: Any = None
+
+
+def _resolve_encoder(codec_name: str) -> tuple[str, frozenset[str]]:
+    """Return ``(encoder name, pixel formats it accepts)`` for ``codec_name``.
+
+    Not every decodable codec has an *encoder* in the installed FFmpeg build, so
+    fall back to h264 (loudly) rather than raising. ``av.Codec("hevc", "w")``
+    resolves to libx265, so the camera's H.265 round-trips as H.265.
+    """
+    import av  # lazy: PyAV is heavy
+
+    for candidate in (codec_name, _FALLBACK_CODEC):
+        try:
+            codec = av.Codec(candidate, "w")
+        except Exception:
+            continue
+        if candidate != codec_name:
+            logger.warning(
+                "stitch_correct: no encoder for source codec %r; re-encoding as %s",
+                codec_name,
+                candidate,
+            )
+        return candidate, frozenset(f.name for f in (codec.video_formats or ()))
+    # Neither resolved — hand the name to add_stream and let FFmpeg say why.
+    return _FALLBACK_CODEC, frozenset()
+
+
+def _output_stream_spec(
+    in_video: Any,
+    container_bit_rate: int | None = None,
+    encoder_lookup: Callable[[str], tuple[str, frozenset[str]]] = _resolve_encoder,
+) -> _OutputStreamSpec:
+    """Build the output stream settings from the input video stream.
+
+    Everything is carried across from the source; the only substitutions are the
+    documented fallbacks (unavailable encoder, unsupported pixel format, absent
+    bitrate), each of which logs.
+    """
+    codec_context = in_video.codec_context
+    codec_name, encoder_pix_fmts = encoder_lookup(
+        getattr(codec_context, "name", None) or _FALLBACK_CODEC
+    )
+
+    width = int(in_video.width)
+    height = int(in_video.height)
+    rate = in_video.average_rate
+
+    pix_fmt = getattr(codec_context, "pix_fmt", None) or "yuv420p"
+    if encoder_pix_fmts and pix_fmt not in encoder_pix_fmts:
+        logger.warning(
+            "stitch_correct: encoder %s does not accept source pix_fmt %s; using yuv420p",
+            codec_name,
+            pix_fmt,
+        )
+        pix_fmt = "yuv420p"
+
+    bit_rate = int(getattr(in_video, "bit_rate", None) or 0)
+    source = "stream"
+    if bit_rate <= 0:
+        # Container bitrate covers audio too, but audio is ~0.5% of a 20 Mbps
+        # video stream — far closer than the encoder default.
+        bit_rate = int(container_bit_rate or 0)
+        source = "container"
+    if bit_rate <= 0:
+        fps = float(rate) if rate else _FALLBACK_FPS
+        bit_rate = int(round(width * height * fps * _FALLBACK_BITS_PER_PIXEL))
+        source = "camera-derived default"
+    logger.info(
+        "stitch_correct: re-encoding %dx%d as %s @ %d bps (%s), pix_fmt %s",
+        width,
+        height,
+        codec_name,
+        bit_rate,
+        source,
+        pix_fmt,
+    )
+
+    return _OutputStreamSpec(
+        codec_name=codec_name,
+        width=width,
+        height=height,
+        pix_fmt=pix_fmt,
+        bit_rate=bit_rate,
+        rate=rate,
+        time_base=getattr(in_video, "time_base", None),
+        color_range=getattr(codec_context, "color_range", None),
+        colorspace=getattr(codec_context, "colorspace", None),
+        color_primaries=getattr(codec_context, "color_primaries", None),
+        color_trc=getattr(codec_context, "color_trc", None),
+    )
+
+
+def _add_output_stream(
+    out_container: OutputContainer, spec: _OutputStreamSpec
+) -> VideoStream:
+    """Add and configure the output video stream described by ``spec``."""
+    # add_stream is typed as the Stream union; a video codec name always yields
+    # a VideoStream (same narrowing render.py does for the audio side).
+    stream = cast(
+        "VideoStream", out_container.add_stream(spec.codec_name, rate=spec.rate)
+    )
+    stream.width = spec.width
+    stream.height = spec.height
+    stream.pix_fmt = spec.pix_fmt
+    codec_context = stream.codec_context
+    codec_context.bit_rate = spec.bit_rate
+    if spec.time_base is not None:
+        # Match the source time_base. PyAV's default mis-budgets rate control
+        # and corrupts duration metadata (see the same fix in steps/render.py).
+        codec_context.time_base = spec.time_base
+    # Carry colour metadata so the corrected copy is interpreted exactly as the
+    # source was; an untagged re-encode is what makes a re-mux look shifted.
+    for attr in ("color_range", "colorspace", "color_primaries", "color_trc"):
+        value = getattr(spec, attr)
+        if value is not None:
+            setattr(codec_context, attr, value)
+    return stream
 
 
 def _correct_video(input_path: str, output_path: str, profile_path: str) -> bool:
@@ -56,11 +222,12 @@ def _correct_video(input_path: str, output_path: str, profile_path: str) -> bool
             dx_lookup = build_dx_lookup(profile, in_video.width, in_video.height)
             seam_x = int(profile.seam_x * (in_video.width / profile.source_width))
 
+            spec = _output_stream_spec(
+                in_video, container_bit_rate=in_container.bit_rate
+            )
+
             with av.open(output_path, mode="w") as out_container:
-                out_video = out_container.add_stream("h264", rate=in_video.average_rate)
-                out_video.width = in_video.width
-                out_video.height = in_video.height
-                out_video.pix_fmt = "yuv420p"
+                out_video = _add_output_stream(out_container, spec)
 
                 for frame in in_container.decode(in_video):
                     rgb = frame.to_ndarray(format="rgb24")

--- a/video_grouper/utils/stitch_remap.py
+++ b/video_grouper/utils/stitch_remap.py
@@ -100,33 +100,101 @@ def build_dx_lookup(
     return np.round(dx).astype(np.int32)
 
 
+def shift_no_wrap(segment: np.ndarray, dx: int) -> np.ndarray:
+    """Return `segment` shifted `dx` samples along axis 0 **without wrapping**.
+
+    `np.roll` is circular: shifting the right half by `dx>0` rolls the far right
+    edge of the panorama around into the first `dx` columns — which are exactly
+    the seam columns this module exists to repair (and the mirror case at the
+    outer edge for `dx<0`). This does the same shift with an edge policy
+    instead: samples pushed past the end are dropped, and the vacated columns
+    take a copy of the nearest surviving sample (replicate, as in
+    `cv2.BORDER_REPLICATE` / `np.pad(mode="edge")`).
+
+    Replicate over "leave a black sliver" because the vacated strip is real
+    un-imaged parallax gap of at most a few tens of pixels: replicating extends
+    the neighbouring content and stays invisible at that scale, whereas a black
+    column is a hard synthetic gradient — a strong edge feature handed to the
+    downstream ball detector and field-outline model on the one part of the
+    frame we are trying to make *less* misleading.
+
+    Works for 1-D rows (a luma row), (N, 2) interleaved chroma pairs, and
+    (N, 3) RGB/BGR rows alike: only axis 0 moves.
+    """
+    if dx == 0 or segment.shape[0] == 0:
+        return segment.copy()
+    out = np.empty_like(segment)
+    if dx > 0:
+        # Shift right: out[i] = segment[i - dx]; the head (the seam) replicates
+        # the sample that lands on the new boundary.
+        out[dx:] = segment[:-dx]
+        out[:dx] = segment[0]
+    else:
+        # Shift left: out[i] = segment[i + |dx|]; the tail (the outer edge of
+        # the panorama) replicates the last surviving sample.
+        out[:dx] = segment[-dx:]
+        out[dx:] = segment[-1]
+    return out
+
+
+def chroma_aligned_dx(dx: int) -> int:
+    """Round `dx` toward zero to an even number of luma pixels.
+
+    4:2:0 chroma is subsampled 2:1 horizontally, so a chroma sample can only be
+    moved in whole 2-luma-pixel steps — an odd luma dx is unrepresentable in
+    chroma. Applying the exact dx to luma and an even dx to chroma leaves the
+    planes disagreeing by up to 1 px, i.e. coloured fringing on exactly the
+    vertical edges the seam is made of, so **both** planes use this value.
+
+    Rounding is toward zero, not `dx // 2 * 2`: floor division rounds toward
+    negative infinity, so odd dx always lost a pixel *leftward* regardless of
+    sign (-35 → -36, +35 → +34) — a directional bias that displaced content one
+    way. Toward zero is symmetric under sign flip and never over-shoots the
+    calibrated shift; the residual is a ≤1 px under-correction of the shift
+    magnitude, against dx values of 10-35 px, and luma/chroma stay in exact
+    agreement.
+    """
+    return (abs(dx) // 2) * 2 * (1 if dx >= 0 else -1)
+
+
 def apply_shift_to_frame_nv12(
     y_plane: np.ndarray, uv_plane: np.ndarray, dx_lookup: np.ndarray, seam_x: int
 ) -> None:
     """In-place per-row shift of the right half of an NV12 frame.
 
     `y_plane` shape is (H, W); `uv_plane` is (H/2, W) with interleaved UV.
-    Rows where `dx_lookup[y] == 0` are skipped entirely. `seam_x` should come
-    from the profile (scaled by the caller if needed).
+    Both planes are shifted by `chroma_aligned_dx(dx)` so luma and chroma stay
+    registered; rows whose dx is 0 (or rounds to 0) are skipped entirely.
+    `seam_x` should come from the profile (scaled by the caller if needed).
     """
     h_y = y_plane.shape[0]
     nonzero = np.nonzero(dx_lookup[:h_y])[0]
     for y in nonzero:
-        dx = int(dx_lookup[y])
-        y_plane[y, seam_x:] = np.roll(y_plane[y, seam_x:], dx)
+        dx = chroma_aligned_dx(int(dx_lookup[y]))
+        if dx == 0:
+            continue
+        y_plane[y, seam_x:] = shift_no_wrap(y_plane[y, seam_x:], dx)
 
-    # UV plane: one chroma row per two luma rows; dx must stay even so U/V
-    # pairs ([U, V, U, V, ...] interleaved) stay aligned.
+    # UV plane: one chroma row per two luma rows.
     h_uv = uv_plane.shape[0]
     # seam_x in UV coords is the same as in Y coords because UV is horizontally
     # interleaved at the luma resolution (only vertically subsampled).
     for y_uv in range(h_uv):
         y_luma = y_uv * 2
-        dx_luma = int(dx_lookup[min(y_luma, dx_lookup.size - 1)])
-        dx_uv = (dx_luma // 2) * 2
-        if dx_uv == 0:
+        dx = chroma_aligned_dx(int(dx_lookup[min(y_luma, dx_lookup.size - 1)]))
+        if dx == 0:
             continue
-        uv_plane[y_uv, seam_x:] = np.roll(uv_plane[y_uv, seam_x:], dx_uv)
+        row = uv_plane[y_uv, seam_x:]
+        n_pairs = int(row.size) // 2
+        if n_pairs == 0:
+            continue
+        # Shift (U, V) pairs, not raw bytes: dx is even so it is a whole number
+        # of chroma samples, and replicating a *pair* at the edge keeps U and V
+        # distinct (replicating one byte would smear a single component across
+        # both and tint the vacated strip).
+        pairs = row[: n_pairs * 2].reshape(n_pairs, 2)
+        shifted = shift_no_wrap(pairs, dx // 2)
+        uv_plane[y_uv, seam_x : seam_x + n_pairs * 2] = shifted.reshape(-1)
 
 
 def apply_shift_to_frame_rgb(
@@ -134,11 +202,13 @@ def apply_shift_to_frame_rgb(
 ) -> np.ndarray:
     """Return a new RGB/BGR frame with the right half shifted per-row.
 
-    Accepts shape (H, W, 3); works for both RGB and BGR.
+    Accepts shape (H, W, 3); works for both RGB and BGR. Every pixel carries its
+    own colour here, so unlike NV12 there is no subsampling constraint and the
+    exact per-row dx is used.
     """
     out = frame.copy()
     nonzero = np.nonzero(dx_lookup[: frame.shape[0]])[0]
     for y in nonzero:
         dx = int(dx_lookup[y])
-        out[y, seam_x:] = np.roll(out[y, seam_x:], dx, axis=0)
+        out[y, seam_x:] = shift_no_wrap(out[y, seam_x:], dx)
     return out


### PR DESCRIPTION
Three defects in the stitch-seam correction, each of which cost more than the
correction gained. This step is **first** in the homegrown preset chain, so
everything it throws away is thrown away for the detector, tracker and renderer
too.

### 1. It silently transcoded the whole panorama

`stitch_correct.py` did `add_stream("h264", rate=...)`: the camera's 7680x2160
**H.265 at 20480 kbps** — its hardware ceiling — was re-encoded to **H.264 at
PyAV's default rate control**, roughly 1 Mbps at any resolution. An
order-of-magnitude cut applied to every frame before any consumer saw it.

Now the output mirrors the source: codec (verified — `av.Codec("hevc","w")`
resolves to libx265, so H.265 round-trips as H.265), bitrate, pixel format,
frame rate, colour metadata, and `time_base`. That last one is load-bearing on
its own — `steps/render.py` already documents that PyAV's default time_base
mis-budgets rate control into ~13x oversized output and corrupts duration.
`stitch_correct` had the same bug. Where no bitrate is declared anywhere, the
fallback is `0.0617 bpp` derived from the camera's own encode
(`20_480_000 / (7680*2160*20)`) rather than a silent default, and every
substitution logs.

### 2. `np.roll` wrapped content *into* the seam

The shift was circular. For `dx > 0` the far right edge of the panorama rolled
around and landed in the first `dx` columns — precisely the seam the module
exists to repair — and the mirror case hit the outer edge for `dx < 0`.

`shift_no_wrap()` does the same shift with edge replication. Replicate over a
black sliver deliberately: the vacated strip is real un-imaged parallax gap a
few tens of pixels wide, so replication is invisible at that scale, whereas a
black column is a hard synthetic edge handed to the ball detector and
field-outline model on the one region we are trying to make less misleading.

### 3. Luma and chroma disagreed by up to 1 px

Luma used the exact `dx`, chroma `(dx // 2) * 2` — coloured fringing on exactly
the vertical edges a seam is made of. Both planes now use `chroma_aligned_dx()`,
so the disagreement is **zero**. Rounding is toward zero rather than floor:
`//` sends -35 to -36 but +35 to +34, displacing content leftward regardless of
sign. The residual is a <=1 px under-correction of shift magnitude against dx
values of 10-35 px, with the planes in exact agreement.

A subtlety the chroma path needed: replicate must copy the whole `(U, V)` pair.
Replicating a single byte smears one component across both and tints the
vacated strip.

### Tests

`tests/test_stitch_remap.py` 9 -> 25. Verified by re-introducing all three
defects in a scratch patch: 14 fail on the old behaviour, all 25 pass after.

### Not fixed here

The frame path is still lossy independently of the encoder: `to_ndarray("rgb24")`
-> shift -> `from_ndarray("rgb24")` round-trips YUV->RGB8->YUV every frame.
Fixing that needs a planar-YUV shift path. No `dy` support and no schema change
either — the v2 profile belongs with the calibration work.

No real-world validation: the only `dx_anchors` in the repo is a synthetic
non-monotone test fixture, so there is no calibration to regress against.