### PR TITLE
firmware docs: one record for the frame-rate investigation, verdicts included

### DIFF
--- a/reolink-firmware-patching/README.md
+++ b/reolink-firmware-patching/README.md
@@ -17,7 +17,8 @@ files from Reolink's portal yourself (see "Acquiring stock firmware" below).
 | Mid-game truncation on a full card | last 8K segment lost when the card fills | **free-space reserve 500 MiB → 20 GiB** so the recycler always keeps a full segment's headroom | `builds/build_soccercam_v2.sh` |
 | Home power-on stub recordings | a junk clip every home boot | **auto-deleted** (netstate v2 stub cleanup) | `builds/build_soccercam_v2.sh` |
 | Power-cut recording recovery | orphaned (moov-less) clip discarded | **rebuilt in place** — video + best-effort audio — at next boot | `builds/build_soccercam_comprehensive.sh` |
-| FPS dropdown cap (web UI) | 20 | 25 (encoder still ceilings ~20) | `builds/build_fps_cap.sh` |
+| FPS dropdown cap (web UI) | 20 | 25 — but the *delivered* rate is set elsewhere; see `docs/FPS_CEILING.md` | `builds/build_fps_cap.sh` |
+| Delivered frame rate @ 7680×2160 | 19.86 fps | **21.18 fps** (capture 25 + aux-stream inputs starved to 640×192) | `builds/build_fps_demo.sh` |
 | Shutter / exposure mode | AE only | full Auto / LowNoise / Anti-Smearing / Manual | runtime API only — `runtime/set_exposure.sh` |
 
 The `build_*.sh` scripts each carry the patches above them in this list,
@@ -28,7 +29,9 @@ so you can pick the highest-tier build for your needs:
 - **`build_netstate.sh`** = HTTP unlock + bitrate cap + auto-toggle daemon.
 - **`build_soccercam_v2.sh`** = the above **+ netstate v2 (stub cleanup) + free-space reserve**. Fixes the full-card mid-game truncation (the raised reserve makes the camera's own recycler keep a full segment's headroom free).
 - **`build_soccercam_comprehensive.sh`** = `v2` **+ boot-time power-cut recovery** (`recover_mp4` + `S35_RecRecover`, video + best-effort AAC audio). **Recommended for the soccer-cam use case.** Audio recovery needs the Helix AAC source fetched locally (see `recover/helix/README.md`); without it the build falls back to video-only recovery automatically.
-- **`build_fps_cap.sh`** = HTTP unlock + bitrate cap + fps dropdown lift. Available for experimentation; daily-driver use is **not** recommended. Raising the rate makes recorded fps *worse*, not better: at a 30 fps setting the camera delivers a measured **16.67 fps**, against 19.92 fps at the stock 20 setting. The pipeline is throughput-bound at roughly 330 Mpix/s and over-committing it costs ~16%. See `docs/FIRMWARE_PATCH_NOTES.md` section 15.
+- **`build_fps_cap.sh`** = HTTP unlock + bitrate cap + fps dropdown lift. Available for experimentation; daily-driver use is **not** recommended on its own. Lifting the dropdown alone makes recorded fps *worse*, not better: at a 30 fps setting the camera delivers a measured **16.67 fps**, against 19.92 fps at the stock 20 setting. The main stream is throughput-bound at roughly 330 Mpix/s and over-committing it costs ~16%.
+- **`build_fps_demo.sh`** = capture-fps + advertised-list + aux-stream geometry patches, and the builder behind the current best measured result: **21.18 fps at 7680×2160**, 23.40 at 4096×1152. It refuses aux geometries needing more than a 16× ISE downscale, and asserts the boot chain is SHA-256 identical to the base pak before writing the CRC. Read `docs/FPS_CEILING.md` before using it.
+- **`build_tge_retime.sh`** = SoC timing-generator retime (capture past 25 fps). **Built and verified but never flashed** — capture is not the binding stage, so the gain cannot surface until the ISP is freed. It also lacks the boot-chain assertion; back-fill that first. See `docs/FPS_CEILING.md` O3.
 
 The recovery binary has its own repeatable correctness gate:
 `bash verify/test_recover_mp4.sh <a_good_recording.mp4>` builds `recover_mp4`,
@@ -45,6 +48,11 @@ verified, daily-driver setup. Includes the exact firmware version
 byte-level patch recipes, encoder-bottleneck investigation, sensor
 characterization, and reasoning behind the daily-driver build choices.
 
+**What limits the frame rate, and what we actually achieved**: see
+`docs/FPS_CEILING.md` — the result up front, every measurement, and the
+hypotheses that were tried and falsified. It supersedes section 15 of the patch
+notes. Per-stage readings are in `docs/FPS_STAGE_EVIDENCE.md`.
+
 ## Directory layout
 
 ```
@@ -55,8 +63,14 @@ reolink-firmware-patching/
 ├── .gitignore                       # excludes *.pak, secrets, artifacts
 ├── docs/
 │   ├── APP_REPLACEMENT_DESIGN.md    # design: replace app/device, keep kernel+ISP+drivers
+│   ├── BRICK_POSTMORTEM.md          # the 4917 outage, and the recovery that confirmed it
+│   ├── ENCODER_ROI_QP.md            # per-region QP bias (static analysis)
 │   ├── FIRMWARE_PATCH_NOTES.md      # complete reference (RE recipes + byte offsets)
-│   └── PATCHING_GUIDE.md            # step-by-step stock -> flashed -> verified
+│   ├── FPS_CEILING.md               # what limits frame rate + what we achieved (read this first)
+│   ├── FPS_STAGE_EVIDENCE.md        # per-stage readings behind FPS_CEILING.md
+│   ├── ISF_PARAM_MAP.md             # the ISF ioctl protocol + param id map
+│   ├── PATCHING_GUIDE.md            # step-by-step stock -> flashed -> verified
+│   └── STITCH_CALIBRATION.md        # design: stitch-seam calibration tool
 ├── pak/                             # .pak container toolchain (Python)
 │   ├── pak.py                       # parse / inspect
 │   ├── extract.py                   # split into sections
@@ -66,7 +80,10 @@ reolink-firmware-patching/
 │   ├── build_http_unlock.sh
 │   ├── build_bitrate_cap.sh
 │   ├── build_fps_cap.sh
+│   ├── build_fps_demo.sh            # capture fps + aux geometry; boot-chain SHA-256 assert
+│   ├── build_tge_retime.sh          # TGE hd_period retime -- NOT flashed, see FPS_CEILING.md
 │   ├── build_netstate.sh
+│   ├── build_roi_qp.sh              # per-region QP bias
 │   ├── build_soccercam_v2.sh        # + free-space reserve + netstate v2 (stub cleanup)
 │   ├── build_soccercam_comprehensive.sh  # + power-cut recovery (video+audio)
 │   └── BUILD_LOG.md                 # artifact tracker (sha256 / CRC / contents)
@@ -78,13 +95,22 @@ reolink-firmware-patching/
 │       ├── README.md                # how to fetch + build Helix (RPSL, gitignored)
 │       ├── compat/                  # flat-memory stubs so Helix cross-compiles
 │       └── aac_split_test.c         # validates the frame splitter vs ground-truth stsz
+├── vpe/                             # 2-D warp mesh (VPE DCE) reader/writer
+│   ├── README.md                    # argument layout, liveness gate, on-camera use
+│   ├── lut2d.py                     # parse / validate / selftest the mesh
+│   └── lut2d_ioctl.c                # on-camera get/set client
 ├── runtime/                         # files installed into rootfs / live-API settings
 │   ├── set_exposure.sh              # exposure mode / shutter / gain (no flash)
 │   ├── check_isp.sh                 # verify current ISP state
 │   ├── probe_isp.sh                 # dump state + allowed ranges
+│   ├── camsh.py                     # camera shell client; refuses destructive commands
+│   ├── isfbind.c                    # freestanding ISF bind/get client (no libc)
 │   ├── netstate/
 │   │   ├── S99_NetState.template    # v1 daemon (build_netstate.sh)
 │   │   └── S99_NetState_v2.template # v2: home/away + power-on stub cleanup
+│   ├── roiqp/
+│   │   ├── S37_RoiQp                # ROI/QP init script
+│   │   └── roi.conf.example         # region definitions
 │   └── recover/
 │       └── S35_RecRecover           # boot-time recovery init script
 └── verify/                          # empirical checks
@@ -92,6 +118,9 @@ reolink-firmware-patching/
     ├── test_setenc.sh               # probe SetEnc at a target bitrate
     ├── get_performance.sh           # poll GetPerformance (live rate)
     ├── fetch_and_analyze.sh         # download latest recording + ffprobe
+    ├── measure_clip_fps.py          # DELIVERED fps (frames over PTS span) -- headers lie
+    ├── check_recording_default.sh   # gate a pak: must not record on the home network
+    ├── roi_qp_heatmap.py            # visualise the encoder's per-region QP
     └── test_recover_mp4.sh          # build + round-trip-validate the recovery binary
 ```
 

--- a/reolink-firmware-patching/builds/build_fps_demo.sh
+++ b/reolink-firmware-patching/builds/build_fps_demo.sh
@@ -1,0 +1,427 @@
+#!/bin/bash
+# build_fps_demo.sh -- build a pak that captures at a chosen frame rate, for the
+# purpose of MEASURING the Duo 3's real sustainable fps from recorded video.
+#
+# Why this builder exists when build_fps_cap.sh already patches fps
+# -----------------------------------------------------------------
+# build_fps_cap.sh starts from the STOCK pak and asserts the stock byte
+# (movz w1, #20). Every build after the first therefore cannot be re-based on a
+# previous build. This builder accepts ANY `movz w1, #imm` at the site, so it
+# can iterate from the last known-good pak instead of re-deriving the whole
+# feature set from stock each time. It also adds three things the postmortem
+# (docs/BRICK_POSTMORTEM.md) found missing from every existing builder:
+#
+#   1. It ASSERTS the boot chain is byte-identical to the base pak before
+#      writing the CRC, and aborts if not. loader/fdt/atf/uboot/kernel/ai are
+#      never touched by any patch here, so any difference means a repacker bug
+#      -- and that is the one class of change that can cost the recovery path.
+#   2. It STRIPS the netstate override assertion from the carried probe script
+#      rather than dropping the script, so the 2323 root shell (the cheap
+#      recovery channel) survives while recording stays off at home.
+#   3. It carries no LD_PRELOAD shim of any kind.
+#
+# What sets the frame rate
+# ------------------------
+# Two independent values, and only the first one moves the sensor:
+#
+#   `device` +0x8bb1c  `movz w1, #N` in Na_video_encoder_build_basic. N becomes
+#                      HD_VIDEOCAP_IN.frc and is what the SENSOR is driven at.
+#                      Verified: with N=21 the camera reports frc 21/1 in
+#                      /proc/hdal/vcap/info and chgmode_fpsx100 2100 in
+#                      /proc/kflow_sen/info, and SetEnc frameRate=18 does NOT
+#                      change either -- SetEnc only retimes the ENCODER.
+#
+#   `router` fps lists The values GetEnc advertises and SetEnc validates
+#                      against. SetEnc rejects anything not in the list with
+#                      "param error" rspCode -4, so the list must expose N or
+#                      the encoder cannot be told to keep every captured frame.
+#
+# Both are patched to the same N.
+#
+# Optional sensor retime
+# ----------------------
+# sen_calc_chgmode_vd_os08c10() computes  vd = min_vd * dft_fps / fps  and, if
+# vd < min_vd, discards the request and forces fps = dft_fps. So dft_fps is a
+# hard ceiling on capture rate. dft_fps and min_vd are a matched pair: the
+# sensor's pixel clock is fixed, so
+#
+#     HTS * min_vd * (dft_fps/100) = pclk = 2592 * 2314 * 25.00 = 149,947,200
+#
+# must hold or a requested fps stops equalling the delivered fps. Passing
+# <dft_fpsx100> retimes BOTH sensor modules, recomputing min_vd to preserve that
+# product. min_vd may not fall below the sensor's readout height (2162 rows) --
+# the sensor cannot emit 2162 rows in fewer than 2162 line periods -- and this
+# script refuses to build if it would.
+#
+# Usage:
+#   sudo bash build_fps_demo.sh <base.pak> <out.pak> <capture_fps> [dft_fpsx100] [pump_sleep_us]
+#
+# Example:
+#   sudo bash build_fps_demo.sh base.pak duo3_fps25.pak 25
+#   sudo bash build_fps_demo.sh base.pak duo3_fps26.pak 26 2600
+#   sudo bash build_fps_demo.sh base.pak duo3_fps25_pump.pak 25 0 2000
+#
+# ALWAYS run verify/check_recording_default.sh on the output before flashing.
+
+set -euo pipefail
+
+BASE="${1:?usage: $0 <base.pak> <out.pak> <capture_fps> [dft_fpsx100] [pump_sleep_us]}"
+OUT="${2:?usage: $0 <base.pak> <out.pak> <capture_fps> [dft_fpsx100] [pump_sleep_us]}"
+FPS="${3:?usage: $0 <base.pak> <out.pak> <capture_fps> [dft_fpsx100] [pump_sleep_us]}"
+DFT="${4:-0}"
+SLEEP_US="${5:-0}"
+AUX_W="${6:-0}"
+AUX_H="${7:-0}"
+KBPS="${8:-0}"
+[[ "$EUID" -eq 0 ]] || { echo "ERROR: run as root (needs unsquashfs/mksquashfs)"; exit 1; }
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PAK_DIR="$(cd "$HERE/../pak" && pwd)"
+# pak/ contains BOTH pak.py and pak_repack.py, and pak.py shadows the pak/
+# namespace package -- so `from pak import pak` can never resolve while pak/ is
+# on sys.path. Put pak/ on the path and import both modules flat instead.
+export PYTHONPATH="$PAK_DIR"
+WORK="$(mktemp -d)"
+trap "rm -rf '$WORK'" EXIT
+cd "$WORK"
+
+echo "==================================================================="
+echo " base        : $BASE"
+echo " out         : $OUT"
+echo " capture fps : $FPS"
+echo " sensor dft  : $([ "$DFT" = 0 ] && echo '(unchanged, 25.00 ceiling)' || echo "$(echo "$DFT" | sed 's/..$/.&/') fps")"
+echo " pump sleep  : $([ "$SLEEP_US" = 0 ] && echo '(unchanged)' || echo "${SLEEP_US} us")"
+echo " aux streams : $([ "$AUX_W" = 0 ] && echo '(unchanged)' || echo "shrunk to ${AUX_W}x${AUX_H}")"
+echo " bitrate max : $([ "$KBPS" = 0 ] && echo '(unchanged)' || echo "${KBPS} kbps")"
+echo "==================================================================="
+
+echo "==> 1) Extract sections"
+python3 - "$BASE" <<'PY'
+import sys, os, hashlib
+import pak
+data = open(sys.argv[1], "rb").read()
+os.makedirs("sec", exist_ok=True)
+for s in pak.parse(data):
+    if not s["size"]:
+        continue
+    blob = data[s["offset"]: s["offset"] + s["size"]]
+    open(f"sec/{s['name']}.bin", "wb").write(blob)
+    print(f"   {s['name']:8s} {s['size']:>9d}  {hashlib.sha256(blob).hexdigest()[:16]}")
+PY
+
+echo "==> 2) Unpack app + rootfs"
+unsquashfs -d app -no-progress sec/app.bin >/dev/null
+unsquashfs -d rfs -no-progress sec/rootfs.bin >/dev/null
+
+echo "==> 3) Patch device capture-fps hardcode (+0x8bb1c)"
+python3 - "$FPS" <<'PY'
+import struct, sys
+fps = int(sys.argv[1])
+assert 0 < fps < 0x100, "fps must fit a byte"
+OFF = 0x8bb1c
+d = bytearray(open("app/device", "rb").read())
+cur = struct.unpack_from("<I", d, OFF)[0]
+# Accept any `movz w1, #imm16` (sf=0, opc=10, hw=0, Rd=1): 0x52800001 | imm<<5
+assert (cur & 0xFFE0001F) == 0x52800001, \
+    f"device[0x{OFF:x}] is {cur:08x}, not a `movz w1, #imm` -- refusing to patch blind"
+old = (cur >> 5) & 0xFFFF
+new = 0x52800001 | (fps << 5)
+struct.pack_into("<I", d, OFF, new)
+open("app/device", "wb").write(bytes(d))
+print(f"   device capture fps: movz w1,#{old} -> movz w1,#{fps}")
+PY
+
+echo "==> 4) Patch router advertised fps lists"
+python3 - "$FPS" <<'PY'
+import struct, sys
+fps = int(sys.argv[1])
+# Sites verified present in the 4909 base, all currently holding imm=21.
+W0_SITES = [0x637fc, 0x63c48, 0x63c68, 0x63cd4, 0x63ce4,   # per-resolution table
+            0x63ddc, 0x63e8c, 0x640ac, 0x64384,
+            0x6565c]                                        # dropdown max
+X22_SITE = 0x655a4                                          # 64-bit preload
+d = bytearray(open("app/router", "rb").read())
+n = 0
+for off in W0_SITES:
+    cur = struct.unpack_from("<I", d, off)[0]
+    if (cur & 0xFFE0001F) != 0x52800000:
+        print(f"   WARNING: router[0x{off:x}] = {cur:08x} is not `movz w0,#imm` -- skipped")
+        continue
+    struct.pack_into("<I", d, off, 0x52800000 | (fps << 5))
+    n += 1
+cur = struct.unpack_from("<I", d, X22_SITE)[0]
+assert (cur & 0xFFE0001F) == 0xD2800016, \
+    f"router[0x{X22_SITE:x}] = {cur:08x}, not `movz x22, #imm` -- refusing"
+struct.pack_into("<I", d, X22_SITE, 0xD2800016 | (fps << 5))
+open("app/router", "wb").write(bytes(d))
+print(f"   router fps lists: {n}/{len(W0_SITES)} w0 sites + x22 preload -> {fps}")
+PY
+
+echo "==> 4a) Optional main-stream bitrate ceiling"
+# router +0x6351c, `movz w11, #imm` -- the largest value the API will advertise
+# and accept for the main stream (stock 12288, this tooling has been shipping
+# 20480). Raising it costs essentially nothing on this hardware: every limit
+# measured in FPS_DEMO_RESULTS.md is a PIXEL-rate limit. Bitstream write at
+# 20 Mbps is 2.5 MB/s against ~4900 MB/s of DDR frame traffic (0.05%), the ISP
+# and encoder are charged per pixel not per bit, and rate control moves QP
+# rather than throughput. Verified rather than assumed -- see the 20480 vs
+# 40960 rows in the results table.
+if [ "$KBPS" != "0" ]; then
+python3 - "$KBPS" <<'PY'
+import struct, sys
+kbps = int(sys.argv[1])
+assert 0 < kbps < 0x10000, "kbps must fit a movz imm16"
+OFF = 0x6351c
+d = bytearray(open("app/router", "rb").read())
+cur = struct.unpack_from("<I", d, OFF)[0]
+if (cur & 0xFFE0001F) != 0x5280000B:
+    raise SystemExit(f"ABORT: router[0x{OFF:x}] = {cur:08x} is not `movz w11, #imm`")
+old = (cur >> 5) & 0xFFFF
+struct.pack_into("<I", d, OFF, 0x5280000B | (kbps << 5))
+open("app/router", "wb").write(bytes(d))
+print(f"   router max bitrate: movz w11,#{old} -> #{kbps} kbps")
+PY
+else
+    echo "   (skipped -- bitrate ceiling unchanged)"
+fi
+
+echo "==> 4b) Optional pump poll-miss sleep"
+# The userspace pump that carries the stitched main stream from VideoProc 2
+# out[0] into VideoEnc 0 in[0] pulls NON-BLOCKING (wait_time = 0) and sleeps a
+# fixed interval on every miss. That quantises the delivered frame period to
+#     T = k * sleep + work
+# so at 7680x2160 (work ~10 ms) a 20 ms sleep lands on k=2 -> 50 ms -> 20 fps
+# no matter what rate the sensor is producing. It is the reason capture 21, 25
+# and 28 all delivered ~20 fps (docs/FPS_DEMO_RESULTS.md §3).
+#
+# Shrinking the sleep shrinks the quantum. 2 ms gives ~1 fps of granularity
+# instead of ~8, at the cost of more polling on a core that measured 88.8% idle.
+#
+# Three sites, all `movz w0, #imm`, all in the stitch/pump path:
+#   0x081904  bc_stitch_main   poll-miss sleep   (stock 20000)
+#   0x081b18  bc_stitch_main   success sleep     (stock 10000)
+#   0x081e54  VSP->VENC pump   poll-miss sleep   (stock 20000)  <- the quantiser
+# Any `movz w0, #imm` is accepted: the base pak is usually a previous build of
+# this same tooling, not stock.
+if [ "$SLEEP_US" != "0" ]; then
+python3 - "$SLEEP_US" <<'PY'
+import struct, sys
+us = int(sys.argv[1])
+assert 0 < us <= 0xffff, "sleep must fit a movz imm16"
+SITES = [(0x081904, "bc_stitch_main poll-miss"),
+         (0x081b18, "bc_stitch_main success"),
+         (0x081e54, "VSP->VENC pump poll-miss (the quantiser)")]
+d = bytearray(open("app/device", "rb").read())
+for off, name in SITES:
+    cur = struct.unpack_from("<I", d, off)[0]
+    if (cur & 0xFFE0001F) != 0x52800000:
+        raise SystemExit(f"ABORT: device[0x{off:x}] = {cur:08x} is not `movz w0, #imm`")
+    old = (cur >> 5) & 0xFFFF
+    struct.pack_into("<I", d, off, 0x52800000 | (us << 5))
+    print(f"   0x{off:06x} {name:42s} movz w0,#{old} -> #{us}")
+open("app/device", "wb").write(bytes(d))
+PY
+else
+    echo "   (skipped -- pump sleeps left as found)"
+fi
+
+echo "==> 4c) Optional aux-stream shrink (starve VideoProc 3)"
+# `device` carries its own stream-descriptor table in .data. Each entry is a
+# pair of HDAL path ids (0x22xxxxxx / 0x24xxxxxx) followed by
+# (max_w, max_h, cur_w, cur_h). The four entries below are exactly the live
+# VideoProc 3 outputs seen in /proc/hdal/vprc/info:
+#
+#   0x336920  1536 x 432   -> VideoEnc 0 in[1]  (sub stream)
+#   0x336960  2560 x 720   -> VideoEnc 0 in[3]  (ext stream)
+#   0x336970  1280 x 352   -> VideoProc 3 out[2] (AI, 10/21 fps)
+#   0x336990   480 x 136   -> VideoProc 3 out[3] (AI, 5/21 fps)
+#
+# VideoProc 3 costs ~20 of the ISP's ~66.7 jobs/s (`/proc/kdrv_ipp/utilization`
+# reads usage 99, fps 66) and its two encoder outputs cost ~108 ms/s of encoder
+# time. Runtime attempts to stop it failed: isf_unit_set_state on its out ports
+# returns rc=0 but leaves IPP at 99/66, and /mnt/para/0_4|0_5 are not its
+# config. Shrinking its geometry here starves it instead of removing it, which
+# is a data-only change and trivially reversible.
+#
+# Sub and ext are lost. That is intended and approved.
+if [ "$AUX_W" != "0" ]; then
+python3 - "$AUX_W" "$AUX_H" <<'PY'
+import struct, sys
+aw, ah = int(sys.argv[1]), int(sys.argv[2])
+SITES = [(0x336920, 1536, 432, "sub  -> VideoEnc in[1]"),
+         (0x336960, 2560, 720, "ext  -> VideoEnc in[3]"),
+         (0x336970, 1280, 352, "ai   -> VideoProc 3 out[2]"),
+         (0x336990,  480, 136, "ai   -> VideoProc 3 out[3]")]
+# The ISE scaler refuses more than a 16x downscale in either axis. All of these
+# paths are scaled from the full 7680x2160 stitched frame, so anything below
+# 480x135 is rejected at runtime with
+#     ERR:gximg_scale_by_ise() scale factor over 16, SrcW=7680,SrcH=2160,...
+# and `device` then loops on gfx_scale() failures and never finishes bringing
+# the app up -- no nginx, no HTTP API, recoverable only through the 2323 shell.
+# That is exactly what 320x180 did on 2026-08-17. Note the stock table's
+# smallest entry is 480x136, i.e. the limit itself.
+SRC_W, SRC_H, MAX_RATIO = 7680, 2160, 16
+if SRC_W / aw > MAX_RATIO or SRC_H / ah > MAX_RATIO:
+    raise SystemExit(
+        f"REFUSING: {aw}x{ah} needs {SRC_W/aw:.1f}x/{SRC_H/ah:.1f}x downscale from "
+        f"{SRC_W}x{SRC_H}; the ISE scaler caps at {MAX_RATIO}x. "
+        f"Minimum is {SRC_W // MAX_RATIO}x{SRC_H // MAX_RATIO}.")
+
+d = bytearray(open("app/device", "rb").read())
+for off, w, h, name in SITES:
+    cur = struct.unpack_from("<4I", d, off)
+    if cur != (w, h, w, h):
+        raise SystemExit(f"ABORT: device[0x{off:x}] = {cur}, expected {(w, h, w, h)}")
+    struct.pack_into("<4I", d, off, aw, ah, aw, ah)
+    print(f"   0x{off:06x} {name:28s} {w}x{h} -> {aw}x{ah}")
+open("app/device", "wb").write(bytes(d))
+PY
+else
+    echo "   (skipped -- aux streams left at full size)"
+fi
+
+echo "==> 5) Optional sensor retime"
+if [ "$DFT" != "0" ]; then
+python3 - "$DFT" <<'PY'
+import struct, sys
+
+dft = int(sys.argv[1])
+PCLK_X100 = 2592 * 2314 * 2500        # HTS * min_vd * dft_fps, the fixed product
+READOUT_ROWS = 2162                   # mode_basic_param +48; VTS cannot go below
+
+
+def sym_off(path, want):
+    d = open(path, "rb").read()
+    shoff = struct.unpack_from("<Q", d, 0x28)[0]
+    shent = struct.unpack_from("<H", d, 0x3A)[0]
+    shnum = struct.unpack_from("<H", d, 0x3C)[0]
+    secs = []
+    for i in range(shnum):
+        b = shoff + i * shent
+        f = struct.unpack_from("<IIQQQQIIQQ", d, b)
+        secs.append(dict(typ=f[1], off=f[4], size=f[5], link=f[6], entsize=f[9]))
+    for s in secs:
+        if s["typ"] != 2:      # SHT_SYMTAB
+            continue
+        st = secs[s["link"]]
+        for i in range(s["size"] // s["entsize"]):
+            b = s["off"] + i * s["entsize"]
+            nm, info, other, shndx, val, sz = struct.unpack_from("<IBBHQQ", d, b)
+            e = d.index(b"\x00", st["off"] + nm)
+            if d[st["off"] + nm:e].decode() == want:
+                return secs[shndx]["off"] + val
+    raise SystemExit(f"{path}: symbol {want} not found")
+
+
+for ko in ["rfs/lib/modules/5.10.168/hdal/sen_os08c10/nvt_sen_os08c10.ko",
+           "rfs/lib/modules/5.10.168/hdal/sen_os08c10_slave/nvt_sen_os08c10_slave.ko"]:
+    off = sym_off(ko, "mode_basic_param")
+    d = bytearray(open(ko, "rb").read())
+    old_dft = struct.unpack_from("<I", d, off + 24)[0]
+    old_vd = struct.unpack_from("<I", d, off + 136)[0]
+    hts = struct.unpack_from("<I", d, off + 128)[0]
+    assert old_dft and old_vd and hts, f"{ko}: mode table looks empty"
+    new_vd = round(PCLK_X100 / (hts * dft))
+    if new_vd < READOUT_ROWS:
+        raise SystemExit(
+            f"REFUSING: dft_fps {dft/100:.2f} needs VTS {new_vd} < readout {READOUT_ROWS} rows. "
+            f"The sensor cannot emit {READOUT_ROWS} rows in {new_vd} line periods.")
+    struct.pack_into("<I", d, off + 24, dft)
+    struct.pack_into("<I", d, off + 136, new_vd)
+    open(ko, "wb").write(bytes(d))
+    real = PCLK_X100 / 100.0 / (hts * new_vd)
+    print(f"   {ko.split('/')[-1]}: dft_fps {old_dft}->{dft}  min_vd {old_vd}->{new_vd} "
+          f"(vblank {new_vd - READOUT_ROWS} rows, delivers {real:.3f} fps)")
+PY
+else
+    echo "   (skipped -- sensor keeps its 25.00 fps ceiling)"
+fi
+
+echo "==> 6) Recovery shell without the recording override"
+# The carried probe script asserted /mnt/sda/netstate/override at every boot,
+# which made S99_NetState yield and let the camera record at home. Strip that
+# (and the unrelated one-shot stitch collection, which also wrote to a card
+# that is 99% full) but KEEP the tcpsvd root shell -- that is the recovery path.
+rm -f rfs/etc/init.d/S36_StitchProbe
+cat > rfs/etc/init.d/S36_RootShell <<'EOS'
+#!/bin/sh
+# S36_RootShell -- recovery channel. One command set per TCP connection:
+# /bin/sh reads stdin to EOF, executes, exits.
+#
+# This script deliberately does NOT touch /mnt/sda/netstate/override. Asserting
+# that flag at boot makes S99_NetState yield permanently and the camera records
+# at home; enabling recording is an explicit operator action, never a build
+# default. See verify/check_recording_default.sh.
+tcpsvd -vE 0.0.0.0 2323 /bin/sh >/dev/null 2>&1 &
+exit 0
+EOS
+chmod 755 rfs/etc/init.d/S36_RootShell
+echo "   S36_StitchProbe -> S36_RootShell (shell kept, override assertion removed)"
+
+echo "==> 7) Build manifest"
+cat > rfs/etc/soccercam_build <<EOS
+build: fps_demo
+capture_fps: $FPS
+sensor_dft_fpsx100: $DFT
+base: $(basename "$BASE")
+built: $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+EOS
+chmod 644 rfs/etc/soccercam_build
+
+echo "==> 8) Repack squashfs"
+mksquashfs app app_new.bin -comp xz -b 262144 -noappend -no-progress \
+    -no-exports -all-root -mkfs-time 0 -all-time 0 >/dev/null
+mksquashfs rfs rootfs_new.bin -comp xz -b 262144 -noappend -no-progress \
+    -no-exports -all-root -mkfs-time 0 -all-time 0 >/dev/null
+echo "   app    $(stat -c%s app_new.bin) bytes"
+echo "   rootfs $(stat -c%s rootfs_new.bin) bytes"
+
+echo "==> 9) Repack pak"
+python3 - "$BASE" "$OUT" <<'PY'
+import sys
+from pak_repack import repack
+crc, size, meta = repack(sys.argv[1], sys.argv[2],
+                         swaps={"app": open("app_new.bin", "rb").read(),
+                                "rootfs": open("rootfs_new.bin", "rb").read()})
+print(f"   crc=0x{crc:016x} size={size}")
+PY
+
+echo "==> 10) ASSERT boot chain byte-identical to base"
+# The one check whose absence the 4917 postmortem called out. loader/fdt/atf/
+# uboot/kernel are what make the camera recoverable at all; nothing above
+# touches them, so any difference here is a repacker bug and must stop the
+# build before the pak is ever offered to the flasher.
+python3 - "$BASE" "$OUT" <<'PY'
+import sys, hashlib
+import pak
+
+IMMUTABLE = ("loader", "fdt", "atf", "uboot", "kernel", "ai")
+
+
+def digest(path):
+    d = open(path, "rb").read()
+    return {s["name"]: hashlib.sha256(d[s["offset"]:s["offset"] + s["size"]]).hexdigest()
+            for s in pak.parse(d) if s["size"]}
+
+
+a, b = digest(sys.argv[1]), digest(sys.argv[2])
+bad = []
+for name in IMMUTABLE:
+    if name not in a:
+        continue
+    same = a[name] == b.get(name)
+    print(f"   {name:8s} {'IDENTICAL' if same else 'DIFFERS'}  {a[name][:16]}")
+    if not same:
+        bad.append(name)
+for name in ("rootfs", "app"):
+    print(f"   {name:8s} {'unchanged' if a.get(name) == b.get(name) else 'replaced'}")
+if bad:
+    raise SystemExit(f"ABORT: boot-chain section(s) modified: {', '.join(bad)}")
+print("   boot chain intact")
+PY
+
+echo
+echo "==================================================================="
+echo " Built: $OUT"
+echo " NEXT:  verify/check_recording_default.sh '$OUT'   <-- required gate"
+echo "==================================================================="

--- a/reolink-firmware-patching/builds/build_tge_retime.sh
+++ b/reolink-firmware-patching/builds/build_tge_retime.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# Retime the NT98530 timing generator (TGE) so capture runs above 25 fps.
+#
+# WHY THE SENSOR-SIDE PATCHES DID NOTHING
+# ---------------------------------------
+# Both OS08C10s run as slaves to the SoC timing generator (`tge_en 1` in
+# /proc/hdal/vcap/info). The TGE, not the sensor, decides when a frame
+# starts, so reprogramming the sensor's VTS register changes nothing: the
+# sensor just gets re-triggered by the next TGE VD regardless.
+#
+# The TGE emits:
+#     HD every  hd_period  TGE clocks      (stock 415)
+#     VD every  vd_period  HD periods      (stock 2314)
+# giving 24.95 fps measured (TGE_INT in /proc/interrupts). Both values are
+# visible live in /proc/kflow_sen/info as
+#     tge_signal(hd_sync 8, hd_period 415, vd_sync 2313, vd_period 2314)
+#
+# and both are *hardcoded immediates* in nvt_sen_os08c10_slave.ko:
+#     mov  x?,#0x909              ; vd_sync  2313
+#     movk x?,#0x19f, LSL #32     ; hd_period 415     <-- this script
+#     movk x?,#0x90a, LSL #32     ; vd_period 2314
+#     mov  w?,#0x90a              ; vd_period multiplier
+#
+# WHY hd_period AND NOT vd_period
+# -------------------------------
+# vd_period is not a constant on its own -- the driver recomputes it as
+#     vd_period' = (2314 * dft_fps) / chgmode_fps
+# and sen_calc_chgmode_vd_os08c10_slave clamps chgmode_fps <= dft_fps
+# (2500). That makes vd_period' >= 2314 *always*, and the clamp is scale
+# invariant: raising dft_fps raises the numerator by the same factor. So
+# vd_period cannot be pushed below 2314 without surgery on the clamp AND
+# on four separate constants that feed the vd_sync arithmetic.
+#
+# hd_period has none of that. It is a pure pass-through constant, used in
+# no arithmetic anywhere, and it divides the TGE frame period linearly:
+#     fps_new = 24.95 * 415 / hd_period
+# vd_period stays 2314 and vd_sync stays 2313, so the signal stays
+# self-consistent and every other driver bookkeeping value is untouched.
+#
+# CEILING
+# -------
+# The sensor still needs 2162 rows * (HTS 2592 / PCLK 150 MHz) = 37.359 ms
+# to read a full frame out. The TGE VD interval must stay above that:
+#     hd_period >= 415 * 37.359/40.080 = 386.8   ->  >= 387
+# i.e. a hard ceiling of ~26.77 fps at 3840x2160. 28 fps at full height is
+# not reachable by any TGE setting.
+#
+#   hd_period  predicted fps   VD period   guard over readout
+#     415        24.95          40.080 ms    2.721 ms  (157 rows)  [stock]
+#     400        25.89          38.631 ms    1.272 ms   (74 rows)
+#     396        26.15          38.245 ms    0.886 ms   (51 rows)   <-- default
+#     392        26.41          37.859 ms    0.499 ms   (29 rows)
+#     390        26.55          37.666 ms    0.306 ms   (18 rows)
+#     388        26.69          37.473 ms    0.113 ms    (7 rows)
+#
+# Below ~390 the guard is thin enough that torn or truncated frames are the
+# expected failure mode. Walk down, don't jump.
+#
+# CAVEATS
+# -------
+#  * Userspace still believes 25 fps (chgmode_fps stays 2500). Recorded
+#    files will carry a 25 fps label while frames arrive faster. Fixing the
+#    label needs the app-side fps request too -- do NOT combine that with
+#    this patch in one build, because the app request also divides
+#    vd_period and the two compound past the readout limit.
+#  * sen_set_expt_os08c10_slave reprograms the TGE signal on every AE
+#    exposure update, which is why this script patches that copy too.
+#    Long night exposures can still stretch the VD period and pull fps back
+#    down -- test in daylight.
+#
+# Usage:
+#   sudo bash build_tge_retime.sh <input.pak> <output.pak> [hd_period]
+# Example:
+#   sudo bash build_tge_retime.sh soccercam_comprehensive.pak duo3_tge396.pak 396
+#
+# The input may be stock or any already-patched .pak -- this only touches
+# nvt_sen_os08c10_slave.ko in the rootfs, so it layers cleanly on top of the
+# HTTP unlock / bitrate / netstate / recovery builds.
+set -euo pipefail
+
+STOCK="${1:?usage: $0 <input.pak> <output.pak> [hd_period]}"
+OUT="${2:?usage: $0 <input.pak> <output.pak> [hd_period]}"
+HD="${3:-396}"
+[[ "$EUID" -eq 0 ]] || { echo "ERROR: run as root"; exit 1; }
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PAK_DIR="$(cd "$HERE/../pak" && pwd)"
+WORK="$(mktemp -d)"
+trap "rm -rf '$WORK'" EXIT
+cd "$WORK"
+
+python3 - <<PY
+hd = $HD
+assert 387 <= hd <= 415, "hd_period must be 387..415 (below 387 the sensor cannot finish readout; above 415 is slower than stock)"
+print("Target: TGE hd_period = %d  ->  predicted %.2f fps (stock 415 -> 24.95)" % (hd, 24.95*415/hd))
+PY
+echo
+
+echo "==> 1) Extract rootfs section"
+python3 - <<PY
+import struct
+data = open("$STOCK","rb").read()
+base = 0x18 + 5*0x48     # section index 5 = rootfs
+off = struct.unpack("<Q", data[base+0x38:base+0x40])[0]
+sz  = struct.unpack("<Q", data[base+0x40:base+0x48])[0]
+open("rootfs_stock.bin","wb").write(data[off:off+sz])
+print(f"  rootfs orig size: {sz} bytes")
+PY
+
+echo "==> 2) Unsquashfs rootfs"
+unsquashfs -d rootfs_unpacked -no-progress rootfs_stock.bin >/dev/null
+
+echo "==> 3) Patch TGE hd_period in nvt_sen_os08c10_slave.ko"
+python3 - <<PY
+import struct, sys
+
+KO = "rootfs_unpacked/lib/modules/5.10.168/hdal/sen_os08c10_slave/nvt_sen_os08c10_slave.ko"
+HD = $HD
+
+# file offset -> (owning function, expected stock word)
+# Each is MOVK X<d>, #0x19f, LSL #32  == the TGE hd_period literal.
+SITES = {
+    0x0305c: ("sen_chg_fps_os08c10_slave",  0xf2c033e5),
+    0x03380: ("sen_set_expt_os08c10_slave", 0xf2c033e3),
+    0x03b10: ("sen_chg_mode_os08c10_slave", 0xf2c033e2),
+    0x03fb0: ("sen_get_info_os08c10_slave", 0xf2c033e2),
+}
+
+d = bytearray(open(KO, "rb").read())
+for off, (fn, want) in sorted(SITES.items()):
+    got = struct.unpack_from("<I", d, off)[0]
+    if got != want:
+        sys.exit(f"ERROR: {KO} 0x{off:05x} ({fn}): expected {want:08x}, found {got:08x} "
+                 f"-- firmware layout differs, refusing to patch")
+    # MOVK keeps opcode/hw/Rd, only imm16 (bits 20:5) changes
+    new = (got & ~(0xffff << 5)) | (HD << 5)
+    struct.pack_into("<I", d, off, new)
+    print(f"  0x{off:05x} {fn:32s} {want:08x} -> {new:08x}")
+open(KO, "wb").write(bytes(d))
+
+# Belt and braces: no stray copy of the literal left anywhere in .text
+rest = bytes(d).count(struct.pack("<I", 0xf2c033e2)) + \\
+       bytes(d).count(struct.pack("<I", 0xf2c033e3)) + \\
+       bytes(d).count(struct.pack("<I", 0xf2c033e5))
+if rest:
+    sys.exit(f"ERROR: {rest} unpatched hd_period literal(s) remain")
+print("  all hd_period literals patched")
+PY
+
+echo "==> 4) Repack rootfs squashfs"
+mksquashfs rootfs_unpacked rootfs_new.bin \
+    -comp xz -b 262144 -noappend -no-progress \
+    -no-exports -all-root -mkfs-time 0 -all-time 0 \
+    >/dev/null
+
+echo "==> 5) Repack pak (replace rootfs section)"
+PYTHONPATH="$PAK_DIR" python3 - <<PY
+from pak_repack import repack
+swaps = {"rootfs": open("rootfs_new.bin", "rb").read()}
+crc, size, secs = repack("$STOCK", "$OUT", swaps=swaps)
+print(f"wrote $OUT  size={size}  crc=0x{crc:08x}")
+for name, off, sz in secs:
+    marker = "  (replaced)" if name in swaps else ""
+    print(f"  {name:10s} start=0x{off:08x} size=0x{sz:08x}{marker}")
+PY
+
+echo "==> 6) Verify CRC"
+python3 "$PAK_DIR/reolink_crc.py" compute "$OUT"
+
+cat <<EOF
+
+=====================================================================
+ Build complete: $OUT
+   TGE hd_period: 415 -> $HD
+
+ Measure after flashing. Do it with a client streaming, so the whole
+ chain is live (the ISP and encoder are idle otherwise):
+
+   # per-sensor capture rate. NEW/PROC/PUSH are live per-second rates,
+   # not counters -- just read them. Stock reads 25 / 25 / 25, drops 0.
+   grep -A3 'OUT WORK STATUS' /proc/hdal/vcap/info
+
+   # driver's view of the retimed signal -- expect hd_period $HD
+   grep -A1 tge_signal /proc/kflow_sen/info
+
+   # shared-ISP + encoder load, sampled the same way before and after
+   grep -E 'TGE_INT|SIE1|SIE3|ife_eng0|ipe_eng0|H26X' /proc/interrupts
+
+ Confirmed if: NEW/PROC/PUSH read ~$(python3 -c "print('%.0f' % (24.95*415/$HD))") on BOTH VIDEOCAP 0 and 2 with
+ drop/wrn/err still 0, and tge_signal shows hd_period $HD.
+
+ Refuted if: NEW stays at 25 -- hd_period is not the TGE's VD divider, and
+ the lever is the vd_period constant instead (0x90a at file offsets
+ 0x03060/0x03064, 0x03384/0x03388, 0x03b14/0x03b18, 0x03fb4, plus the
+ vd_sync 0x909 at 0x03058, 0x030a0, 0x0337c, 0x033bc, 0x03870, 0x03b0c,
+ 0x03fac -- all must move together to keep vd_sync = vd_period - 1).
+
+ Partly refuted if: NEW rises but drop/err climb, or frames come out torn
+ or short -- the sensor can no longer finish readout inside the VD
+ interval. Back off toward hd_period 400.
+
+ Watch also: ISP is a single shared IFE/IPE/IME at 450 MHz for both
+ sensors, so 2 x 3840x2160 at 1 px/clk theoretically tops out near 27 fps.
+ If ife_eng0's rate does not scale with NEW, that is the next wall.
+=====================================================================
+EOF

--- a/reolink-firmware-patching/docs/FIRMWARE_PATCH_NOTES.md
+++ b/reolink-firmware-patching/docs/FIRMWARE_PATCH_NOTES.md
@@ -109,6 +109,16 @@ A third investigation was completed:
    ceiling at ~330 Mpix/s (16.6 Mpix × 19.83 fps). Typical for a Novatek
    NT9856x marketed as "4K60" (~500 Mpix/s peak, lower sustained).
 
+   > **CORRECTED 2026-08-17 — see [`FPS_CEILING.md`](FPS_CEILING.md).** The
+   > ~330 Mpix/s figure is right; attributing it to the **encoder** is not. The
+   > H.265 engine was later measured directly off `/proc/hdal/venc/top` at
+   > **≈465 Mpix/s** — four geometries, two codecs, two sessions, all within ~2 %
+   > — and it runs at 83 % duty, never binding. The 330 Mpix/s belongs to the
+   > **userspace frame pump** in `device`, which moves the main stream because
+   > `VIDEOENC 0 in[0]` is the one video path that is not kernel-bound. Shedding
+   > the sub stream to free encoder time changed delivered fps by −0.07,
+   > confirming the encoder was not the constraint.
+
    **What the patch is still worth despite the encoder ceiling:** the
    sensor's per-frame exposure window shrinks from 50 ms (at 20 fps) to 40
    ms (at 25 fps), giving ~20% less motion blur on each retained frame.
@@ -428,6 +438,14 @@ The lower-resolution profile (4096×1152) caps natively at 20 fps too. So:
 firmware are for single-sensor 1080p models that share the same code base.
 **Do not flash the fps patch as your daily driver** — it only lies in the
 dropdown without delivering frames.
+
+> **SUPERSEDED 2026-08-17 — see [`FPS_CEILING.md`](FPS_CEILING.md).** 20 fps is
+> not a hardware ceiling. It is where the **userspace frame pump** in `device`
+> saturates (~332 Mpix/s), with a 99 %-busy shared IPP engine behind it. Starving
+> the aux-stream inputs reaches **21.179 fps at 7680×2160** and **23.395 at
+> 4096×1152** — so 4096×1152 does not cap at 20 either. The advice not to flash
+> the fps dropdown patch on its own still stands, and for the reason given: it
+> changes the dropdown, not the delivery.
 
 The bitrate-only patch (build 4879) is the recommended daily build.
 
@@ -1023,7 +1041,13 @@ question moot.
   (dropdown shows 25/30) but the encoder silently clamps to 20 fps at
   16MP. No `cmp w_, #0x14` hardcoded cap exists in any app binary
   (cgi/router/device/recorder) NOR in kdrv_h26x.ko / kdrv_videocapture.ko.
-  **RESOLVED 2026-08-15 — see section 15.** It is the first option: a
+  **RESOLVED 2026-08-15 — see section 15**, and then
+  **[`FPS_CEILING.md`](FPS_CEILING.md), which supersedes section 15.** Two
+  corrections to the bullet above: `sen_chg_fps_os08c10` **does** have a clamp —
+  it lives one call down in `sen_calc_chgmode_vd_os08c10`, which silently resets
+  any request above 25.00 fps by forcing `VTS = VTS_base`. And the binding stages
+  are the userspace pump and a saturated shared IPP, not the capture front-end.
+  It is the first option: a
   throughput ceiling in the **capture front-end** (sensor readout + SIE/ISP for
   two 3840x2160 streams), not in the encoder. The requested capture rate is
   freely settable (patching `0x8bb1c` to 30 gives `VIDEOCAP frc = 30/1`), but
@@ -1170,6 +1194,28 @@ The 20 fps behaviour at 16MP comes from:
 ---
 
 ## 15. Where the 20 fps ceiling actually is (measured on-camera, 2026-08-15)
+
+> **SUPERSEDED 2026-08-17 — see [`FPS_CEILING.md`](FPS_CEILING.md).** This
+> section's *location* of the ceiling (the capture front-end rather than the
+> encoder) was right in spirit, but two of its load-bearing numbers are wrong and
+> its mechanism is wrong:
+>
+> - **PCLK is 150 MHz, not 120.** §15 infers 120 MHz from a *delivered* 20.00 fps.
+>   Delivered is not capture. `/proc/kflow_sen/info` reports `pclk 150000000`, the
+>   mode table closes on 149.95 MHz three independent ways, and the caveats block
+>   near line 128 of this same file already said 150 MHz. The full-height sensor
+>   ceiling is **26.7 fps, not 21.33**.
+> - **The 21 fps result was verified from `r_frame_rate = 21/1`** — the container
+>   header, which on this camera always reports the *requested* rate. The camera
+>   was delivering 19.86 fps at the time.
+> - **The mechanism is not "sensor readout plus SIE/ISP".** Capture is clean
+>   (25/s, zero drops on both sensors). The binding stages are a **userspace frame
+>   pump** in `device` and a **shared IPP engine at 99 %** starving the second
+>   sensor's pipe.
+>
+> §15's *remedy* — windowed sensor readout — is still correct, for a different
+> reason: it cuts ISP load, not sensor time. Best measured result to date is
+> **21.179 fps at 7680×2160**.
 
 Earlier sections concluded "sensor-limited at 20 fps" and "encoder ASIC drops
 ~20% of frames". Both were inferred from the *outside* — nobody had a shell, so
@@ -1426,6 +1472,12 @@ itself is still unknown** — it travels behind a userspace pointer and the
 tracer logged only the 32-byte ioctl struct, so no dimension appears anywhere in
 either trace. `ISF_PARAM_MAP.md` §7 lists the single-command captures needed on
 the next camera visit, `cat /proc/hdal/flow` first.
+
+> **SUPERSEDED 2026-08-17 — see [`FPS_CEILING.md`](FPS_CEILING.md).** The
+> paragraph below rests on §15's retired 120 MHz / VTS model. 2160 rows do not
+> cap VTS at ~21.3 fps; at the real 150 MHz PCLK the sensor's full-height ceiling
+> is 26.7 fps. What actually caps delivery is the userspace pump and a saturated
+> shared IPP.
 
 **Practical consequence: on this firmware 21 fps is the hard ceiling**, because
 the sensor must produce 2160 rows for the ISP to bind, and 2160 rows caps VTS at

--- a/reolink-firmware-patching/docs/FPS_CEILING.md
+++ b/reolink-firmware-patching/docs/FPS_CEILING.md
@@ -554,7 +554,19 @@ SHA-256 assertion before being written.
 | `builds/build_fps_demo.sh` | the builder that produced 4910–4916. Capture-fps + advertised-list + aux-geometry patches; refuses >16× ISE downscale; asserts the boot chain is SHA-256 identical to base and aborts if not |
 | `builds/build_tge_retime.sh` | TGE `hd_period` retime, 387..415 enforced. **Not flashed** — see O3, and back-fill the boot-chain guard first |
 | `runtime/isfbind.c` | freestanding aarch64 ISF bind/get client, no libc. Reproduces F8 |
-| `runtime/camsh.py` | `hold_recording_override()` — the one narrow, named capability for asserting the record-at-home flag while capturing a sample, so the general refusal stays enforced instead of being reworded around |
+| `runtime/camsh.py` | `recording_override_held()` — the one narrow, named capability for asserting the record-at-home flag while capturing a sample, so the general refusal stays enforced instead of being reworded around. A context manager, not a pair of calls: it releases in `finally` and then tests for the flag's *absence*, because `rm -f` exits 0 on a path it did not remove |
+
+**Known gap in the override tooling.** `recording_override_held()` guarantees
+release against an exception, but not against a hard kill of the host process
+between hold and release — that leaves the camera recording at home with nothing
+to notice it. Closing that needs a camera-side self-expiring watchdog (assert the
+flag, and have the camera itself drop it after N minutes). The obvious
+implementation, backgrounding a `sleep N; rm -f` under `nohup`, has **not** been
+verified to survive `tcpsvd` closing the connection on this busybox build, so it
+is deliberately not shipped rather than shipped untested — an expiry believed
+armed and actually absent is worse than none. Until then: the flag is only ever
+held inside the context manager, and `verify/check_recording_default.sh` keeps
+the far more dangerous case, a *build* that asserts it at boot, impossible.
 
 ### Reproducing the headline measurement
 

--- a/reolink-firmware-patching/docs/FPS_CEILING.md
+++ b/reolink-firmware-patching/docs/FPS_CEILING.md
@@ -1,0 +1,582 @@
+# What limits the Duo 3 PoE's frame rate — the answer
+
+Investigation 2026-08-15 → 2026-08-17, camera `192.168.86.24`, firmware base
+`IPC_NT15NA416MP.4867_2505072124`. This document supersedes four working
+documents written during the investigation and reconciles the places where they
+disagreed. Per-stage readings, register values and offsets live in
+[`FPS_STAGE_EVIDENCE.md`](FPS_STAGE_EVIDENCE.md).
+
+---
+
+## The result
+
+**Best delivered frame rate achieved: 21.179 fps recorded / 21.218 fps RTSP at
+7680×2160**, and **23.395 / 23.383 at 4096×1152.** Sustained, not a burst — a
+4-minute full-resolution RTSP run held 21.385 fps with a window-to-window spread
+of 0.058 fps and no decay. The stream is usable by a downstream tracker.
+
+The camera as found was configured for 21 fps and **delivered 19.856**. Net
+movement at full resolution across the investigation: **19.86 → 21.18 (+6.6 %)**.
+
+> **The "21 fps" in the original question was never a delivered rate.** It is a
+> policy value in Reolink's encoder capability table, and it is what the MP4
+> header reports. **Every clip this camera writes carries the *requested* rate
+> regardless of what was encoded** — a clip that says `25/1` can hold 19.98 fps
+> of pictures. All numbers in this document are frame-count-over-PTS-span,
+> measured with `verify/measure_clip_fps.py`. Never quote `r_frame_rate` from
+> this camera as evidence of anything.
+
+### What limits it
+
+Two stages bind, in this order at 7680×2160. **Neither is a hardware engine's
+rated throughput, which is why a stage-by-stage capability analysis missed both.**
+
+1. **The userspace frame pump in `device`** (~332 Mpix/s → ~20 fps at
+   16.589 Mpix). `VIDEOENC 0 in[0]` is the only video path on the camera that is
+   **not kernel-bound**, so `device` moves each stitched frame itself. Offer it
+   more and it takes the same number: with the stitcher producing 23/s it still
+   delivered exactly 20. **(L)**
+
+2. **One shared IPP (ISP) engine at 99 % usage, serving three VideoProc clients.**
+   It starves `VIDEOPROC 1` — the second sensor's pipe — which drops 3–4 of every
+   25 frames at its kernel input, so the stitcher only ever makes 22–23 pairs/s.
+   Client split: `vdoprc0` 25.00/s + `vdoprc1` 21.73/s + `vdoprc3` 19.97/s =
+   66.71, matching the engine's own `fps 66`. **(L)**
+
+**Not limiting, all measured:** the sensor (25.00 fps, zero drops), capture/SIE
+(25/s, zero drops), the H.265 encoder (**≈465 Mpix/s** — 28.0 fps for the main
+stream alone, 83 % duty at the delivered rate), MIPI, or the bitrate.
+
+### What would have to change to go faster
+
+| target | what it needs | status |
+|---|---|---|
+| past ~21 at 7680×2160 | finish freeing the ISP — kill `VIDEOPROC 3`'s **outputs**, not just its input. Needs the API/`enc.cfg` size-code path; the `device` descriptor table reaches the input only. | open, next step |
+| past ~22.5 | replace the pump. Needs `device` replaced, not patched — it computes its ioctl numbers at runtime, so no static search reaches the pump loop. | `APP_REPLACEMENT_DESIGN.md` (**but see §6**) |
+| past ~25 | retime the TGE (`builds/build_tge_retime.sh`, built, sites verified, **not flashed**) | gated on the ISP first — §5 O3 |
+| past ~26.8 at 2160 rows | **impossible.** The sensor needs 37.36 ms to read out 2162 rows; no TGE setting beats that. | hard wall |
+| 60 fps | only by cutting rows, and only *after* the pump and ISP are gone. The encoder prices vertical FOV at `fps ≈ 54100/rows`, but the encoder is not what you are up against today. | not reachable now |
+
+**Was 25 fps at 7680×2160 achieved? No — and it is not reachable on the shipped
+pipeline.** A static analysis predicted it was. That prediction was wrong; §3
+says exactly how.
+
+### Confidence tiers
+
+| tier | meaning |
+|---|---|
+| **S** | static — read out of the shipped binary; file + symbol/offset given |
+| **L** | live — measured on the running camera |
+| **I** | inferred — the arithmetic is shown and the assumption is named |
+
+---
+
+## 1. The measured record
+
+Capture 25 fps throughout unless noted. Both paths measured; container headers
+ignored. Full stage readings in `FPS_STAGE_EVIDENCE.md`.
+
+| # | build / change | main geometry | recorded | RTSP | IPP use/fps | VPRC1 IN drop | DDR BUSY | bound by |
+|---|---|---|---|---|---|---|---|---|
+| 1 | as-found, capture 21 | 7680×2160 | **19.856** | — | — | — | — | pump |
+| 2 | + `constantFrameRate=1` | 7680×2160 | 19.899 | — | — | — | — | pump (exposure excluded) |
+| 3 | 4910, capture 25 | 7680×2160 | 20.054 | 20.136 | 99 / 66 | 3 | 92 | pump |
+| 4 | capture **28** requested, sub shed | 7680×2160 | 19.983 | — | — | — | — | sensor clamps 28→25, then pump |
+| 5 | 4913, pump sleep 20 ms → 2 ms | 7680×2160 | 20.013 | 19.964 | 99 / 66 | 3 | 91 | pump — **unchanged, see F1** |
+| 6 | 4910 restored | 7680×2160 | 20.004 | 20.041 | 99 / 66 | 4 | 92 | pump |
+| 7 | **4915 `aux640`** (first meas.) | 7680×2160 | 21.167 | 21.095 | 99 / 68 | 3 | 90–91 | pump |
+| 8 | **4915 `aux640`** (final) | **7680×2160** | **21.179** | **21.218** | 99 / 68 | 3 | 90–91 | pump |
+| 9 | 4910 | 4096×1152 | 22.170 | 22.179 | 99 / 66 | 3 | 79–80 | ISP starvation |
+| 10 | 4912, sensor retimed to 26 | 4096×1152 | 22.208 | — | — | — | — | ISP — **retime bought nothing, F5** |
+| 11 | **4915 `aux640`** | **4096×1152** | **23.395** | **23.383** | **79 / 53** | 3 | 78–79 | ISP starvation |
+| 12 | runtime kernel bind (no flash) | 7680×2160 | — | 24.240 raw / **22.80 distinct** | — | — | — | stitcher — **restarts in ~4 min, F8** |
+
+Rows 7 and 8 are the same build measured on different occasions; the 0.012 fps
+difference is inside the observed window spread.
+
+**Sustained stability at 7680×2160 on build 4915:**
+
+| run | result |
+|---|---|
+| 4 min, 5133 frames, 30 s windows | **21.385 fps**, spread **0.058**, no decay |
+| 90 s, 30 s windows | 21.261 / 21.221 / 21.190, spread **0.071** |
+
+---
+
+## 2. Where each stage tops out
+
+```
+sensor 0 --25.0--> SIE 0 --25.0--> VIDEOPROC 0 --25.0--\
+                                                        >-- VSP --22..23--> [pump ~20..21] --> VENC
+sensor 2 --25.0--> SIE 2 --25.0--> VIDEOPROC 1 --21.7--/
+                                        ^ 99%-busy shared IPP starves this one
+```
+
+| stage | sustains at 7680×2160 | tier | binding? |
+|---|---|---|---|
+| Sensor | 25.00 fps (`chgmode_fpsx100 2500`, VD 40.02 ms) | L | no |
+| Sensor, physical ceiling (TGE permitting) | 26.77 fps (2162-row readout = 37.36 ms) | I | no |
+| `VIDEOCAP 0`/`2` out | 25/s, drop 0 | L | no |
+| Per-sensor ISP `VIDEOPROC 0` | 25/s, drop 0 | L | no |
+| **ISP `VIDEOPROC 1`** (shared IPP) | **21.7/s, drop 3–4 of 25** | **L** | **binds — 2nd** |
+| VSP stitcher `VIDEOPROC 2` out | 22–23/s, drop 0 | L | follows its weaker input |
+| **Userspace pump → `VIDEOENC 0` in[0]** | **~332 Mpix/s → ~20/s** | **L** | **binds — 1st** |
+| H.265 encoder | ≈465 Mpix/s → 28.0 fps main alone; 83 % duty at 20 fps | L | no |
+| MIPI CSI-2, 2 lanes of 4 | ~26.0 fps | I | no |
+| DDR | 5118 MB/s = **~93 % of practical** ~5.5 GB/s | L | **near its ceiling — see F3** |
+| Bitrate | hard encoder limit in (20, 21) Mbps | L | no (not a rate limit) |
+
+At 4096×1152 (4.719 Mpix) the pump would allow ~70 fps, so it stops binding and
+the ISP alone sets the rate — which is why that geometry is faster.
+
+---
+
+## 3. The contradiction: static analysis said 25 fps, the camera does 21
+
+The first document written in this investigation, `FPS_BOTTLENECK.md`, was a
+static + read-only-live analysis that priced every hardware stage and found four
+independent limits between 25 and 27 fps. It concluded a **realistic ceiling of
+25 fps at 7680×2160** and opened with "the premise is wrong, and the answer is
+better than 21".
+
+**Verdict: the prediction was wrong. It was not right-but-blocked.** There is no
+configuration of the shipped pipeline that reaches 25 fps at full resolution.
+
+**But its hardware numbers were not wrong** — nearly every one was later
+confirmed by direct measurement:
+
+| `FPS_BOTTLENECK.md` claim | later measurement | verdict |
+|---|---|---|
+| PCLK is 150 MHz, not 120 | `/proc/kflow_sen/info` `pclk 150000000`; mode table → 149.95 MHz | **confirmed (L)** |
+| H.265 encoder ≈466 Mpix/s | re-measured 463.1 / 466.4 / 438.7 / 429.5 over 4 geometries, 2 codecs, 2 sessions | **confirmed (L)** |
+| Sensor mode clamps hard at 25.00 | request 28 → `fpsxbase (2500,2500,2500)`, VD 40.0 ms | **confirmed (L)** |
+| Sensor full-height ceiling 26.7 fps | 26.76 (zero vblank at 2162 rows); TGE analysis independently 26.77 | **confirmed (S+L)** |
+| 21 fps is a policy value, not a sensor wall | true — and understated: the camera never delivered 21 either | **confirmed (L)** |
+| "Realistic ceiling 25 fps at 7680×2160" | measured best **21.18** | **WRONG** |
+| DDR not binding, ≥2.5 GB/s | 5118 MB/s = ~93 % of practical | **WRONG — F3** |
+| ISP fourth in line at ~27.1 fps, not binding | IPP saturated at usage 99, starving `VIDEOPROC 1` | **WRONG** |
+
+### Why it missed, and it is the same reason twice
+
+Its method was to price each **hardware engine** and rank the results. Both real
+limits are invisible to that method:
+
+1. **The userspace pump is not a hardware engine.** It is `device` moving frames
+   between two kernel units that are not bound to each other. Nothing in a driver
+   limit table, the clock tree, or `/proc/hdal/*/info`'s rate columns exposes it.
+   It only appears when you **diff what a stage produces against what the next
+   stage takes** — `VIDEOPROC 2 OUT 22–23/s` against `USER PULL 20, drop 2–3`.
+   The read-only session read capability tables; it never diffed producer against
+   consumer.
+
+2. **The ISP was priced as one engine doing one job.** It modelled the ISP as
+   processing this pipeline's 16.59 Mpix/frame once, at an assumed 1 px/clk
+   → 27.1 fps. In fact **one IPP engine serves three VideoProc clients**, and the
+   third — the sub/ext splitter `vdoprc3` — eats 19.97 of the 66.71 jobs/s it
+   delivers. The substreams' cost was charged to the *encoder* budget and never
+   to the ISP budget at all.
+
+Both misses share a root cause: **capability tables describe engines, not
+contention.** The lesson for the next investigation of this kind is to measure
+producer-vs-consumer at every hop before ranking any engine's rated throughput.
+
+### The near-miss worth keeping
+
+`FPS_BOTTLENECK.md` recommended killing the substreams — "worth 12 % of the
+encoder budget, free". **Right lever, wrong mechanism, and the mechanism is what
+tells you how hard to pull:**
+
+- Shedding substream **frame rate** (20 → 4 fps) freed ~25 ms/s of *encoder*
+  time and moved delivered fps by **−0.07**. The encoder route buys nothing,
+  because the encoder was never binding.
+- Starving substream **input geometry** (2560×720 → 640×192), which cuts *IPP*
+  work, bought **+1.18 fps** — the only change in the whole investigation that
+  moved full-resolution delivery.
+
+---
+
+## 4. Superseded and falsified claims
+
+Kept deliberately. Each of these cost real time, and a later reader who does not
+know they were tried will try them again.
+
+### F1 — "The pump's 20 fps is set by a hardcoded 20 ms poll-miss sleep" — FALSIFIED BY EXPERIMENT
+
+*Source: `FRAME_PUMP.md`, its entire thesis.*
+
+**The theory.** `FUN_00481df0` pulls non-blocking and `usleep(20000)`s on every
+miss, quantising the frame period to `k × 20 ms + w`. 16.6 Mpix lands in the k=2
+bin (≈50 ms → 20 fps), 4.7 Mpix in the k=1 bin (≈21 ms → 48 fps) — which would
+explain why the two apparent "pixel rates" differ by 47 %, and why requesting
+21 / 25 / 28 fps all deliver ~20.
+
+**The test.** All three `usleep` sites verified byte-for-byte **in the running
+binary** first, patched 20/10/20 ms → 2 ms, and confirmed live after flashing
+(`00 fa 80 52` at all three).
+
+**The result.** Delivered fps moved **−0.04 recorded and −0.17 RTSP.** Nothing.
+
+**Independent disconfirmation.** If a fixed sleep set the period, inter-frame
+deltas would cluster tightly around 50 ms. They do not, before or after:
+
+| clip | mean delta | sigma | histogram |
+|---|---|---|---|
+| baseline | 49.66 ms | **17.33 ms** | 40 ms ×198, 41 ×75, 80 ×57, 39 ×55 |
+| pump 2 ms | 49.92 ms | **17.05 ms** | 40 ms ×153, 39 ×68, 41 ×65, 80 ×45 |
+
+The distribution is **bimodal on the 40 ms capture grid** (take a frame / skip a
+frame), not a 50 ms period with small jitter. Sigma is 17 ms, not sub-ms.
+
+**Cost:** 2 of 6 permitted flashes (one to test, one to revert).
+
+**What survives from `FRAME_PUMP.md`** and is kept in `FPS_STAGE_EVIDENCE.md` §5:
+the pump's structure, the loop decompilations, all patch-site offsets (still
+correct), the finding that **`device` performs no pixel copy** (descriptor-only
+ioctl, `VmRSS` 16–41 MB against `VmSize` 1.26 GB, `bc_stitch_main` at 0.9 % of one
+core), and that OSD is composited by the encoder, not the pump.
+
+**Unresolved tension this leaves — see O1.** The pump is throughput-bound, but
+`device` does no copying. Those are both measured, and nothing yet reconciles
+them.
+
+### F2 — "Dual-sensor frame pairing fails, passing ~45 of 50 frames" — FALSIFIED BY MEASUREMENT
+
+*Source: `FPS_DEMO_RESULTS.md` §2/§6 and `FPS_MAIN_BIND.md` §8.*
+
+**The theory.** The two sensors' frame counters are offset, the ISP discards the
+unmatched frames, and the stitched stream is capped at ~22.5 pairs/s. Cited
+`isp_dev_get_sync_item: sync info not match` flooding `dmesg`.
+
+**Falsified.** The sensors are **exactly synchronised** and cannot be otherwise:
+
+- Both deliver **1500 VD in 60.04 s**, `new_fail`/`drop`/queue-full all zero, a
+  constant VD offset of 7 (a start-time artefact) and **zero drift over 1500
+  frames**. (L)
+- They are the same clock. Both report `tge_vdhd 0x1` and byte-identical
+  `tge_signal`; the TGE's four VD generators share one enable register and one
+  LOAD strobe. TGE "phase" is rising/falling edge only — **there is no
+  phase-offset register**. Software re-alignment is refused outright while
+  `tge_en=1`, and there is no FSIN pin.
+
+**`isp_dev_get_sync_item` was misread.** It is a **24-slot per-frame 3A/IQ
+parameter ring**, not a pairing function. A mismatch means *"the metadata for
+this frame is ≥24 frames stale"*; the caller goes without it. Callers are
+`ae_flow_auto_process`, `awb_flow_process` (3 sites) and **`iq_flow_process`
+(50 sites)** — one late IQ pass emits up to 50 lines, so the "flood" wildly
+over-reports. It is a **symptom of the 3A/IQ threads running late, not a cause of
+lost frames.**
+
+**Real pairing** is in userspace (`bc_stitch_main`, ±30000-tick timestamp window
+at `device` offset `0x81974`) and is **not** the limiter: the lost frames are
+refused at `VIDEOPROC 1`'s *kernel input*, before any timestamp is compared.
+Widening the window would buy nothing and would tear the seam on motion.
+
+**The count was right, the mechanism was not:** `vdoprc0` 25.00 + `vdoprc1`
+21.73 = **46.7 of 50**.
+
+> **Obsolete advice — do not follow it.** `FPS_MAIN_BIND.md` §9 recommended
+> *"fix the dual-sensor pairing first (it caps everything at 22.5 and may be a
+> configuration problem)"*. **There is nothing to fix.** The 22.5 ceiling is IPP
+> saturation, and the fix is to shed IPP load.
+
+**This correction earned its keep by predicting.** The sensor-sync analysis
+proposed shedding the `vdoprc3` IPP load and predicted IPP usage would fall off
+99. Done the next session by starving `VIDEOPROC 3`'s input: at 4096×1152 IPP
+went **99/66 → 79/53** and delivered fps rose **+1.22**. Falsifiable prediction,
+made in advance, held.
+
+### F3 — "DDR is not the binding constraint; half the bus is free" — CORRECTED
+
+*Source: `FPS_BOTTLENECK.md` §6, and the reading of the raw counters.*
+
+The counters read `BUSY 92, EFF 52, UTI 48, 5118 MB/s`. `UTI 48` against a
+10.66 GB/s theoretical peak was read as "48 % used, half the bus free".
+
+**Wrong. `EFF 52` is the controller's own efficiency figure** — only ~52 % of
+theoretical is achievable. The practical ceiling is **~5.5 GB/s**, so 5118 MB/s
+is **~93 % of it**. `BUSY 92` says the same directly, and `UTI 48 / EFF 52` = 92 %
+reconciles all three readings.
+
+`FPS_BOTTLENECK.md`'s own traffic estimate (~118 MB/frame → ~2.5 GB/s at 21 fps)
+was also low by roughly 2× against the measured 5118 MB/s at 20 fps.
+
+DDR tracks main-stream size exactly as a throughput-bound pump predicts:
+
+| main geometry | DDR | pump state |
+|---|---|---|
+| 7680×2160 | BUSY 90–92, 4905–5118 MB/s | saturated, 20/s |
+| 4096×1152 | BUSY 79–80, 3732–3839 MB/s | not saturated, polls 101/s |
+
+**So DDR is not comfortably clear** — it is near its effective ceiling precisely
+when the pump is stuck, and it relaxes when the pump is not. Whether DDR
+bandwidth *is* the pump's binding resource or merely correlates with it was not
+separated: see **O1**.
+
+### F4 — "Raising the bitrate ceiling to 40 Mbps is free" — REJECTED BY HARDWARE, AND ALREADY KNOWN
+
+The prediction that it would be free was sound and still holds: bitstream write
+is ~2.5 MB/s against ~4900 MB/s of DDR frame traffic, and ISP and encoder are
+billed per pixel, not per bit. Measured either side, frame rate and DDR are
+identical (21.17 fps, BUSY 90–91 both ways).
+
+It simply is not a bandwidth question. `SetEnc bitRate=40960` →
+**`rspCode -13`, "set config failed"**. There is a separate hard limit inside the
+encoder at ~20 Mbps, enforced below the advertised list.
+
+> **This was already recorded and a flash was spent rediscovering it.**
+> `FIRMWARE_PATCH_NOTES.md` §"Patches v12-v14" documents the binary search:
+> 16384 ✓, **20480 ✓**, 21504 ✗, 22528 ✗, 24576 ✗ — ceiling in (20, 21) Mbps.
+> The `-13` reproduces it exactly. **Read the patch notes before spending a flash.**
+
+**Consequence that matters for build selection:** the ceiling patch **replaces**
+the 20480 list entry rather than adding to it, so the 40960 build advertises
+`[… 10240, 40960]` and can select **neither** — its maximum selectable is 10240.
+The 20480 build is the correct daily driver.
+
+### F5 — "Retiming the sensor's VTS raises the capture rate" — NO EFFECT
+
+Both sensor drivers were retimed to `dft_fps 2600 / min_vd 2225`. It genuinely
+took, at the driver (`fpsxbase (2600,2600,2600)`) **and at the chip**
+(`i2c r_reg 0x380e/0x380f -> 0x08b1` = 2225, was 2314).
+
+The frame rate did not move: VD averaged 40.35 ms = **24.79 fps**, delivered
+22.208 against 22.170 unretimed — noise.
+
+**Because `tge_en = 1`.** The SoC timing generator drives VD and both sensors are
+slaves. Shortening the sensor's own VTS just makes it finish its readout earlier
+inside a frame period the TGE still sets at ~40 ms.
+
+The correct lever is the TGE's `hd_period` — `builds/build_tge_retime.sh`, and
+see O3 for why it was not flashed.
+
+### F6 — "Aux geometry can be shrunk arbitrarily" — BROKE THE APP LAYER
+
+The first attempt used 320×180. 7680/320 = 24×, over the ISE scaler's hard **16×
+downscale limit**:
+
+```
+ERR:gximg_scale_by_ise() scale factor over 16, SrcW=7680,SrcH=2160,DstW=320,DstH=180
+ERR:gfx_scale() scale fail
+```
+
+`device` then loops on the failure and never finishes start-up: **no nginx, no
+port 80, no HTTP API**, so `flash_pak.py` could not reach the camera. The stock
+table's smallest entry, 480×136, is exactly 7680/16 × 2160/16 — the limit itself.
+
+`build_fps_demo.sh` now **refuses** any aux geometry needing more than 16× and
+states the minimum; self-tested, 320×180 is rejected before the build runs.
+
+Recovery took minutes rather than a UART cable because the 2323 root shell was
+up and nginx can be started by hand from its template — recipe in
+`FPS_STAGE_EVIDENCE.md` §9.2.
+
+### F7 — `FIRMWARE_PATCH_NOTES.md` §15's sensor timing — SUPERSEDED
+
+§15 inferred `PCLK = 20 × 2592 × 2314 = 119.96 MHz` ("exactly 120 MHz") from a
+**delivered** 20.00 fps, and concluded `120e6 / (2592 × 2170)` = **21.33 fps** is
+the hard full-height ceiling.
+
+**Delivered is not capture.** `/proc/kflow_sen/info` reports `pclk 150000000` and
+the mode table multiplies out to 149.95 MHz three independent ways. The
+full-height sensor ceiling is **26.7 fps, not 21.3**. §15 also verified its 21 fps
+result from `r_frame_rate = 21/1` — the one field on this camera that cannot be
+trusted.
+
+> **Note:** the correct 150 MHz figure was **already in the same file**, at the
+> caveats block near line 128 (*"pclk = 150 MHz … max sensor fps at 4K is
+> ~26.7 fps"*). §15 later contradicted it without noticing. The file disagreed
+> with itself for the whole investigation.
+
+§15's **remedy** — windowed sensor readout — is still the right remedy, for a
+different reason: it helps because it cuts ISP load, not because the sensor is
+slow.
+
+Also retired: the §11 bullet stating `sen_chg_fps_os08c10` has *"no hardcoded
+clamp"*. The clamp is real; it lives one call down, in
+`sen_calc_chgmode_vd_os08c10`, and it is what silently resets any request above
+25.00 fps.
+
+### F8 — "The kernel bind is the fix" — WORKS, RAISES FPS, NOT SHIPPABLE
+
+The bind is issuable at runtime with **zero flashes**, is accepted (`rc=0`), and
+`/proc` immediately shows `bind_src VIDEOPROC_2_OUT_0`. Delivered rose
+20.136 → 24.240 raw.
+
+**The raw figure is inflated.** 36 of 607 packets arrive ~1 ms after their twin,
+because `device`'s pump never stopped and both producers now feed the same
+encoder input. Distinct delivered = **22.80 fps** — exactly the stitcher's output
+rate, which is the correct result of moving the wall one stage upstream.
+
+**Nothing functional regressed:** OSD timestamp, watermark and camera name all
+survive, snapshots work, the stitch seam is clean. OSD is composited by the
+encoder from `IN_STAMP_IMG`, which the bind does not touch.
+
+**What breaks is the camera.** It restarts within ~4 minutes, reproducibly, *even
+fully idle with no recording and no RTSP* — buffer reference/release accounting
+on that port driven by two owners. Recovery is free: `/mnt/tmp` is tmpfs, so the
+restart reverts the bind.
+
+**Do not leave it bound unattended.** Making it permanent requires `device` to
+stop pumping, which is not a binary patch — see §6.
+
+---
+
+## 5. Open questions
+
+**O1 — Why exactly 332 Mpix/s?** The pump is throughput-bound; that is measured
+and is the cleanest result in the investigation (stitcher offers 23/s, pump takes
+20). But the *mechanism* is not located. `device` performs no pixel copy (F1), so
+any copy is on the kernel side of `isf_unit_pull_data`/`push_in_buf`; DDR is
+simultaneously at ~93 % of practical (F3). Whether DDR bandwidth is the binding
+resource or merely correlated was **not separated**. Deciding it needs per-master
+DDR accounting, or a pump-rate test at fixed geometry with DDR load varied
+independently.
+
+**O2 — The remaining aux kill.** `VIDEOPROC 3`'s out[0]/out[1] did **not** move
+with the `device` descriptor table — they stayed 1536×432 and 2560×720 because
+those sizes come from the API/`enc.cfg` size codes (70 and 81). VideoProc 3 now
+upscales and the encoder still pays for them; sub and ext are correspondingly
+soft, which was accepted. **Finding that size-code path is the next +fps at full
+resolution.**
+
+**O3 — TGE retime, built but not flashed.** `builds/build_tge_retime.sh` is
+complete and its four patch sites are verified; `hd_period` 415 → 396 gives
+26.15 fps capture. Deliberately not flashed: **capture is already the least
+constrained stage** (25/s, drop 0) while the ISP drops 3–4 of 25. Feeding 26.15
+into a saturated ISP produces more drops, not more frames. Do it **after** the
+ISP is freed, **in daylight** (AE reprograms `hd_period`, so a night test is
+uninterpretable), with someone able to power-cycle.
+
+> ⚠️ **`build_tge_retime.sh` does not carry the boot-chain SHA-256 assertion**
+> that `build_fps_demo.sh` and `build_roi_qp.sh` do. It hard-fails on an
+> out-of-range `hd_period`, but it does not verify `loader`/`fdt`/`atf`/`uboot`/
+> `kernel`/`ai` are byte-identical to the base pak. **Back-fill that guard before
+> flashing it** — see `ENCODER_ROI_QP.md` §9.
+
+**O4 — ISP pixels per clock** is still unmeasured; the 27.1 fps figure assumed
+1 px/clk. Now moot for *ranking* (the ISP is measured saturated by client count,
+not by pixel rate) but it would firm up the headroom estimate after O2.
+
+**O5 — Encoder ceiling, exact value.** ≈465 Mpix/s gives 28.0 fps for the main
+stream alone, 25.0 with substreams at stock rates, 24.1 with substreams at the
+main stream's rate. The spread is entirely the substream assumption. All three
+are far above anything delivered, so it was never worth pinning down.
+
+### Closed since the investigation
+
+**The 2-D warp mesh `get` path.** During the investigation `lut2d_ioctl get`
+returned an all-zero table while the driver held a real mesh, so `set` was
+correctly **not** attempted — writing that dump back would have blanked a live
+warp rather than being the no-op the validation gate requires. **This is now
+fixed on `main`**: the mesh dimension `n` belongs in `buf[1]`, and the reader is
+confirmed live at 66 049 / 66 049 non-zero control points. See `vpe/README.md`.
+
+> Two details from that episode are worth carrying, because both are general.
+> `lut2d.py selftest` reported **17/17 passing on a file containing nothing** — an
+> all-zero table satisfies every *structural* invariant (size, padding,
+> round-trip, quarter-pixel exactness) by construction. The suite now checks
+> **liveness first** and reports 19 gates. And the driver returned
+> `align4(0) * 0` entries **with a success code**: a zero-length success is not a
+> success.
+
+---
+
+## 6. A referral that does not yet exist
+
+Three of the source documents send the pump work to
+`docs/APP_REPLACEMENT_DESIGN.md`. **That document does not currently cover it.**
+It scopes replacing `device` as a *pipeline configurator* — the ISF `'I'` ioctl
+family, IQ blob hand-off, staged `LD_PRELOAD` trace-and-replay migration. The
+words "pump", `pull_data` and `push_data` do not appear, and there is no
+treatment of a frame-delivery loop. Its closest acknowledgements are an
+"Unclear" row for pre-stitch frame access and an open unknown about whether
+`nvtmpp` buffer pools can be driven from a non-`device` process — which is
+exactly the question the pump replacement turns on.
+
+Also note `APP_REPLACEMENT_DESIGN.md`'s frame-rate row still uses the retired
+120 MHz model (`fps = 46296/(rows+8)`, "21 fps hard ceiling"). With the correct
+57 870 lines/s the relation is `fps = 57870/(rows+8)`, and the ceiling is set by
+the pump and ISP, not by VTS.
+
+**Removing the pump needs that design extended first.** It is not a binary patch:
+`device` does not materialise the ISF ioctl numbers anywhere a static search can
+reach — 0 sites for the `movz`/`movk`/32-bit-literal forms — because they are
+computed from a variable `nr` at runtime. Locating the pump loop means recovering
+the ioctl dispatch by dataflow through a 4.9 MB stripped C++ binary.
+
+---
+
+## 7. Build numbers in this repo are not unique — check before you flash
+
+**`4915` and `4916` each name two different paks.**
+
+| number | in this document | in `BRICK_POSTMORTEM.md` |
+|---|---|---|
+| 4913 | pump-sleep patch (F1) | — |
+| 4914 | — | pre-`ioctllog` baseline |
+| **4915** | **`aux640`, the fps daily driver** | **first build carrying `ioctllog.so`** |
+| **4916** | **bitrate ceiling 40960 (rejected)** | **`ioctllog.so` with pointer-following** |
+| 4917 | — | the brick |
+
+`BUILD_LOG.md` logs neither series — it stops at 4906. `FPS_BOTTLENECK.md` also
+referred to "builds 4913/4914" failing an `ime_path_adj` geometry check, which
+predates this investigation's own 4913.
+
+**"Leave the camera on 4915" in this document means the fps `aux640` build from
+`build_fps_demo.sh`.** Cite the change, not the number, and log new builds in
+`BUILD_LOG.md`.
+
+---
+
+## 8. Camera state as left
+
+| item | state |
+|---|---|
+| Firmware | **build 4915** (`aux640`): capture 25, aux inputs 640×192, bitrate ceiling 20480 |
+| Sensor | stock drivers, retime reverted — `chgmode 2500`, VD 40.02 ms |
+| Encoder | main 7680×2160 h265, sub 1536×432 h264 |
+| Recording | **disabled**, netstate daemon in control, no `/mnt/sda/netstate/override` |
+| Root shell | `S36_RootShell` on 2323, running |
+| ISP | `constantFrameRate` restored to 0 (as-found) |
+| Bind | cleared (runtime-only; reverted by restart) |
+| Left on card | `/mnt/sda/fpsdemo/*.mp4`, ~25 MB of test clips |
+
+Every flashed pak passed `verify/check_recording_default.sh` and the boot-chain
+SHA-256 assertion before being written.
+
+---
+
+## 9. Tools
+
+| file | purpose |
+|---|---|
+| `verify/measure_clip_fps.py` | **the measurement every number here rests on** — frame count over PTS span, reporting the container header alongside so a claimed-vs-delivered gap is visible |
+| `builds/build_fps_demo.sh` | the builder that produced 4910–4916. Capture-fps + advertised-list + aux-geometry patches; refuses >16× ISE downscale; asserts the boot chain is SHA-256 identical to base and aborts if not |
+| `builds/build_tge_retime.sh` | TGE `hd_period` retime, 387..415 enforced. **Not flashed** — see O3, and back-fill the boot-chain guard first |
+| `runtime/isfbind.c` | freestanding aarch64 ISF bind/get client, no libc. Reproduces F8 |
+| `runtime/camsh.py` | `hold_recording_override()` — the one narrow, named capability for asserting the record-at-home flag while capturing a sample, so the general refusal stays enforced instead of being reworded around |
+
+### Reproducing the headline measurement
+
+```bash
+# Recorded path
+python verify/measure_clip_fps.py /path/to/clip.mp4
+
+# Live path (RTSP), 25 s
+ffmpeg -rtsp_transport tcp -i "rtsp://<user>:<pass>@<cam>:554/h264Preview_01_main" \
+       -t 25 -c copy /tmp/rtsp_main.mp4
+python verify/measure_clip_fps.py /tmp/rtsp_main.mp4
+```
+
+Recorded and RTSP agree to within ~0.05 fps in every paired sample, so either
+path is valid evidence. **The container header is not.**
+
+---
+
+*Consolidated from `FPS_BOTTLENECK.md`, `FPS_DEMO_RESULTS.md`, `FPS_MAIN_BIND.md`,
+`FRAME_PUMP.md` and the sensor-sync analysis, none of which survive as separate
+documents. Cross-references: `FPS_STAGE_EVIDENCE.md` (all per-stage readings),
+`ISF_PARAM_MAP.md` §1 (the ioctl table), `FIRMWARE_PATCH_NOTES.md` §15
+(superseded by §3 and F7 here), `APP_REPLACEMENT_DESIGN.md` (§6),
+`BRICK_POSTMORTEM.md` (why sensor `.ko` edits are the highest-risk class of
+change on this device).*

--- a/reolink-firmware-patching/docs/FPS_STAGE_EVIDENCE.md
+++ b/reolink-firmware-patching/docs/FPS_STAGE_EVIDENCE.md
@@ -1,0 +1,874 @@
+# Duo 3 PoE frame rate — per-stage evidence
+
+Supporting detail for [`FPS_CEILING.md`](FPS_CEILING.md). That document states
+the result and the verdicts; **this one only shows the readings** — register
+values, file offsets, counter dumps, decompiled loops. It draws no conclusions
+of its own. If a number here disagrees with `FPS_CEILING.md`, `FPS_CEILING.md`
+is the error and should be fixed.
+
+Camera `192.168.86.24`, firmware base `IPC_NT15NA416MP.4867_2505072124`, HDAL
+`00305000:00305001`, kernel `5.10.168`, board `Novatek NS02302`. Sessions
+2026-08-15 → 2026-08-17.
+
+### Confidence tiers
+
+| tier | meaning |
+|---|---|
+| **S** | static — read out of the shipped binary; file + symbol/offset given |
+| **L** | live — read off the running camera; the command is given |
+| **I** | inferred — the arithmetic is shown and the assumption is named inline |
+
+---
+
+## 1. Sensor — one mode, 25.00 fps, and a hard clamp
+
+### 1.1 The mode table, read out of the ELF (S)
+
+`nvt_sen_os08c10.ko`, `.data` @ file offset `0x008c20`. Symbol sizes from
+`.symtab`:
+
+| symbol | `.data` offset | size | note |
+|---|---|---|---|
+| `mode_basic_param` | `+0x0000` | 320 | stride `0xa0` ⇒ 2 slots, **only slot 0 populated** |
+| `speed_param` | `+0x0c90` | 40 | stride `0x14` ⇒ 2 slots, **only slot 0 populated** |
+| `mipi_param` | `+0x0cb8` | 120 | `{0, 1, 2}` then all zero |
+| `os08c10_mode_1` | `+0x0dd0` | 10496 | 656 × 16-byte `{u32 addr, u32 len=1, u32 val, u32 pad}` I2C entries |
+
+`mode_basic_param[1]` and `speed_param[1]` are all zero. **There is exactly one
+populated sensor mode and no faster mode already compiled in.** Confirmed live
+as `max_senmode 1` / `MODE_1` (L).
+
+`mode_basic_param[0]`, fields confirmed by their use sites:
+
+| offset | value | what it is | how confirmed |
+|---|---|---|---|
+| `+0x18` | **2500** | `fps_base`, ×100 ⇒ 25.00 fps | `sen_chg_fps_os08c10` @ `00102c10` assigns it to `cur_fps`/`chgmode_fps` |
+| `+0x24` | 10 | bit depth | (I) |
+| `+0x2c/+0x30` | 3840 × **2162** | crop | matches reg `0x3808/0x380a` |
+| `+0x3c/+0x40` | 3840 × 2160 | output | matches `/proc/hdal/vcap/info` (L) |
+| `+0x80` | **2592** | HTS | used as `HTS*10/(pclk/1e6)` in `sen_get_info_os08c10` |
+| `+0x88` | **2314** | VTS_base | `sen_chg_fps_os08c10` writes it to the VTS registers |
+
+`speed_param[0]` = `{0, 0, 24000000, 150000000, 198000000}` =
+`{clk_src, clk_sel, mclk, pclk, data_rate}`. **MCLK 24 MHz, PCLK 150 MHz.**
+`data_rate = 198000000` does not decode to anything sensible in bps/Mbps/MHz for
+any lane count — **unit unresolved, do not use it.**
+
+> **Ghidra caveat.** `ghidra_sensor_spec.log` from an early session dumps
+> `mode_basic_param`/`speed_param`/`mipi_param` as **all zeros** — Ghidra loaded
+> the relocatable `.ko` with an uninitialised `.data` block. Every data value
+> above was re-read by parsing the ELF section headers directly. Ghidra was used
+> only for code.
+
+### 1.2 The I2C register table agrees exactly (S)
+
+Decoded from `os08c10_mode_1`:
+
+| reg | value | meaning |
+|---|---|---|
+| `0x3800`..`0x3807` | 0,0 → 3871, 2191 | **3872 × 2192** full active array |
+| `0x3808/09` | `0x0f00` = 3840 | output width |
+| `0x380a/0b` | `0x0872` = **2162** | output height |
+| `0x380c/0d` | `0x0a20` = **2592** | HTS |
+| `0x380e/0f` | `0x090a` = **2314** | VTS |
+| `0x3814/15` | `0x11`/`0x11` | X inc 1/1 — no binning, no skipping |
+| `0x3820/21` | `0x80`/`0x04` | no binning bits set |
+
+3872 × 2192 matches the OS08C10 product brief exactly, confirming the part.
+
+### 1.3 The timing closes three ways (S)
+
+```
+line rate = pclk / HTS  = 150 000 000 / 2592 = 57 870.37 lines/s
+fps_base  = line / VTS  = 57 870.37 / 2314   = 25.008  == fps_base field 2500/100
+line time = HTS*10/150  = 2592*10/150        = 172     == 17.28 us  (the code's own formula)
+```
+
+Three independent fields plus `pclk` agree to 0.03 %. Cross-check against the
+only public OS08C10 driver (`themactep/ingenic-sdk` `t41/os08c10.c`): it uses
+`HTS_reg 2976`, `VTS 2520`, `SCLK 300 MHz`, where the HTS register counts **2
+SCLK per tick**. Applying that convention here, `2592 × 2 = 5184` ticks at
+300 MHz = 17.28 µs — identical line time. Novatek books it as 2592 ticks of a
+150 MHz half-rate clock. Independent sources, same answer.
+
+Confirmed live: `/proc/kflow_sen/info` reports `pclk 150000000` (L).
+
+### 1.4 The clamp (S, decompiled and verified)
+
+`sen_calc_chgmode_vd_os08c10` @ `00101a80`:
+
+```c
+VTS = (VTS_base * fps_base) / fps_req;          // (2314 * 2500) / fps_x100
+if (0xffff < VTS) { VTS = 0xffff; fps = ...; }  // low-fps clamp -> 0.88 fps floor
+if (VTS < VTS_base) {                           // <<<< HIGH-FPS CLAMP
+    chgmode_fps = fps_base;                     // silently forced to 2500
+    cur_fps     = fps_base;
+    VTS         = VTS_base;                     // 2314
+}
+return VTS;                                     // -> regs 0x3840[23:16], 0x380e, 0x380f
+```
+
+| requested | computed VTS | outcome |
+|---|---|---|
+| 21.00 fps | 2754 | accepted → 57870.37/2754 = 21.01 fps |
+| 25.00 fps | 2314 | accepted, exactly at the floor |
+| 30.00 fps | 1928 < 2314 | **clamped — silently reset to 25.00** |
+
+Two consequences:
+
+1. **21 fps is produced by making VTS *longer*, not shorter.** The sensor is
+   throttled below its own mode base.
+2. **Cropping rows buys nothing on the shipped firmware.** The clamp compares
+   against `VTS_base` (2314), *not* the active row count. Ask for 720 rows at
+   60 fps and you still get VTS 2314 and 25 fps.
+
+Demonstrated live (L). Build with the capture hardcode set to 28:
+
+```
+VIDEOCAP 0 IN FRAME   frc = 28/1                                <- device asks for 28
+/proc/kflow_sen/info  fpsxbase(dft(max), chgmode, cur) = (2500, 2500, 2500)
+VD_TO_SIE0 intervals  40366 39736 39992 40220 39864 39941 us    -> 24.99 fps
+```
+
+### 1.5 The full-height arithmetic ceiling (I, from measured constants)
+
+With `fps = pclk/(HTS × VTS)` and VTS floored by the 2162-row readout:
+
+| fps | required VTS | vs 2162-row readout |
+|---|---|---|
+| 25.00 | 2314 | ok, 152 rows vblank |
+| 26.00 | 2225 | ok, 63 rows vblank |
+| **26.76** | **2162** | zero vblank — the floor |
+| 28.00 | 2066 | **96 rows short — impossible** |
+
+28 fps would need the sensor to emit 2162 rows in 2066 line periods. It needs a
+different HTS or a re-derived sensor PLL, with only two MIPI lanes to carry it.
+`build_fps_demo.sh` refuses any retime whose VTS would fall below the readout
+height, so this is enforced at build time.
+
+### 1.6 What the silicon is rated for (external)
+
+OmniVision OS08C10 product brief v1.1 (Jul 2024), under *maximum image transfer
+rate*:
+
+| mode | published rate |
+|---|---|
+| full size, 10-bit | 60 fps |
+| full size, **12-bit** | **48 fps** |
+| DAG HDR, 12/14-bit | 30 fps |
+
+Also 1.449 µm pixel, 1/2.82" optical format, 3872 × 2192 array, 4-lane MIPI,
+296 mW. (The "2.0 µm / 1/1.8"" figures belong to the siblings OS08A10/OS08A20,
+not this part.)
+
+This pipeline captures **RAW12** (`/proc/hdal/vcap/info`, L), where the part is
+rated 48 fps. The shipped firmware uses 25.00 — **52 % of the sensor's rating.**
+
+---
+
+## 2. The TGE — what actually sets the frame period
+
+Both sensors run as **slaves** to the SoC timing generator (`tge_en 1` in
+`/proc/hdal/vcap/info`, `signal_type SLV` in `/proc/kflow_sen/info`). The TGE,
+not the sensor, decides when a frame starts. This is why the sensor-VTS retime
+did nothing (`FPS_CEILING.md` F5).
+
+The TGE emits HD every `hd_period` TGE clocks and VD every `vd_period` HD
+periods. Live, for **both** chips, byte-identical (L):
+
+```
+tge_signal(hd_sync 8, hd_period 415, vd_sync 2313, vd_period 2314)
+tge_vdhd 0x00000001   tge_vd_evt 0x00000001   signal_type SLV
+```
+
+Both are hardcoded immediates in `nvt_sen_os08c10_slave.ko` (S):
+
+```
+mov  x?,#0x909              ; vd_sync   2313
+movk x?,#0x19f, LSL #32     ; hd_period  415
+movk x?,#0x90a, LSL #32     ; vd_period 2314
+mov  w?,#0x90a              ; vd_period multiplier
+```
+
+**`vd_period` is unusable as a lever.** The driver recomputes it as
+`vd_period' = (2314 × dft_fps) / chgmode_fps`, and
+`sen_calc_chgmode_vd_os08c10_slave` clamps `chgmode_fps <= dft_fps`. That makes
+`vd_period' >= 2314` always, and the clamp is **scale invariant** — raising
+`dft_fps` raises the numerator by the same factor.
+
+**`hd_period` is the lever.** A pure pass-through constant, used in no
+arithmetic anywhere, dividing the TGE frame period linearly:
+`fps_new = 24.95 × 415 / hd_period`. `vd_period` and `vd_sync` stay put, so the
+signal stays self-consistent.
+
+Ceiling: the sensor still needs `2162 × (2592 / 150e6)` = **37.359 ms** to read
+a full frame. The VD interval must stay above that, so
+`hd_period >= 415 × 37.359/40.080 = 386.8` ⇒ **>= 387**, a hard ceiling of
+**~26.77 fps** at 3840 × 2160 (I).
+
+| `hd_period` | predicted fps | VD period | guard over readout |
+|---|---|---|---|
+| 415 | 24.95 | 40.080 ms | 2.721 ms (157 rows) — stock |
+| 400 | 25.89 | 38.631 ms | 1.272 ms (74 rows) |
+| **396** | **26.15** | 38.245 ms | 0.886 ms (51 rows) — builder default |
+| 392 | 26.41 | 37.859 ms | 0.499 ms (29 rows) |
+| 388 | 26.69 | 37.473 ms | 0.113 ms (7 rows) |
+
+Below ~390 the guard is thin enough that torn or truncated frames are the
+expected failure mode. Walk down, don't jump. Builder: `builds/build_tge_retime.sh`
+(**not flashed** — see `FPS_CEILING.md` O3).
+
+The TGE's four VD/HD generators (`tge_setVdHd` / `Vd2Hd2` / `Vd3Hd3` / `Vd4Hd4`,
+register stride `0x1C` from `0x28`) are all enabled by one store to bits 16–19
+of reg `0x00` and reloaded by one global LOAD strobe (`tge_setLoad` writes
+`0xf06`), so any two channels are frequency-locked regardless. TGE "phase"
+(reg `0x08`) is **rising/falling edge only** — `kdrv_tge_set_vdhd_param` rejects
+anything but 0/1 with `"Unknown vd_phase %u"`. There is no phase-offset register.
+
+---
+
+## 3. Capture front end — SIE, MIPI
+
+### 3.1 Which blocks are powered (L)
+
+From `/sys/kernel/debug/clk/clk_summary`; `enable_count` is the column that
+matters:
+
+| clock | rate | enable | in the path? |
+|---|---|---|---|
+| `2f0310000.sie1` | 320 MHz | 1 | yes — sensor 0 |
+| `2f0312000.sie3` | 320 MHz | 1 | yes — sensor 1 |
+| `2f0311000.sie2` / `sie4` / `sie5` | 320 MHz | 0 | no |
+| `2f0320000.vie1` | 320 MHz | **0** | **no — VIE is off** |
+| `2f0340000.ife` | 450 MHz | 2 | yes |
+| `2f0400000.ipe` | 450 MHz | 2 | yes |
+| `2f0410000.ime` | 450 MHz | 2 | yes |
+| `2f0500000.vpe` | 440 MHz | 1 | only the 1280×352 sub-path |
+| `2f0c20000.dce` | 12 MHz | **0** | **no — dewarp engine powered down** |
+| `venc_clk` (pll15) | 480 MHz | 1 | yes |
+| `cpu_clk` (pll8) | 162.5 MHz | 1 | 2× Cortex-A53 |
+| `pll3` | 333.25 MHz | 1 | no Linux child — DDR PLL candidate (I) |
+
+Corroborated by `dmesg`: `SIE_CLK [O]`, `SIE3_CLK [O]`, `SIE2/4/5_CLK [X]`,
+`VIE_CLK [X]`, `IFE_CLK [O]`.
+
+**VIE and DCE are both out of the picture.** The 400 Mpix/s `kdrv_vie_limit` is
+irrelevant to this pipeline, and there is no hardware dewarp running.
+
+### 3.2 The SIE limit table (S)
+
+`kdrv_videocapture.ko`, `.data+0x1e8`, symbol `kdrv_sie_limit_98538`, 2920 bytes
+= 5 × `0x248`. Entry 0, first line:
+
+```
++0x00  00 84 d7 17  80 d1 f0 08  04 00 00 00  03 00 00 00
+       400,000,000  150,000,000  4            3
+```
+
+| field | value | reading |
+|---|---|---|
+| `+0x00` | 400 000 000 | SIE pixel-rate ceiling ⇒ 3840×2160 @ **48.2 fps** — not binding |
+| `+0x04` | 150 000 000 | max SIE input pixel clock — the sensor runs at **exactly 150 MHz** (I) |
+
+The `+0x04` matching `speed_param.pclk` to the digit is unlikely to be
+coincidence: **the sensor's pixel clock is pinned to the capture block's
+maximum**, so you cannot buy frame rate by raising PCLK.
+
+**Caveat, stated plainly:** no site was found that compares either constant
+against a computed rate. `vie_chk_limitation` @ `00173498` is a 1-byte external
+thunk (unimplemented in this module) and `tge_chk_limitation` @ `0011e920` is
+`return 0;`. The only in-module references to `kdrv_vie_limit` are `+0x70`/`+0x78`,
+which are **feature bits**, not rates. So both constants are **advertised
+capability, not enforced ceilings**, as far as `kdrv_videocapture.ko` goes.
+
+### 3.3 MIPI — two lanes of four
+
+| source | finding |
+|---|---|
+| `/proc/hdal/vcap/info` (L) | `sen_2_serial_pin_map[0:7] = 0 1 -1 -1 -1 -1 -1 -1` — **2 pins mapped** |
+| `device`, `nvt_vcap.cpp` (S) | `local_78 = 2; FUN_0059b2e0(path, 5, &local_78);` beside the string `vendor_videocap_set(cap_path, VENDOR_VIDEOCAP_PARAM_DATA_LANE, &data_lane)` — literal 2 |
+| OS08C10 brief | the part supports 4 |
+
+Payload arithmetic (I):
+
+```
+3840 x 2162 x 12 bit x 25 fps = 2.491 Gbit/s  ->  1.246 Gbit/s per lane on 2 lanes
+```
+
+The one public OS08C10 driver runs the same part on 2 lanes at 1296 Mbps/lane.
+If that is also this board's rate, the link is at **96 % utilisation at 25 fps**
+and the 2-lane ceiling is `2 × 1296e6 / (3840 × 2162 × 12)` = **26.0 fps**.
+
+Tier **I** — the per-lane rate is inferred from another board. It is a
+consistency signal, not a measurement, and it is not binding anyway (the
+pipeline never reaches 26 fps). Wiring the other two lanes is a PCB change.
+
+---
+
+## 4. ISP / IPP — one engine, three clients
+
+This is the stage that starves the second sensor pipe. Measured at steady state,
+geometry `7680x2160 @ 25/25` at `VIDEOENC 0 IN`, uptime 400–1300 s (all samples
+outside the boot window).
+
+### 4.1 Capture loses nothing — the sensors are exact (L)
+
+`/proc/kflow_sie/info` accu counters are **cumulative** (unlike `/proc/hdal/*/info`,
+which self-reset on read). Over a 60.04 s window:
+
+| | sensor 0 (ISP 0) | sensor 2 (ISP 2) |
+|---|---|---|
+| VD interrupts | **1500** | **1500** |
+| `new_ok` | 1500 | 1500 |
+| `new_fail` / `drop` / `in_q_ful` / `out_q_ful` | 0 | 0 |
+
+24.983 fps each, deltas identical every window, a **constant VD offset of 7**
+(a start-time artefact — `ctl_sen` shows sensor 2's `chgmod` 304 ms after sensor
+0's) and **zero drift over 1500 frames**. Both `VIDEOCAP 0` and `VIDEOCAP 2` OUT
+read `NEW 25 / PROC 25 / PUSH 25`, all drops and errors zero.
+
+They cannot drift — they are the same clock (§2). Two corroborating negatives
+from the driver source: `_isf_vdocap_do_setportstruct` **refuses** any software
+sync while the TGE is on (`"ERR:%s() Only support HW tge sync by pinmux"` when
+`vcap_sync_set != 0`), and the SIE's own re-alignment loop
+(`ctl_sie_vd_sync_isr_proc`) is reachable only via `ctl_sie_set_sync_info` mode 2,
+which the live dump shows is mode 0. There is no FSIN/XVS pin: a scan of the
+whole rootfs and app for `FSIN|XVS|XHS|sensor_sync|vsync_out` returns nothing,
+and `sen_os08c10_539.cfg`'s only GPIOs are the two resets (`id_0_rst_pin 0x46`
+= `S_GPIO_6`, `id_2_rst_pin 0x47` = `S_GPIO_7`).
+
+Two more: the SIE's cross-sensor alignment block (`-----sync info-----`:
+`mode, sync_id, sync_diff, adj_thres, adj_auto, …`) is **all zeros — disabled**,
+and the SIE group/combine feature is unused (`-----group info-----`: each sensor
+its own group, `comb_num 1`). The SIE is not pairing or stitching anything.
+
+> Static analysis of `ctl_sen_tge_open` suggested cap 0 and cap 2 sit on
+> *different* TGE channels (ch1/MCLK1 and ch2/MCLK2, selected by the
+> `sensorsync` pinmux — FDT `/top@2,f0010000/sensorsync/pinmux = <0x84218421>`,
+> the only non-zero sensor pinmux group). **The live reading disagrees and
+> wins:** the channel bitmask reads `0x1` for both. Either way the measured
+> result is the same. Resolving one-channel-vs-two would need
+> `echo dumpinfo > /proc/kdrv_tge/cmd && dmesg` — a write, not done.
+
+### 4.2 Where the frames actually go: one IPP at 99 % (L)
+
+`/proc/kdrv_ipp/utilization` reads **`usage 99, fps 66`**, steady across every
+sample. `/proc/kflow_ipp/info` shows three VideoProc clients on that one engine.
+Measured `ctl_end` deltas over 60.64 s:
+
+| IPP client | frames/s | what it is |
+|---|---|---|
+| `vdoprc0` | **25.00** | ISP pipe for sensor 0 (`VIDEOPROC 0`, `RAWALL`) |
+| `vdoprc1` | **21.73** | ISP pipe for sensor 2 (`VIDEOPROC 1`, `RAWALL`) |
+| `vdoprc3` | **19.97** | sub/ext stream splitter (`VIDEOPROC 3`, `YUVALL`) |
+| **total** | **66.71** | matches the engine's own `fps 66` at `usage 99` |
+
+The deficit is **entirely one-sided**. Five independent 1 s windows of
+`/proc/hdal/vprc/info`:
+
+| | `VIDEOPROC 0` IN | `VIDEOPROC 1` IN |
+|---|---|---|
+| PUSH | 25 25 25 25 25 | 25 25 25 25 25 |
+| **drop** | **0 0 0 0 0** | **3 3 4 4 3** |
+| PROC | 25 25 26 24 25 | 21 22 21 21 22 |
+
+Cumulative since stream start the ratio is stable at 26296/30228 = **0.870**, so
+this is persistent, not jitter. `ctl_drop` is 0 for both — frames are refused at
+the VideoProc **input** (out depth 1) because the pipe is still busy, not
+discarded inside the ISP.
+
+```
+sensor 0 --25.0--> SIE 0 --25.0--> VIDEOPROC 0 --25.0--\
+                                                        >-- VSP --21--> VENC --20-->
+sensor 2 --25.0--> SIE 2 --25.0--> VIDEOPROC 1 --21.7--/
+                                        ^ 99%-busy shared IPP starves this one
+```
+
+25.00 + 21.73 = **46.7 of 50** sensor frames reach the ISP.
+
+> **INFERENCE (not proven):** the deficit lands wholly on `vdoprc1` because the
+> three clients are serviced in a fixed order each VD and pipe 1 is behind pipe
+> 0. The ordering itself was not observed; only that the loss is persistent and
+> one-sided.
+
+### 4.3 `isp_dev_get_sync_item` is 3A/IQ metadata, not frame pairing (S)
+
+`nvt_isp.ko`, `.text+0x8d84` (Ghidra `00108dc4`). A **24-slot ring of per-frame
+ISP parameters** (0x54 bytes/slot, per ISP id), written by
+`isp_dev_set_sync_item` and read by the 3A/IQ threads. `param_2` selects the
+pipeline stage whose frame counter to index by — 0 `isp_sync_id_sie`,
+1 `isp_sync_id_ipp`, 2 `isp_sync_id_enc`; `param_3` selects the item
+(`AE_STATUS`, `TOTAL_GAIN`, `DGAIN`, `LV`, `EV_RATIO`, `CGAIN`, `CT`,
+`HBS_PARAM`, the `ca`/`la`/`va` ROIs …).
+
+The mismatch test at `001096xx` is `(cur_framecnt - slot_framecnt) < 0x18`. It
+means *"the metadata for the frame I am asking about is ≥ 24 frames stale"* and
+returns `-5`; the caller goes without that parameter. Callers, from `.rela.text`:
+`ae_flow_auto_process`, `awb_flow_process` (3 sites) and **`iq_flow_process`
+(50 sites)**. **Nothing pairs sensors anywhere in it.**
+
+A `sync info not match` flood is therefore a **symptom of the 3A/IQ threads
+running late**, and it over-reports badly — one late IQ pass emits up to 50
+lines.
+
+It is also gated harder than it looks. From the disassembly at `00109698`:
+
+```
+0010969c  and w20,w0,#0x20000000       ; dbg_mode & WRN bit
+001096a0  tbz w0,#0x1d,0x001096b4      ; bit clear -> skip the unlimited printk
+001096b0  b.hi 0x00109774              ; isp_debug_level > 1 -> PRINTK (no rate limit)
+001096c0  bl  isp_dbg_check_wrn_msg    ; returns (arg == 0 && counter < 20)
+001096c4  cbz w0,0x001096e0            ; -> return -5 silently
+```
+
+`isp_debug_level` is `.data+0x11f8` = **3** (file offset `0x14620`), so the level
+gate passes. `dbg_mode[]` is `.bss` (`0x11b2f8`) = **0 at load**, so the
+unlimited printk is off and the surviving path is capped by
+`isp_dbg_check_wrn_msg` at **20 lines for the module's lifetime** (counter `.bss`
+`0x11b320`, threshold `0x14`; `isp_dbg_clr_wrn_msg` has no caller in any hdal
+module).
+
+**A sustained flood therefore requires something to have set `dbg_mode` bit 29
+(`0x20000000`) for that ISP id** — after which every mismatch prints, unlimited,
+to `console=ttyS0,115200` (`/proc/cmdline`; `/proc/sys/kernel/printk` = `7 4 1 7`,
+so plain `printk()` at level 4 reaches the UART). At ~65 chars that is ~5.6 ms of
+blocking UART per line, ~280 ms per late IQ pass. If a flood was genuinely
+observed it was self-amplifying and worth killing on its own — but it is a
+consequence of the ISP being late, not a cause of frames failing to pair.
+
+### 4.4 The real pairing mechanism: userspace, ±30000 ticks (S + L)
+
+Pairing is not in the kernel. `device` runs a thread literally named
+**`bc_stitch_main`** — confirmed live, `/proc/751/task/*/comm`. It pulls one
+frame from `VIDEOPROC 0` out0 and one from `VIDEOPROC 1` out0 (200 ms timeout
+each), compares `HD_VIDEO_FRAME+0x28` (timestamp), and pushes both into
+`VIDEOPROC 2` in[0] as a 2-frame group.
+
+The tolerance is a hardcoded immediate at `device` file offset `0x81974`,
+verified by decoding the instruction word rather than trusting a decompiler:
+
+```
+0x81974: d2 8e a6 02  ->  sf=1 opc=2 fixed=0x25 hw=0 imm16=0x7530 Rd=x2
+                      ->  MOVZ x2, #30000
+```
+
+followed by `subs`/`cneg`/`cmp`/`b.le` — i.e. `if (|tsA - tsB| <= 30000) push`.
+Out of tolerance it increments a streak counter, logs `stitch thread frame %u
+timestamp don't match`, and **still pushes the pair**; only on the 3rd
+consecutive miss does it log `drop main %u.%s frame to sync` and release+re-pull
+on whichever side is ahead. (All three format strings are in `device` at
+`0x3345d8`, `0x334620`, `0x3345b0`.) The kernel side
+(`_isf_vdoprc_iport_do_push`) pairs only on an ordered index nibble and an
+exact-equality "count" field — no window, no timeout, no wait.
+
+**This tolerance is not the limiter.** The missing frames are lost *before*
+pairing: `VIDEOPROC 1 IN drop` is a kernel counter at the VideoProc **input**,
+upstream of anything the stitch thread can see. A frame refused there never
+reaches an out-queue and never gets a timestamp compared. The tolerance's only
+visible effect is secondary — it is what discards the fast side's surplus, which
+is why `VIDEOPROC 0 USER PULL` reads 26/s against `VIDEOPROC 1 USER PULL` 22/s.
+
+Widening `0x7530` would buy nothing and would cost picture quality — it would
+push temporally-offset halves through the stitcher, tearing the seam on motion.
+
+### 4.5 The levers on IPP load
+
+Only **less IPP work per second** helps, from one of:
+
+- **fewer IPP clients** — `vdoprc3` alone accounts for 19.97 of the 66.71 jobs/s.
+  This is the one that was tried and worked (§7.2).
+- **fewer pixels per frame** — windowed sensor readout.
+- **fewer per-frame ISP functions** — both raw pipes run `func_en 0x000002ad`
+  with `WDR`, `DEFOG`, `3DNR`, `3DNR_STA`, `PRIMASK`, `YUV_SUBOUT` enabled
+  (`/proc/kflow_ipp/info`, `---- ctrl handle func_en ----`). The bit-to-flag
+  mapping is **not** sequential and has **not** been decoded — do not guess it.
+
+Deeper input queues on `VIDEOPROC 1` cannot help: with the engine at 99 % the
+shortfall is sustained throughput, so a longer queue only adds latency before
+dropping the same frames.
+
+### 4.6 `ctl_ipp_int_ime_path_adj` is a geometry check, not a rate check (S)
+
+Located in `kflow_videoprocess.ko` `.rodata`:
+
+| `.rodata` off | string |
+|---|---|
+| `0x0a13a0` | `ERR:%s() p%u precrp w/h (%u, %u) != in_size (%u, %u) or (w, 0) or (0, h)` |
+| `0x0a1520` | `ERR:%s() p%u scl_size (%u, %u) != in_size (%u, %u)` |
+| `0x0a14a0` | `ERR:%s() p%u postcrp w/h (%u, %u) != scl_size (%u, %u)` |
+| `0x09eb00` | `WRN:%s() buf overflow in_size (%d,%d), max size (%d,%d)` |
+| `0x095bf0` | `ctl_ipp_int_ime_path_adj` (the `__func__`) |
+
+All three are **equality** checks — "the IME scaler is bypassed on this path, so
+pre-crop, scale and post-crop sizes must agree exactly". A build that changed
+input height to 720 and left the IME scaler configured for 2160 rejected with
+`scl_size (3840, 2160) != in_size (3840, 720)`. **That is a patch bug, not a
+bandwidth limit.** Keep `scl_size == in_size == post-crop` when changing
+geometry.
+
+---
+
+## 5. The userspace pump
+
+Static RE of `sections/app_extracted/device` (aarch64, ET_EXEC, load base
+`0x400000`, so **file offset = VMA − 0x400000**), plus live `/proc` sampling.
+
+### 5.1 The graph, and where userspace sits in it
+
+```
+VIDEOCAP 0 ──bound──► VIDEOPROC 0 (ISP, 3840x2160 NVX2, out depth 1) ─┐
+VIDEOCAP 2 ──bound──► VIDEOPROC 1 (ISP, 3840x2160 NVX2, out depth 1) ─┤
+                                                                      │ USERSPACE
+                                            bc_stitch_main ◄──────────┘ pull x2
+                                                   │ push x2
+                                                   ▼
+                              VIDEOPROC 2  pipe=VSP  in[0] bind_src (null)
+                              out[0] 7680x2160 NVX2 depth 2
+                              out[1]  256x2160 NVX2 depth 2  (seam strip)
+                                                   │
+                    ┌──────────────────────────────┴─── sometimes kernel-bound to
+                    │ USERSPACE (when out[0] is unbound)   VIDEOENC_0_IN_0
+                    ▼
+             FUN_00481df0  pull(wait=0) → hd_videoenc_push_in_buf → VIDEOENC 0 in[0]
+
+VIDEOPROC 3 ──bound──► VIDEOENC 0 in[1] (sub) and in[3] (ext)   ← never touches userspace
+```
+
+Two userspace hops exist, not one:
+
+| hop | function | thread | always in path? |
+|---|---|---|---|
+| ISP ×2 → VSP in[0] | `FUN_00481800` | `bc_stitch_main` | **yes** — `VIDEOPROC 2 in[0] bind_src` is `(null)` in every sample |
+| VSP out[0] → VENC in[0] | `FUN_00481df0` (thunk `0x00482470`) | a `bc_avencoder` thread (I) | only when `VIDEOPROC_2_OUT_0` is unbound |
+
+`VIDEOPROC 2 out[0]`'s bind state **changes between builds** — it read
+`VIDEOENC_0_IN_0` in one sample and `(null)` in another during the same session.
+The VSP *input* is never bound, so `bc_stitch_main` cannot be bypassed.
+
+### 5.2 The loops (S, decompiled)
+
+`FUN_00481800` — `bc_stitch_main` (`prctl(PR_SET_NAME)` at `0x00481840`):
+
+```c
+for (;;) {
+    lock(mtx);
+    if (!stitching_enabled) { unlock; usleep(20000); continue; }   /* 0x481904 */
+    rc0 = hd_videoproc_pull_out_buf(src0, &f0, 200);               /* 0x481924: mov w2,#0xc8 */
+    rc1 = hd_videoproc_pull_out_buf(src1, &f1, 200);               /* 0x481950: mov w2,#0xc8 */
+    if (rc0 || rc1) { release_what_we_got(); unlock; usleep(20000); continue; }
+    if (llabs(f0.ts - f1.ts) >= 30001) { ... "drop main %u.%s frame to sync" ... }
+    f0.tag = 'VSPE'; hd_videoproc_push_in_buf(vsp, &f0, 0, 0);     /* 0x4819f8 */
+    f1.tag = 'VSPE'; hd_videoproc_push_in_buf(vsp, &f1, 0, 0);     /* 0x481a34 */
+    hd_videoproc_release_out_buf(src0); hd_videoproc_release_out_buf(src1);
+    unlock;
+    sched_yield();                                                 /* 0x481b14 */
+    usleep(10000);                                                 /* 0x481b18 */
+}
+```
+
+`FUN_00481df0` — VSP out[0] → VIDEOENC 0 in[0]:
+
+```c
+for (;;) {
+    if (!enabled) { usleep(20000); continue; }                     /* 0x481e54 */
+    rc = hd_videoproc_pull_out_buf(vsp_out0, &frm, 0);             /* 0x481e7c: mov w2,#0x0  NON-BLOCKING */
+    if (rc) {                                                      /* -0x38 / -0x0f silently ignored */
+        usleep(20000);                                             /* 0x481e54 */
+        continue;
+    }
+    hd_videoenc_push_in_buf(venc_in0, &frm, 0, 0);                 /* 0x481f18 -> FUN_00499e80 */
+    gfx_scale(&frm, w, h, &scaled);                                /* -> FUN_00480510 */
+    hd_videoproc_push_in_buf(other, &scaled, ...);
+    enqueue 200-byte descriptor into a std::deque
+        (if full: usleep(1000) x up to 100)                        /* 0x4821e0 */
+    hd_videoproc_release_out_buf(vsp_out0, &frm);
+    /* NO SLEEP ON THE SUCCESS PATH -- poll again immediately */
+}
+```
+
+### 5.3 Patch sites (S, verified byte-for-byte in `app_extracted/device` *and* in the running binary)
+
+| file offset | VMA | bytes | instruction | meaning |
+|---|---|---|---|---|
+| `0x081904` | `0x00481904` | `00 c4 89 52` | `movz w0,#0x4e20` | `bc_stitch_main` miss sleep, 20 ms |
+| `0x081b18` | `0x00481b18` | `00 e2 84 52` | `movz w0,#0x2710` | `bc_stitch_main` success sleep, 10 ms |
+| `0x081e54` | `0x00481e54` | `00 c4 89 52` | `movz w0,#0x4e20` | VSP→VENC pump miss sleep, 20 ms |
+| `0x0821e0` | `0x004821e0` | `00 7d 80 52` | `movz w0,#0x3e8` | queue-full retry, 1 ms |
+| `0x081924`, `0x081950` | | `02 19 80 52` | `movz w2,#0xc8` | pull `wait_time` = 200 ms (blocking) |
+| `0x081e7c` | `0x00481e7c` | `02 00 80 52` | `movz w2,#0x0` | pull `wait_time` = 0 (non-blocking) |
+| `0x081974` | `0x00481974` | `d2 8e a6 02` | `movz x2,#30000` | stitch pairing tolerance (§4.4) |
+
+`movz w0,#imm16` encodes as `0x52800000 | (imm << 5)`; same-length 4-byte patch.
+
+**All three sleep sites were patched 20/10/20 ms → 2 ms and it changed nothing**
+— see `FPS_CEILING.md` F1. The offsets remain correct and are recorded for
+whoever needs them next; the *theory* they were patched to test is dead.
+
+### 5.4 What the pump does *not* do
+
+- **No pixel copy.** `hd_videoproc_pull_out_buf` = `FUN_005b65b0` issues
+  `ioctl(isf_fd, 0xc020490c, &arg)` (`isf_unit_pull_data`) and copies out a
+  0x128-byte **descriptor**. Push is the mirror. No bounce buffer, no `memcpy` of
+  frame data — the only `memcpy`s in `FUN_00481df0` move 200-byte descriptors
+  into a `std::deque`.
+- **No uncached-memcpy pathology.** `device` never faults in the frame pool:
+  `VmSize 1.26 GB` vs `VmRSS 15.9 MB` (at 2500 s uptime) / `41 MB` (at 400 s). A
+  single 25 MB frame touched per iteration would dominate RSS.
+  `hd_common_mem_flush_cache` / `_cache_sync` exist in the binary but are not on
+  this path.
+- **CPU is not the constraint.** `bc_stitch_main` accumulated `utime 332` +
+  `stime 1923` ticks over 2501 s uptime = **0.9 % of one core**. During recording
+  `top` reads **88.8 % idle** with `device` at 1.8 %. A 500 MB/s memcpy would peg
+  a core.
+- **OSD is not why the pump exists.** OSD is a hardware stamp applied by the
+  *encoder*: `hd_videoenc_open(enc_in_id, HD_MASK(i), &mask_path[i])` +
+  `HD_VIDEOENC_PARAM_IN_STAMP_{BUF,IMG,ATTR}` / `IN_MASK_ATTR`
+  (`Nvt52xAdapter_osd.cpp`, strings at `0x734f40`–`0x7353f8`).
+  `/proc/hdal/venc/top` reports `do_osd ≈ 100 µs` on paths **0, 1 and 3** —
+  including the two that are fully kernel-bound and never enter userspace.
+
+### 5.5 Threading and buffers
+
+- Every `device` thread is `policy=0` (SCHED_OTHER), `nice=0`, `prio=20`,
+  `rt_prio=0`. No realtime priority anywhere.
+- One stitch thread. Three `bc_avencoder` threads.
+- `VIDEOPROC 0/1 out[0] depth = 1` — the ISP has a **single** output buffer, so
+  it cannot start frame N+1 until userspace releases frame N.
+  `VIDEOPROC 2 out[0]/out[1] depth = 2`.
+
+### 5.6 The saturation measurement (L) — this is the load-bearing one
+
+The pump consumes a fixed ~20 frames/s at 16.589 Mpix and **does not move when
+more are offered**:
+
+| main geometry | stitcher offers | pump takes | delivered |
+|---|---|---|---|
+| 7680×2160 (16.589 Mpix) | 22/s | **20, drop 2** | 20.0 |
+| 7680×2160, ISP eased | **23/s** | **20, drop 3** | — |
+| 4096×1152 (4.719 Mpix) | 22/s | **101, drop 79** | 22.2 |
+
+At 4.7 Mpix the pump polls 101/s and mostly finds nothing — nowhere near its
+limit. At 16.6 Mpix it saturates at 20/s = `20 × 16.589` = **332 Mpix/s**.
+
+The middle row is the cleanest single proof: easing the ISP made the stitcher
+produce **23/s** and the pump still delivered exactly **20**. More supply, same
+output — that is the definition of the binding stage.
+
+---
+
+## 6. The H.265 encoder — measured, never binding
+
+`/proc/hdal/venc/top` reports per-frame **hardware** encode time per stream.
+
+Session 1, two reads ~5 minutes apart, three concurrent streams (L):
+
+| stream | codec | w × h | pixels | `hw` min (µs) | Mpix/s |
+|---|---|---|---|---|---|
+| 0 | H.265 | 7680 × 2160 | 16 588 800 | 35 335 | **469.5** |
+| 0 | H.265 | 7680 × 2160 | 16 588 800 | 35 410 | **468.5** |
+| 3 | H.264 | 2560 × 720 | 1 843 200 | 3 957 | **465.8** |
+| 1 | H.264 | 1536 × 432 | 663 552 | 1 439 | **461.1** |
+
+Session 2, `cur / min / max` across four geometries including a second H.265
+size (L):
+
+| stream | pixels | hw µs (cur/min/max) | Mpix/s |
+|---|---|---|---|
+| 7680×2160 H.265 | 16.589 M | 35818 / 35276 / 36554 | 463.1 |
+| 4096×1152 H.265 | 4.719 M | 10116 / 9988 / 10370 | 466.4 |
+| 2560×720 H.264 | 1.843 M | 4201 / 3949 / 4673 | 438.7 |
+| 1536×432 H.264 | 0.664 M | 1545 / 1432 / 1773 | 429.5 |
+
+Two codecs, four resolutions, a 25× spread in frame size, two sessions — all
+within ~2 % of the same pixel rate. **≈465 Mpix/s.**
+
+```
+465e6 / 480e6 (venc_clk) = 0.97 pixels per clock  ->  1 px/clk at 480 MHz
+```
+
+`h26x@2,f0a10000` is a **single** node and `venc_clk` a **single** clock — all
+three streams share one engine, so the budget is additive.
+
+Main-stream ceiling at 7680×2160 (I, from the measured rate):
+
+| assumption | ceiling |
+|---|---|
+| main stream alone | `1000 / 35.7` = **28.0 fps** |
+| substreams at stock rates (~108 ms/s reserved) | `(1000 − 108) / 35.7` = **25.0 fps** |
+| substreams at the *same* rate as main (41.46 ms/frame-set) | **24.1 fps** |
+
+The spread 24.1–28.0 is entirely the substream assumption. **All three are above
+anything ever delivered**, so the encoder is not the constraint and the exact
+figure does not matter. At the delivered 20.05 fps the engine sits at **83 %
+duty**.
+
+Confirmed directly by experiment: shedding the sub stream from 20 fps to 4 fps
+freed ~25 ms/s of engine time and changed delivered fps by **−0.07**
+(20.054 → 19.983). The engine was not the constraint.
+
+No level check, MB-rate check or resolution clamp exists in the encoder driver:
+the H.26x validator surface is entirely QP/GOP/flag/`ddr_id` shaped, with no
+width, height, fps or bitrate range check (S). But there **is** a hard bitrate
+limit at ~20 Mbps enforced somewhere below the advertised list — see
+`FPS_CEILING.md` F4.
+
+`/proc/kdrv_vdocdc/chn_info` shows the path-0 reference buffer at 25 067 520
+bytes, consistent with 7680×2160 NV12.
+
+---
+
+## 7. DDR
+
+### 7.1 What is known (L)
+
+| fact | source |
+|---|---|
+| **1 GiB total**, single channel (`ddr_id: 0 … size: 0x40000000 active: 1`) | `dmesg nvtmem_dram_mapping_init` |
+| Linux gets 256 MiB; HDAL media pool `0x10000000`+`0x30000000` = **768 MiB** | `dmesg nvtmem_load_hdal_base` |
+| `/proc/device-tree/nvt_memory_cfg/dram/reg` = `0x0 + 0x40000000` | live |
+| **No DDR/DRAM clock** anywhere in the 293-entry clock tree | `/sys/kernel/debug/clk` |
+| `pll3` = 333.25 MHz, `enable_count` 1, parent `osc_in`, **no children** | the only unassigned active PLL (I) |
+| `0_loader.bin` / `3_uboot.bin` contain **no** printable DDR strings | (S) |
+
+### 7.2 The measured load (L)
+
+| main geometry | BUSY | EFF | UTI | MB/s | pump state |
+|---|---|---|---|---|---|
+| 7680×2160 | **90–92** | 52 | 48 | **4905–5118** | saturated, 20/s |
+| 4096×1152 | **79–80** | — | — | **3732–3839** | not saturated, polls 101/s |
+
+**`EFF 52` is the controller's efficiency**: only ~52 % of theoretical is
+achievable. Against a 10.66 GB/s theoretical peak the practical ceiling is
+**~5.5 GB/s**, so 5118 MB/s is **~93 % of practical**. `BUSY 92` says the same
+directly, and `UTI 48 / EFF 52` = 92 % reconciles all three. Reading `UTI 48` as
+"half the bus is free" is the error corrected in `FPS_CEILING.md` F3.
+
+DDR load tracks main-stream size, which is what a throughput-bound pump predicts.
+
+> **(I)** A 10.66 GB/s theoretical peak is consistent with a **32-bit LPDDR4-2666**
+> bus (4 B × 2666 MT/s = 10.66 GB/s). That would settle the open question of bus
+> width — 16-bit is indeed impossible for this traffic. But the provenance of the
+> 10.66 GB/s figure is not recorded in any source doc, so this is arithmetic, not
+> a reading. Confirm against the DDR controller ID registers before relying on it.
+
+---
+
+## 8. The ISF bind protocol
+
+`/dev/isf_flow0`, handled by `isf_flow_drv_ioctl` (`kflow_common.ko`).
+
+| cmd | `_IOWR` | arg | driver call |
+|---|---|---|---|
+| `0xc00c4901` | `('I',1,12)` | 12 bytes | `isf_unit_set_bind` |
+| `0xc00c4902` | `('I',2,12)` | 12 bytes | `isf_unit_get_bind` |
+| `0xc020490c` | `('I',12,32)` | 32 bytes | `isf_unit_pull_data` |
+
+The 12-byte argument, read straight off the dispatch — `copy_from_user(sp+0x40,
+arg, 12)` then `ldp w1, w2, [sp, #68]` before `bl isf_unit_set_bind`:
+
+```c
+struct { u32 ret_slot; u32 src_path_id; u32 dst_path_id; };
+```
+
+`isf_unit_set_bind(minor, src, dst)` splits each path_id as
+`unit = id>>16, port = id & 0xffff` and enforces direction:
+
+| operand | required port class | branch |
+|---|---|---|
+| `src` | **out**, `port < 0x80` | `tst w3,#0xff80` → `b.eq` accept |
+| `dst` | **in**, `port − 0x80 <= 0x7f` | accepted |
+
+So a bind is strictly `some_unit.out[n] -> other_unit.in[m]`.
+
+**The decode is confirmed, not assumed.** `get_bind` on all four encoder inputs,
+before touching anything (L):
+
+| path | `get_bind` result | `/proc/hdal/venc/info` says |
+|---|---|---|
+| `0x01110080` in[0] main | `0x00000000` | `bind_src (null)` |
+| `0x01110081` in[1] sub | **`0x00940000`** | `bind_src VIDEOPROC_3_OUT_0` |
+| `0x01110083` in[3] ext | **`0x00940001`** | `bind_src VIDEOPROC_3_OUT_1` |
+| `0x01110087` in[7] jpeg | `0x00000000` | `bind_src (null)` |
+
+The two bound ports read back exactly the unit/port `/proc` names independently,
+confirming both the 12-byte layout and the `0x91+N` VideoProc unit-id mapping.
+in[0] and in[7] are genuinely unbound — `device` pumps those two in userspace.
+
+Client: `runtime/isfbind.c` — freestanding aarch64, no libc, 4.3 KB, built with
+`aarch64-linux-gnu-gcc -O2 -nostdlib -static -ffreestanding`. Pushed to
+`/mnt/tmp`, which is tmpfs, so a restart removes it and any bind it made — the
+experiment is inherently reversible.
+
+`device` does **not** materialise these ioctl numbers anywhere a static search
+can reach:
+
+| searched for | in `device` | in `libbase.so` |
+|---|---|---|
+| `movz w?, #0x490b/0x490c/0x4901/0x4905/0x490a` | **0 sites** | n/a |
+| `movk w?, #0xc020/#0xc00c, lsl #16` | **0 sites** | n/a |
+| 32-bit literals `0xc020490b` etc. | **0** | 0 |
+| string `isf_flow0` | 1 | — |
+
+`device` opens `/dev/isf_flow0` and `LD_PRELOAD` traces prove it issues
+`0xc0204905` at runtime, so the command numbers are **computed** — an `_IOWR`
+built from a variable `nr`, not folded to a constant. HDAL is statically linked
+into `device` (no `hd_*` dynamic symbols). Locating the pump therefore means
+recovering the ioctl dispatch by dataflow through a 4.9 MB stripped C++ binary,
+which is `APP_REPLACEMENT_DESIGN.md`, not a patch.
+
+---
+
+## 9. Operational notes
+
+### 9.1 The ISE scaler caps at 16× downscale
+
+```
+ERR:gximg_scale_by_ise() scale factor over 16, SrcW=7680,SrcH=2160,DstW=320,DstH=180
+ERR:gfx_scale() scale fail
+```
+
+7680/320 = 24×, over the limit. `device` then loops on `gfx_scale()` failures
+and **never finishes start-up: no nginx, no port 80, no HTTP API**, so
+`flash_pak.py` cannot reach the camera. The stock table's smallest entry,
+480×136, is exactly 7680/16 × 2160/16 — the limit itself.
+`build_fps_demo.sh` refuses any aux geometry needing more than 16× and states
+the minimum; self-tested, 320×180 is rejected before the build runs.
+
+### 9.2 Restoring the HTTP API by hand when `device` stalls before nginx
+
+Worth keeping — this is why the above cost minutes rather than a UART cable. The
+2323 root shell was up throughout. nginx was not running because `device` never
+got far enough to write `/mnt/tmp/nginx.conf`, but the template lives at
+`/mnt/app/nginx_conf/conf/nginx.conf` with `_HTTP_PORT_` placeholders, and
+`cgiserver.cgi` was already listening on `127.0.0.1:9527`:
+
+```sh
+mkdir -p /mnt/tmp/run /mnt/tmp/logs /mnt/tmp/download
+cp /mnt/app/nginx_conf/conf/mime.types /mnt/tmp/mime.types
+sed -e 's/_HTTP_PORT_/80/' -e 's/_HTTPS_PORT_/443/' -e 's/_RTMP_PORT_/1935/' \
+    /mnt/app/nginx_conf/conf/nginx.conf > /mnt/tmp/nginx.conf
+/mnt/app/nginx -p /mnt/tmp/ -c /mnt/tmp/nginx.conf
+```
+
+Port 80 comes up, the API answers, and a normal reflash recovers the camera.
+
+### 9.3 The pak filename matters
+
+`UpgradePrepare` returns `check err` (rspCode −3) for a file not named
+`IPC_NT15NA416MP.<build>_<date>.Reolink-Duo-3-PoE.16MP.REOLINK*.pak`. This is
+**not** a busy-camera condition and rebooting does not help; the flash tool's
+"still busy, reboot and retry" advice is misleading here.
+
+### 9.4 Geometry changes restart the pipeline
+
+Changing main-stream geometry or frame rate restarts the video pipeline and
+drops the shell and RTSP for ~15–30 s. Wait before sampling.
+
+### 9.5 Counter semantics differ by proc file
+
+- `/proc/hdal/*/info` counters are **rolling per-second rates** that self-reset
+  on read.
+- `/proc/kflow_sie/info` accu counters are **cumulative**.
+
+Mixing the two up will produce nonsense. Sample the cumulative ones over a known
+wall-clock window.

--- a/reolink-firmware-patching/runtime/camsh.py
+++ b/reolink-firmware-patching/runtime/camsh.py
@@ -32,9 +32,17 @@ from __future__ import annotations
 import re
 import socket
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 DEFAULT_HOST = "192.168.86.24"
 DEFAULT_PORT = 2323
+
+# The netstate daemon's kill switch. Asserting this is legitimate as a
+# deliberate, released operator act and never as build state -- see
+# hold_recording_override() and verify/check_recording_default.sh.
+OVERRIDE_DIR = "/mnt/sda/netstate"
+OVERRIDE_FLAG = f"{OVERRIDE_DIR}/override"
 
 # Paths that hold the only on-camera copy of anything we care about. Nothing
 # this tool sends may delete, move, truncate or reformat inside them.
@@ -89,6 +97,14 @@ class CameraCommandRefused(RuntimeError):
     """Raised instead of sending a command that could destroy data."""
 
 
+class RecordingOverrideStuck(RuntimeError):
+    """Raised when the override flag survives a release attempt.
+
+    Loud on purpose: while it is set the camera records at home, and nothing
+    else in the system will notice.
+    """
+
+
 def check(cmd: str) -> None:
     """Raise CameraCommandRefused if `cmd` is in the forbidden class."""
     for pattern, why in REFUSALS:
@@ -107,15 +123,15 @@ def check(cmd: str) -> None:
                 )
 
 
-def sh(
+def _send(
     cmd: str, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, timeout: int = 40
 ) -> str:
-    """Send one command set to the probe shell and return its combined output.
+    """Put `cmd` on the wire and return its output. NO refusal checks.
 
-    The listener runs `sh` per connection: it reads stdin to EOF, executes, and
-    exits. So one call is one batch, and state does not carry between calls.
+    Private. Every caller from outside this module goes through `sh()`, which
+    checks first; the only other user is the override pair below, which sends
+    two fixed strings and no free-form input.
     """
-    check(cmd)
     s = socket.create_connection((host, port), timeout=timeout)
     try:
         s.sendall((cmd + "\n").encode())
@@ -132,6 +148,18 @@ def sh(
     finally:
         s.close()
     return b"".join(chunks).decode(errors="replace")
+
+
+def sh(
+    cmd: str, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, timeout: int = 40
+) -> str:
+    """Send one command set to the probe shell and return its combined output.
+
+    The listener runs `sh` per connection: it reads stdin to EOF, executes, and
+    exits. So one call is one batch, and state does not carry between calls.
+    """
+    check(cmd)
+    return _send(cmd, host, port, timeout)
 
 
 def hold_recording_override(
@@ -152,33 +180,60 @@ def hold_recording_override(
     and pairs with its own release. Every other refusal still applies to
     everything else.
 
-    Callers MUST release it -- wrap in try/finally. Releasing also lets
-    S99_NetState resume and clean this boot's stubs, which is how test clips
-    get tidied without anyone running `rm` near Mp4Record.
+    Prefer `recording_override_held()` over calling this directly: it releases
+    in a `finally` and then *verifies* the flag is gone, so a crash between hold
+    and release cannot leave the camera recording at home. Releasing also lets
+    S99_NetState resume and clean this boot's stubs, which is how test clips get
+    tidied without anyone running `rm` near Mp4Record.
     """
-    path = "/mnt/sda/netstate/override"
     if on:
-        cmd = f"mkdir -p /mnt/sda/netstate && touch {path} && echo held"
+        cmd = f"mkdir -p {OVERRIDE_DIR} && touch {OVERRIDE_FLAG} && echo held"
     else:
         # Exact path, no wildcard -- allowed by check(), but we bypass it here
-        # too so the pair is symmetric and auditable in one place.
-        cmd = f"rm -f {path} && echo released"
-    s = socket.create_connection((host, port), timeout=40)
+        # too so the pair is symmetric and auditable in one place. Report the
+        # post-state rather than the exit code: `rm -f` succeeds on a path it
+        # did not remove, so only an existence test proves the release.
+        cmd = (
+            f"rm -f {OVERRIDE_FLAG}; "
+            f"[ -e {OVERRIDE_FLAG} ] && echo STILL-HELD || echo released"
+        )
+    return _send(cmd, host, port)
+
+
+@contextmanager
+def recording_override_held(
+    host: str = DEFAULT_HOST, port: int = DEFAULT_PORT
+) -> Iterator[None]:
+    """Hold the override for the duration of the block, then prove it released.
+
+    The docstring above used to say callers *must* release in a try/finally.
+    That is an instruction, not a guard, and this project's rule is that a
+    guard nothing enforces is a comment: the failure it invites -- an exception
+    between hold and release -- leaves the camera recording at home silently,
+    discovered only by noticing the card filling. Exactly the 2026-08-16 shape,
+    reached by a different road.
+
+    So the release is structural. It runs in `finally`, and it then tests for
+    the flag's absence rather than trusting `rm`'s exit code; if the flag is
+    still there the block raises, because a hold believed released is worse
+    than one known held.
+
+    Not covered: a hold that outlives this *process* (a hard kill between the
+    two calls). Closing that needs a camera-side self-expiring watchdog, which
+    is unverified on hardware and therefore not shipped -- see the note in
+    docs/FPS_CEILING.md rather than assuming this is airtight.
+    """
+    hold_recording_override(True, host, port)
     try:
-        s.sendall((cmd + "\n").encode())
-        s.shutdown(socket.SHUT_WR)
-        chunks = []
-        try:
-            while True:
-                buf = s.recv(65536)
-                if not buf:
-                    break
-                chunks.append(buf)
-        except TimeoutError:
-            pass
+        yield
     finally:
-        s.close()
-    return b"".join(chunks).decode(errors="replace")
+        out = hold_recording_override(False, host, port)
+        if "released" not in out:
+            raise RecordingOverrideStuck(
+                "the recording override did not release; the camera may still "
+                f"be recording at home. Remove {OVERRIDE_FLAG} by hand.\n"
+                f"  camera said: {out.strip()[:200]}"
+            )
 
 
 def _selftest() -> int:
@@ -213,9 +268,55 @@ def _selftest() -> int:
         except CameraCommandRefused as e:
             print(f"  [FAIL] should have been allowed: {c}  ({e})")
             fails += 1
-    print(
-        f"\n{len(blocked) + len(allowed) - fails}/{len(blocked) + len(allowed)} gates passed"
-    )
+    total = len(blocked) + len(allowed)
+
+    # The override context manager, exercised against a fake camera. These are
+    # the gates that matter most: the flag left set is the failure that recorded
+    # at home for hours without anyone noticing.
+    global _send  # noqa: PLW0603 -- test seam; restored below
+    real_send = _send
+    for name, ok, body, camera_says in (
+        ("releases on the happy path", True, lambda: None, "released"),
+        (
+            "releases when the block raises",
+            True,
+            lambda: (_ for _ in ()).throw(ValueError("boom")),
+            "released",
+        ),
+        ("raises when the flag survives release", False, lambda: None, "STILL-HELD"),
+    ):
+        total += 1
+        sent: list[str] = []
+
+        def fake(
+            cmd: str,
+            *a: object,
+            says: str = camera_says,
+            log: list[str] = sent,
+            **k: object,
+        ) -> str:
+            log.append(cmd)
+            return "held" if "touch" in cmd else says
+
+        _send = fake  # type: ignore[assignment]
+        stuck = False
+        try:
+            with recording_override_held():
+                body()
+        except RecordingOverrideStuck:
+            stuck = True
+        except ValueError:
+            pass
+        finally:
+            _send = real_send  # type: ignore[assignment]
+        released = any("rm -f" in c and OVERRIDE_FLAG in c for c in sent)
+        if released and stuck is not ok:
+            print(f"  [ok]   {name}")
+        else:
+            print(f"  [FAIL] {name}: release_attempted={released} raised={stuck}")
+            fails += 1
+
+    print(f"\n{total - fails}/{total} gates passed")
     return 1 if fails else 0
 
 

--- a/reolink-firmware-patching/runtime/camsh.py
+++ b/reolink-firmware-patching/runtime/camsh.py
@@ -134,6 +134,53 @@ def sh(
     return b"".join(chunks).decode(errors="replace")
 
 
+def hold_recording_override(
+    on: bool, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT
+) -> str:
+    """Assert or release /mnt/sda/netstate/override as a deliberate operator act.
+
+    `check()` refuses `touch .../netstate/override` in a general command, and
+    must keep doing so: the 2026-08-16 incident was an *init script* asserting
+    that flag at every boot, so the camera recorded at home invisibly. That is a
+    build defect and `verify/check_recording_default.sh` gates paks against it
+    independently of this module.
+
+    Capturing a sample recording at home is the one legitimate reason to hold
+    the flag, and it needs to be expressible without weakening the general rule
+    or tempting anyone to word their way around the regex. So it lives here: a
+    named function that touches exactly one path, takes no free-form command,
+    and pairs with its own release. Every other refusal still applies to
+    everything else.
+
+    Callers MUST release it -- wrap in try/finally. Releasing also lets
+    S99_NetState resume and clean this boot's stubs, which is how test clips
+    get tidied without anyone running `rm` near Mp4Record.
+    """
+    path = "/mnt/sda/netstate/override"
+    if on:
+        cmd = f"mkdir -p /mnt/sda/netstate && touch {path} && echo held"
+    else:
+        # Exact path, no wildcard -- allowed by check(), but we bypass it here
+        # too so the pair is symmetric and auditable in one place.
+        cmd = f"rm -f {path} && echo released"
+    s = socket.create_connection((host, port), timeout=40)
+    try:
+        s.sendall((cmd + "\n").encode())
+        s.shutdown(socket.SHUT_WR)
+        chunks = []
+        try:
+            while True:
+                buf = s.recv(65536)
+                if not buf:
+                    break
+                chunks.append(buf)
+        except TimeoutError:
+            pass
+    finally:
+        s.close()
+    return b"".join(chunks).decode(errors="replace")
+
+
 def _selftest() -> int:
     blocked = [
         "rm -f /mnt/sda/Mp4Record/*/*.mp4",

--- a/reolink-firmware-patching/runtime/isfbind.c
+++ b/reolink-firmware-patching/runtime/isfbind.c
@@ -1,0 +1,142 @@
+/* isfbind -- issue ISF bind ioctls on /dev/isf_flow0, freestanding aarch64.
+ *
+ * Protocol (decoded from kflow_common.ko, see docs/ISF_PARAM_MAP.md):
+ *   0xc00c4901 isf_unit_set_bind  arg = {u32 ret, u32 src_path_id, u32 dst_path_id}
+ *   0xc00c4902 isf_unit_get_bind  arg = {u32 ret, u32 path_id,     u32 result}
+ *   0xc00c4903 isf_unit_set_state arg = {u32 ret, u32 path_id,     u32 state}
+ *   0xc00c4904 isf_unit_get_state arg = {u32 ret, u32 path_id,     u32 state}
+ * isf_flow_drv_ioctl copies 12 bytes then `ldp w1,w2,[sp,#68]`, so words 1 and
+ * 2 are the two operands and word 0 is the driver's return slot.
+ *
+ * set_bind validates src port < 0x80 (an OUT port) and dst port in 0x80..0xff
+ * (an IN port); anything else is rejected before the unit is touched.
+ *
+ * No libc: -nostdlib keeps it ~2 KB so it can be pushed to /mnt/tmp over wget.
+ *
+ * usage:  isfbind get  <path_id>
+ *         isfbind set  <src_path_id> <dst_path_id>
+ *         isfbind state <path_id>
+ */
+
+#define SYS_openat 56
+#define SYS_close  57
+#define SYS_ioctl  29
+#define SYS_write  64
+#define SYS_exit   93
+
+static long sys3(long n, long a, long b, long c)
+{
+    register long x8 __asm__("x8") = n;
+    register long x0 __asm__("x0") = a;
+    register long x1 __asm__("x1") = b;
+    register long x2 __asm__("x2") = c;
+    __asm__ volatile("svc #0" : "+r"(x0) : "r"(x8), "r"(x1), "r"(x2) : "memory");
+    return x0;
+}
+
+static long sys4(long n, long a, long b, long c, long d)
+{
+    register long x8 __asm__("x8") = n;
+    register long x0 __asm__("x0") = a;
+    register long x1 __asm__("x1") = b;
+    register long x2 __asm__("x2") = c;
+    register long x3 __asm__("x3") = d;
+    __asm__ volatile("svc #0" : "+r"(x0) : "r"(x8), "r"(x1), "r"(x2), "r"(x3) : "memory");
+    return x0;
+}
+
+static unsigned slen(const char *s) { unsigned n = 0; while (s[n]) n++; return n; }
+static void out(const char *s) { sys3(SYS_write, 1, (long)s, slen(s)); }
+
+static void hex32(unsigned v, char *b)
+{
+    static const char d[] = "0123456789abcdef";
+    b[0] = '0'; b[1] = 'x';
+    for (int i = 0; i < 8; i++) b[2 + i] = d[(v >> ((7 - i) * 4)) & 0xf];
+    b[10] = 0;
+}
+
+static void dec(long v, char *b)
+{
+    char t[24]; int n = 0, neg = 0;
+    if (v < 0) { neg = 1; v = -v; }
+    if (!v) t[n++] = '0';
+    while (v) { t[n++] = '0' + (v % 10); v /= 10; }
+    int i = 0;
+    if (neg) b[i++] = '-';
+    while (n) b[i++] = t[--n];
+    b[i] = 0;
+}
+
+static unsigned parse(const char *s)
+{
+    unsigned v = 0;
+    if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) s += 2;
+    while (*s) {
+        char c = *s++;
+        unsigned d;
+        if (c >= '0' && c <= '9') d = c - '0';
+        else if (c >= 'a' && c <= 'f') d = c - 'a' + 10;
+        else if (c >= 'A' && c <= 'F') d = c - 'A' + 10;
+        else break;
+        v = v * 16 + d;
+    }
+    return v;
+}
+
+static int eq(const char *a, const char *b)
+{
+    while (*a && *a == *b) { a++; b++; }
+    return *a == *b;
+}
+
+void _c_start(long *sp)
+{
+    long argc = sp[0];
+    char **argv = (char **)(sp + 1);
+    char buf[16];
+
+    int fd = (int)sys4(SYS_openat, -100 /*AT_FDCWD*/, (long)"/dev/isf_flow0", 2 /*O_RDWR*/, 0);
+    if (fd < 0) { out("open /dev/isf_flow0 failed rc="); dec(fd, buf); out(buf); out("\n"); sys3(SYS_exit, 1, 0, 0); }
+
+    unsigned a[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    unsigned long cmd = 0;
+    int isparam = 0;
+
+    if (argc >= 3 && eq(argv[1], "get")) {
+        cmd = 0xc00c4902; a[1] = parse(argv[2]);
+    } else if (argc >= 3 && eq(argv[1], "state")) {
+        cmd = 0xc00c4904; a[1] = parse(argv[2]);
+    } else if (argc >= 4 && eq(argv[1], "set")) {
+        cmd = 0xc00c4901; a[1] = parse(argv[2]); a[2] = parse(argv[3]);
+    } else if (argc >= 4 && eq(argv[1], "getparam")) {
+        /* 32-byte form: [1]=path_id [2]=param_id [4..5]=value [6]=len(0=scalar) */
+        cmd = 0xc0204906; a[1] = parse(argv[2]); a[2] = parse(argv[3]); isparam = 1;
+    } else if (argc >= 5 && eq(argv[1], "setparam")) {
+        cmd = 0xc0204905; a[1] = parse(argv[2]); a[2] = parse(argv[3]);
+        a[4] = parse(argv[4]); isparam = 1;
+    } else {
+        out("usage: isfbind get <path> | state <path> | set <src> <dst>\n"
+            "       isfbind getparam <path> <param> | setparam <path> <param> <val>\n");
+        sys3(SYS_exit, 2, 0, 0);
+    }
+
+    long rc = sys3(SYS_ioctl, fd, (long)cmd, (long)a);
+
+    out("cmd="); hex32((unsigned)cmd, buf); out(buf);
+    out(" arg1="); hex32(a[1], buf); out(buf);
+    out(" arg2="); hex32(a[2], buf); out(buf);
+    if (isparam) { out(" val="); hex32(a[4], buf); out(buf); }
+    out(" ret_slot="); hex32(a[0], buf); out(buf);
+    out(" rc="); dec(rc, buf); out(buf);
+    out("\n");
+
+    sys3(SYS_close, fd, 0, 0);
+    sys3(SYS_exit, rc == 0 ? 0 : 1, 0, 0);
+}
+
+__asm__(
+    ".global _start\n"
+    "_start:\n"
+    "  mov x0, sp\n"
+    "  b _c_start\n");

--- a/reolink-firmware-patching/verify/measure_clip_fps.py
+++ b/reolink-firmware-patching/verify/measure_clip_fps.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Measure the REAL frame rate of a camera recording.
+
+The container header is not evidence. The Duo 3 writes the *requested* rate
+into the MP4 regardless of what the encoder actually delivered, so a clip whose
+header says 25 fps can easily hold 21 fps of pictures. This decodes the stream,
+counts frames, and divides by the presentation-timestamp span:
+
+    measured_fps = (frames - 1) / (last_pts - first_pts)
+
+using (frames - 1) because N frames span N-1 inter-frame intervals. The
+container's nb_frames / r_frame_rate / avg_frame_rate are reported alongside so
+a disagreement between claimed and delivered is visible rather than hidden.
+
+Usage:
+    python verify/measure_clip_fps.py <clip.mp4> [<clip.mp4> ...]
+    python verify/measure_clip_fps.py --json <clip.mp4>
+"""
+
+import json
+import subprocess
+import sys
+
+
+def probe(path):
+    stream = json.loads(
+        subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-count_frames",
+                "-show_entries",
+                "stream=nb_frames,nb_read_frames,r_frame_rate,avg_frame_rate,"
+                "width,height,codec_name,duration,time_base",
+                "-show_entries",
+                "format=duration,bit_rate",
+                "-of",
+                "json",
+                path,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    )
+    st = stream["streams"][0]
+    fmt = stream.get("format", {})
+
+    # Packet PTS span -- the authoritative duration of the picture sequence.
+    pk = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "packet=pts_time",
+            "-of",
+            "csv=p=0",
+            path,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    pts = sorted(float(x) for x in pk if x and x != "N/A")
+
+    frames = int(st.get("nb_read_frames") or 0) or len(pts)
+    span = (pts[-1] - pts[0]) if len(pts) > 1 else 0.0
+    measured = (len(pts) - 1) / span if span > 0 else 0.0
+
+    def rat(v):
+        try:
+            n, d = v.split("/")
+            return int(n) / int(d) if int(d) else 0.0
+        except Exception:
+            return 0.0
+
+    return {
+        "file": path.replace("\\", "/").rsplit("/", 1)[-1],
+        "codec": st.get("codec_name"),
+        "size": f"{st.get('width')}x{st.get('height')}",
+        "decoded_frames": frames,
+        "packets": len(pts),
+        "pts_span_s": round(span, 4),
+        "container_duration_s": round(
+            float(fmt.get("duration") or st.get("duration") or 0), 4
+        ),
+        "container_r_frame_rate": st.get("r_frame_rate"),
+        "container_avg_frame_rate": round(rat(st.get("avg_frame_rate", "0/1")), 4),
+        "measured_fps": round(measured, 4),
+        "bit_rate_kbps": round(int(fmt.get("bit_rate") or 0) / 1000),
+    }
+
+
+def main():
+    args = [a for a in sys.argv[1:] if a != "--json"]
+    rows = [probe(p) for p in args]
+    if "--json" in sys.argv:
+        print(json.dumps(rows, indent=2))
+        return
+    hdr = (
+        "file",
+        "size",
+        "codec",
+        "frames",
+        "pts_span_s",
+        "measured_fps",
+        "hdr_r_fps",
+        "hdr_avg_fps",
+        "kbps",
+    )
+    print(
+        f"{hdr[0]:<26} {hdr[1]:>10} {hdr[2]:>5} {hdr[3]:>7} {hdr[4]:>11} "
+        f"{hdr[5]:>13} {hdr[6]:>10} {hdr[7]:>12} {hdr[8]:>7}"
+    )
+    for r in rows:
+        print(
+            f"{r['file']:<26} {r['size']:>10} {r['codec']:>5} "
+            f"{r['decoded_frames']:>7} {r['pts_span_s']:>11.3f} "
+            f"{r['measured_fps']:>13.4f} {r['container_r_frame_rate']:>10} "
+            f"{r['container_avg_frame_rate']:>12.3f} {r['bit_rate_kbps']:>7}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Four working documents from the frame-rate investigation, overlapping and in
places contradicting each other, folded into one record that states a verdict —
plus the tools every number rests on.

### The result, on screen one

**21.179 fps recorded / 21.218 RTSP at 7680x2160**, and 23.395 at 4096x1152.
Sustained: a 4-minute full-resolution run held 21.385 fps with a 0.058 fps
window-to-window spread and no decay. The camera as found delivered 19.856, so
net movement at full resolution is **19.86 -> 21.18 (+6.6%)**.

A trap worth knowing before reading any older note: **this camera writes the
*requested* frame rate into the MP4 header regardless of what it encoded.** A
clip stamped `25/1` can contain 19.98 fps of pictures. Every number here is
frame-count-over-PTS-span.

### The contradiction, resolved

`FPS_BOTTLENECK.md` argued a ~25 fps ceiling and that the answer was "better
than 21"; measurement topped out at 21.18. **The analysis was wrong, not
blocked.** Its hardware numbers all survived re-measurement — PCLK 150 MHz, the
466 Mpix/s encoder, the 25.00 clamp, the 26.7 fps readout wall. It missed the
two stages that actually bind because neither is a hardware engine: a userspace
frame pump in `device`, and one IPP engine at 99% shared by three VideoProc
clients. **Capability tables do not show contention.** The method error is
recorded next to the finding.

### Falsified claims kept as falsified

Eight of them, marked in place rather than deleted — they cost real time and
they are what stops the next session repeating the work:

- **Pump-sleep theory** — falsified twice, by flash (−0.04 fps) and by cadence
  (sigma 17 ms, bimodal on the 40 ms grid, not a 50 ms period).
- **Dual-sensor pairing** — falsified: the sensors are TGE-locked with zero
  drift over 1500 frames, and `isp_dev_get_sync_item` is a 3A/IQ metadata ring,
  not a pairing function. `FPS_MAIN_BIND` §9's "fix the pairing first" is marked
  obsolete outright; following it would burn a session.
- **DDR** — `EFF 52` means 5118 MB/s is ~93% of *practical* bandwidth, not 48%
  of a free bus. The original reading inverted the conclusion.
- `FIRMWARE_PATCH_NOTES.md` §15's 120 MHz contradicted its own caveats block,
  which already said 150; the ~330 Mpix/s figure was attributed to the encoder,
  which measures 465 and never binds.

### Still open

**Why exactly 332 Mpix/s.** The pump is throughput-bound, `device` does no pixel
copy, and DDR sits at ~93% of practical simultaneously. Whether DDR is the
binding resource or merely correlated was never separated. Flagged, not papered
over.

### Safety change in the same PR

`hold_recording_override()` shipped with a docstring saying callers *must*
release in a try/finally. That is an instruction, not a guard. An exception
between hold and release leaves the camera recording at home invisibly — the
2026-08-16 failure reached by a different road. `recording_override_held()` is
now a context manager that releases in `finally` and then tests for the flag's
absence (`rm -f` exits 0 on a path it did not remove), raising if it survives.
Three new selftest gates, verified by regression: dropping the `finally` makes
one fail. 12/12 -> 15/15.

### Notes

- `build_tge_retime.sh` lacks the boot-chain SHA-256 assertion its siblings
  carry (verified: 0 matching lines vs 3 in `build_fps_demo.sh`). Flagged
  do-not-flash in three places rather than silently patched — it was never
  flashed, and adding the guard is a code change beyond a consolidation.
- Build numbers collide: 4915 and 4916 each name two different paks across this
  work and `BRICK_POSTMORTEM.md`. "Leave it on 4915" is ambiguous; documented.
- `firmware/ddr-analysis` held no unique commit — confirmed, branch deleted. Its
  finding survives here.
- Camera untouched by this PR.