### PR TITLE
firmware: camera-side stitch-seam calibration — compose onto the factory mesh, re-apply at boot

### DIFF
--- a/reolink-firmware-patching/builds/BUILD_LOG.md
+++ b/reolink-firmware-patching/builds/BUILD_LOG.md
@@ -33,6 +33,33 @@ Contents (layered on stock 4867):
 
 Build: `builds/build_soccercam_v2.sh` (driven by `/tmp` wrapper that carries creds/MAC from 4896).
 
+## "Stitchcal" firmware — comprehensive + the seam-calibration boot hook
+
+Build: `builds/build_stitchcal.sh`. Everything the comprehensive pak carries,
+plus `/usr/bin/lut2d_ioctl` (static aarch64: `get` / `set` / `compose`),
+`/etc/init.d/S98_StitchCal`, and `/etc/init.d/S36_RootShell`.
+
+The point of baking it once is that **a calibration is then a file drop, not a
+reflash**: `/mnt/sda/stitchcal/anchors.txt` is a few hundred bytes and the hook
+composes it onto whatever factory mesh the firmware generated that boot. With no
+`anchors.txt` the hook exits 0 and the mesh stays factory, so the pak is a safe
+no-op on an uncalibrated unit.
+
+Two gates run inside the builder and both refuse rather than warn: the boot chain
+(`loader`, `fdt`, `atf`, `uboot`, `kernel`) must be byte-identical to stock —
+enforced inside `pak_repack.repack()` before assembly and long before the CRC is
+computed — and `verify/check_recording_default.sh` must pass.
+
+| File | Notes |
+|---|---|
+| **`IPC_…4920…_stitchcal.pak`** | **CURRENT.** 4919 + **idempotent hook.** Re-running S98 within one boot composed the correction onto its *own output* and silently doubled the shear (3 px → 6 px) while the log read healthy. The hook now records a signature of what it wrote and, on recognising it, composes from the saved baseline instead. Verified on camera: three consecutive runs all produce mesh crc `0bf0934f`. |
+| `IPC_…4919…_stitchcal.pak` | superseded — first build whose hook actually ran. 4918 + **wait for `/mnt/sda` before reading config** + `S36_RootShell` restored. **On-camera validated:** S98 applied a ±3 px calibration 38 s into boot, read-back ok, and the correction was visible in a snapshot. |
+| `IPC_…4918…_stitchcal.pak` | superseded, and instructive. Gates passed, flashed clean — and the hook **did nothing, silently**. `rcS` does `mount -a` then runs `S*`, but `/mnt/sda` is `/dev/hd/sda1`, mounted later by the app; S98 checked for `anchors.txt` first, found none, and could not even log it because `/` is read-only squashfs. It also dropped `S36_RootShell` (the comprehensive builder never installed one), taking tcp/2323 with it. |
+
+Known gap: `commit=` in the manifest reads `unknown` unless `SOCCERCAM_COMMIT` is
+set, because `git rev-parse` refuses a `/mnt/c` worktree from WSL (dubious
+ownership). Pass it explicitly.
+
 ## "Comprehensive" firmware — ready to flash
 | File | sha256 | Notes |
 |---|---|---|

--- a/reolink-firmware-patching/builds/build_stitchcal.sh
+++ b/reolink-firmware-patching/builds/build_stitchcal.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# Comprehensive soccer-cam firmware + stitch-seam calibration boot hook.
+#
+# Everything build_soccercam_comprehensive.sh installs, plus:
+#   - /usr/bin/lut2d_ioctl            (static aarch64; get / set / compose)   (rootfs)
+#   - /etc/init.d/S98_StitchCal       (re-apply the seam correction at boot)  (rootfs)
+#   - /etc/init.d/S36_RootShell       (tcp/2323 recovery channel)              (rootfs)
+#
+# WHY THIS NEEDS A FLASH AT ALL. /etc/init.d is squashfs and read-only, so the
+# hook itself cannot be dropped onto the SD card. It is baked ONCE; every
+# calibration afterwards is a few hundred bytes of anchors.txt copied to
+# /mnt/sda/stitchcal/, no reflash. That is the S99_NetState pattern -- fixed
+# script in firmware, mutable configuration on the card.
+#
+# The helper binary is baked too, rather than living on the SD card as the
+# design first proposed. It is code, not configuration; baking it means the hook
+# still works on a card that was reformatted, and it keeps the boot path from
+# depending on a file an operator can delete. S98_StitchCal still prefers
+# /mnt/sda/stitchcal/bin/lut2d_ioctl when present, so it can be iterated on
+# without a reflash.
+#
+# TWO GATES RUN BEFORE THE PAK IS USABLE, and both refuse rather than warn:
+#   1. The boot chain (loader, fdt, atf, uboot, kernel) must be byte-identical
+#      to stock. Enforced inside pak_repack.repack() itself, before a byte is
+#      assembled and long before the CRC is computed -- a pak with a good CRC
+#      and a damaged loader is indistinguishable from a good one until after you
+#      have flashed it. Re-asserted here against the finished file.
+#   2. verify/check_recording_default.sh -- the pak must not record at home.
+#
+# No sudo needed (unsquashfs -no-xattrs, mksquashfs -all-root).
+#
+# Usage:
+#   bash build_stitchcal.sh <stock.pak> <out.pak> <kbps> <user> <pass> <reserve_gb> <home_mac> [more_macs...]
+#
+# NOTE: <out.pak> MUST match the Reolink filename pattern or Local Upgrade
+# rejects it regardless of contents:
+#   IPC_NT15NA416MP.<build>_2505072124.Reolink-Duo-3-PoE.16MP.REOLINK_stitchcal.pak
+set -euo pipefail
+STOCK="${1:?}"; OUT="${2:?}"; KBPS="${3:?}"; USER="${4:?}"; PASS="${5:?}"; RES_GB="${6:?}"; shift 6
+HOME_MACS="$*"; [[ -n "$HOME_MACS" ]] || { echo "ERROR: home MAC required"; exit 1; }
+case "$(basename "$OUT")" in
+  IPC_NT15NA416MP.*_*.Reolink-Duo-3-PoE.16MP.REOLINK*.pak) : ;;
+  *) echo "WARNING: output name '$(basename "$OUT")' does NOT match the Reolink pattern;" >&2
+     echo "         the camera's Local Upgrade will reject it." >&2 ;;
+esac
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+PAK_DIR="$ROOT/pak"
+NS_TPL="$ROOT/runtime/netstate/S99_NetState_v2.template"
+REC_SH="$ROOT/runtime/recover/S35_RecRecover"
+REC_C="$ROOT/recover/recover_mp4.c"
+SC_SH="$ROOT/runtime/stitchcal/S98_StitchCal"
+RS_SH="$ROOT/runtime/rootshell/S36_RootShell"
+LUT_C="$ROOT/vpe/lut2d_ioctl.c"
+for x in "$NS_TPL" "$REC_SH" "$REC_C" "$SC_SH" "$LUT_C" "$RS_SH"; do
+  [[ -f "$x" ]] || { echo "ERROR: missing $x"; exit 1; }
+done
+command -v aarch64-linux-gnu-gcc >/dev/null || { echo "ERROR: need aarch64-linux-gnu-gcc"; exit 1; }
+WORK="$(mktemp -d)"; trap "rm -rf '$WORK'" EXIT; cd "$WORK"
+HOME_MACS_LC=$(echo "$HOME_MACS" | tr 'A-Z' 'a-z')
+
+echo "==> 1) extract app + rootfs"
+python3 - "$STOCK" <<'PY'
+import struct,sys
+d=open(sys.argv[1],"rb").read()
+for i,n in [(5,"rootfs"),(7,"app")]:
+    b=0x18+i*0x48; off=struct.unpack("<Q",d[b+0x38:b+0x40])[0]; sz=struct.unpack("<Q",d[b+0x40:b+0x48])[0]
+    open(n+"_stock.bin","wb").write(d[off:off+sz])
+PY
+unsquashfs -no-xattrs -d app_unpacked    -no-progress app_stock.bin    >/dev/null
+unsquashfs -no-xattrs -d rootfs_unpacked -no-progress rootfs_stock.bin >/dev/null
+
+echo "==> 2) HTTP /downloadfile/ unlock"
+python3 - <<'PY'
+SRC=(b"location /downloadfile/ {\n            internal;\n            limit_conn one 1;\n            limit_rate 1024k;\n            alias /mnt/sda/;\n        }")
+DST=(b"location /downloadfile/ {\n           #internal;\n            limit_conn one 1;\n            limit_rate 0;    \n            alias /mnt/sda/;\n        }")
+d=bytearray(open("app_unpacked/device","rb").read())
+assert d.count(SRC)==2, f"http: expected 2, got {d.count(SRC)}"
+open("app_unpacked/device","wb").write(bytes(d).replace(SRC,DST)); print("   http unlocked")
+PY
+
+echo "==> 3) bitrate cap -> ${KBPS}"
+python3 - <<PY
+OFF=0x6351c; SRC=bytes.fromhex("0b008652"); inst=0x5280000B|($KBPS<<5)
+DST=bytes([inst&0xff,(inst>>8)&0xff,(inst>>16)&0xff,(inst>>24)&0xff])
+d=bytearray(open("app_unpacked/router","rb").read())
+assert bytes(d[OFF:OFF+4])==SRC, "bitrate site mismatch"
+d[OFF:OFF+4]=DST; open("app_unpacked/router","wb").write(bytes(d)); print(f"   bitrate {$KBPS}")
+PY
+
+echo "==> 4) free-space reserve 500MiB -> ${RES_GB}GiB"
+python3 - <<PY
+OFF=0x44788; CUR=(0xd2a3e800).to_bytes(4,"little"); SO="app_unpacked/libStorageFileManager.so"
+V=$RES_GB*(1<<30); enc=None
+for sh in (0,16,32,48):
+    imm=V>>sh
+    if (imm<<sh)==V and 0<=imm<=0xffff: enc=(imm,sh); break
+assert enc, f"{V} not single-movz"
+imm,sh=enc; word=0xD2800000|((sh//16)<<21)|(imm<<5); new=word.to_bytes(4,"little")
+d=bytearray(open(SO,"rb").read())
+assert bytes(d[OFF:OFF+4])==CUR, "reserve site mismatch"
+d[OFF:OFF+4]=new; open(SO,"wb").write(bytes(d)); print(f"   reserve {$RES_GB}GiB ({new.hex()})")
+PY
+
+echo "==> 5) install S99_NetState v2"
+python3 - <<PY
+t=open("$NS_TPL").read().replace("%%HOME_MACS%%","$HOME_MACS_LC").replace("%%CAMERA_USER%%","$USER").replace("%%CAMERA_PASS%%","$PASS")
+import os; os.makedirs("rootfs_unpacked/etc/init.d",exist_ok=True)
+open("rootfs_unpacked/etc/init.d/S99_NetState","w",newline="\n").write(t); os.chmod("rootfs_unpacked/etc/init.d/S99_NetState",0o755)
+print(f"   S99_NetState ({len(t)}b)")
+PY
+
+echo "==> 6) build + install recover_mp4 (static aarch64) + boot script"
+HELIX_SRC="$ROOT/recover/helix/ESP8266Audio/src/libhelix-aac"
+HELIX_COMPAT="$ROOT/recover/helix/compat"
+if [[ -d "$HELIX_SRC" && -f "$HELIX_COMPAT/Arduino.h" ]]; then
+  echo "   building libhelix-aac -> recover_mp4 WITH best-effort audio recovery"
+  HXB="$WORK/hx"; mkdir -p "$HXB"
+  for c in "$HELIX_SRC"/*.c; do
+    aarch64-linux-gnu-gcc -O2 -DNDEBUG -DARDUINO -Wno-format -ffunction-sections -fdata-sections \
+      -I"$HELIX_COMPAT" -I"$HELIX_SRC" -c "$c" -o "$HXB/$(basename "$c" .c).o"
+  done
+  aarch64-linux-gnu-ar rcs "$HXB/libhelixaac.a" "$HXB"/*.o
+  aarch64-linux-gnu-gcc -O2 -DNDEBUG -DARDUINO -static \
+    -I"$HELIX_COMPAT" -I"$HELIX_SRC" \
+    -o rootfs_unpacked/usr/bin/recover_mp4 "$REC_C" "$HXB/libhelixaac.a"
+  AUDIO=yes
+elif [[ "${ALLOW_NO_AUDIO:-0}" == "1" ]]; then
+  echo "   ALLOW_NO_AUDIO=1: Helix AAC source absent -> VIDEO-ONLY recovery (-DNO_AUDIO)"
+  aarch64-linux-gnu-gcc -O2 -DNDEBUG -DNO_AUDIO -static -o rootfs_unpacked/usr/bin/recover_mp4 "$REC_C"
+  AUDIO=no
+else
+  # The comprehensive builder only warns here. That is fine when someone is
+  # watching a terminal; it is not fine for a pak that gets flashed, because a
+  # silent downgrade from audio=yes to audio=no is invisible afterwards and
+  # costs the sound on every power-cut recovery. Fetch the source (see
+  # recover/helix/README.md) or say ALLOW_NO_AUDIO=1 and mean it.
+  echo "ERROR: Helix AAC source absent -- this pak would silently downgrade" >&2
+  echo "       recover_mp4 to video-only. See recover/helix/README.md to fetch it," >&2
+  echo "       or re-run with ALLOW_NO_AUDIO=1 to accept the downgrade." >&2
+  exit 1
+fi
+chmod 755 rootfs_unpacked/usr/bin/recover_mp4
+install -m 0755 "$REC_SH" rootfs_unpacked/etc/init.d/S35_RecRecover
+echo "   recover_mp4 + S35_RecRecover installed"
+
+echo "==> 6b) build + install lut2d_ioctl and S98_StitchCal"
+aarch64-linux-gnu-gcc -O2 -Wall -Wextra -static \
+    -o rootfs_unpacked/usr/bin/lut2d_ioctl "$LUT_C" -lm
+chmod 755 rootfs_unpacked/usr/bin/lut2d_ioctl
+file rootfs_unpacked/usr/bin/lut2d_ioctl | cut -d, -f1-3
+# The helper must refuse to run without arguments rather than doing something;
+# a boot hook that silently no-ops on a broken binary is the failure this whole
+# path is trying to avoid.
+if rootfs_unpacked/usr/bin/lut2d_ioctl >/dev/null 2>&1; then
+  echo "ERROR: lut2d_ioctl with no arguments returned success"; exit 1
+fi
+install -m 0755 "$SC_SH" rootfs_unpacked/etc/init.d/S98_StitchCal
+# Gates on the hook's actual code, comments stripped -- these encode the two
+# invariants the whole design rests on, so they are checked in the build rather
+# than trusted to review.
+SC_CODE="$(sed 's/#.*//' rootfs_unpacked/etc/init.d/S98_StitchCal)"
+grep -q '\$BIN" compose' <<<"$SC_CODE" \
+  || { echo "ERROR: S98_StitchCal does not compose -- it would write a generated mesh"; exit 1; }
+if grep -q 'require-baseline' <<<"$SC_CODE"; then
+  echo "ERROR: the boot hook must NOT require a baseline match: one legitimate" >&2
+  echo "       SetStitch would then disable it permanently (see S98 comments)." >&2
+  exit 1
+fi
+grep -q 'give_up' <<<"$SC_CODE" \
+  || { echo "ERROR: S98_StitchCal has no bounded failure path"; exit 1; }
+# rcS runs S* scripts before the app mounts /dev/hd/sda1, so a hook that reads
+# its config first exits silently on a read-only rootfs and leaves no trace.
+# That shipped once; it does not ship again.
+grep -q 'wait_for_sdcard' <<<"$SC_CODE" \
+  || { echo "ERROR: S98_StitchCal must wait for /mnt/sda before reading config"; exit 1; }
+awk '/^main\(\)/,/^}/' <<<"$SC_CODE" | grep -n 'wait_for_sdcard\|ANCHORS\|DISABLE' \
+  | head -1 | grep -q 'wait_for_sdcard' \
+  || { echo "ERROR: S98_StitchCal reads config before waiting for /mnt/sda"; exit 1; }
+# Composing onto an already-corrected mesh silently doubles the shear, and the
+# log looks healthy while it happens. The hook must recognise its own output.
+grep -q 'APPLIED_SIG' <<<"$SC_CODE" \
+  || { echo "ERROR: S98_StitchCal is not idempotent -- a re-run would double-apply"; exit 1; }
+echo "   lut2d_ioctl + S98_StitchCal installed"
+
+echo "==> 6d) install S36_RootShell (recovery channel)"
+install -m 0755 "$RS_SH" rootfs_unpacked/etc/init.d/S36_RootShell
+# The 2026-08-16 investigation builds asserted the netstate override at boot and
+# the camera recorded at home for hours. check_recording_default.sh catches that
+# at step 11; this is the same check one layer earlier, on the file we just
+# wrote, so the failure is attributed to the right script.
+if grep -qE '^[^#]*(touch|>|cp|echo).*netstate/override' rootfs_unpacked/etc/init.d/S36_RootShell; then
+  echo "ERROR: S36_RootShell asserts the netstate override"; exit 1
+fi
+echo "   S36_RootShell installed (tcp/2323, one command set per connection)"
+
+echo "==> 6c) bake build manifest (/etc/soccercam_build)"
+COMMIT="${SOCCERCAM_COMMIT:-$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+cat > rootfs_unpacked/etc/soccercam_build <<EOF
+variant=stitchcal
+pak=$(basename "$OUT")
+base=v3.0.0.4867_2505072124
+kbps=$KBPS
+reserve_gb=$RES_GB
+netstate=v2
+recover=yes
+audio=$AUDIO
+stitchcal=S98+lut2d_ioctl
+rootshell=S36
+commit=$COMMIT
+EOF
+chmod 644 rootfs_unpacked/etc/soccercam_build
+
+echo "==> 7) repack app + rootfs"
+mksquashfs app_unpacked    app_new.bin    -comp xz -b 262144 -noappend -no-progress -no-exports -all-root -mkfs-time 0 -all-time 0 >/dev/null
+mksquashfs rootfs_unpacked rootfs_new.bin -comp xz -b 262144 -noappend -no-progress -no-exports -all-root -mkfs-time 0 -all-time 0 >/dev/null
+ROOTFS_SZ=$(stat -c %s rootfs_new.bin)
+echo "   rootfs $ROOTFS_SZ bytes"
+[[ "$ROOTFS_SZ" -lt $((8*1024*1024)) ]] || { echo "ERROR: rootfs exceeds its 8 MiB partition"; exit 1; }
+
+echo "==> 8) repack pak (boot chain asserted inside repack, before the CRC)"
+PYTHONPATH="$PAK_DIR" python3 - <<PY
+from pak_repack import repack, BootChainChanged
+try:
+    crc,size,_=repack("$STOCK","$OUT",swaps={"rootfs":open("rootfs_new.bin","rb").read(),"app":open("app_new.bin","rb").read()})
+except BootChainChanged as e:
+    raise SystemExit(f"REFUSING: {e}")
+print(f"   wrote $OUT size={size} crc=0x{crc:08x}")
+PY
+
+echo "==> 9) verify CRC"
+python3 "$PAK_DIR/reolink_crc.py" compute "$OUT"
+
+echo "==> 10) GATE: boot chain byte-identical to stock"
+python3 "$PAK_DIR/pak_repack.py" --check-boot-chain "$STOCK" "$OUT"
+
+echo "==> 11) GATE: this pak must not record at home"
+bash "$ROOT/verify/check_recording_default.sh" "$OUT"
+
+echo "==================================================================="
+echo " STITCHCAL: comprehensive + S98_StitchCal + /usr/bin/lut2d_ioctl"
+echo " Boot chain verified identical to stock; recording defaults to off at home."
+echo
+echo " After flashing, a calibration is a FILE DROP, not a reflash:"
+echo "   /mnt/sda/stitchcal/anchors.txt   the correction"
+echo "   /mnt/sda/stitchcal/disable       presence => hook exits 0, factory mesh"
+echo "   /mnt/sda/stitchcal/log           what happened at boot"
+echo "   /mnt/sda/stitchcal/state.json    what was applied, and against what baseline"
+echo " With no anchors.txt the hook exits 0 and the mesh stays factory, so this"
+echo " pak is a safe no-op until a calibration actually exists."
+echo "==================================================================="

--- a/reolink-firmware-patching/pak/pak_repack.py
+++ b/reolink-firmware-patching/pak/pak_repack.py
@@ -39,6 +39,15 @@ HEADER_SIZE = 0x18
 ENTRY_SIZE = 0x48
 NUM_TABLE_ENTRIES = 15  # full section table (8 used + 7 empty), per stock layout
 
+# Sections that, if wrong, produce a camera that does not come back. Everything
+# this project patches lives in `rootfs` and `app`, which are recoverable by
+# reflashing; these five are not, without a UART cable.
+BOOT_CHAIN = ("loader", "fdt", "atf", "uboot", "kernel")
+
+
+class BootChainChanged(Exception):
+    """A repack would have altered a section that has to survive byte-for-byte."""
+
 
 def parse_section_table(data: bytes):
     """Return list of dicts for all 15 entries (empty ones included)."""
@@ -65,6 +74,46 @@ def parse_section_table(data: bytes):
             }
         )
     return entries
+
+
+def _assert_boot_chain(built: bytes, stock: bytes, what: str) -> list[str]:
+    """Every BOOT_CHAIN section in `built` must equal the one in `stock`.
+
+    Compared at each file's own advertised offsets, so this catches a section
+    that was preserved but relocated as well as one that was modified.
+    """
+    stock_by_name = {s["name"]: s for s in parse_section_table(stock)}
+    checked: list[str] = []
+    for s in parse_section_table(built):
+        if s["name"] not in BOOT_CHAIN or s["size"] == 0:
+            continue
+        ref = stock_by_name.get(s["name"])
+        if ref is None or ref["size"] == 0:
+            raise BootChainChanged(
+                f"{what}: '{s['name']}' is absent from the stock pak"
+            )
+        if s["size"] != ref["size"]:
+            raise BootChainChanged(
+                f"{what}: '{s['name']}' size {s['size']} != stock {ref['size']}"
+            )
+        if s["off"] != ref["off"]:
+            raise BootChainChanged(
+                f"{what}: '{s['name']}' moved from 0x{ref['off']:x} to 0x{s['off']:x}"
+            )
+        if (
+            built[s["off"] : s["off"] + s["size"]]
+            != stock[ref["off"] : ref["off"] + ref["size"]]
+        ):
+            raise BootChainChanged(f"{what}: '{s['name']}' payload differs from stock")
+        checked.append(s["name"])
+    missing = [
+        n
+        for n in BOOT_CHAIN
+        if n not in checked and n in stock_by_name and stock_by_name[n]["size"]
+    ]
+    if missing:
+        raise BootChainChanged(f"{what}: sections {missing} vanished from the pak")
+    return checked
 
 
 def repack(
@@ -105,6 +154,22 @@ def repack(
         else:
             new_blobs[s["name"]] = stock[s["off"] : s["off"] + s["size"]]
 
+    # The boot chain must survive byte-for-byte, and the check goes here --
+    # before a single byte is assembled and long before the CRC is computed --
+    # so that a build which would have moved it cannot produce a file at all.
+    # A pak with a valid CRC and a damaged loader is exactly the artifact you
+    # cannot tell apart from a good one until you have already flashed it.
+    for s in used:
+        if s["name"] not in BOOT_CHAIN:
+            continue
+        original = stock[s["off"] : s["off"] + s["size"]]
+        if new_blobs[s["name"]] != original:
+            raise BootChainChanged(
+                f"section '{s['name']}' would change "
+                f"({len(original)} -> {len(new_blobs[s['name']])} bytes). "
+                "Only 'rootfs' and 'app' may be replaced."
+            )
+
     # Rebuild section table entries in same order, recompute offsets/sizes.
     out = bytearray(head_region)  # preserve header geometry exactly
     cursor = first_off  # payload starts here, same as original
@@ -124,6 +189,12 @@ def repack(
 
     # Empty entries (i not in new_meta) — leave them as-is from head_region.
 
+    # Assert it again against the ASSEMBLED image, at the offsets the new
+    # section table advertises. The check above proves the payloads are equal;
+    # this one proves the layout did not move them, which is a different bug
+    # and one the CRC would happily bless.
+    _assert_boot_chain(bytes(out), stock, "assembled image")
+
     # Recompute and write Reolink CRC.
     out[CRC_FIELD_OFFSET : CRC_FIELD_OFFSET + 8] = b"\x00" * 8
     crc = compute_reolink_crc(bytes(out))
@@ -138,9 +209,21 @@ def repack(
 
 
 if __name__ == "__main__":
+    if len(sys.argv) >= 4 and sys.argv[1] == "--check-boot-chain":
+        stock_b = open(sys.argv[2], "rb").read()
+        built_b = open(sys.argv[3], "rb").read()
+        try:
+            names = _assert_boot_chain(built_b, stock_b, sys.argv[3])
+        except BootChainChanged as exc:
+            print(f"REFUSING: {exc}")
+            sys.exit(1)
+        print(f"PASS: boot chain byte-identical to stock ({', '.join(names)})")
+        sys.exit(0)
+
     if len(sys.argv) < 3:
         print(
-            "usage: pak_repack.py <stock.pak> <output.pak> [section_name replacement_blob]"
+            "usage: pak_repack.py <stock.pak> <output.pak> [section_name replacement_blob]\n"
+            "       pak_repack.py --check-boot-chain <stock.pak> <built.pak>"
         )
         sys.exit(2)
 

--- a/reolink-firmware-patching/runtime/rootshell/S36_RootShell
+++ b/reolink-firmware-patching/runtime/rootshell/S36_RootShell
@@ -1,0 +1,19 @@
+#!/bin/sh
+# S36_RootShell -- recovery channel. One command set per TCP connection:
+# /bin/sh reads stdin to EOF, executes, exits. There is no login, no banner and
+# no prompt, so any client must be written for that model rather than as an
+# interactive session (see runtime/camsh.py, which is the only sanctioned way to
+# drive it).
+#
+# This is the reason recovery from the 2026-08-16 outage took minutes instead of
+# waiting on a UART cable. It is also a loaded gun -- the same shell has write
+# access to /mnt/sda, where every recording lives -- which is why camsh.py
+# refuses the class of command that caused that incident before it reaches the
+# camera.
+#
+# This script deliberately does NOT touch /mnt/sda/netstate/override. Asserting
+# that flag at boot makes S99_NetState yield permanently and the camera records
+# at home; enabling recording is an explicit operator action, never a build
+# default. See verify/check_recording_default.sh.
+tcpsvd -vE 0.0.0.0 2323 /bin/sh >/dev/null 2>&1 &
+exit 0

--- a/reolink-firmware-patching/runtime/stitchcal/S98_StitchCal
+++ b/reolink-firmware-patching/runtime/stitchcal/S98_StitchCal
@@ -1,0 +1,234 @@
+#!/bin/sh
+# /etc/init.d/S98_StitchCal
+# Re-apply the stitch-seam correction to the VPE 0 warp mesh at every boot.
+#
+# The mesh is RUNTIME state. The firmware regenerates it from CamStitchPara
+# (mtd11) plus the persisted scalars in /mnt/para/stitch.cfg on every power-on,
+# so anything written to it dies at the next reboot. That is a safety property
+# worth keeping -- a bad mesh is undone by a power cycle -- but it means a real
+# calibration needs re-applying, which is this script.
+#
+# WHAT IS STORED IS THE CORRECTION, NEVER A COMPOSED MESH.
+#
+# /mnt/sda/stitchcal/anchors.txt holds a few hundred bytes of [row, dx] anchors.
+# At each boot this script dumps THIS BOOT'S factory mesh and composes the
+# anchors onto that. Three things follow, and they are the whole reason for the
+# design:
+#
+#   * "the production mesh is the factory mesh plus a correction" becomes an
+#     invariant rather than a rule, because no composed mesh has any persistent
+#     existence to drift out of date;
+#   * it self-heals -- if the vendor scalars change, or a firmware update
+#     changes the factory calibration, the next boot composes onto the new
+#     baseline instead of restoring a stale mesh over it;
+#   * the ordering constraint is satisfied structurally. SetStitch re-runs the
+#     firmware's own optimiser (Na_calc_2dlut_data) and destroys any mesh we
+#     wrote, so scalars must always be applied BEFORE the mesh. Here that is
+#     automatic: whatever mesh the firmware generated already reflects whatever
+#     scalars were persisted, and that generated mesh is our input.
+#
+# Runtime configuration, all on the writable SD card (the S99_NetState pattern:
+# fixed script in read-only firmware, mutable config on the card):
+#
+#   /mnt/sda/stitchcal/anchors.txt   the correction; the only file routinely updated
+#   /mnt/sda/stitchcal/disable       presence => this script exits 0, uncorrected
+#   /mnt/sda/stitchcal/bin/lut2d_ioctl   optional override for the baked-in helper
+#   /mnt/sda/stitchcal/factory_boot.bin  this boot's factory dump (overwritten)
+#   /mnt/sda/stitchcal/mesh_boot.bin     what was written (overwritten)
+#   /mnt/sda/stitchcal/state.json        witness: what was applied, when, against what
+#   /mnt/sda/stitchcal/log               rotates at 256 KB, as S99_NetState does
+#
+# EVERY FAILURE PATH EXITS 0 AND UNCORRECTED. A camera that records an
+# uncorrected game is a degraded camera; a camera that fails to boot is a lost
+# weekend. Nothing here is allowed to be the second thing.
+#
+# Runs at S98: after S15_NvtAppInit has the media pipeline up, and before
+# S99_NetState makes its record/idle decision -- the mesh must be live before
+# the first recorded frame.
+
+CFG_DIR=/mnt/sda/stitchcal
+ANCHORS=$CFG_DIR/anchors.txt
+DISABLE=$CFG_DIR/disable
+LOG=$CFG_DIR/log
+STATE=$CFG_DIR/state.json
+FACTORY=$CFG_DIR/factory_boot.bin
+LIVE=$CFG_DIR/live_now.bin
+APPLIED_SIG=$CFG_DIR/applied.sig
+MESH=$CFG_DIR/mesh_boot.bin
+BAKED=/usr/bin/lut2d_ioctl
+OVERRIDE_BIN=$CFG_DIR/bin/lut2d_ioctl
+
+LOG_MAX_BYTES=262144
+WAIT_TRIES=60          # x 2s = up to 2 minutes for the pipeline to settle
+SD_TRIES=60            # x 2s = up to 2 minutes for the SD card to appear
+VPRC=/proc/hdal/vprc/info
+
+log() {
+    MSG="[$(date '+%F %T')] $*"
+    echo "$MSG"
+    if [ -d "$CFG_DIR" ] || mkdir -p "$CFG_DIR" 2>/dev/null; then
+        if [ -f "$LOG" ] && [ "$(wc -c <"$LOG" 2>/dev/null)" -gt $LOG_MAX_BYTES ]; then
+            mv "$LOG" "$LOG.old" 2>/dev/null
+        fi
+        echo "$MSG" >>"$LOG"
+    fi
+}
+
+give_up() {
+    log "  NOT APPLIED: $*"
+    log "===== stitchcal finished: mesh left at factory ====="
+    exit 0
+}
+
+# The SD card is NOT mounted by rcS's `mount -a` -- /dev/hd/sda1 is brought up
+# later by the app, well after rcS starts running S* scripts. Everything this
+# hook reads and writes lives there, so nothing may be read until it is up.
+#
+# This is not hypothetical: the first flashed build checked for anchors.txt
+# immediately, found nothing because the card was not mounted yet, and exited.
+# It could not even say so -- / is read-only squashfs, so log() could not create
+# /mnt/sda/stitchcal and the message went to the boot console and nowhere else.
+# The result was a hook that had provably run and left no trace at all, which is
+# the most expensive kind of silence. Wait for the mount FIRST, then read config,
+# so every subsequent decision is both correct and recorded.
+# Identify a mesh by its table alone. The 8-byte header differs between a
+# driver dump and a composed file even when the tables are identical, so it must
+# not be part of the identity.
+mesh_sig() {
+    dd if="$1" bs=8 skip=1 2>/dev/null | md5sum | cut -d' ' -f1
+}
+
+wait_for_sdcard() {
+    i=0
+    while [ $i -lt $SD_TRIES ]; do
+        if grep -q ' /mnt/sda ' /proc/mounts 2>/dev/null; then
+            return 0
+        fi
+        sleep 2
+        i=$((i + 1))
+    done
+    return 1
+}
+
+# Wait on a CONDITION, never a fixed sleep. The stitcher (VIDEOPROC 2) has to be
+# running at the full panorama size and pushing frames before the mesh means
+# anything, and how long that takes varies with what else booted first.
+wait_for_stitcher() {
+    i=0
+    prev=""
+    while [ $i -lt $WAIT_TRIES ]; do
+        if [ -r "$VPRC" ]; then
+            # out 0 of VIDEOPROC 2 must be the full panorama...
+            if grep -q '7680  2160' "$VPRC" 2>/dev/null; then
+                # ...and its push counter must be advancing, not merely present
+                cur=$(grep -c . "$VPRC" 2>/dev/null)$(md5sum "$VPRC" 2>/dev/null | cut -c1-16)
+                if [ -n "$prev" ] && [ "$cur" != "$prev" ]; then
+                    return 0
+                fi
+                prev="$cur"
+            fi
+        fi
+        sleep 2
+        i=$((i + 1))
+    done
+    return 1
+}
+
+main() {
+    # Before the mount, log() can only echo to the boot console -- so do the
+    # waiting before the announcing, and the first line in the file is then a
+    # complete record of the run.
+    if ! wait_for_sdcard; then
+        echo "[stitchcal] /mnt/sda never mounted after $((SD_TRIES * 2))s -- giving up"
+        exit 0
+    fi
+    log "===== stitchcal starting ====="
+
+    [ -e "$DISABLE" ] && give_up "$DISABLE present (operator rollback)"
+    [ -r "$ANCHORS" ] || give_up "no $ANCHORS -- nothing is calibrated on this unit"
+
+    BIN=$BAKED
+    if [ -x "$OVERRIDE_BIN" ]; then
+        BIN=$OVERRIDE_BIN
+        log "  using SD-card helper override $OVERRIDE_BIN"
+    fi
+    [ -x "$BIN" ] || give_up "no usable lut2d_ioctl ($BAKED / $OVERRIDE_BIN)"
+
+    if wait_for_stitcher; then
+        log "  stitcher is up and pushing 7680x2160"
+    else
+        give_up "stitcher did not reach 7680x2160 within $((WAIT_TRIES * 2))s"
+    fi
+
+    # 1) dump the live mesh. `compose` liveness-gates it: an all-zero read
+    #    satisfies every structural check by construction, and the driver
+    #    returns success on one, so a dump that looks perfect can be empty.
+    rm -f "$LIVE" 2>/dev/null
+    "$BIN" get 0 "$LIVE" >>"$LOG" 2>&1 || give_up "mesh dump failed"
+    [ -s "$LIVE" ] || give_up "mesh dump produced no file"
+
+    # 1b) IS THE LIVE MESH THE FACTORY BASELINE, OR OUR OWN OUTPUT?
+    #
+    # At boot it is always the baseline -- the firmware regenerates the mesh
+    # from CamStitchPara on every power-on. But this script must also be safe to
+    # run by hand, because "run it again and see" is the first thing anyone does
+    # when debugging, and composing a correction onto an already-corrected mesh
+    # silently DOUBLES it. That is not hypothetical: it happened during
+    # bring-up, and the log looked entirely healthy while the shear went from
+    # 3 px to 6 px.
+    #
+    # So: remember the signature of what we last wrote. If the live mesh is
+    # that, the true baseline is the copy we saved; otherwise the live mesh IS
+    # the baseline and the saved copy is stale. This also self-heals through a
+    # SetStitch, which produces a new factory mesh whose signature matches
+    # neither.
+    #
+    # Signature skips the 8-byte header: a dump carries {id, n} plus whatever
+    # the driver left in the third word, while a composed file carries a
+    # canonical header, so only the table is comparable.
+    LIVE_SIG=$(mesh_sig "$LIVE")
+    PREV_SIG=$(cat "$APPLIED_SIG" 2>/dev/null)
+    if [ -n "$PREV_SIG" ] && [ "$LIVE_SIG" = "$PREV_SIG" ] && [ -s "$FACTORY" ]; then
+        log "  our correction is already live; composing from the saved baseline"
+    else
+        cp "$LIVE" "$FACTORY" || give_up "could not save the factory baseline"
+        log "  live mesh is the factory baseline for this boot"
+    fi
+
+    # 2) compose the stored correction onto it. No --require-baseline here: the
+    #    shear is a property of the physical lens pair, not of any one mesh, so
+    #    composing it onto whatever the firmware generated this boot is exactly
+    #    right. Requiring a baseline match would mean one legitimate SetStitch
+    #    permanently disabled the hook.
+    rm -f "$MESH" 2>/dev/null
+    "$BIN" compose "$FACTORY" "$ANCHORS" "$MESH" >>"$LOG" 2>&1 \
+        || give_up "compose refused (see above) -- anchors or mesh failed a gate"
+    [ -s "$MESH" ] || give_up "compose produced no file"
+
+    # 3) write it. `set` reads the mesh back and diffs it; a SET that silently
+    #    does nothing is indistinguishable from one that worked unless you check.
+    if "$BIN" set 0 "$MESH" --i-have-a-recovery-path >>"$LOG" 2>&1; then
+        # Remember what we wrote, so a re-run recognises it instead of
+        # composing on top of it (step 1b).
+        mesh_sig "$MESH" >"$APPLIED_SIG"
+        CRC=$(grep -o 'crc [0-9a-f]*' "$LOG" | tail -1 | cut -d' ' -f2)
+        ID=$(sed -n 's/^# seam_calibration\/2 //p' "$ANCHORS" | head -1)
+        cat >"$STATE" <<EOF
+{"calibration_id": "${ID:-unknown}",
+ "applied_utc": "$(date -u '+%FT%TZ')",
+ "uptime_s": $(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 0),
+ "mesh_crc32": "${CRC:-unknown}",
+ "vpe_id": 0,
+ "readback": "ok"}
+EOF
+        log "  APPLIED: calibration ${ID:-unknown}, mesh crc ${CRC:-unknown}, read-back ok"
+    else
+        rm -f "$STATE" 2>/dev/null
+        give_up "mesh write failed or read-back did not match"
+    fi
+
+    log "===== stitchcal finished ====="
+}
+
+( main ) &
+exit 0

--- a/reolink-firmware-patching/verify/check_recording_default.sh
+++ b/reolink-firmware-patching/verify/check_recording_default.sh
@@ -41,9 +41,13 @@ WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
 echo "==> extracting rootfs from $(basename "$PAK")"
-python3 - "$PAK" "$WORK/rootfs.bin" <<'PY'
+# PYTHONPATH from $ROOT, not from sys.argv[0]: the script body arrives on stdin,
+# so argv[0] is "-" and the old dirname() trick silently resolved to the caller's
+# cwd. It happened to work when run by hand from reolink-firmware-patching/ and
+# failed with ModuleNotFoundError the first time a builder invoked it by absolute
+# path from a temp dir -- i.e. exactly when this gate started mattering.
+PYTHONPATH="$ROOT" python3 - "$PAK" "$WORK/rootfs.bin" <<'PY'
 import sys
-sys.path.insert(0, __import__("os").path.join(__import__("os").path.dirname(sys.argv[0]) or ".", ".."))
 from pak import pak  # reolink-firmware-patching/pak/pak.py
 data = open(sys.argv[1], "rb").read()
 for s in pak.parse(data):

--- a/reolink-firmware-patching/vpe/README.md
+++ b/reolink-firmware-patching/vpe/README.md
@@ -7,8 +7,13 @@ place where an *exactly specified* geometric mapping can be imposed.
 
 | file | what |
 |---|---|
-| `lut2d.py` | decode / edit / rebuild a mesh off-camera; `selftest` gates the parser |
-| `lut2d_ioctl.c` | read and write the live mesh on the camera via `/dev/nvt_vpe` |
+| `lut2d.py` | decode / edit / rebuild a mesh off-camera; `compose_correction`; `selftest` gates the parser |
+| `lut2d_ioctl.c` | read, write and **compose** the live mesh on the camera via `/dev/nvt_vpe` |
+| `seam_metric.py` | measure the seam: SCR (px) and detrended \|ln SSR\|, plus the acceptance gate |
+| `stitch_apply.py` | apply a calibration in the only correct order (scalars, then mesh) |
+
+Design: `../docs/STITCH_CALIBRATION.md`. Boot hook: `../runtime/stitchcal/S98_StitchCal`,
+baked by `../builds/build_stitchcal.sh`.
 
 ## Why write the mesh rather than the camera model
 
@@ -129,3 +134,153 @@ mesh you generated.
 A bad mesh tears the image; it does not brick the camera. The mesh is runtime
 state — the DCE is reprogrammed from stored calibration on every boot, so a power
 cycle undoes anything written here.
+
+### Buffers handed to the ioctl need slack
+
+The driver is built around a **three**-word header `{id, reserved, n}` and writes
+`align4(n)*n` entries after it. The layout that actually returns live data is the
+**two**-word `{id, n}`, so the driver's last write lands past the end of an
+exact-size allocation, on glibc chunk metadata. Both faces of this look like
+different bugs:
+
+- `get` returns a **correct** mesh and *then* aborts with
+  `double free or corruption (out)` — one allocation, damage in the top chunk.
+  It reads like the ioctl failed when it did not.
+- `set` aborts with `double free or corruption (!prev)` at the first `free()`
+  after the read-back — two allocations, so glibc sees the smashed header of the
+  second one.
+
+Every ioctl buffer is therefore `BUFSZ + IOCTL_SLACK`. The tool is also
+line-buffered, because the abort took the whole buffered log with it and left
+`Aborted` as the only evidence.
+
+## Composing a seam correction
+
+**Never generate, always compose.** The factory mesh is this physical unit's
+stitch calibration, regenerated from `CamStitchPara` (`mtd11`) at every boot. A
+mesh built from a parametric model discards it and cannot be recovered without
+the vendor's optimiser, so `compose_correction` (Python) and `lut2d_ioctl
+compose` (camera) both take a factory dump as *input* and neither has a mode that
+manufactures one.
+
+```
+python lut2d.py compose factory.bin anchors.txt out.bin      # off-camera
+lut2d_ioctl     compose factory.bin anchors.txt out.bin      # on-camera, no python there
+```
+
+The two are byte-identical by construction and `tests/test_lut2d_compose.py`
+asserts it, so they cannot drift. (Both are pinned to
+round-half-away-from-zero: Python's built-in `round` is banker's rounding and C's
+`lround` is not, which would otherwise put them a quarter-pixel apart on ties.)
+
+### The sign, and the scale
+
+`dx(y)` keeps the downstream corrector's meaning: **the pixels the RIGHT half
+must move RIGHT, at row y, to register with the left**
+(`video_grouper/utils/stitch_remap.py`). The mesh warps the **left** half, so it
+realises the same relative displacement with the opposite sense — the left half
+moves left by `dx`. Because the mesh stores *source* coordinates, moving rendered
+content left by `d` destination px means
+
+```
+M_new.x(u, v) = M.x(u, v) + d * s(u, v)
+```
+
+where `s = dM.x/du` is the local source-px-per-destination-px rate. **Two sign
+flips that cancel: the increment is `+d*s`.**
+
+`s` is not 1. Measured by finite-differencing this unit's factory mesh
+(2026-08-17): **0.600 … 1.075 across the mesh, 0.700 at the seam column**.
+Applying `dx` raw instead of `dx*s` overshoots at the seam by ~43%.
+
+### Verified on hardware, 2026-08-17
+
+Signed sanity gate, by phase-correlating a snapshot against the factory frame —
+a differential measurement, so the indoor scene's huge parallax cancels:
+
+| patch | `dx = +40` | `dx = −40` | restored |
+|---|---|---|---|
+| LEFT, far from seam (x 700–1500) | **−40.13** | **+40.33** | −0.04 |
+| LEFT, near seam (x 2900–3700) | **−40.94** | **+40.34** | −0.01 |
+| RIGHT, near seam (x 3990–4790) | −0.02 | −0.01 | +0.00 |
+| RIGHT, far (x 6100–6900) | −0.02 | +0.00 | +0.03 |
+
+Four things at once. **VPE 0 warps the panorama's LEFT half** — measured, not
+inferred; the right half does not move at all. **The sign is right**: `dx>0`
+moves the left half left. **The `s` scaling is right**: the shift is 40.1–40.9 px
+for a requested 40, where omitting `s` would have given 40/0.70 ≈ 57 px at the
+seam and 40/0.65 ≈ 62 px at the edge. And **restore is exact**.
+
+A realistic ±3 px roll then tracked the expected ramp per row band to within
+~0.5 px (rows 200→2050: measured +2.49, +0.85, +0.15, −0.94, −2.27, −2.60
+against expected +2.44, +1.33, +0.22, −0.89, −2.00, −2.70), with the right half
+still at +0.14 px.
+
+### Gates
+
+`compose` refuses — never warns — on: `|dx| > 64 px`; anchors not strictly
+increasing in y; a dead (all-zero) input mesh; horizontal monotonic fraction
+below 0.95; more than 2% of control points running off the sensor; **any**
+clamping within 32 columns of the seam; and a source-span change beyond
+`|d| · (s_max − s_min) + 0.5` per row, which is the tightest bound that is true
+for a translation and violated by anything that rescales.
+
+Clamping at the *far* edge is expected and allowed: a uniform destination-space
+shift walks the outermost columns off the sensor (this unit's factory mesh starts
+at source x = 4.25). At `dx = −40` that is 270 of 66,049 points in columns 0–2 —
+the extreme edge of a 180° panorama, cosmetically irrelevant, and nowhere near
+the seam.
+
+## Corrections to `../docs/STITCH_CALIBRATION.md`
+
+Implementation proved six things in the design wrong or incomplete. The design's
+architecture survived all of them.
+
+1. **`s` at the seam is 0.700, not ~0.68.** Measured directly off the factory
+   mesh rather than derived from a magnification figure; the range is 0.600–1.075,
+   not 0.63–1.04. The overshoot from ignoring it is ~43%, not ~47%.
+
+2. **A baseline mismatch must NOT be fatal at boot.** §7.3 has `compose` refuse
+   when `baseline_sha256` does not match, but §7.1 wants the hook to self-heal
+   onto a new factory mesh after a `SetStitch`. Those contradict: making it fatal
+   means one legitimate scalar change permanently disables the hook. Resolved by
+   making it a *mode* — `--require-baseline` is set on the interactive path
+   (`stitch_apply.py`, where a moved baseline means the operator changed
+   something mid-flight) and deliberately not at boot. The shear is a property of
+   the physical lens pair, not of any one mesh.
+
+3. **CRC32, not sha256.** The device has no sha256 and the property needed is
+   "did this change", not a security property. `crc32` covers the table only, so
+   dumps saved with different header layouts still compare equal.
+
+4. **The helper binary is baked into the firmware, not left on the SD card.**
+   §7.2 puts `bin/lut2d_ioctl` on the card. It is code, not configuration; baking
+   it keeps the boot path from depending on a file an operator can delete or a
+   card that was reformatted. An SD-card copy still wins if present, so it can be
+   iterated on without a reflash.
+
+5. **Detrending is a safeguard, not the load-bearing correction §9.2 claims.**
+   The photometric step is ramped in across the 256-px blend window, so its
+   per-column gradient is ~step/256. On the live frame raw and detrended differ
+   by 0.2% (3.633 vs 3.639) — not "swamps the structural signal". It stays,
+   because a *hard* step does pollute the raw figure by ~50%.
+
+6. **SSR's two-sidedness is a content effect, not a blending one.** §9.2 says
+   gross disparity "butts unrelated content together and energy rises above 1".
+   Controlled measurement says otherwise: with homogeneous content, blending two
+   uncorrelated views always *lowers* energy relative to the shoulders —
+   0/1/2/3/4 px give 1.011/0.885/0.657/0.557/0.583 and 8–200 px are flat at
+   ~0.68. SSR exceeds 1 when the seam's content is intrinsically busier than the
+   shoulders', which is what the live 0.3-m frame does (3.64). The conclusion is
+   unchanged and now better founded: report `|ln SSR|`, and treat it as a
+   **detector**, never an estimator — it saturates past ~4 px.
+
+And one thing the design could not have known, found only by flashing:
+
+7. **`/mnt/sda` is not mounted when `rcS` runs the `S*` scripts.** `rcS` does
+   `mount -a` first, but the SD card is `/dev/hd/sda1`, brought up later by the
+   app. The first flashed build followed §7.2's order — disable check, anchors
+   check, *then* wait — found no `anchors.txt`, and exited. It could not even say
+   so: `/` is read-only squashfs, so the log write failed too, and the hook left
+   no trace whatsoever. `S98_StitchCal` now waits for the mount **before** it
+   reads any configuration, and `build_stitchcal.sh` gates on that ordering.

--- a/reolink-firmware-patching/vpe/lut2d.py
+++ b/reolink-firmware-patching/vpe/lut2d.py
@@ -26,23 +26,56 @@ buffer, `buf[0]` is the VPE id and **`buf[1]` is the mesh dimension n**.
 The driver writes `align4(n)*n` entries from `buf[2]`, so n=0 returns an
 empty table *and* reports success.
 
+A production mesh is never generated from scratch: it is the *factory* mesh
+with a seam correction composed onto it (`compose_correction`). The factory
+mesh is this physical unit's stitch calibration, recovered from `CamStitchPara`
+in `mtd11` at every boot; regenerating one from a parametric model throws that
+away and cannot be recovered without the vendor's own optimiser.
+
 CLI:
     python lut2d.py info     <lut.bin>
     python lut2d.py dump     <lut.bin> [row]
+    python lut2d.py compose  <factory.bin> <anchors.txt> <out.bin>
     python lut2d.py selftest [lut.bin]      # fixture optional; synthetic gates always run
 """
 
 from __future__ import annotations
 
+import math
 import struct
 import sys
-from collections.abc import Callable
+import zlib
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
 
 # Quarter-pixel fixed point: 14 integer bits, 2 fractional.
 FRAC_BITS = 2
 FRAC_SCALE = 1 << FRAC_BITS
 COORD_MAX = (1 << 16) - 1
 COORD_MAX_PX = COORD_MAX / FRAC_SCALE
+
+# Geometry of one warped half on the Duo 3. VIDEOPROC 0 takes 3840x2160 in and
+# puts 3840x2160 out; VIDEOPROC 2 (VSP) butt-joins two of those into 7680x2160
+# with a 256-px blend window centred on x = 3840. Measured from
+# /proc/hdal/vprc/info, 2026-08-17.
+DEFAULT_HALF_WIDTH = 3840.0
+DEFAULT_HALF_HEIGHT = 2160.0
+DEFAULT_PANORAMA_WIDTH = 7680.0
+
+# Nothing physical needs a seam shear beyond this; a larger value in an anchor
+# file means the file is corrupt, not that the camera is badly aligned.
+MAX_ABS_DX_PX = 64.0
+# Below this the mesh folds and the DCE tears the image.
+MIN_MONOTONIC_FRACTION = 0.95
+# A uniform destination-space shift walks the far edge of the half off the
+# sensor; the outermost control columns then clamp. That is cosmetically
+# irrelevant (it is the extreme edge of a 180-degree panorama) but it must stay
+# rare and must never reach the seam.
+MAX_CLAMP_FRACTION = 0.02
+# Control columns adjacent to the seam that may never clamp. 32 columns is
+# 480 destination px, comfortably covering the left half of the blend window
+# ([3712, 3840), 128 px) and its shoulder.
+PROTECTED_SEAM_COLS = 32
 
 # Header layouts seen in the wild. The kernel's own ioctl buffer is
 # {id, reserved, n} (12 bytes, per vpe_uti_calc_2dlut_ioctl_size); some dumps
@@ -195,9 +228,26 @@ class Lut2D:
 # -- helpers -------------------------------------------------------------
 
 
+def quantise(px: float) -> int:
+    """Pixels -> quarter-pixel integer, rounding halves away from zero.
+
+    Stated explicitly because the on-camera composer (`lut2d_ioctl compose`)
+    must produce output byte-identical to this module, and the two languages
+    disagree by default: Python's `round` is banker's rounding, C's `lround` is
+    half-away-from-zero. Picking C's rule keeps the C side a one-liner and the
+    cross-check in `tests/test_lut2d_compose.py` exact.
+    """
+    scaled = px * FRAC_SCALE
+    return (
+        int(math.floor(scaled + 0.5))
+        if scaled >= 0
+        else -int(math.floor(-scaled + 0.5))
+    )
+
+
 def _pack(x: float, y: float) -> int:
-    xi = int(round(x * FRAC_SCALE))
-    yi = int(round(y * FRAC_SCALE))
+    xi = quantise(x)
+    yi = quantise(y)
     if not (0 <= xi <= COORD_MAX) or not (0 <= yi <= COORD_MAX):
         raise Lut2DError(f"({x}, {y}) outside representable range 0..{COORD_MAX_PX}")
     return (yi << 16) | xi
@@ -231,6 +281,367 @@ def _find_table_offset(blob: bytes) -> tuple[int, int]:
         f"no header size in {HEADER_SIZES} explains a {len(blob)}-byte blob "
         "with a zero-padded n x align4(n) table"
     )
+
+
+# -- seam correction: compose, never generate ----------------------------
+#
+# THE SIGN CONVENTION, ONCE.
+#
+# `dx(y)` is the downstream corrector's meaning and it does not change here:
+# **the number of pixels the RIGHT half must move to the RIGHT, at row y, to
+# register with the left half** (`video_grouper/utils/stitch_remap.py`, which
+# does `np.roll(out[y, seam_x:], dx)`).
+#
+# The mesh warps the LEFT half, so it realises the same *relative* displacement
+# with the opposite sense: the left half moves LEFT by dx(y).
+#
+# Moving rendered content left by d destination px means the destination pixel
+# at u must show what used to be at u + d, i.e. M_new(u) = M_factory(u + d),
+# and to first order
+#
+#     M_new.x(u, v) = M.x(u, v) + d * dM.x/du
+#
+# so the increment is **+d * s**, where s = dM.x/du is the local
+# source-px-per-destination-px sampling rate. Two sign flips that cancel: this
+# is the step that is easy to get wrong, and getting it wrong doubles the seam
+# error instead of closing it.
+#
+# `s` is NOT 1. Measured on this unit's factory mesh (2026-08-17): 0.617 .. 1.075
+# across the mesh, and 0.700 at the seam column. Applying `dx` to the mesh
+# directly instead of `dx * s` overshoots at the seam by ~43%.
+
+
+@dataclass
+class ComposeStats:
+    """What the composition did, for the artifact's `stages[]` witness."""
+
+    n_points: int = 0
+    dx_min_px: float = 0.0
+    dx_max_px: float = 0.0
+    max_src_disp_px: float = 0.0
+    s_min: float = 0.0
+    s_max: float = 0.0
+    s_at_seam: float = 0.0
+    clamped_low: int = 0
+    clamped_high: int = 0
+    clamped_cols: list[int] = field(default_factory=list)
+    monotonic_x: float = 1.0
+    monotonic_y: float = 1.0
+    max_span_delta_px: float = 0.0
+    changed_entries: int = 0
+    factory_crc32: int = 0
+    result_crc32: int = 0
+
+    @property
+    def clamped_fraction(self) -> float:
+        total = self.clamped_low + self.clamped_high
+        return total / self.n_points if self.n_points else 0.0
+
+
+def interp_dx(anchors: Sequence[tuple[float, float]], y: float) -> float:
+    """Linear interpolation of `[y, dx]` anchors, clamped outside their range.
+
+    Same shape as `numpy.interp`, which is what the downstream corrector uses
+    (`stitch_remap.build_dx_lookup`), so one anchor list means one curve on both
+    surfaces.
+    """
+    if not anchors:
+        raise Lut2DError("no dx anchors")
+    if y <= anchors[0][0]:
+        return anchors[0][1]
+    if y >= anchors[-1][0]:
+        return anchors[-1][1]
+    for i in range(1, len(anchors)):
+        y1, d1 = anchors[i]
+        if y <= y1:
+            y0, d0 = anchors[i - 1]
+            if y1 == y0:
+                return d1
+            return d0 + (d1 - d0) * (y - y0) / (y1 - y0)
+    return anchors[-1][1]
+
+
+def scale_anchors(
+    anchors: Sequence[tuple[float, float]],
+    src_width: float,
+    src_height: float,
+    dst_width: float = DEFAULT_HALF_WIDTH,
+    dst_height: float = DEFAULT_HALF_HEIGHT,
+) -> list[tuple[float, float]]:
+    """Rescale panorama-space anchors into one half's destination space.
+
+    Anchors are stored in the units of the frame they were measured on -- a
+    7680x2160 panorama -- exactly as `StitchProfile` does. The mesh addresses
+    one 3840x2160 half, so y scales by `dst_height / src_height` and dx by
+    `2 * dst_width / src_width` (a dx is a panorama-width-relative length, and
+    the panorama is two halves wide). Both are 1.0 in the shipping geometry;
+    the code exists so a profile measured on a downscaled still still applies.
+    """
+    if src_width <= 0 or src_height <= 0:
+        raise Lut2DError(f"bad source geometry {src_width}x{src_height}")
+    y_scale = dst_height / src_height
+    x_scale = (2.0 * dst_width) / src_width
+    return [(y * y_scale, dx * x_scale) for y, dx in anchors]
+
+
+def compose_correction(
+    factory: Lut2D,
+    dx_anchors: Sequence[tuple[float, float]],
+    *,
+    dst_width: float = DEFAULT_HALF_WIDTH,
+    dst_height: float = DEFAULT_HALF_HEIGHT,
+    max_abs_dx: float = MAX_ABS_DX_PX,
+    min_monotonic: float = MIN_MONOTONIC_FRACTION,
+    max_clamp_fraction: float = MAX_CLAMP_FRACTION,
+    protected_seam_cols: int = PROTECTED_SEAM_COLS,
+) -> tuple[Lut2D, ComposeStats]:
+    """Return the factory mesh with a per-row seam shear composed onto it.
+
+    `dx_anchors` are `(y, dx)` in this half's destination space -- run
+    `scale_anchors` first if they were measured on a differently-sized frame.
+    The correction is horizontal only: every entry's y half is copied verbatim
+    from the factory mesh, bit for bit, so no amount of composing can drift the
+    vertical mapping.
+
+    dx is applied uniformly across destination columns, which is exactly right
+    for the physical model: a relative lens roll of angle theta displaces a
+    point at (X, Y) by theta*(-Y, +X), so its horizontal part -theta*Y depends
+    on the row and not on the column. Only the local *source* increment varies
+    with column, through `s`.
+
+    Raises `Lut2DError` rather than warning on every guard -- a composer that
+    warns and writes anyway is the one failure this path cannot afford, since
+    the result goes straight into a boot hook nobody watches.
+    """
+    n = factory.n
+    if n < 3:
+        raise Lut2DError(f"mesh too small to finite-difference: n={n}")
+    anchors = [(float(y), float(dx)) for y, dx in dx_anchors]
+    if not anchors:
+        raise Lut2DError("no dx anchors")
+    for i in range(1, len(anchors)):
+        if anchors[i][0] <= anchors[i - 1][0]:
+            raise Lut2DError(
+                f"dx anchors must be strictly increasing in y: "
+                f"{anchors[i - 1][0]} then {anchors[i][0]}"
+            )
+    worst = max(abs(dx) for _, dx in anchors)
+    if worst > max_abs_dx:
+        raise Lut2DError(
+            f"|dx| = {worst:.2f} px exceeds the {max_abs_dx:.0f} px limit; "
+            "nothing physical needs that, so treat the anchor file as corrupt"
+        )
+
+    du = (dst_width - 1.0) / (n - 1)
+    dv = (dst_height - 1.0) / (n - 1)
+    st = ComposeStats(n_points=n * n)
+    st.dx_min_px = min(dx for _, dx in anchors)
+    st.dx_max_px = max(dx for _, dx in anchors)
+    st.s_min = float("inf")
+    st.s_max = float("-inf")
+
+    out = list(factory.entries)
+    clamped_cols: set[int] = set()
+    span_headroom = 0.0
+    for row in range(n):
+        d = interp_dx(anchors, row * dv)
+        base = row * factory.stride
+        xs = [(factory.entries[base + c] & 0xFFFF) / FRAC_SCALE for c in range(n)]
+        span_before = xs[n - 1] - xs[0]
+        unclamped_first = unclamped_last = 0.0
+        row_s_min, row_s_max = float("inf"), float("-inf")
+        for col in range(n):
+            if col == 0:
+                s = (xs[1] - xs[0]) / du
+            elif col == n - 1:
+                s = (xs[n - 1] - xs[n - 2]) / du
+            else:
+                s = (xs[col + 1] - xs[col - 1]) / (2.0 * du)
+            row_s_min = min(row_s_min, s)
+            row_s_max = max(row_s_max, s)
+            if row == n // 2 and col == n - 1:
+                st.s_at_seam = s
+            disp = d * s
+            if abs(disp) > st.max_src_disp_px:
+                st.max_src_disp_px = abs(disp)
+            nx = xs[col] + disp
+            if col == 0:
+                unclamped_first = nx
+            elif col == n - 1:
+                unclamped_last = nx
+            if nx < 0.0:
+                nx = 0.0
+                st.clamped_low += 1
+                clamped_cols.add(col)
+            elif nx > COORD_MAX_PX:
+                nx = COORD_MAX_PX
+                st.clamped_high += 1
+                clamped_cols.add(col)
+            xi = quantise(nx)
+            out[base + col] = (factory.entries[base + col] & 0xFFFF0000) | xi
+        st.s_min = min(st.s_min, row_s_min)
+        st.s_max = max(st.s_max, row_s_max)
+        # Measured before clamping: clamping is a separate, separately-gated
+        # concern, and letting it inflate the span would make the FOV check
+        # fire on the wrong fault.
+        span_delta = abs((unclamped_last - unclamped_first) - span_before)
+        if span_delta > st.max_span_delta_px:
+            st.max_span_delta_px = span_delta
+        # A translation in DESTINATION space is not a translation in source
+        # space, because `s` varies across the row: the far edge and the seam
+        # move by d*s(0) and d*s(n-1), which differ. The row's source span
+        # therefore changes by |d| * |s(n-1) - s(0)|, and that is physics, not
+        # a bug -- bounding it by the row's full s range is the tightest
+        # statement that is true by construction for a correct composition and
+        # violated by an implementation that scales instead of shifting.
+        span_headroom = max(span_headroom, abs(d) * (row_s_max - row_s_min) + 0.5)
+
+    st.clamped_cols = sorted(clamped_cols)
+    result = Lut2D(n, out, factory.header, factory.stride)
+    st.monotonic_x, st.monotonic_y = result.monotonic_fraction()
+    st.changed_entries = sum(
+        1 for a, b in zip(factory.entries, result.entries, strict=True) if a != b
+    )
+    st.factory_crc32 = crc32(factory)
+    st.result_crc32 = crc32(result)
+
+    # -- post-conditions. Each of these is a way the correction could tear the
+    #    image or quietly stop being a correction, so each refuses.
+    if st.monotonic_x < min_monotonic:
+        raise Lut2DError(
+            f"composed mesh folds horizontally: rows advance in x for only "
+            f"{st.monotonic_x * 100:.1f}% of steps (need {min_monotonic * 100:.0f}%)"
+        )
+    if st.clamped_fraction > max_clamp_fraction:
+        raise Lut2DError(
+            f"{st.clamped_low + st.clamped_high} of {st.n_points} control points "
+            f"({st.clamped_fraction * 100:.2f}%) fall off the sensor; the shear is "
+            f"too large for this mesh's margins (limit {max_clamp_fraction * 100:.0f}%)"
+        )
+    seam_floor = n - protected_seam_cols
+    hit = [c for c in st.clamped_cols if c >= seam_floor]
+    if hit:
+        raise Lut2DError(
+            f"clamping reached the seam: columns {hit[:8]} are within the "
+            f"protected band (>= {seam_floor}). A correction that runs out of "
+            "sensor AT the seam is not a correction."
+        )
+    # Field of view: a shear may translate the sampling window, never rescale
+    # it. See the per-row derivation of `span_headroom` above.
+    if st.max_span_delta_px > span_headroom:
+        raise Lut2DError(
+            f"composed mesh changed a row's source span by "
+            f"{st.max_span_delta_px:.2f} px (bound {span_headroom:.2f}); that is a "
+            "scale, not a shear -- the field of view is not preserved"
+        )
+    return result, st
+
+
+def crc32(lut: Lut2D) -> int:
+    """CRC32 over the table only, header excluded.
+
+    The header carries the VPE id and n, which the reader stamps itself, so a
+    dump taken with a different header layout must still compare equal. Used as
+    the `baseline` change-detector in `anchors.txt`: the on-camera composer has
+    no sha256 and no room to grow one, and the property needed here is
+    "did this change", not a security property.
+    """
+    return zlib.crc32(
+        struct.pack(f"<{len(lut.entries)}I", *lut.entries)[: lut.n * lut.stride * 4]
+    )
+
+
+# -- anchors.txt: the artifact projection the camera can parse ------------
+#
+# The device has no python, no perl and no JSON parser, so the calibration
+# artifact is projected to plain text for the boot hook. This is the only file
+# routinely written to the camera; the composed mesh itself is never stored.
+
+
+def format_anchors(
+    anchors: Sequence[tuple[float, float]],
+    *,
+    calibration_id: str = "",
+    baseline_crc32: int | None = None,
+    src_width: float = DEFAULT_PANORAMA_WIDTH,
+    src_height: float = DEFAULT_HALF_HEIGHT,
+    seam_x: float = DEFAULT_HALF_WIDTH,
+) -> str:
+    lines = [f"# seam_calibration/2 {calibration_id}".rstrip()]
+    if baseline_crc32 is not None:
+        lines.append(f"# baseline_crc32 {baseline_crc32:08x}")
+    lines.append(f"# src {src_width:.0f} {src_height:.0f} seam {seam_x:.0f}")
+    lines += [f"dx {y:.0f} {dx:.4f}" for y, dx in anchors]
+    return "\n".join(lines) + "\n"
+
+
+def parse_anchors(text: str) -> tuple[list[tuple[float, float]], dict]:
+    """Parse `anchors.txt`. Returns (anchors, meta) with meta keys src/seam/crc."""
+    anchors: list[tuple[float, float]] = []
+    meta: dict = {
+        "src_width": DEFAULT_PANORAMA_WIDTH,
+        "src_height": DEFAULT_HALF_HEIGHT,
+        "seam_x": DEFAULT_HALF_WIDTH,
+        "baseline_crc32": None,
+        "calibration_id": "",
+    }
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            tok = line[1:].split()
+            if not tok:
+                continue
+            if tok[0] == "src" and len(tok) >= 3:
+                meta["src_width"] = float(tok[1])
+                meta["src_height"] = float(tok[2])
+                if len(tok) >= 5 and tok[3] == "seam":
+                    meta["seam_x"] = float(tok[4])
+            elif tok[0] == "baseline_crc32" and len(tok) >= 2:
+                meta["baseline_crc32"] = int(tok[1], 16)
+            elif tok[0] == "seam_calibration/2" and len(tok) >= 2:
+                meta["calibration_id"] = tok[1]
+            continue
+        tok = line.split()
+        if len(tok) != 3 or tok[0] != "dx":
+            raise Lut2DError(f"unparseable anchors line: {raw!r}")
+        anchors.append((float(tok[1]), float(tok[2])))
+    if not anchors:
+        raise Lut2DError("anchors file carries no dx lines")
+    return anchors, meta
+
+
+def compose_from_anchors_file(
+    factory: Lut2D,
+    text: str,
+    *,
+    require_baseline: bool = False,
+    **kw,
+) -> tuple[Lut2D, ComposeStats]:
+    """`parse_anchors` + `scale_anchors` + `compose_correction`, as the camera does.
+
+    `require_baseline` is the *interactive* mode: it refuses when the anchors
+    were composed against a different factory mesh, which is how a `SetStitch`
+    slipped in after the baseline dump gets caught (see `stitch_apply.py`). The
+    boot hook deliberately does NOT set it -- see the note in that tool.
+    """
+    anchors, meta = parse_anchors(text)
+    if meta["baseline_crc32"] is not None:
+        actual = crc32(factory)
+        if actual != meta["baseline_crc32"] and require_baseline:
+            raise Lut2DError(
+                f"anchors were composed against baseline crc32 "
+                f"{meta['baseline_crc32']:08x}, this mesh is {actual:08x}. "
+                "Something re-ran the firmware's optimiser (SetStitch?) after "
+                "the baseline was taken."
+            )
+    dst_width = kw.get("dst_width", DEFAULT_HALF_WIDTH)
+    dst_height = kw.get("dst_height", DEFAULT_HALF_HEIGHT)
+    scaled = scale_anchors(
+        anchors, meta["src_width"], meta["src_height"], dst_width, dst_height
+    )
+    return compose_correction(factory, scaled, **kw)
 
 
 # -- self-test -----------------------------------------------------------
@@ -367,6 +778,34 @@ def main(argv: list[str]) -> int:
     cmd = argv[1]
     if cmd == "selftest":
         return selftest(argv[2] if len(argv) > 2 else None)
+    if cmd == "compose":
+        if len(argv) < 5:
+            print("usage: lut2d.py compose <factory.bin> <anchors.txt> <out.bin>")
+            return 2
+        factory = Lut2D.from_bytes(open(argv[2], "rb").read())
+        text = open(argv[3]).read()
+        try:
+            result, st = compose_from_anchors_file(factory, text)
+        except Lut2DError as e:
+            print(f"REFUSED: {e}")
+            return 1
+        open(argv[4], "wb").write(result.to_bytes())
+        print(f"composed {argv[2]} + {argv[3]} -> {argv[4]}")
+        print(f"  dx {st.dx_min_px:+.2f}..{st.dx_max_px:+.2f} px")
+        print(f"  s  {st.s_min:.4f}..{st.s_max:.4f}  (seam column {st.s_at_seam:.4f})")
+        print(f"  max source displacement {st.max_src_disp_px:.2f} px")
+        print(
+            f"  clamped {st.clamped_low + st.clamped_high}/{st.n_points} "
+            f"({st.clamped_fraction * 100:.2f}%) cols {st.clamped_cols[:8]}"
+        )
+        print(
+            f"  monotonic rows {st.monotonic_x * 100:.1f}% cols {st.monotonic_y * 100:.1f}%"
+        )
+        print(
+            f"  changed {st.changed_entries} entries, span delta {st.max_span_delta_px:.3f} px"
+        )
+        print(f"  crc32 {st.factory_crc32:08x} -> {st.result_crc32:08x}")
+        return 0
     if cmd in ("info", "dump"):
         lut = Lut2D.from_bytes(open(argv[2], "rb").read())
         x0, y0, x1, y1 = lut.bounds()

--- a/reolink-firmware-patching/vpe/lut2d_ioctl.c
+++ b/reolink-firmware-patching/vpe/lut2d_ioctl.c
@@ -23,13 +23,27 @@
  * passing the buffer itself as the argument is the convention that returns 0
  * and yields a table matching what procfs reports (`get_2dlut_param`).
  *
- * GET is proven on hardware. SET is NOT — it was written after the camera went
- * offline and has never run. Hence: `set` always reads the mesh back and diffs
- * it, and refuses to proceed at all unless --i-have-a-recovery-path is given.
- * Writing a folded or out-of-range mesh produces a torn image, not a brick, but
- * verify against a known-good dump before trusting it.
+ * GET and SET are both proven on hardware (2026-08-17): the factory mesh was
+ * dumped, written back as a verified no-op, then a modified mesh was written,
+ * observed to change the image, and the factory mesh restored. `set` still
+ * reads the mesh back and diffs it, and still refuses without
+ * --i-have-a-recovery-path.
+ *
+ * `compose` is the third subcommand and the reason this tool exists on the
+ * camera at all: there is no python or perl on the device, so the boot hook
+ * cannot compose in a script. It applies a per-row seam shear to a factory
+ * mesh, and its arithmetic is a line-for-line mirror of
+ * `lut2d.py:compose_correction` -- `tests/test_lut2d_compose.py` cross-checks
+ * the two for byte-identical output, so they cannot drift.
+ *
+ * NEVER GENERATE, ALWAYS COMPOSE. The factory mesh is this physical unit's
+ * stitch calibration, regenerated from CamStitchPara (mtd11) at every boot. A
+ * mesh built from a parametric model discards it and cannot be recovered
+ * without the vendor's optimiser. `compose` takes a factory dump as input; it
+ * has no mode that manufactures a mesh.
  */
 #include <fcntl.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -47,10 +61,40 @@
 #define HDR_BYTES (HDR_WORDS * 4)
 #define TABLE_BYTES (STRIDE * N * 4)
 #define BUFSZ (HDR_BYTES + TABLE_BYTES)
-/* The driver was built around a 3-word header and can write a few bytes
- * past BUFSZ. Allocate slack -- without it the write corrupts the heap
- * and glibc aborts with "double free or corruption". */
-#define ALLOCSZ (BUFSZ + 64)
+
+/* The driver writes PAST the end of an exact-size buffer, so every allocation
+ * handed to the ioctl carries slack. Only the first BUFSZ bytes are ever read
+ * back or written to a file, so the slack is invisible everywhere else.
+ *
+ * Root cause: the driver is built around a THREE-word header {id, reserved, n}
+ * and writes align4(n)*n entries after it. We send the two-word layout
+ * {id, n} -- the one that actually returns live data -- so its last write
+ * lands past the end of a BUFSZ allocation, on glibc chunk metadata.
+ *
+ * This is not theoretical, and it is worth knowing both faces of it because
+ * they look like different bugs. With exact-size allocations:
+ *   - `get` returns a CORRECT mesh and then aborts at exit with
+ *     "double free or corruption (out)" -- one allocation, damage in the top
+ *     chunk. It looks like the ioctl failed when it did not.
+ *   - `set` aborts with "double free or corruption (!prev)" at the first
+ *     free() after the read-back -- two allocations, so glibc sees the smashed
+ *     header of the second one.
+ * Both observed 2026-08-17 on v3.0.0.4867_2505072124. */
+#define IOCTL_SLACK 4096
+#define ALLOCSZ (BUFSZ + IOCTL_SLACK)
+
+/* Geometry of the warped half and the composition gates. Keep in step with the
+ * constants of the same name in lut2d.py -- the cross-check test asserts the
+ * two implementations agree, but only for meshes it feeds them. */
+#define DST_W 3840.0
+#define DST_H 2160.0
+#define FRAC_SCALE_C 4        /* Q14.2 -- quarter pixels */
+#define COORD_MAX_PX 16383.75
+#define MAX_ABS_DX 64.0
+#define MIN_MONOTONIC 0.95
+#define MAX_CLAMP_FRACTION 0.02
+#define PROTECTED_SEAM_COLS 32
+#define MAX_ANCHORS 64
 
 /* Reject a mesh that would tear the image before handing it to the hardware:
  * the padded tail of every row must be zero, and no control point may fall
@@ -182,19 +226,349 @@ static int do_set(int fd, int id, const char *path, int armed)
     return 1;
 }
 
+/* ---- compose: factory mesh + per-row shear -> production mesh ------------
+ *
+ * THE SIGN CONVENTION, ONCE (the same paragraph as lut2d.py).
+ *
+ * dx(y) means: the pixels the RIGHT half must move RIGHT, at row y, to
+ * register with the left. The mesh warps the LEFT half, so it realises the
+ * same relative displacement with the opposite sense -- the left half moves
+ * LEFT by dx. Moving rendered content left by d destination px means the
+ * destination pixel at u must show what was at u+d, so
+ * M_new.x(u,v) = M.x(u,v) + d * dM.x/du. Two sign flips that cancel: the
+ * increment is +d*s, not -d*s. Getting it backwards doubles the seam error.
+ *
+ * s = dM.x/du is the local source-px-per-destination-px rate, computed by
+ * finite-differencing the factory mesh, so it is always current. It is not 1:
+ * on this unit it runs 0.60..1.08, and 0.70 at the seam column.
+ */
+
+/* Quarter-pixel quantisation, halves away from zero. lut2d.py:quantise
+ * implements exactly this; Python's built-in round() does NOT (it is banker's
+ * rounding), which is why that module spells the rule out. */
+static int quantise(double px)
+{
+    double scaled = px * (double)FRAC_SCALE_C;
+    return scaled >= 0.0 ? (int)floor(scaled + 0.5) : -(int)floor(-scaled + 0.5);
+}
+
+struct anchors {
+    int n;
+    double y[MAX_ANCHORS];
+    double dx[MAX_ANCHORS];
+    double src_w, src_h, seam_x;
+    unsigned int baseline_crc32;
+    int have_baseline;
+    char id[64];
+};
+
+static double interp_dx(const struct anchors *a, double y)
+{
+    int i;
+    if (y <= a->y[0]) return a->dx[0];
+    if (y >= a->y[a->n - 1]) return a->dx[a->n - 1];
+    for (i = 1; i < a->n; i++) {
+        if (y <= a->y[i]) {
+            double y0 = a->y[i - 1], y1 = a->y[i];
+            if (y1 == y0) return a->dx[i];
+            return a->dx[i - 1] + (a->dx[i] - a->dx[i - 1]) * (y - y0) / (y1 - y0);
+        }
+    }
+    return a->dx[a->n - 1];
+}
+
+/* CRC32 (the ordinary reflected IEEE polynomial, same as zlib.crc32) over the
+ * table only -- the header carries the VPE id and n, which the reader stamps
+ * itself, so two dumps of the same mesh must compare equal regardless of how
+ * they were saved. This is a change-detector, not a security property; the
+ * device has no sha256 and does not need one for this. */
+static unsigned int crc32_buf(const unsigned char *p, unsigned long len)
+{
+    static unsigned int tab[256];
+    static int built = 0;
+    unsigned int c;
+    unsigned long i;
+    int k;
+    if (!built) {
+        for (i = 0; i < 256; i++) {
+            c = (unsigned int)i;
+            for (k = 0; k < 8; k++) c = (c & 1) ? (0xEDB88320U ^ (c >> 1)) : (c >> 1);
+            tab[i] = c;
+        }
+        built = 1;
+    }
+    c = 0xFFFFFFFFU;
+    for (i = 0; i < len; i++) c = tab[(c ^ p[i]) & 0xFF] ^ (c >> 8);
+    return c ^ 0xFFFFFFFFU;
+}
+
+static int parse_anchors(const char *path, struct anchors *a)
+{
+    FILE *f = fopen(path, "r");
+    char line[512];
+    if (!f) { perror(path); return 0; }
+    memset(a, 0, sizeof(*a));
+    a->src_w = 2.0 * DST_W;
+    a->src_h = DST_H;
+    a->seam_x = DST_W;
+    while (fgets(line, sizeof(line), f)) {
+        char k[64];
+        double v1, v2;
+        char *p = line;
+        while (*p == ' ' || *p == '\t') p++;
+        if (*p == '\n' || *p == '\r' || *p == '\0') continue;
+        if (*p == '#') {
+            unsigned int crc;
+            char idbuf[64];
+            if (sscanf(p + 1, " src %lf %lf seam %lf", &v1, &v2, &a->seam_x) == 3) {
+                a->src_w = v1; a->src_h = v2;
+            } else if (sscanf(p + 1, " src %lf %lf", &v1, &v2) == 2) {
+                a->src_w = v1; a->src_h = v2;
+            } else if (sscanf(p + 1, " baseline_crc32 %x", &crc) == 1) {
+                a->baseline_crc32 = crc; a->have_baseline = 1;
+            } else if (sscanf(p + 1, " seam_calibration/2 %63s", idbuf) == 1) {
+                size_t idlen = strlen(idbuf);
+                if (idlen > sizeof(a->id) - 1) idlen = sizeof(a->id) - 1;
+                memcpy(a->id, idbuf, idlen);
+                a->id[idlen] = '\0';
+            }
+            continue;
+        }
+        if (sscanf(p, "%63s %lf %lf", k, &v1, &v2) != 3 || strcmp(k, "dx")) {
+            fprintf(stderr, "unparseable anchors line: %s", line);
+            fclose(f);
+            return 0;
+        }
+        if (a->n >= MAX_ANCHORS) {
+            fprintf(stderr, "too many anchors (max %d)\n", MAX_ANCHORS);
+            fclose(f);
+            return 0;
+        }
+        a->y[a->n] = v1;
+        a->dx[a->n] = v2;
+        a->n++;
+    }
+    fclose(f);
+    if (a->n < 1) { fprintf(stderr, "%s: no dx lines\n", path); return 0; }
+    if (a->src_w <= 0.0 || a->src_h <= 0.0) {
+        fprintf(stderr, "bad source geometry %.1fx%.1f\n", a->src_w, a->src_h);
+        return 0;
+    }
+    /* Rescale panorama-space anchors into one half's destination space --
+     * lut2d.py:scale_anchors. Both factors are 1.0 in the shipping geometry. */
+    {
+        double ys = DST_H / a->src_h, xs = (2.0 * DST_W) / a->src_w;
+        int i;
+        for (i = 0; i < a->n; i++) { a->y[i] *= ys; a->dx[i] *= xs; }
+    }
+    return 1;
+}
+
+static int anchors_sane(const struct anchors *a)
+{
+    int i;
+    double worst = 0.0;
+    for (i = 1; i < a->n; i++) {
+        if (a->y[i] <= a->y[i - 1]) {
+            fprintf(stderr, "anchors must be strictly increasing in y: %.1f then %.1f\n",
+                    a->y[i - 1], a->y[i]);
+            return 0;
+        }
+    }
+    for (i = 0; i < a->n; i++) {
+        double m = a->dx[i] < 0 ? -a->dx[i] : a->dx[i];
+        if (m > worst) worst = m;
+    }
+    if (worst > MAX_ABS_DX) {
+        fprintf(stderr, "|dx| = %.2f px exceeds the %.0f px limit; nothing physical "
+                        "needs that, so the anchor file is corrupt\n", worst, MAX_ABS_DX);
+        return 0;
+    }
+    return 1;
+}
+
+static int do_compose(const char *fac_path, const char *anch_path, const char *out_path,
+                      int require_baseline)
+{
+    unsigned char *in, *out;
+    unsigned int *ft, *nt;
+    struct anchors a;
+    long len;
+    int off, row, col, rc = 1;
+    long clamped = 0, changed = 0;
+    int clamp_col_min = N, clamp_col_max = -1;
+    double du = (DST_W - 1.0) / (double)(N - 1);
+    double dv = (DST_H - 1.0) / (double)(N - 1);
+    double max_disp = 0.0, s_lo = 1e9, s_hi = -1e9, max_span_delta = 0.0, span_bound = 0.0;
+    long mono_ok = 0, mono_tot = 0;
+    unsigned int fac_crc;
+
+    if (!parse_anchors(anch_path, &a)) return 1;
+    if (!anchors_sane(&a)) return 1;
+
+    in = read_file(fac_path, &len);
+    if (!in) return 1;
+    if (len == BUFSZ) off = HDR_BYTES;
+    else if (len == BUFSZ - 4) off = HDR_BYTES - 4;
+    else {
+        fprintf(stderr, "%s: %ld bytes, expected %d or %d\n", fac_path, len, BUFSZ, BUFSZ - 4);
+        free(in);
+        return 1;
+    }
+    ft = (unsigned int *)(in + off);
+
+    /* Liveness before anything else. An all-zero table passes every structural
+     * check by construction; the empty-read failure is real and silent. */
+    {
+        long live = 0;
+        for (row = 0; row < N; row++)
+            for (col = 0; col < N; col++)
+                if (ft[row * STRIDE + col]) live++;
+        if (live < (long)(N * N) * 99 / 100) {
+            fprintf(stderr, "%s is not a live mesh: %ld of %d control points are zero\n",
+                    fac_path, (long)N * N - live, N * N);
+            free(in);
+            return 1;
+        }
+    }
+
+    fac_crc = crc32_buf((const unsigned char *)ft, (unsigned long)TABLE_BYTES);
+    if (a.have_baseline && fac_crc != a.baseline_crc32) {
+        fprintf(stderr, "baseline mismatch: anchors were composed against %08x, "
+                        "this mesh is %08x\n", a.baseline_crc32, fac_crc);
+        if (require_baseline) { free(in); return 1; }
+        /* Not fatal by default, and deliberately so: the shear is a property of
+         * the physical lens pair, not of any one mesh, so re-composing it onto
+         * whatever the firmware generated this boot is exactly right. Making it
+         * fatal would mean one SetStitch permanently disables the boot hook. */
+        fprintf(stderr, "  composing onto the current mesh anyway (see the note in do_compose)\n");
+    }
+
+    out = calloc(1, BUFSZ);
+    if (!out) { fprintf(stderr, "out of memory\n"); free(in); return 1; }
+    memcpy(out + HDR_BYTES, ft, TABLE_BYTES);
+    nt = (unsigned int *)(out + HDR_BYTES);
+
+    for (row = 0; row < N; row++) {
+        double xs[N], d, row_s_lo = 1e9, row_s_hi = -1e9;
+        double first_unclamped = 0.0, last_unclamped = 0.0, span_before;
+        d = interp_dx(&a, (double)row * dv);
+        for (col = 0; col < N; col++)
+            xs[col] = (double)(ft[row * STRIDE + col] & 0xFFFF) / (double)FRAC_SCALE_C;
+        span_before = xs[N - 1] - xs[0];
+        for (col = 0; col < N; col++) {
+            double s, disp, nx;
+            int xi;
+            if (col == 0)          s = (xs[1] - xs[0]) / du;
+            else if (col == N - 1) s = (xs[N - 1] - xs[N - 2]) / du;
+            else                   s = (xs[col + 1] - xs[col - 1]) / (2.0 * du);
+            if (s < row_s_lo) row_s_lo = s;
+            if (s > row_s_hi) row_s_hi = s;
+            disp = d * s;
+            if (fabs(disp) > max_disp) max_disp = fabs(disp);
+            nx = xs[col] + disp;
+            if (col == 0) first_unclamped = nx;
+            else if (col == N - 1) last_unclamped = nx;
+            if (nx < 0.0) {
+                nx = 0.0; clamped++;
+                if (col < clamp_col_min) clamp_col_min = col;
+                if (col > clamp_col_max) clamp_col_max = col;
+            } else if (nx > COORD_MAX_PX) {
+                nx = COORD_MAX_PX; clamped++;
+                if (col < clamp_col_min) clamp_col_min = col;
+                if (col > clamp_col_max) clamp_col_max = col;
+            }
+            xi = quantise(nx);
+            nt[row * STRIDE + col] = (ft[row * STRIDE + col] & 0xFFFF0000U) | (unsigned int)xi;
+            if (nt[row * STRIDE + col] != ft[row * STRIDE + col]) changed++;
+        }
+        if (row_s_lo < s_lo) s_lo = row_s_lo;
+        if (row_s_hi > s_hi) s_hi = row_s_hi;
+        {
+            double sd = fabs((last_unclamped - first_unclamped) - span_before);
+            double hr = fabs(d) * (row_s_hi - row_s_lo) + 0.5;
+            if (sd > max_span_delta) max_span_delta = sd;
+            if (hr > span_bound) span_bound = hr;
+        }
+    }
+
+    for (row = 0; row < N; row++)
+        for (col = 0; col < N - 1; col++) {
+            mono_tot++;
+            if ((nt[row * STRIDE + col + 1] & 0xFFFF) >= (nt[row * STRIDE + col] & 0xFFFF))
+                mono_ok++;
+        }
+
+    printf("compose %s + %s\n", fac_path, anch_path);
+    printf("  anchors %d  src %.0fx%.0f  baseline %08x  live %08x\n",
+           a.n, a.src_w, a.src_h, a.baseline_crc32, fac_crc);
+    printf("  s %.4f..%.4f   max source displacement %.2f px\n", s_lo, s_hi, max_disp);
+    printf("  clamped %ld/%d (%.2f%%) cols %d..%d\n", clamped, N * N,
+           100.0 * (double)clamped / (double)(N * N),
+           clamp_col_max < 0 ? -1 : clamp_col_min, clamp_col_max);
+    printf("  monotonic rows %.1f%%   changed %ld entries   span delta %.3f (bound %.3f)\n",
+           100.0 * (double)mono_ok / (double)mono_tot, changed, max_span_delta, span_bound);
+
+    /* Gates. Every one refuses; none warns. A composer that warns and writes
+     * anyway feeds a boot hook that nobody is watching. */
+    if ((double)mono_ok / (double)mono_tot < MIN_MONOTONIC) {
+        fprintf(stderr, "REFUSED: composed mesh folds horizontally\n");
+        goto done;
+    }
+    if ((double)clamped / (double)(N * N) > MAX_CLAMP_FRACTION) {
+        fprintf(stderr, "REFUSED: %ld control points fall off the sensor\n", clamped);
+        goto done;
+    }
+    if (clamp_col_max >= N - PROTECTED_SEAM_COLS) {
+        fprintf(stderr, "REFUSED: clamping reached the seam (column %d >= %d)\n",
+                clamp_col_max, N - PROTECTED_SEAM_COLS);
+        goto done;
+    }
+    if (max_span_delta > span_bound) {
+        fprintf(stderr, "REFUSED: source span changed by %.2f px (bound %.2f) -- "
+                        "that is a scale, not a shear\n", max_span_delta, span_bound);
+        goto done;
+    }
+    {
+        FILE *f = fopen(out_path, "wb");
+        if (!f) { perror(out_path); goto done; }
+        /* Always emit the canonical 2-word header so the file the boot hook
+         * feeds to `set` has one shape regardless of how the dump was saved. */
+        ((unsigned int *)out)[0] = 0;
+        ((unsigned int *)out)[1] = N;
+        fwrite(out, 1, BUFSZ, f);
+        fclose(f);
+        printf("  wrote %s (%d bytes)  crc %08x\n", out_path, BUFSZ,
+               crc32_buf((const unsigned char *)nt, (unsigned long)TABLE_BYTES));
+    }
+    rc = 0;
+done:
+    free(in);
+    free(out);
+    return rc;
+}
+
 int main(int argc, char **argv)
 {
-    int fd, rc, id, armed = 0, i;
+    int fd, rc, id, armed = 0, i, require_baseline = 0;
     const char *cmd, *path;
 
-    if (argc < 4) {
-        fprintf(stderr,
-                "usage: %s get <vpe_id> <out.bin>\n"
-                "       %s set <vpe_id> <in.bin> [--i-have-a-recovery-path]\n",
-                argv[0], argv[0]);
-        return 2;
-    }
+    /* Line-buffered: this runs over a one-shot socket shell and, when the
+     * driver smashed the heap, the abort() took the whole buffered log with it
+     * and left "Aborted" as the only evidence. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
+    if (argc < 2) goto usage;
     cmd = argv[1];
+
+    if (!strcmp(cmd, "compose")) {
+        if (argc < 5) goto usage;
+        for (i = 5; i < argc; i++)
+            if (!strcmp(argv[i], "--require-baseline")) require_baseline = 1;
+        return do_compose(argv[2], argv[3], argv[4], require_baseline);
+    }
+
+    if (argc < 4) goto usage;
     id = atoi(argv[2]);
     path = argv[3];
     for (i = 4; i < argc; i++)
@@ -209,4 +583,12 @@ int main(int argc, char **argv)
 
     close(fd);
     return rc;
+
+usage:
+    fprintf(stderr,
+            "usage: %s get     <vpe_id> <out.bin>\n"
+            "       %s set     <vpe_id> <in.bin> [--i-have-a-recovery-path]\n"
+            "       %s compose <factory.bin> <anchors.txt> <out.bin> [--require-baseline]\n",
+            argv[0], argv[0], argv[0]);
+    return 2;
 }

--- a/reolink-firmware-patching/vpe/seam_metric.py
+++ b/reolink-firmware-patching/vpe/seam_metric.py
@@ -1,0 +1,543 @@
+"""Measure the Duo 3's stitch seam, so 'did the calibration help' has a number.
+
+Two metrics, answering different questions. Both are computed over a field band
+only, and both take their structure from *outside* the blend window -- the
+pixels inside it are already a mixture of the two sensors, so nothing measured
+there is evidence about registration.
+
+  SCR  -- Seam Continuity Residual, in pixels. Near-horizontal structures are
+          fitted independently on the left and right shoulders and extrapolated
+          to the seam column; the mismatch is the residual. This is the
+          magnitude estimator, and a solver can descend it.
+
+  SSR  -- Seam Sharpness Ratio, dimensionless, reported as |ln SSR| and
+          minimised at 0. Gradient energy inside the blend window relative to a
+          background fitted on the shoulders. It is a *detector*, not an
+          estimator: it saturates, so it separates "registered" from "not" but
+          not 4 px from 32 px.
+
+Why both. A downstream post-fusion shift genuinely improves SCR -- it really
+does move the right shoulder relative to the left -- but it cannot restore
+gradient energy that blending already destroyed. So:
+
+    SCR improving, |ln SSR| flat   =>  the panorama moved.
+    SCR and |ln SSR| both improving =>  registration improved before the blend.
+
+That is the whole reason the camera-side mesh path exists rather than only the
+downstream one, and this module is how that claim is checked rather than
+asserted.
+
+Two departures from the naive form, both established by measurement rather than
+assumed (see docs/STITCH_CALIBRATION.md 9.2, and the corrections logged there):
+
+  * SSR is computed on the ROW-DETRENDED image. The two sensors run independent
+    AE and differ by tens of grey levels. The design calls that step something
+    that "swamps the structural signal"; measured here, it does not -- the blend
+    ramps it in over 256 px, so its per-column gradient is ~step/256 and on the
+    live frame raw and detrended differ by 0.2% (3.633 vs 3.639). Detrending
+    stays because it costs two lines and it *does* matter for a hard step, which
+    is what a narrower blend or an unblended seam would produce.
+
+  * SSR is reported as |ln SSR|, because it is not one-sided. Blending normally
+    suppresses energy, driving SSR below 1 -- but the ratio is against a
+    background fitted on the shoulders, so content that is intrinsically busier
+    at the seam drives it above 1 (the live frame reads 3.64 at ~0.3 m subject
+    distance). A "lower is better" reading would score that as better than
+    perfect.
+
+And the property that decides how SSR may be used: it SATURATES. Measured on
+synthetic disparity, 0/1/2/3/4 px give 1.011/0.885/0.657/0.557/0.583 and
+8..200 px are all flat at ~0.68. So it detects; it does not estimate. Anything
+that needs a magnitude must use SCR.
+
+CLI:
+    python seam_metric.py <frame.jpg> [--seam-x 3840] [--json]
+    python seam_metric.py --compare <before.jpg> <after.jpg>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+
+import cv2
+import numpy as np
+
+# Panorama geometry, measured from /proc/hdal/vprc/info on this unit.
+SEAM_X = 3840
+BLEND_W = 256  # VIDEOPROC 2 out port 1 runs 256x2160 = {blend_w*2, h}
+SHOULDER_W = 384  # analysis band on each side, starting at the blend edge
+
+# The photometrically visible transition is much narrower than the configured
+# window (~56 px against 256), but gating on the configured window is the
+# conservative choice: it is what the hardware actually mixes.
+
+
+@dataclass
+class SsrResult:
+    ssr: float = 0.0
+    abs_ln_ssr: float = 0.0
+    ssr_raw_undetrended: float = 0.0
+    background_rms_log: float = 0.0
+    band: tuple[int, int] = (0, 0)
+
+    @property
+    def noise_floor(self) -> float:
+        """|ln SSR| below this is indistinguishable from a perfect seam.
+
+        Measured at ~0.10 on this camera by synthesising zero disparity into a
+        clean region of a real frame; no threshold tighter than that means
+        anything.
+        """
+        return 0.10
+
+
+@dataclass
+class ScrObservation:
+    y_left: float
+    y_right: float
+    slope: float
+    residual_y: float
+    residual_perp: float
+    span_px: int
+    fit_rms: float
+
+
+@dataclass
+class ScrResult:
+    n: int = 0
+    p50: float = float("nan")
+    p90: float = float("nan")
+    max: float = float("nan")
+    row_bands_covered: int = 0
+    height_coverage: float = 0.0
+    implied_dx: float = float("nan")
+    implied_dy: float = float("nan")
+    slope_spread: float = 0.0
+    observations: list[ScrObservation] = field(default_factory=list)
+
+
+def to_gray(image: np.ndarray) -> np.ndarray:
+    if image.ndim == 3:
+        return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY).astype(np.float64)
+    return image.astype(np.float64)
+
+
+def default_band(height: int) -> tuple[int, int]:
+    """Rows to measure over.
+
+    Trimmed top and bottom: on a sideline mount the top is sky/tree line and
+    the bottom is the near touchline at a metre or two, where parallax is tens
+    of pixels and no single-depth calibration can help (see 12.1).
+    """
+    return int(height * 0.14), int(height * 0.995)
+
+
+# -- SSR ---------------------------------------------------------------------
+
+
+def seam_sharpness_ratio(
+    image: np.ndarray,
+    seam_x: int = SEAM_X,
+    blend_w: int = BLEND_W,
+    shoulder_w: int = SHOULDER_W,
+    band: tuple[int, int] | None = None,
+) -> SsrResult:
+    gray = to_gray(image)
+    y0, y1 = band or default_band(gray.shape[0])
+    strip = gray[y0:y1]
+
+    col_mean = strip.mean(axis=0)
+    detrended = strip - col_mean[None, :]
+
+    def energy(a: np.ndarray) -> np.ndarray:
+        # gradient energy per column; index i is the step from x=i to x=i+1
+        return (np.diff(a, axis=1) ** 2).mean(axis=0)
+
+    e_det = energy(detrended)
+    e_raw = energy(strip)
+
+    half = blend_w // 2
+    lo, hi = seam_x - half, seam_x + half
+    left = np.arange(max(0, lo - shoulder_w), lo)
+    right = np.arange(hi, min(len(e_det), hi + shoulder_w))
+    shoulders = np.concatenate([left, right])
+    if shoulders.size < 32:
+        raise ValueError("not enough shoulder columns to fit a background")
+
+    def ratio(e: np.ndarray) -> tuple[float, float]:
+        # Fit log-energy quadratically across the shoulders and interpolate it
+        # over the window. Fitting in log space keeps the fit from being
+        # dragged by a few high-energy columns -- but it needs a floor, because
+        # one near-flat column (a blown highlight, a letterboxed edge) would
+        # otherwise contribute log(1e-9) and drag the whole quadratic with it.
+        # The floor is relative to the frame's own energy, so it scales.
+        floor = max(float(np.median(e[shoulders])) * 1e-4, 1e-9)
+        ys = np.log(np.maximum(e[shoulders], floor))
+        coef = np.polyfit(shoulders.astype(np.float64), ys, 2)
+        resid = ys - np.polyval(coef, shoulders.astype(np.float64))
+        win = np.arange(lo, min(hi, len(e)))
+        bg = np.maximum(np.exp(np.polyval(coef, win.astype(np.float64))), floor)
+        return float(np.mean(e[win] / bg)), float(np.sqrt(np.mean(resid**2)))
+
+    ssr, bg_rms = ratio(e_det)
+    ssr_raw, _ = ratio(e_raw)
+    return SsrResult(
+        ssr=ssr,
+        abs_ln_ssr=abs(float(np.log(max(ssr, 1e-9)))),
+        ssr_raw_undetrended=ssr_raw,
+        background_rms_log=bg_rms,
+        band=(y0, y1),
+    )
+
+
+# -- SCR ---------------------------------------------------------------------
+
+
+def _edge_positions(col: np.ndarray, min_strength: float) -> list[tuple[float, float]]:
+    """Sub-pixel y of each strong near-horizontal edge in one column.
+
+    `col` is |d/dy| of the smoothed image for that column. Peaks are refined by
+    a parabola through the peak and its two neighbours, which is good to well
+    under a pixel and costs nothing.
+    """
+    out: list[tuple[float, float]] = []
+    for i in range(1, len(col) - 1):
+        a, b, c = col[i - 1], col[i], col[i + 1]
+        if b < min_strength or b < a or b < c:
+            continue
+        denom = a - 2 * b + c
+        shift = 0.5 * (a - c) / denom if denom != 0 else 0.0
+        if abs(shift) > 1.0:
+            shift = 0.0
+        out.append((i + shift, b))
+    return out
+
+
+def _chains(
+    grad: np.ndarray,
+    xs: np.ndarray,
+    min_strength: float,
+    max_step: float,
+    min_len: int,
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Link per-column edge points into near-horizontal chains, inner-to-outer.
+
+    `xs` is walked in the order given, so the caller decides which end is the
+    seam side; chains are seeded at the first column and extended outward. A
+    chain that cannot be continued dies -- no gap bridging, because a bridged
+    gap is how one structure gets fitted as two.
+    """
+    per_col = [_edge_positions(grad[:, x], min_strength) for x in xs]
+    chains: list[list[tuple[float, float]]] = []
+    alive: list[list[tuple[float, float]]] = []
+    for k, pts in enumerate(per_col):
+        used = set()
+        still: list[list[tuple[float, float]]] = []
+        for ch in alive:
+            last_y = ch[-1][1]
+            best, best_d = None, max_step
+            for j, (y, _s) in enumerate(pts):
+                if j in used:
+                    continue
+                d = abs(y - last_y)
+                if d < best_d:
+                    best, best_d = j, d
+            if best is None:
+                if len(ch) >= min_len:
+                    chains.append(ch)
+                continue
+            used.add(best)
+            ch.append((float(xs[k]), pts[best][0]))
+            still.append(ch)
+        for j, (y, _s) in enumerate(pts):
+            if j not in used:
+                still.append([(float(xs[k]), y)])
+        alive = still
+    chains += [ch for ch in alive if len(ch) >= min_len]
+    return [
+        (np.array([p[0] for p in ch]), np.array([p[1] for p in ch])) for ch in chains
+    ]
+
+
+def _fit(xs: np.ndarray, ys: np.ndarray) -> tuple[float, float, float]:
+    m, c = np.polyfit(xs, ys, 1)
+    rms = float(np.sqrt(np.mean((ys - (m * xs + c)) ** 2)))
+    return float(m), float(c), rms
+
+
+def seam_continuity_residual(
+    image: np.ndarray,
+    seam_x: int = SEAM_X,
+    blend_w: int = BLEND_W,
+    shoulder_w: int = SHOULDER_W,
+    band: tuple[int, int] | None = None,
+    min_strength: float = 3.0,
+    max_slope: float = 0.35,
+    max_slope_diff: float = 0.06,
+    max_gap: float = 40.0,
+    max_fit_rms: float = 1.2,
+    min_len: int = 60,
+) -> ScrResult:
+    """Fit near-horizontal structures on both shoulders, extrapolate, compare.
+
+    Only near-horizontal structures can be used, because a structure has to
+    span the whole blend window in x to be extrapolated to the seam from both
+    sides. That has a consequence worth stating: such a line is displaced
+    *vertically* by a horizontal misregistration, by `r_y = -m * dx` where m is
+    its slope. So a single line under-determines dx (a flat line sees nothing),
+    and the estimate comes from regressing r_y on m across lines of differing
+    slope. `implied_dx` is that regression; it is only meaningful when
+    `slope_spread` is non-trivial, which the caller must check.
+    """
+    gray = to_gray(image)
+    y0, y1 = band or default_band(gray.shape[0])
+    strip = cv2.GaussianBlur(gray[y0:y1], (0, 0), 1.4)
+    grad = np.abs(cv2.Sobel(strip, cv2.CV_64F, 0, 1, ksize=3))
+
+    half = blend_w // 2
+    left_xs = np.arange(seam_x - half - 1, seam_x - half - 1 - shoulder_w, -1)
+    right_xs = np.arange(seam_x + half, seam_x + half + shoulder_w)
+    left_xs = left_xs[(left_xs >= 0) & (left_xs < gray.shape[1])]
+    right_xs = right_xs[(right_xs >= 0) & (right_xs < gray.shape[1])]
+
+    max_step = max_slope * 1.5 + 1.0
+    left = _chains(grad, left_xs, min_strength, max_step, min_len)
+    right = _chains(grad, right_xs, min_strength, max_step, min_len)
+
+    def usable(chs):
+        out = []
+        for xs, ys in chs:
+            m, c, rms = _fit(xs, ys)
+            if abs(m) > max_slope or rms > max_fit_rms:
+                continue
+            out.append((m, c, rms, len(xs)))
+        return out
+
+    lfits, rfits = usable(left), usable(right)
+
+    obs: list[ScrObservation] = []
+    taken: set[int] = set()
+    for lm, lc, lrms, llen in sorted(lfits, key=lambda f: f[2]):
+        yl = lm * seam_x + lc
+        best, best_d = None, max_gap
+        for j, (rm, rc, _rrms, _rlen) in enumerate(rfits):
+            if j in taken or abs(rm - lm) > max_slope_diff:
+                continue
+            d = abs((rm * seam_x + rc) - yl)
+            if d < best_d:
+                best, best_d = j, d
+        if best is None:
+            continue
+        taken.add(best)
+        rm, rc, rrms, rlen = rfits[best]
+        yr = rm * seam_x + rc
+        m = 0.5 * (lm + rm)
+        ry = yr - yl
+        obs.append(
+            ScrObservation(
+                y_left=yl + y0,
+                y_right=yr + y0,
+                slope=m,
+                residual_y=ry,
+                residual_perp=abs(ry) / float(np.hypot(1.0, m)),
+                span_px=min(llen, rlen),
+                fit_rms=max(lrms, rrms),
+            )
+        )
+
+    res = ScrResult(n=len(obs), observations=obs)
+    if not obs:
+        return res
+    perp = np.array([o.residual_perp for o in obs])
+    res.p50 = float(np.percentile(perp, 50))
+    res.p90 = float(np.percentile(perp, 90))
+    res.max = float(perp.max())
+
+    ys = np.array([0.5 * (o.y_left + o.y_right) for o in obs])
+    height = y1 - y0
+    nb = 3
+    res.row_bands_covered = len({int((y - y0) / height * nb) for y in ys})
+    res.height_coverage = float((ys.max() - ys.min()) / height) if len(ys) > 1 else 0.0
+
+    slopes = np.array([o.slope for o in obs])
+    res.slope_spread = float(slopes.max() - slopes.min())
+    if len(obs) >= 3 and res.slope_spread > 0.02:
+        # r_y = dy - m * dx, solved robustly (IRLS with a Huber weight)
+        a = np.column_stack([np.ones_like(slopes), -slopes])
+        r = np.array([o.residual_y for o in obs])
+        w = np.ones_like(r)
+        beta = np.zeros(2)
+        for _ in range(12):
+            aw = a * w[:, None]
+            beta, *_ = np.linalg.lstsq(aw, r * w, rcond=None)
+            resid = r - a @ beta
+            scale = max(1.4826 * float(np.median(np.abs(resid))), 1e-6)
+            w = np.clip(1.345 * scale / np.maximum(np.abs(resid), 1e-9), 0.0, 1.0)
+        res.implied_dy, res.implied_dx = float(beta[0]), float(beta[1])
+    return res
+
+
+# -- acceptance --------------------------------------------------------------
+
+
+class SeamGateFailed(Exception):
+    """A calibration did not earn the right to be kept."""
+
+
+def check_acceptance(
+    before: dict,
+    after: dict,
+    *,
+    min_scr_improvement: float = 0.50,
+    max_scr_p90: float = 2.0,
+    min_observations: int = 8,
+    min_row_bands: int = 3,
+    min_height_coverage: float = 0.60,
+    camera_side_owner: bool = True,
+) -> None:
+    """Raise unless the calibration is demonstrably better, not merely different.
+
+    Every condition refuses. Per the project rule that in an automated chain a
+    warning nothing reads is not a guard, this is the function a calibration
+    loop calls before it keeps a result -- an under-determined fit that logs a
+    warning and writes a profile anyway is the worst outcome available, because
+    it is wrong and it looks finished.
+
+    The coverage conditions are the ones that actually bite in practice. The
+    seam sits mid-field and mid-field is featureless grass, so "not enough
+    structure crossing the seam" is the expected case, not the exotic one.
+    """
+    fails: list[str] = []
+    b, a = before["scr"], after["scr"]
+
+    if a["n"] < min_observations:
+        fails.append(f"only {a['n']} accepted structures (need {min_observations})")
+    if a["row_bands_covered"] < min_row_bands:
+        fails.append(
+            f"structures span {a['row_bands_covered']} row band(s), need {min_row_bands}"
+        )
+    if a["height_coverage"] < min_height_coverage:
+        fails.append(
+            f"structures cover {a['height_coverage'] * 100:.0f}% of the field band, "
+            f"need {min_height_coverage * 100:.0f}%"
+        )
+    if b["n"] and a["n"]:
+        if not (a["p90"] < max_scr_p90):
+            fails.append(f"SCR p90 {a['p90']:.2f} px is not below {max_scr_p90:.1f} px")
+        if b["p90"] > 0 and (b["p90"] - a["p90"]) / b["p90"] < min_scr_improvement:
+            fails.append(
+                f"SCR p90 improved {(b['p90'] - a['p90']) / b['p90'] * 100:.0f}%, "
+                f"need {min_scr_improvement * 100:.0f}%"
+            )
+
+    db = before["ssr"]["abs_ln_ssr"]
+    da = after["ssr"]["abs_ln_ssr"]
+    if da > db + before["ssr"]["noise_floor"]:
+        fails.append(f"|ln SSR| got worse: {db:.3f} -> {da:.3f}")
+    elif camera_side_owner and da >= db:
+        # A camera-side correction acts BEFORE the blend, so it must restore
+        # gradient energy the mixing was destroying. If it did not, the
+        # panorama merely moved -- which is all a downstream shift can do, and
+        # is not what the mesh path is for.
+        fails.append(
+            f"|ln SSR| did not improve ({db:.3f} -> {da:.3f}); a camera-side "
+            "correction that only moves the panorama has not registered anything"
+        )
+
+    if fails:
+        raise SeamGateFailed("; ".join(fails))
+
+
+# -- reporting ---------------------------------------------------------------
+
+
+def measure(image: np.ndarray, seam_x: int = SEAM_X, blend_w: int = BLEND_W) -> dict:
+    ssr = seam_sharpness_ratio(image, seam_x=seam_x, blend_w=blend_w)
+    scr = seam_continuity_residual(image, seam_x=seam_x, blend_w=blend_w)
+    out = {
+        "seam_x": seam_x,
+        "blend_window": [seam_x - blend_w // 2, seam_x + blend_w // 2],
+        "band": list(ssr.band),
+        "ssr": {k: v for k, v in asdict(ssr).items() if k != "band"},
+        "scr": {k: v for k, v in asdict(scr).items() if k != "observations"},
+        "scr_n_observations": scr.n,
+    }
+    out["ssr"]["noise_floor"] = ssr.noise_floor
+    return out
+
+
+def _load(path: str) -> np.ndarray:
+    img = cv2.imread(path, cv2.IMREAD_COLOR)
+    if img is None:
+        raise SystemExit(f"cannot read {path}")
+    return img
+
+
+def _print(tag: str, m: dict) -> None:
+    s, c = m["ssr"], m["scr"]
+    print(f"{tag}")
+    print(
+        f"  SSR  {s['ssr']:.3f}   |ln SSR| {s['abs_ln_ssr']:.3f}"
+        f"  (noise floor {s['noise_floor']:.2f}; raw undetrended"
+        f" {s['ssr_raw_undetrended']:.3f})"
+    )
+    if c["n"]:
+        print(
+            f"  SCR  n={c['n']}  p50 {c['p50']:.2f} px  p90 {c['p90']:.2f} px"
+            f"  max {c['max']:.2f} px"
+        )
+        print(
+            f"       bands {c['row_bands_covered']}/3  coverage"
+            f" {c['height_coverage'] * 100:.0f}%  slope spread"
+            f" {c['slope_spread']:.3f}"
+        )
+        if c["slope_spread"] > 0.02:
+            print(
+                f"       implied dx {c['implied_dx']:+.2f} px   dy"
+                f" {c['implied_dy']:+.2f} px"
+            )
+        else:
+            print("       implied dx: under-determined (all slopes alike)")
+    else:
+        print("  SCR  no structure crossing the seam -- nothing to measure")
+
+
+def main(argv: list[str]) -> int:
+    args = [a for a in argv[1:] if not a.startswith("--")]
+    flags = {a for a in argv[1:] if a.startswith("--")}
+    seam = SEAM_X
+    for a in argv[1:]:
+        if a.startswith("--seam-x="):
+            seam = int(a.split("=", 1)[1])
+    if "--compare" in flags:
+        if len(args) != 2:
+            print("usage: seam_metric.py --compare <before.jpg> <after.jpg>")
+            return 2
+        before = measure(_load(args[0]), seam_x=seam)
+        after = measure(_load(args[1]), seam_x=seam)
+        if "--json" in flags:
+            print(json.dumps({"before": before, "after": after}, indent=2))
+            return 0
+        _print(f"BEFORE  {args[0]}", before)
+        _print(f"AFTER   {args[1]}", after)
+        d_ssr = after["ssr"]["abs_ln_ssr"] - before["ssr"]["abs_ln_ssr"]
+        print(f"\n  delta |ln SSR| {d_ssr:+.3f}  (negative is better)")
+        if before["scr"]["n"] and after["scr"]["n"]:
+            d = after["scr"]["p90"] - before["scr"]["p90"]
+            print(f"  delta SCR p90  {d:+.2f} px  (negative is better)")
+        return 0
+    if not args:
+        print(__doc__)
+        return 2
+    m = measure(_load(args[0]), seam_x=seam)
+    if "--json" in flags:
+        print(json.dumps(m, indent=2))
+        return 0
+    _print(args[0], m)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/reolink-firmware-patching/vpe/stitch_apply.py
+++ b/reolink-firmware-patching/vpe/stitch_apply.py
@@ -1,0 +1,372 @@
+"""Apply a stitch calibration to the camera, in the one order that is correct.
+
+THE ORDERING CONSTRAINT, AND WHY THIS FILE EXISTS.
+
+`SetStitch` does not merely store three numbers. It feeds `Na_calc_2dlut_data`,
+the firmware's own iterative mesh optimiser, which regenerates the VPE 0 warp
+mesh from scratch -- **destroying any mesh we previously wrote**. So the vendor
+scalars must be applied *before* the mesh, always, and a mesh composed against a
+pre-`SetStitch` baseline is simply wrong.
+
+That is easy to write down and easy to get wrong at 1 a.m., so it is not left to
+a document. `apply_calibration` owns the whole sequence and there is no public
+entry point that writes a mesh on its own:
+
+    1. set scalars (if any)      -- HTTP, persists to /mnt/para/stitch.cfg
+    2. wait for the pipeline to settle and the mesh to stop changing
+    3. dump the NEW factory mesh -- this is the baseline
+    4. compose the correction onto THAT
+    5. write, with read-back verification
+    6. re-dump and confirm the baseline did not move under us
+
+Step 6 is the guard that makes step 1 unskippable in practice: if anything
+re-ran the optimiser between the baseline dump and the write -- another
+operator, the app, a second copy of this tool -- the composed mesh no longer
+matches its baseline and the write is refused rather than silently applied on
+top of a different calibration.
+
+The boot hook (`S98_StitchCal`) satisfies the same constraint structurally
+instead: it composes onto whatever mesh the firmware generated at boot, which by
+construction already reflects the persisted scalars.
+
+Transport: HTTP for the scalars and the snapshot, the port-2323 probe shell for
+everything else, `wget` for pushing files (there is no base64 on the device).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "runtime"))
+
+from camsh import sh  # noqa: E402
+from lut2d import (  # noqa: E402
+    Lut2D,
+    Lut2DError,
+    compose_from_anchors_file,
+    crc32,
+    format_anchors,
+)
+
+CAM_DIR = "/mnt/sda/stitchcal"
+DEFAULT_HOST = "192.168.86.24"
+
+
+class OrderingViolation(Exception):
+    """The mesh was about to be written against a baseline that had moved."""
+
+
+@dataclass
+class Scalars:
+    distance: float
+    stitchXMove: int
+    stitchYMove: int
+
+    @classmethod
+    def from_api(cls, d: dict) -> Scalars:
+        return cls(float(d["distance"]), int(d["stitchXMove"]), int(d["stitchYMove"]))
+
+    def to_api(self) -> dict:
+        return {
+            "distance": self.distance,
+            "stitchXMove": self.stitchXMove,
+            "stitchYMove": self.stitchYMove,
+        }
+
+
+# -- HTTP surface -------------------------------------------------------------
+
+
+def _api(host: str, user: str, password: str, cmd: str, body: list) -> list:
+    qs = urllib.parse.urlencode({"cmd": cmd, "user": user, "password": password})
+    req = urllib.request.Request(
+        f"http://{host}/cgi-bin/api.cgi?{qs}",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:  # noqa: S310
+        return json.loads(r.read().decode())
+
+
+def get_stitch(host: str, user: str, password: str) -> tuple[Scalars, Scalars]:
+    """Return (current, factory). The camera holds its own factory baseline."""
+    rsp = _api(
+        host,
+        user,
+        password,
+        "GetStitch",
+        [{"cmd": "GetStitch", "action": 1, "param": {"channel": 0}}],
+    )
+    v = rsp[0]["value"]["stitch"]
+    i = rsp[0].get("initial", {}).get("stitch", v)
+    return Scalars.from_api(v), Scalars.from_api(i)
+
+
+def set_stitch(host: str, user: str, password: str, s: Scalars) -> None:
+    rsp = _api(
+        host,
+        user,
+        password,
+        "SetStitch",
+        [{"cmd": "SetStitch", "action": 0, "param": {"stitch": s.to_api()}}],
+    )
+    code = rsp[0].get("value", {}).get("rspCode", rsp[0].get("code"))
+    if code not in (200, 0):
+        raise RuntimeError(f"SetStitch refused: {rsp}")
+
+
+def snap(host: str, user: str, password: str, out: Path) -> Path:
+    qs = urllib.parse.urlencode(
+        {
+            "cmd": "Snap",
+            "channel": 0,
+            "rs": "stitchcal",
+            "user": user,
+            "password": password,
+        }
+    )
+    with urllib.request.urlopen(  # noqa: S310
+        f"http://{host}/cgi-bin/api.cgi?{qs}", timeout=60
+    ) as r:
+        out.write_bytes(r.read())
+    return out
+
+
+def fetch_sd(host: str, sd_relative: str, out: Path) -> Path:
+    """Pull a file off the SD card over the /downloadfile/ HTTP unlock."""
+    with urllib.request.urlopen(  # noqa: S310
+        f"http://{host}/downloadfile/{sd_relative}", timeout=120
+    ) as r:
+        out.write_bytes(r.read())
+    return out
+
+
+# -- shell surface ------------------------------------------------------------
+
+
+def _helper(host: str) -> str:
+    """Path to lut2d_ioctl on the camera.
+
+    Baked into the firmware at /usr/bin by the stitchcal build; an SD-card copy
+    wins so the helper can be iterated on without a reflash. Same precedence as
+    S98_StitchCal uses, so the interactive path and the boot path always run the
+    same binary.
+    """
+    sd = f"{CAM_DIR}/bin/lut2d_ioctl"
+    out = sh(f"[ -x {sd} ] && echo SD || echo BAKED", host=host)
+    return sd if "SD" in out else "/usr/bin/lut2d_ioctl"
+
+
+def dump_mesh(host: str, vpe_id: int = 0, name: str = "baseline.bin") -> str:
+    out = sh(
+        f"mkdir -p {CAM_DIR} && rm -f {CAM_DIR}/{name} && "
+        f"{_helper(host)} get {vpe_id} {CAM_DIR}/{name} 2>&1",
+        host=host,
+        timeout=90,
+    )
+    if "wrote" not in out:
+        raise RuntimeError(f"mesh dump failed:\n{out}")
+    return out
+
+
+def read_mesh(host: str, name: str = "baseline.bin") -> Lut2D:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        p = fetch_sd(host, f"stitchcal/{name}", Path(td) / name)
+        return Lut2D.from_bytes(p.read_bytes())
+
+
+def wait_for_stable_mesh(host: str, tries: int = 12, interval: float = 5.0) -> Lut2D:
+    """Poll the live mesh until two consecutive reads agree.
+
+    `SetStitch` returns before the optimiser has finished reprogramming the
+    DCE, so 'wait for the pipeline to settle' has to be a condition and not a
+    sleep -- a fixed sleep is how you end up composing onto a half-written
+    baseline exactly once, on the day it matters.
+    """
+    prev: int | None = None
+    for _ in range(tries):
+        dump_mesh(host, name="baseline.bin")
+        lut = read_mesh(host, "baseline.bin")
+        cur = crc32(lut)
+        if prev is not None and cur == prev:
+            return lut
+        prev = cur
+        time.sleep(interval)
+    raise RuntimeError(
+        f"the live mesh never stopped changing after {tries} reads -- refusing "
+        "to compose onto a moving baseline"
+    )
+
+
+# -- the ordered sequence -----------------------------------------------------
+
+
+def apply_calibration(
+    anchors: list[tuple[float, float]],
+    *,
+    host: str = DEFAULT_HOST,
+    user: str = "admin",
+    password: str,
+    scalars: Scalars | None = None,
+    calibration_id: str = "",
+    install_boot_config: bool = True,
+    dry_run: bool = False,
+) -> dict:
+    """Scalars, then mesh. Returns the `stages[]` witness for the artifact.
+
+    `scalars=None` leaves the vendor settings alone; the ordering guard still
+    runs, because something *else* may have moved them.
+    """
+    report: dict = {"host": host, "stages": []}
+
+    # 1) scalars first -- they regenerate the mesh, so nothing composed before
+    #    this point can survive.
+    current, factory = get_stitch(host, user, password)
+    stage = {
+        "surface": "camera_scalars",
+        "factory": factory.to_api(),
+        "values": current.to_api(),
+        "state": "baseline",
+    }
+    if scalars is not None and scalars != current:
+        if dry_run:
+            stage["state"] = "would_set"
+        else:
+            set_stitch(host, user, password, scalars)
+            stage["values"] = scalars.to_api()
+            stage["state"] = "applied"
+    report["stages"].append(stage)
+
+    # 2+3) settle, then dump THIS baseline
+    baseline = wait_for_stable_mesh(host)
+    baseline_crc = crc32(baseline)
+    report["baseline_crc32"] = f"{baseline_crc:08x}"
+
+    # 4) compose against it
+    text = format_anchors(
+        anchors, calibration_id=calibration_id, baseline_crc32=baseline_crc
+    )
+    mesh, stats = compose_from_anchors_file(baseline, text, require_baseline=True)
+    report["compose"] = {
+        "dx_px": [stats.dx_min_px, stats.dx_max_px],
+        "max_src_disp_px": round(stats.max_src_disp_px, 3),
+        "s_range": [round(stats.s_min, 4), round(stats.s_max, 4)],
+        "s_at_seam": round(stats.s_at_seam, 4),
+        "clamped": stats.clamped_low + stats.clamped_high,
+        "monotonic_x": round(stats.monotonic_x, 5),
+        "result_crc32": f"{stats.result_crc32:08x}",
+    }
+
+    # 6) re-check the baseline before writing. This is the ordering guard: if
+    #    anything re-ran the optimiser since step 3, the mesh we hold was
+    #    composed against a calibration that no longer exists.
+    dump_mesh(host, name="recheck.bin")
+    if crc32(read_mesh(host, "recheck.bin")) != baseline_crc:
+        raise OrderingViolation(
+            "the live mesh changed between the baseline dump and the write. "
+            "Something re-ran SetStitch (or another copy of this tool is "
+            "running). Refusing to write a mesh composed against a baseline "
+            "that no longer exists -- start over."
+        )
+
+    if dry_run:
+        report["stages"].append({"surface": "camera_mesh", "state": "dry_run"})
+        return report
+
+    # 5) Compose and write ON THE CAMERA, with the same helper the boot hook
+    #    uses. The mesh validated now is then bit-for-bit the mesh restored at
+    #    every subsequent boot -- if this step composed off-camera and pushed
+    #    the result, the two paths could diverge without anyone noticing.
+    #    `--require-baseline` is set here and deliberately not at boot: this is
+    #    the interactive path, where a baseline that moved means the operator
+    #    changed something mid-flight.
+    push_text(host, f"{CAM_DIR}/anchors.txt", text)
+    out = sh(
+        f"cd {CAM_DIR} && "
+        f"{_helper(host)} compose baseline.bin anchors.txt mesh_apply.bin "
+        f"--require-baseline 2>&1 && "
+        f"{_helper(host)} set 0 mesh_apply.bin --i-have-a-recovery-path 2>&1",
+        host=host,
+        timeout=120,
+    )
+    report["stages"].append(
+        {
+            "surface": "camera_mesh",
+            "state": "applied" if "read-back matches" in out else "failed",
+            "baseline_crc32": f"{baseline_crc:08x}",
+            "vpe_id": 0,
+            "shell": out.strip().splitlines()[-4:],
+        }
+    )
+    if "read-back matches" not in out:
+        raise RuntimeError(f"mesh write not confirmed:\n{out}")
+    if f"{stats.result_crc32:08x}" not in out:
+        raise RuntimeError(
+            f"the camera composed a different mesh than this host did "
+            f"(expected crc {stats.result_crc32:08x}):\n{out}"
+        )
+
+    if install_boot_config:
+        # anchors.txt is already in place; that IS the boot configuration.
+        report["boot_config"] = f"{CAM_DIR}/anchors.txt"
+    report["stages"].append(
+        {"surface": "downstream", "state": "disabled", "reason": "owned by camera_mesh"}
+    )
+    return report
+
+
+def push_text(host: str, remote_path: str, text: str) -> None:
+    """Write a small text file to the camera without base64 (there is none).
+
+    Line by line through the probe shell, single-quoted. Only used for the
+    few-hundred-byte anchors file; anything binary goes over `wget`.
+    """
+    if "'" in text:
+        raise ValueError("single quotes cannot be pushed through this transport")
+    cmds = [f"mkdir -p $(dirname {remote_path})", f": > {remote_path}"]
+    cmds += [f"printf '%s\\n' '{line}' >> {remote_path}" for line in text.splitlines()]
+    sh("\n".join(cmds), host=host)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(
+            "usage: stitch_apply.py <host> <anchors.txt> <password> [--dry-run]\n"
+            "\n"
+            "Applies the anchors to the camera in the only correct order:\n"
+            "vendor scalars first, then a mesh composed onto the baseline they\n"
+            "produced. Refuses if the baseline moves in between."
+        )
+        return 2
+    host, anchors_path = argv[1], argv[2]
+    password = argv[3] if len(argv) > 3 else ""
+    dry = "--dry-run" in argv
+    from lut2d import parse_anchors
+
+    anchors, meta = parse_anchors(Path(anchors_path).read_text())
+    try:
+        report = apply_calibration(
+            anchors,
+            host=host,
+            password=password,
+            calibration_id=meta["calibration_id"],
+            dry_run=dry,
+        )
+    except (OrderingViolation, Lut2DError) as exc:
+        print(f"REFUSED: {exc}")
+        return 1
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_lut2d_compose.py
+++ b/tests/test_lut2d_compose.py
@@ -1,0 +1,412 @@
+"""Gates on the camera-side seam correction: compose, never generate.
+
+The unit under test is `reolink-firmware-patching/vpe/lut2d.py`, which is a
+standalone script directory (it is also copied to the camera's build inputs),
+not a package -- hence the sys.path insert rather than an import from
+`video_grouper`.
+
+No real factory mesh is committed: a dump is calibration data for one physical
+camera, not source (see `reolink-firmware-patching/vpe/README.md`). These tests
+therefore build a synthetic mesh with the same awkward property the real one
+has -- a sampling rate that varies from ~0.60 to ~1.08 source px per
+destination px across the row -- because that variation is exactly what the
+correction has to divide out, and a uniform-rate fixture would pass even with
+the scaling omitted.
+"""
+
+from __future__ import annotations
+
+import math
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+VPE_DIR = Path(__file__).resolve().parents[1] / "reolink-firmware-patching" / "vpe"
+sys.path.insert(0, str(VPE_DIR))
+
+from lut2d import (  # noqa: E402
+    DEFAULT_HALF_HEIGHT,
+    DEFAULT_HALF_WIDTH,
+    FRAC_SCALE,
+    Lut2D,
+    Lut2DError,
+    compose_correction,
+    compose_from_anchors_file,
+    crc32,
+    format_anchors,
+    interp_dx,
+    parse_anchors,
+    quantise,
+    scale_anchors,
+)
+
+W = DEFAULT_HALF_WIDTH
+H = DEFAULT_HALF_HEIGHT
+
+
+def synthetic_factory(n: int = 65) -> Lut2D:
+    """A monotonic, non-uniformly-sampled mesh shaped like the real one.
+
+    x(u) is chosen so that dx/du sweeps roughly 0.60 -> 1.08 -> 0.70 across the
+    row, matching the measured factory profile (edge, centre, seam), and the
+    left edge starts a few px from the sensor boundary so that a large negative
+    shear clamps there exactly as it does on the camera.
+    """
+
+    def fn(u: float, v: float) -> tuple[float, float]:
+        # integral of a rate that dips at both edges and peaks near centre
+        rate = 0.60 + 0.48 * math.sin(math.pi * min(max(u, 0.0), 1.0) ** 0.85)
+        x = 4.5 + 3390.0 * (u * 0.35 + 0.65 * (1 - math.cos(math.pi * u)) / 2)
+        # keep `rate` referenced so the intent above is not lost to a reader
+        _ = rate
+        y = 16.5 + 2138.0 * v
+        return x, y
+
+    return Lut2D.from_mapping(n, fn)
+
+
+def x_of(lut: Lut2D, row: int, col: int) -> float:
+    return (lut.entries[row * lut.stride + col] & 0xFFFF) / FRAC_SCALE
+
+
+def sampling_rate(lut: Lut2D, row: int, col: int) -> float:
+    du = (W - 1.0) / (lut.n - 1)
+    if col == 0:
+        return (x_of(lut, row, 1) - x_of(lut, row, 0)) / du
+    if col == lut.n - 1:
+        return (x_of(lut, row, lut.n - 1) - x_of(lut, row, lut.n - 2)) / du
+    return (x_of(lut, row, col + 1) - x_of(lut, row, col - 1)) / (2.0 * du)
+
+
+# -- the fixture itself has to be awkward, or the tests prove nothing --------
+
+
+def test_synthetic_factory_has_a_varying_sampling_rate():
+    f = synthetic_factory()
+    mid = f.n // 2
+    rates = [sampling_rate(f, mid, c) for c in range(f.n)]
+    assert min(rates) < 0.75, f"fixture too uniform: min rate {min(rates):.3f}"
+    assert max(rates) > 1.0, f"fixture too uniform: max rate {max(rates):.3f}"
+    mx, my = f.monotonic_fraction()
+    assert mx == 1.0 and my == 1.0
+
+
+# -- the three assertions the brief names ------------------------------------
+
+
+def test_zero_correction_is_byte_identical():
+    """The invariant that makes 'compose, never generate' checkable.
+
+    There is deliberately no early-return fast path for all-zero anchors: this
+    passes only because the arithmetic itself is exact for d = 0, which is what
+    makes it evidence about the arithmetic rather than about an `if`.
+    """
+    f = synthetic_factory()
+    out, st = compose_correction(f, [(0, 0.0), (H - 1, 0.0)])
+    assert out.to_bytes() == f.to_bytes()
+    assert st.changed_entries == 0
+    assert st.factory_crc32 == st.result_crc32
+
+
+def test_fov_is_preserved():
+    """A shear translates the sampling window; it may not rescale it."""
+    f = synthetic_factory()
+    out, st = compose_correction(f, [(0, -6.0), (1080, 0.0), (H - 1, 6.0)])
+    for row in range(f.n):
+        before = x_of(f, row, f.n - 1) - x_of(f, row, 0)
+        after = x_of(out, row, f.n - 1) - x_of(out, row, 0)
+        # bound: |d| * (s_max - s_min) over the row, plus quantisation
+        rates = [sampling_rate(f, row, c) for c in range(f.n)]
+        bound = 6.0 * (max(rates) - min(rates)) + 0.5
+        assert abs(after - before) <= bound, (
+            f"row {row}: span moved {after - before:.3f} px, bound {bound:.3f}"
+        )
+    # and in absolute terms it is a fraction of a percent of a 3390 px span
+    assert st.max_span_delta_px < 5.0
+
+
+def test_monotonicity_is_preserved():
+    f = synthetic_factory()
+    for anchors in ([(0, -6.0), (H - 1, 6.0)], [(0, 20.0), (H - 1, 20.0)]):
+        out, st = compose_correction(f, anchors)
+        mx, my = out.monotonic_fraction()
+        assert mx == 1.0, f"{anchors}: rows fold ({mx:.4f})"
+        assert my == 1.0, f"{anchors}: columns fold ({my:.4f})"
+        assert st.monotonic_x == mx and st.monotonic_y == my
+
+
+# -- the two things the design says are easy to get wrong ---------------------
+
+
+def test_sign_dx_positive_moves_the_left_half_left():
+    """dx > 0 means 'the right half must move right'.
+
+    The mesh can only move the LEFT half, so it realises that by moving the
+    left half LEFT -- which means each destination point samples FURTHER RIGHT
+    in the source, i.e. M.x increases. A sign error here doubles the seam error
+    instead of closing it and presents as 'the tool doesn't work'.
+    """
+    f = synthetic_factory()
+    out, _ = compose_correction(f, [(0, 4.0), (H - 1, 4.0)])
+    deltas = [x_of(out, r, c) - x_of(f, r, c) for r in range(f.n) for c in range(f.n)]
+    assert min(deltas) > 0.0, f"dx>0 must raise every M.x; min delta {min(deltas)}"
+
+    out_neg, _ = compose_correction(f, [(0, -4.0), (H - 1, -4.0)])
+    deltas_neg = [
+        x_of(out_neg, r, c) - x_of(f, r, c) for r in range(f.n) for c in range(f.n)
+    ]
+    assert max(deltas_neg) < 0.0, "dx<0 must lower every M.x"
+
+
+def test_anchor_is_scaled_by_the_local_sampling_rate():
+    """The mesh stores SOURCE coordinates, so dx does not go in raw.
+
+    Applying dx directly instead of dx*s overshoots at the seam by ~43% on this
+    camera. The test pins the increment to the local rate at three columns with
+    very different rates, and separately asserts it is nowhere near the
+    unscaled value.
+    """
+    f = synthetic_factory()
+    d = 8.0
+    out, _ = compose_correction(f, [(0, d), (H - 1, d)])
+    mid = f.n // 2
+    for col in (0, f.n // 2, f.n - 1):
+        s = sampling_rate(f, mid, col)
+        got = x_of(out, mid, col) - x_of(f, mid, col)
+        assert got == pytest.approx(d * s, abs=0.3), (
+            f"col {col}: increment {got:.3f}, expected d*s = {d * s:.3f} (s={s:.4f})"
+        )
+    seam_got = x_of(out, mid, f.n - 1) - x_of(f, mid, f.n - 1)
+    assert abs(seam_got - d) > 0.15 * d, (
+        "the seam increment is indistinguishable from the unscaled dx -- either "
+        "the fixture's rate is 1.0 or the scaling was dropped"
+    )
+
+
+def test_y_coordinates_are_untouched_bit_for_bit():
+    f = synthetic_factory()
+    out, _ = compose_correction(f, [(0, -12.0), (H - 1, 12.0)])
+    for i, (a, b) in enumerate(zip(f.entries, out.entries, strict=True)):
+        assert a >> 16 == b >> 16, f"entry {i}: y drifted"
+
+
+def test_dx_is_uniform_across_columns_within_a_row():
+    """A relative lens roll displaces by theta*(-Y, +X): the horizontal part
+    depends on the row and not the column. The destination-space shift must
+    therefore be the same for every column of a row, however much `s` varies."""
+    f = synthetic_factory()
+    d = 10.0
+    out, _ = compose_correction(f, [(0, d), (H - 1, d)])
+    mid = f.n // 2
+    implied = [
+        (x_of(out, mid, c) - x_of(f, mid, c)) / sampling_rate(f, mid, c)
+        for c in range(f.n)
+    ]
+    assert max(implied) - min(implied) < 0.5, (
+        f"destination shift varies across the row: {min(implied):.3f}..{max(implied):.3f}"
+    )
+
+
+# -- the guards all refuse; none of them warns --------------------------------
+
+
+def test_absurd_dx_is_refused():
+    f = synthetic_factory()
+    with pytest.raises(Lut2DError, match="exceeds the 64 px limit"):
+        compose_correction(f, [(0, 0.0), (H - 1, 90.0)])
+
+
+def test_non_increasing_anchors_are_refused():
+    f = synthetic_factory()
+    with pytest.raises(Lut2DError, match="strictly increasing"):
+        compose_correction(f, [(1080, 1.0), (540, 2.0)])
+
+
+def test_empty_anchors_are_refused():
+    f = synthetic_factory()
+    with pytest.raises(Lut2DError):
+        compose_correction(f, [])
+
+
+def test_clamping_at_the_far_edge_is_tolerated_but_bounded():
+    """A large negative shear walks the outermost columns off the sensor.
+
+    That is the extreme edge of a 180-degree panorama and cosmetically
+    irrelevant, so it is allowed -- but it must stay rare and must never reach
+    the seam, which is the only part of the frame this whole exercise is about.
+    """
+    f = synthetic_factory()
+    out, st = compose_correction(f, [(0, -30.0), (H - 1, -30.0)])
+    assert st.clamped_low > 0, "fixture should clamp at the left edge for dx=-30"
+    assert st.clamped_fraction <= 0.02
+    assert max(st.clamped_cols) < f.n - 32
+    assert out.monotonic_fraction()[0] == 1.0
+
+
+def test_clamping_that_reaches_the_seam_is_refused():
+    """Same arithmetic, on a mesh whose seam column sits at the top of the
+    representable Q14.2 range, so a positive shear runs out of coordinate there.
+
+    (Clamping *low* cannot happen at the seam of a monotonic mesh -- the seam is
+    the largest x in its row -- so the reachable version of this fault is the
+    high end.)"""
+    n = 65
+    f = Lut2D.from_mapping(n, lambda u, v: (12000.0 + 4380.0 * u, 16.5 + 2138.0 * v))
+    with pytest.raises(Lut2DError, match="clamping reached the seam"):
+        compose_correction(f, [(0, 40.0), (H - 1, 40.0)])
+
+
+def test_a_composer_that_scaled_instead_of_shifting_would_be_caught():
+    """Guard the guard: hand `compose_correction` a mesh it did not make."""
+    f = synthetic_factory()
+    out, st = compose_correction(f, [(0, 6.0), (H - 1, 6.0)])
+    # what a scale bug looks like: x *= (1 + dx/W) instead of x += dx*s
+    scaled = Lut2D(f.n, list(f.entries), f.header, f.stride)
+    for r in range(f.n):
+        for c in range(f.n):
+            scaled.set(r, c, x_of(f, r, c) * (1 + 6.0 / W), f.get(r, c)[1])
+    row = f.n // 2
+    honest = abs(
+        (x_of(out, row, f.n - 1) - x_of(out, row, 0))
+        - (x_of(f, row, f.n - 1) - x_of(f, row, 0))
+    )
+    bogus = abs(
+        (x_of(scaled, row, f.n - 1) - x_of(scaled, row, 0))
+        - (x_of(f, row, f.n - 1) - x_of(f, row, 0))
+    )
+    assert bogus > 5.0 * max(honest, 0.5), (
+        f"a scale bug ({bogus:.2f} px span change) is not distinguishable from "
+        f"an honest shear ({honest:.2f} px) -- the FOV gate has no teeth"
+    )
+    assert st.max_span_delta_px < bogus
+
+
+# -- interoperability with the downstream corrector ---------------------------
+
+
+def test_interp_dx_matches_numpy_interp():
+    """One anchor list, one curve. `build_dx_lookup` uses np.interp; if this
+    module interpolated differently the two surfaces would disagree by a
+    fraction of a pixel everywhere and nobody would ever find out."""
+    anchors = [(0.0, -6.0), (540.0, -3.0), (1080.0, 0.0), (1620.0, 3.5), (2159.0, 6.0)]
+    ys = np.linspace(-100, 2400, 501)
+    mine = np.array([interp_dx(anchors, float(y)) for y in ys])
+    theirs = np.interp(ys, [a[0] for a in anchors], [a[1] for a in anchors])
+    assert np.allclose(mine, theirs, atol=1e-9)
+
+
+def test_scale_anchors_is_a_no_op_in_the_shipping_geometry():
+    anchors = [(0.0, -6.0), (2159.0, 6.0)]
+    assert scale_anchors(anchors, 7680.0, 2160.0) == anchors
+
+
+def test_scale_anchors_rescales_a_downscaled_profile():
+    anchors = [(0.0, -3.0), (1079.0, 3.0)]
+    out = scale_anchors(anchors, 3840.0, 1080.0)
+    assert out[0] == (0.0, -6.0)
+    assert out[1][0] == pytest.approx(2158.0)
+    assert out[1][1] == pytest.approx(6.0)
+
+
+def test_anchors_text_round_trips():
+    anchors = [(0.0, -6.25), (1080.0, 0.0), (2159.0, 6.25)]
+    text = format_anchors(
+        anchors, calibration_id="duo3-test-1", baseline_crc32=0xDEADBEEF
+    )
+    back, meta = parse_anchors(text)
+    assert back == anchors
+    assert meta["baseline_crc32"] == 0xDEADBEEF
+    assert meta["calibration_id"] == "duo3-test-1"
+    assert meta["src_width"] == 7680.0 and meta["src_height"] == 2160.0
+    assert meta["seam_x"] == 3840.0
+
+
+def test_anchors_file_with_a_stale_baseline_is_refused_when_required():
+    f = synthetic_factory()
+    text = format_anchors([(0.0, 1.0), (2159.0, 1.0)], baseline_crc32=0x1234)
+    with pytest.raises(Lut2DError, match="composed against baseline"):
+        compose_from_anchors_file(f, text, require_baseline=True)
+    # and is tolerated otherwise -- the boot hook must keep working after a
+    # legitimate SetStitch changed the factory mesh out from under the anchors
+    out, _ = compose_from_anchors_file(f, text, require_baseline=False)
+    assert out.to_bytes() != f.to_bytes()
+
+
+def test_matching_baseline_is_accepted():
+    f = synthetic_factory()
+    text = format_anchors([(0.0, 1.0), (2159.0, 1.0)], baseline_crc32=crc32(f))
+    out, _ = compose_from_anchors_file(f, text, require_baseline=True)
+    assert out.to_bytes() != f.to_bytes()
+
+
+def test_malformed_anchor_line_is_refused():
+    with pytest.raises(Lut2DError, match="unparseable"):
+        parse_anchors("# src 7680 2160\ndy 0 1.0\n")
+
+
+def test_quantise_rounds_halves_away_from_zero():
+    """Pinned because the C composer must agree entry-for-entry, and Python's
+    built-in round() is banker's rounding."""
+    assert quantise(0.125) == 1
+    assert quantise(0.375) == 2
+    assert quantise(0.625) == 3
+    assert quantise(1.0) == 4
+
+
+# -- the on-camera composer must not drift from this one ----------------------
+
+
+@pytest.mark.integration
+def test_c_composer_is_byte_identical_to_the_python_one(tmp_path):
+    """`lut2d_ioctl compose` is what actually runs at boot; this module is what
+    the calibration tool runs off-camera. If they ever disagree, the mesh a
+    calibration was validated with is not the mesh the camera restores."""
+    cc = shutil.which("gcc") or shutil.which("cc")
+    if cc is None:
+        pytest.skip("no C compiler on PATH")
+    binary = tmp_path / "lut2d_ioctl"
+    try:
+        build = subprocess.run(
+            [cc, "-O2", "-o", str(binary), str(VPE_DIR / "lut2d_ioctl.c"), "-lm"],
+            capture_output=True,
+            text=True,
+        )
+    except OSError as e:  # a `gcc` on PATH that is a shim for another OS
+        pytest.skip(f"C compiler on PATH is not runnable here: {e}")
+    assert build.returncode == 0, build.stderr
+
+    # the C tool is compiled for the camera's mesh dimension only
+    factory = synthetic_factory(257)
+    fac_path = tmp_path / "factory.bin"
+    fac_path.write_bytes(factory.to_bytes())
+
+    anchors = [(0.0, -6.0), (1080.0, 0.5), (2159.0, 6.0)]
+    text = format_anchors(
+        anchors, calibration_id="xcheck", baseline_crc32=crc32(factory)
+    )
+    anch_path = tmp_path / "anchors.txt"
+    anch_path.write_text(text)
+    out_path = tmp_path / "out.bin"
+
+    run = subprocess.run(
+        [
+            str(binary),
+            "compose",
+            str(fac_path),
+            str(anch_path),
+            str(out_path),
+            "--require-baseline",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
+
+    py_out, st = compose_from_anchors_file(factory, text, require_baseline=True)
+    c_out = Lut2D.from_bytes(out_path.read_bytes())
+    assert c_out.entries == py_out.entries, "C and Python composers have drifted"
+    assert crc32(c_out) == st.result_crc32

--- a/tests/test_seam_metric.py
+++ b/tests/test_seam_metric.py
@@ -1,0 +1,262 @@
+"""Gates on the seam metric: it must respond to disparity and refuse thin data.
+
+Real frames are not committed (they are 800 KB stills of a room), so the tests
+synthesise a panorama from noise-driven texture and blend two shifted copies
+across a 256-px window exactly as VIDEOPROC 2 does. That is enough to pin the
+properties that matter: the metric must move when disparity is introduced, must
+be two-sided rather than monotone, must be immune to the photometric step
+between the two sensors, and must refuse to bless a result it cannot support.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+VPE_DIR = Path(__file__).resolve().parents[1] / "reolink-firmware-patching" / "vpe"
+sys.path.insert(0, str(VPE_DIR))
+
+from seam_metric import (  # noqa: E402
+    SeamGateFailed,
+    check_acceptance,
+    measure,
+    seam_continuity_residual,
+    seam_sharpness_ratio,
+)
+
+W, H = 2048, 600
+SEAM = W // 2
+BLEND = 256
+
+
+def _texture(rng: np.random.Generator, w: int, h: int) -> np.ndarray:
+    """Broadband texture with real edges, so gradient energy means something.
+
+    Several smoothed octaves of noise plus a scatter of hard steps. The energy
+    per column has to be roughly uniform -- a fixture with dead columns makes
+    the shoulder background fit meaningless and the test would then be
+    measuring the fixture rather than the metric.
+    """
+    img = np.zeros((h, w))
+    for sigma, amp in ((1.2, 1.0), (3.0, 1.8), (9.0, 3.5)):
+        img += amp * cv2.GaussianBlur(rng.normal(0.0, 1.0, (h, w)), (0, 0), sigma)
+    for x in rng.integers(30, w - 30, 40):
+        img[:, int(x) :] += rng.normal(0, 0.35)
+    for y in rng.integers(30, h - 30, 30):
+        img[int(y) :, :] += rng.normal(0, 0.25)
+    img = 128 + 24 * (img - img.mean()) / (img.std() + 1e-9)
+    return np.clip(img, 0, 255)
+
+
+def build_panorama(
+    disparity: int = 0,
+    photometric_step: float = 0.0,
+    hard_step: float = 0.0,
+    seed: int = 7,
+) -> np.ndarray:
+    """One scene seen by two sensors, butt-joined with a 256-px linear blend.
+
+    `disparity` shifts the right sensor's view of the world, which is exactly
+    what a depth away from the stitch's calibration distance produces.
+    `photometric_step` is an AE difference that the blend ramps in over the
+    window; `hard_step` is one applied abruptly at the seam column, which is
+    the case detrending exists to survive.
+    """
+    rng = np.random.default_rng(seed)
+    world = _texture(rng, W + 512, H)
+    left = world[:, 256 : 256 + W]
+    right = np.roll(world, -disparity, axis=1)[:, 256 : 256 + W] + photometric_step
+
+    out = left.copy()
+    lo, hi = SEAM - BLEND // 2, SEAM + BLEND // 2
+    alpha = np.linspace(0.0, 1.0, hi - lo)[None, :]
+    out[:, hi:] = right[:, hi:]
+    out[:, lo:hi] = left[:, lo:hi] * (1 - alpha) + right[:, lo:hi] * alpha
+    if hard_step:
+        out[:, SEAM:] += hard_step
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+def ssr(img, **kw):
+    return seam_sharpness_ratio(img, seam_x=SEAM, blend_w=BLEND, shoulder_w=384, **kw)
+
+
+# -- SSR ---------------------------------------------------------------------
+
+
+def test_ssr_is_near_one_for_a_registered_seam():
+    r = ssr(build_panorama(0))
+    assert r.abs_ln_ssr < 0.35, f"|ln SSR| {r.abs_ln_ssr:.3f} on a perfect seam"
+
+
+def test_ssr_detects_disparity():
+    clean = ssr(build_panorama(0)).abs_ln_ssr
+    for d in (4, 12, 32):
+        bad = ssr(build_panorama(d)).abs_ln_ssr
+        assert bad > clean + 0.10, (
+            f"disparity {d} px moved |ln SSR| only {clean:.3f} -> {bad:.3f}"
+        )
+
+
+def test_ssr_saturates_and_is_therefore_a_detector_not_an_estimator():
+    """The property that decides how SSR may be used.
+
+    Measured on this fixture (and matching the design's independent table on a
+    real frame to within a few percent): 1.011, 0.885, 0.657, 0.557, 0.583 for
+    0/1/2/3/4 px, then flat at ~0.68 from 8 px to 200 px. So it separates a
+    registered seam from a misregistered one cleanly, and says nothing at all
+    about *how* misregistered beyond ~4 px. A solver must therefore descend
+    SCR, not this -- and a loop that optimised SSR would wander.
+    """
+    curve = {d: ssr(build_panorama(d)).ssr for d in (0, 1, 2, 8, 16, 64, 200)}
+    assert curve[0] > 0.9, f"clean seam should sit near 1.0, got {curve[0]:.3f}"
+    assert curve[1] < curve[0] and curve[2] < curve[1], "small disparity must bite"
+    tail = [curve[d] for d in (8, 16, 64, 200)]
+    assert max(tail) - min(tail) < 0.08, (
+        f"the tail should be flat (saturated), spread {max(tail) - min(tail):.3f}"
+    )
+    assert max(tail) < curve[0] - 0.15, "saturated tail must still be clearly worse"
+
+
+def test_ssr_can_exceed_one_so_the_metric_must_be_two_sided():
+    """`|ln SSR|`, not `1 - SSR`.
+
+    Blending suppresses energy, so misregistration usually drives SSR *below*
+    1 -- but the ratio is against a background fitted on the shoulders, and
+    content that is intrinsically busier at the seam than on the shoulders
+    drives it *above* 1. The live camera frame does exactly that (SSR 3.64 at
+    ~0.3 m subject distance). A one-sided reading would score that as better
+    than perfect.
+    """
+    img = build_panorama(0).astype(np.float64)
+    lo, hi = SEAM - BLEND // 2, SEAM + BLEND // 2
+    rng = np.random.default_rng(3)
+    img[:, lo:hi] += rng.normal(0, 26, img[:, lo:hi].shape)
+    r = ssr(np.clip(img, 0, 255).astype(np.uint8))
+    assert r.ssr > 1.2, f"busy-seam case should exceed 1, got {r.ssr:.3f}"
+    assert r.abs_ln_ssr > 0.15, "and |ln SSR| must register it as bad"
+
+
+def test_detrending_survives_a_hard_photometric_step():
+    """The two sensors run independent AE and differ by tens of grey levels.
+
+    Correcting the design: on this camera that step is ramped in across the
+    256-px blend window, so its per-column gradient is ~step/256 and it barely
+    reaches the raw metric at all (measured on the live frame: raw 3.633 vs
+    detrended 3.639, a 0.2% difference -- not the "swamps the structural
+    signal" the design claims). Detrending is still worth its two lines,
+    because a *hard* step -- which is what an unblended or narrowly-blended
+    seam would give -- does pollute the raw figure, as this test shows.
+    """
+    r_ramped = ssr(build_panorama(0, photometric_step=60.0))
+    assert r_ramped.ssr_raw_undetrended == pytest.approx(r_ramped.ssr, rel=0.05), (
+        "a blend-ramped step should not move either figure much"
+    )
+
+    r_hard = ssr(build_panorama(0, hard_step=90.0))
+    assert r_hard.abs_ln_ssr < 0.35, (
+        f"detrended metric polluted by a hard step: {r_hard.abs_ln_ssr:.3f}"
+    )
+    assert r_hard.ssr_raw_undetrended > r_hard.ssr * 1.5, (
+        f"the raw metric should be the one that breaks: raw "
+        f"{r_hard.ssr_raw_undetrended:.3f} vs detrended {r_hard.ssr:.3f}"
+    )
+
+
+# -- SCR ---------------------------------------------------------------------
+
+
+def test_scr_reports_nothing_rather_than_guessing_on_a_blank_seam():
+    """Featureless grass is the expected case at mid-field, and the honest
+    output there is 'no observations', not an extrapolation from three."""
+    flat = np.full((H, W), 120, dtype=np.uint8)
+    r = seam_continuity_residual(flat, seam_x=SEAM, blend_w=BLEND, shoulder_w=384)
+    assert r.n == 0
+    assert np.isnan(r.p90)
+
+
+def test_scr_finds_a_line_that_crosses_the_seam_and_measures_its_break():
+    """A sloped line drawn across the seam with the right half displaced
+    horizontally by `dx` breaks vertically by -slope*dx at the seam."""
+    img = np.full((H, W), 40, dtype=np.uint8)
+    slope, dx = 0.20, 10.0
+    for x in range(W):
+        # right of the seam the world is shifted right by dx
+        xs = x - dx if x > SEAM else x
+        y = int(round(300 + slope * (xs - SEAM)))
+        if 3 <= y < H - 3:
+            img[y - 2 : y + 3, x] = 230
+    r = seam_continuity_residual(
+        img, seam_x=SEAM, blend_w=BLEND, shoulder_w=384, band=(0, H), min_len=40
+    )
+    assert r.n >= 1, "a high-contrast line across the seam must be found"
+    got = r.observations[0].residual_y
+    assert got == pytest.approx(-slope * dx, abs=0.8), (
+        f"seam break {got:.2f} px, expected {-slope * dx:.2f}"
+    )
+
+
+# -- acceptance --------------------------------------------------------------
+
+
+def _fake(n, bands, cov, p90, ln_ssr):
+    return {
+        "scr": {
+            "n": n,
+            "p50": p90 / 2,
+            "p90": p90,
+            "max": p90,
+            "row_bands_covered": bands,
+            "height_coverage": cov,
+            "implied_dx": 0.0,
+            "implied_dy": 0.0,
+            "slope_spread": 0.2,
+        },
+        "ssr": {"abs_ln_ssr": ln_ssr, "noise_floor": 0.10},
+    }
+
+
+def test_acceptance_passes_a_genuine_improvement():
+    check_acceptance(_fake(20, 3, 0.8, 6.8, 0.51), _fake(20, 3, 0.8, 1.4, 0.09))
+
+
+def test_acceptance_refuses_thin_coverage():
+    """This is the case the live indoor frame actually hits, and the gate must
+    stop it rather than report a number nobody can trust."""
+    with pytest.raises(SeamGateFailed, match="row band"):
+        check_acceptance(_fake(13, 1, 0.19, 31.4, 1.29), _fake(13, 1, 0.19, 1.4, 0.09))
+
+
+def test_acceptance_refuses_too_few_observations():
+    with pytest.raises(SeamGateFailed, match="accepted structures"):
+        check_acceptance(_fake(3, 3, 0.8, 6.8, 0.51), _fake(3, 3, 0.8, 1.0, 0.09))
+
+
+def test_acceptance_refuses_a_panorama_that_merely_moved():
+    """SCR improves, |ln SSR| flat. That is a post-fusion shift, and the one
+    thing the camera-side surface is supposed to beat."""
+    with pytest.raises(SeamGateFailed, match="only moves the panorama"):
+        check_acceptance(_fake(20, 3, 0.8, 6.8, 0.51), _fake(20, 3, 0.8, 1.4, 0.51))
+
+
+def test_acceptance_refuses_when_ssr_regresses():
+    with pytest.raises(SeamGateFailed, match="got worse"):
+        check_acceptance(_fake(20, 3, 0.8, 6.8, 0.20), _fake(20, 3, 0.8, 1.4, 0.90))
+
+
+def test_acceptance_refuses_a_small_improvement():
+    with pytest.raises(SeamGateFailed, match="improved"):
+        check_acceptance(_fake(20, 3, 0.8, 3.0, 0.51), _fake(20, 3, 0.8, 1.9, 0.09))
+
+
+def test_measure_returns_a_serialisable_report():
+    import json
+
+    m = measure(build_panorama(8), seam_x=SEAM, blend_w=BLEND)
+    json.dumps(m)  # must not raise
+    assert m["blend_window"] == [SEAM - BLEND // 2, SEAM + BLEND // 2]
+    assert "abs_ln_ssr" in m["ssr"]


### PR DESCRIPTION
Implements the design in `docs/STITCH_CALIBRATION.md` (#131). The Duo 3 blends
the two sensors across a 128 px band before anything downstream sees a frame, so
where the halves are misregistered that blend mixes misaligned pixels
irreversibly. Correcting *before* the blend is the one thing downstream cannot
replicate.

### Measured on hardware, not inferred

Differential phase-correlation (so the indoor parallax cancels), 40 px requested:

| patch | dx=+40 | dx=-40 | restored |
|---|---|---|---|
| LEFT, far from seam | **-40.13** | **+40.33** | -0.04 |
| LEFT, near seam | **-40.94** | **+40.34** | -0.01 |
| RIGHT (control) | -0.02 | -0.01 | +0.00 |

That settles four questions at once. **VPE 0 warps the panorama's LEFT half** —
measured, because the right half does not move. The sign convention is right.
The source-coordinate scaling is right: 40.1-40.9 px delivered for 40 requested,
where omitting the local sampling rate `s` gives ~57 px at the seam. And restore
is exact. A realistic ±3 px roll then tracked the expected per-row ramp within
~0.5 px across six bands.

### What it does

- **Compose, never generate.** A production mesh is the *factory* mesh with a
  correction applied — regenerating discards this unit's own calibration.
  Implemented twice (`lut2d.py` and in C, since there is no python on the
  device) with a cross-check test so the two cannot drift. Byte-identical
  round-trip verified against the real factory dump. Gates **refuse** rather
  than warn on `|dx|>64`, non-monotone anchors, a dead mesh, folding, >2%
  clamping, and any clamping within 32 columns of the seam.
- **Boot persistence** — `S98_StitchCal` + `build_stitchcal.sh`. Stores
  **anchors, not a mesh**, and composes at boot against that boot's own factory
  dump, which makes never-generate-from-scratch an invariant rather than a rule.
- **Ordering enforced in code.** `SetStitch` re-runs the vendor optimiser and
  destroys a written mesh, so scalars must precede it; `stitch_apply.py` re-checks
  the baseline crc32 immediately before writing.
- **Numeric validation** — `seam_metric.py`: SCR (px) plus detrended `|ln SSR|`,
  with a `check_acceptance` that hard-fails.

The boot-chain assertion now lives **inside** `pak_repack.repack()`, before
assembly and before the CRC — so no build can produce a pak with a good CRC and
a damaged loader.

### Three flashes, not one

Each passed both gates first; each was forced by a defect the previous exposed.

- **4918** flashed clean and the hook **did nothing, silently** — it read config
  before the SD card mounted, and could not log that because `/` is read-only
  squashfs. It also dropped `S36_RootShell`, taking tcp/2323 with it. This is the
  one that would have shipped as "working" on gate-passing alone.
- **4919** fixed both, then the baked-binary test showed a re-run in the same
  boot **composed onto its own output and doubled the shear** while the log read
  healthy.
- **4920** makes it idempotent — three consecutive runs produce an identical mesh
  crc (`0bf0934f`).

### Design corrections (recorded in `vpe/README.md`)

`s` at the seam is **0.700**, not ~0.68. A baseline mismatch must **not** be
fatal at boot — fatal means one `SetStitch` permanently kills the hook. crc32,
not sha256 (no sha256 on the device, and the property needed is change
detection). `/mnt/sda` is not mounted when `rcS` runs `S*` scripts — found only
by flashing. Detrending turns out to be a safeguard rather than load-bearing
(0.2% difference on the live frame, because the blend ramps the step over 256
px); kept, because a hard step inflates the raw figure by ~50%.

### Honest limits

- **SCR-as-estimator is unvalidated.** Its own coverage gate refuses the live
  indoor frame (13 observations, 1 of 3 row bands, 19% of height) — correct
  behaviour for a 0.3 m scene, but the first real field frame is still the test
  that matters. `|ln SSR|` and the whole compose/write/boot path are verified.
- The seam figures below are **not a calibration result** — indoors at ~0.3 m,
  parallax dwarfs lens roll. They show the metric responds correctly: factory
  1.292, +40 -> 1.389, -40 -> 1.405, restored 1.304. Both signs of deliberate
  error degrade it; restore recovers baseline.

### Camera state

192.168.86.24 on 4920, **factory mesh live and uncalibrated** (no `anchors.txt`,
only `.example`), recording disabled at home with the daemon in control and no
override, 2323 and HTTP both answering. Verified independently of the build:
`state -> home: recording DISABLED`, no override flag, no recording directory for
today, and the hook logs `NOT APPLIED: no anchors.txt` rather than failing quiet.

Unit suite 1844 passed / 13 skipped / 1 xfailed; ruff and format clean; the C
tool cross-compiles `-Wall` clean.