### PR TITLE
firmware: solve seam anchors from footage — and prove the objective can't steer it

### DIFF
--- a/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
+++ b/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
@@ -753,11 +753,56 @@ crossing the seam and fit them:
 **Accumulate across the game, not within a frame.** A 90-minute game at 20 fps is ~108,000 frames;
 a few hundred good observations is plenty, and no single frame needs to be good.
 
-**Solve.** Weighted robust regression of `dx` on `y` over the accumulated observations: Huber loss,
-weights from fit quality and depth agreement. Fit a **line** first, because §2 says a lens roll is
-linear in y — then emit anchors by sampling that line at 5 rows. Record `r²` and the max residual
-(§5.2). Only if the residual is structured and large does a higher-order anchor curve become
-justified, and that fact goes in the artifact as a finding.
+**Solve.** ~~Weighted robust regression of `dx` on `y`~~ — **corrected in implementation
+(`../vpe/stitch_solver.py`, 2026-08-17): there is no per-observation `dx` to regress.** A structure
+must span the whole blend window in x to be extrapolated to the seam from both sides, so the usable
+ones are *near-horizontal*, and a near-horizontal line of slope `m` displaced horizontally by `dx`
+moves **vertically** at the seam:
+
+```
+r_y  =  dy  +  m * dx(y)
+```
+
+A flat line therefore sees nothing of `dx`, one line under-determines it, and `dx` is recoverable
+only **jointly**, from structures of differing slope. Substituting the linear-in-y model of §2,
+`dx(y) = a + b*(y − y_ref)`, gives one three-parameter fit over every accumulated observation, with
+design row `[1, m, m*(y − y_ref)]` and unknowns `(dy, a, b)`. Huber loss; weights are the inverse of
+each observation's extrapolation variance (below). Emit anchors by sampling the fitted line at 5
+rows. Record `r²` and the max residual (§5.2), and test a quadratic term — if it is significant, that
+is a finding about the camera and goes in the artifact, but the emitted curve stays straight until a
+human has looked at it. **[M]**
+
+What the fit can and cannot separate, stated so the artifact does not overclaim:
+
+- It **does** separate translate (`a`) from shear (`b`) — that needs spread in `m*(y − y_ref)`, i.e.
+  differing slopes at differing heights, which is a property of the *design matrix*, not of `n`.
+- It **does not** separate a rigid relative rotation from a linear-in-y shear (§2): both are `dx`
+  linear in y observed at one column. `roll_theta_rad` in the metadata is the roll *interpretation*
+  of `b`, not an independently measured angle.
+- It **does not** attribute the misregistration to a half. `dx` is relative, which is all either
+  surface needs.
+
+**Weights, and what the blend window costs.** Every observation is extrapolated from a shoulder
+across at least `blend_w/2 = 128` px of already-mixed pixels. For a chain of length `L` seeded at the
+blend edge, the fit's centroid is `D = 128 + L/2` from the seam, and the variance of a linear
+extrapolation is `sigma^2/L * (1 + 12 D^2 / L^2)` per side, doubled because `r_y` is a difference
+**[D]**. That is ~9× the in-span variance for a full 384-px chain and ~90× for a 96-px one, so
+weighting by it — rather than by chain length or fit quality alone — is what stops a handful of
+scraps outvoting the good data. It bounds *precision*, not correctness; what is irrecoverable is the
+ghosting already fused into the window, which is what SSR measures (§9.2).
+
+**Free consistency check.** §2 says the same roll `theta` that shears `dx` must also produce a
+constant `dy = theta * 1920` at the seam. The fit estimates `dy` anyway, as a nuisance parameter, so
+comparing it to `b * 1920` costs nothing and is a check on the *physics* rather than the algebra. A
+disagreement means something other than roll contributes — relative pitch, or parallax at a depth
+away from the calibration (§12.1) — and is reported as a finding. `dy` itself is still not emitted:
+the downstream surface cannot express it (§4.2, §12.2).
+
+**Sign, once more, because two modules disagree by design.** `seam_metric.ScrResult.implied_dx`
+models `r_y = dy − m*dx` and so reports the misregistration the right half currently *carries*; the
+artifact's `dx` is the *correction*, "px the right half must move right" (§4.4). Equal and opposite.
+The solver fits the correction directly rather than negating anything, and a test pins the
+relationship. **[M]**
 
 **Converge.** Apply → re-measure on held-out frames → iterate. Stop when `SCR p90 < 1.0 px`, or the
 improvement between iterations is `< 0.2 px`, or after 4 iterations. **Revert-on-regression**: if an
@@ -777,6 +822,25 @@ the seam sits mid-field, and mid-field is featureless grass. Handling, in order:
 4. Documented recovery: a **deliberate target**. Stand a high-contrast vertical edge — a taped board,
    or just walk the goal to the halfway line — so it straddles the seam at roughly the calibration
    depth, and grab a 10-second clip. One decisive observation set, ~2 minutes of a volunteer's time.
+
+**§9.3's counts are necessary but not sufficient — corrected in implementation.** The coverage
+conditions (`n ≥ 8`, ≥ 3 row bands, ≥ 60% of height) are all *proxies* for a design matrix that pins
+the curve, and a case exists that satisfies every one of them and is still unusable: structures
+spread over the full height and all three bands, but with slopes so shallow that `dx` — which enters
+only as `m*dx` — has almost no lever. Demonstrated with 18 observations across three bands over 70%
+of the height at slopes ±0.011, where the fitted `dx` is uncertain to ±1.35 px **[M]**. So the
+governing gate is the **standard error on `dx` at the anchor rows**, refused above 1.0 px, which is
+the target §10 stops iterating at: a fit whose own uncertainty exceeds the accuracy it is aiming for
+has not measured anything. The count and coverage conditions are kept as well, because they give a
+far better error message and because passing them means `check_acceptance` cannot later reject the
+same solve on coverage grounds. The solver reports **per-band observation counts** in every result,
+accepted or refused, so a caller can see which of these bit.
+
+**One unit trap, worth stating.** Anchors are in the pixel units of the frame they were measured on,
+and `build_dx_lookup` rescales them — so a profile solved on a downscaled still is correct, but its
+*integer* downstream projection is not free: `StitchProfile` stores `int` dx, so a profile solved at
+half resolution carries a ±0.5 px quantisation that becomes ±1.0 px after rescaling. Solve at full
+resolution where possible; the camera-mesh surface is unaffected (quarter-pixel, §5.1). **[D]**
 
 ---
 

--- a/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
+++ b/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
@@ -836,6 +836,129 @@ far better error message and because passing them means `check_acceptance` canno
 same solve on coverage grounds. The solver reports **per-band observation counts** in every result,
 accepted or refused, so a caller can see which of these bit.
 
+### 10.1 What 27 archived games actually contained — measured 2026-08-17
+
+The solver was run against the Duo 3 archive on `DESKTOP-5L867J8`: every `2026.*` directory under
+`F:\Heat_2012s\` and `F:\Flash_2013s\` holding `RecM09_*.mp4`, which is 27 games and ~400 segments.
+Four frames per game were extracted server-side, one per segment at t = 30 s, spread across the game
+(`F:\archive\duo3_stitch\solver_frames\`), 96 frames total, each verified 7680×2160 before use
+**[M]**. 27 distinct tripod placements, indoor domes and outdoor pitches.
+
+**All 27 games refused. None produced a calibration.** That is the headline, and it is a result about
+the *observation primitive*, not about the fit.
+
+| What was measured | Value |
+|---|---|
+| Observations found per game | 40–498 (4 games: 0, single-segment dirs) |
+| Fraction of observations in the **top** row band | 73–98%; smallest band's share ≤ 9.2% in every game |
+| Top-band share **per frame** | 0.48–1.00, median 0.87 — stable across frames within a game **[M]** |
+| Chain span | median **68 px** against a 384-px shoulder; `min_len=150` returns **zero** observations |
+| `r_y` scatter inside one 150-row slice | 7–20 px, against a ~1.3 px per-observation noise model |
+| `corr(r_y, slope)` inside a slice | \|0.04\|–\|0.28\|; per-slice implied `dx` −58…+91 px, incoherent |
+| Weighted `r²` of the joint fit | **0.00–0.24** across all 27 games |
+| Robust dispersion | 5–17× the noise model |
+| `\|ln SSR\|` over the 96 frames | median **0.093**, p90 0.390; **52/96 below the 0.10 noise floor** |
+
+Read together:
+
+1. **Usable near-horizontal structure lives only on the far touchline and the crowd behind it.** Below
+   about row 900 of 2160 the frame is grass, and grass produces no edge that chains for 60 px on both
+   shoulders. This is the failure mode §10 predicts, and it is worse than predicted: it is not
+   "sometimes there is nothing", it is *every game, every frame*.
+2. **More frames do not fix it.** The imbalance is per-frame and stable, so accumulating across the
+   whole game — §10's remedy — adds mass to the same band. Checked, not assumed **[M]**.
+3. **The residuals do not describe a per-row `dx`.** With `r²` ≈ 0 and almost no correlation between
+   `r_y` and slope within a row slice, whatever produces the 7–20 px scatter (spurious left/right
+   pairings, moving people, objects at differing depths sharing a row) is not a common shear.
+4. **There may be little to correct.** More than half the frames are below the SSR noise floor, i.e.
+   indistinguishable from a registered seam at the ~1 px level. Only the indoor dome game
+   (2026.03.21) is consistently high (0.405–0.533). SSR saturates past ~4 px so this is not proof of
+   sub-pixel registration, but it is evidence against a gross one.
+
+**Consequence for the design: §10 step 4 is the primary path, not the fallback.** A deliberate target
+straddling the seam at calibration depth is the only route this footage supports. The automatic
+solver's job on archived footage is to *say so*, with numbers, which is what it now does.
+
+**And a gate §9.3 was missing.** `height_coverage` is a *range* — `(y_max − y_min) / band` — so two
+stragglers at the extremes satisfy it. On this archive, range coverage read 81–98% on 24 of 27 games
+while 73–98% of the mass sat in one band **[M]**. Leverage on a shear comes from mass at differing
+heights, so the solver adds `MIN_ROW_BAND_FRACTION = 0.10`: every row band must hold at least a tenth
+of the observations. With it, 23 of the 27 refusals name the actual problem ("piled into one band")
+instead of reporting an uninterpretable ±50–375 px error bar.
+
+**Limitations of this run, stated.** Four frames per game is a thin sample of ~108,000 (finding 2 is
+why that is defensible, not an excuse). The frames are single stills, so no within-game drift over
+time was measured. And no calibration was applied to any camera, so nothing here is an end-to-end
+before/after.
+
+### 10.2 Verdict: SCR cannot be the objective for an automatic solver on fused frames
+
+This is the load-bearing correction to the design, and it is measured.
+
+**Root cause, in one line: on a soccer field almost everything that crosses a vertical seam runs
+horizontally, and a horizontal edge is invariant under a horizontal shift.**
+
+`dx` enters every SCR observation only as `m · dx` (§10). So the lever is the structure's slope. Over
+**4239 observations from the 27-game archive** **[M]**:
+
+| | median | p90 | max |
+|---|---|---|---|
+| \|slope\| | **0.034** | 0.089 | 0.265 |
+
+A 10 px misregistration therefore moves the median observation by **0.34 px** vertically — below the
+~1.3 px noise on one observation. And this is not fixable by tuning: a structure must span the 256-px
+blend window in x to be extrapolated to the seam from both shoulders, which is *why* only
+near-horizontal ones qualify, and `seam_metric` enforces `|m| ≤ 0.35` accordingly. The admissible
+feature set and the informative feature set barely overlap.
+
+**The discriminative sweep, which is the check with teeth.** Apply a constant `dx`, re-detect, and
+look at whether the score moves. Three frames, chosen by vertical-edge energy in the blend window —
+two of the richest, one of the poorest **[M]**:
+
+| dx | rich A (ratio 1.31) p90 | rich B (ratio 1.26) p90 | poor control (ratio 0.65) p90 |
+|---|---|---|---|
+| −32 | 26.12 | 30.29 | 36.63 |
+| −16 | 26.36 | 27.98 | 36.88 |
+| −4 | 29.31 | 26.89 | 37.10 |
+| **0** | **29.15** | **27.51** | **37.17** |
+| +4 | 30.20 | 27.27 | 37.23 |
+| +16 | 24.85 | 29.44 | 37.49 |
+| +32 | **23.47** | 27.03 | 37.71 |
+| | 22% range, **argmin at endpoint** | 14% range, 3 troughs | 4% range, **argmin at endpoint** |
+
+Read it: on rich A, deliberately breaking the seam by 32 px makes the score **better** (29.15 →
+23.47). `implied_dx` on the same frame wanders over −0.8 … −53 px *across the sweep of a single
+frame*, and on the control it sits at −100 … −170 px regardless of what shift was applied. The
+objective is not merely noisy — it is uninformative, and in places anti-correlated with the truth.
+This reproduces independently on a fourth frame swept by the calibration-UI work.
+
+**Mark's insight — "it's easy to see misregistration if there's a person in the seam" — is correct,
+and it is also the reason SCR cannot use it.** A person is vertical structure, which is exactly what
+a horizontal shift displaces visibly. But a vertical structure at the seam sits *inside* the blend
+window, where it exists only as a superposition of the two sensors' views. There is no left-shoulder
+copy and right-shoulder copy to extrapolate and compare, so the extrapolation primitive cannot
+consume it at any weighting. Tested rather than argued: selecting the 12 frames richest in
+vertical-edge energy at the seam gave `implied_dx` spanning **−55 … +141 px across a fixed camera**,
+4 of the 12 yielded **zero** usable observations, and the sweep above is on two of those frames
+**[M]**. Frame selection and orientation weighting do not rescue it; they select for the content SCR
+must discard.
+
+**What this leaves.**
+
+- SCR remains a fine *reporting* metric for a human (Workflow B shows it live, §11) and a fine
+  acceptance check once a correction exists. It is not a solvable objective.
+- The information about `dx` is in the **ghosting inside the blend window** — two copies of the world
+  at a fixed offset, `(1−α)·W(x) + α·W(x−e)`. Recovering `e` from that is an echo-separation problem,
+  not an extrapolation problem, and it is the one fused-frame primitive that can use a person at the
+  seam. Unbuilt, and the honest next step for Workflow A.
+- Better still, §14 question 1: `VIDEOPROC 2` out port 1 is a live 256×2160 output nobody reads. If
+  it carries the two contributions separately, this stops being an inference problem and becomes
+  direct two-image registration, where vertical structure is precisely what one correlates. The
+  archive result promotes that from "highest-value lead" to "the thing to do next".
+- `stitch_solver` therefore ships with `sweep_dx` / `require_responsive_objective`: before any curve
+  is trusted, the objective must be shown to have an interior, deep, single-troughed minimum. On this
+  footage it does not, and the solver says so.
+
 **One unit trap, worth stating.** Anchors are in the pixel units of the frame they were measured on,
 and `build_dx_lookup` rescales them — so a profile solved on a downscaled still is correct, but its
 *integer* downstream projection is not free: `StitchProfile` stores `int` dx, so a profile solved at
@@ -988,9 +1111,16 @@ Not fixed here — this branch is design only — but they are real, reproduced,
    settles it; it needs a write, so it was out of scope here (§1.4).
 4. **Is `distance` in metres?** Determines whether §12.1's reading of the 20.0 cap is right.
 5. **Does the DCE resample chroma correctly at fractional offsets?** (§5.3.)
-6. **What does real `dx(y)` look like?** No real profile exists on disk **[M]**; the roll model of §2
-   is physically motivated but unmeasured on this unit. The first calibration answers it, and the
-   answer decides whether the mesh's y-coarseness matters at all (§5.2).
+6. **What does real `dx(y)` look like?** ~~No real profile exists on disk~~ — **still open, and now
+   known to be harder than expected.** 27 archived games could not answer it: the seam observations
+   they contain do not determine `dx` at all (§10.1, `r²` ≈ 0 on every game), so the roll model of §2
+   remains unmeasured on this unit. Answering it needs the deliberate target of §10 step 4, or the
+   pre-stitch source images of question 1 — which would turn this from an extrapolation problem into
+   a direct registration one and is now the highest-value lead in the document for this reason too.
+7. **Is there anything to correct on outdoor footage at all?** 52 of 96 archived frames sit below the
+   SSR noise floor **[M]**. SSR saturates past ~4 px so this is not proof of sub-pixel registration,
+   but before more effort goes into Workflow A it is worth establishing whether the far-field seam on
+   a tripod-mounted unit is misregistered by an amount detection cares about.
 
 ---
 

--- a/reolink-firmware-patching/vpe/seam_metric.py
+++ b/reolink-firmware-patching/vpe/seam_metric.py
@@ -290,6 +290,19 @@ def seam_continuity_residual(
     and the estimate comes from regressing r_y on m across lines of differing
     slope. `implied_dx` is that regression; it is only meaningful when
     `slope_spread` is non-trivial, which the caller must check.
+
+    SENSE, because it is the opposite of the artifact's and nothing else says
+    so. `implied_dx` here is the misregistration the right half currently
+    CARRIES -- positive means its content sits that many px too far right. The
+    profile's `dx_anchors` are the CORRECTION, "px the right half must move
+    right" (`stitch_remap.build_dx_lookup`, STITCH_CALIBRATION.md 4.4), so the
+    two are equal and opposite. `stitch_solver` fits the correction directly
+    rather than negating this, and `tests/test_stitch_solver.py` pins the
+    relationship so the trap stays visible.
+
+    `implied_dx` is also a single whole-frame number, not a curve: it assumes
+    one dx for every row. A per-row shear needs the joint fit in
+    `stitch_solver.solve`, which this deliberately is not.
     """
     gray = to_gray(image)
     y0, y1 = band or default_band(gray.shape[0])

--- a/reolink-firmware-patching/vpe/stitch_solver.py
+++ b/reolink-firmware-patching/vpe/stitch_solver.py
@@ -1,0 +1,872 @@
+"""Derive `dx_anchors` from footage -- the automated half of the seam calibration.
+
+This is Workflow A of `docs/STITCH_CALIBRATION.md` 10. It consumes panorama
+frames, accumulates seam observations across them with `seam_metric`, and emits
+the same artifact a human produces by dragging handles in Workflow B: a short
+list of `[y, dx]` anchors in source-pixel units, plus a metadata dict saying
+what was measured, how well, and what was refused.
+
+WHAT AN OBSERVATION ACTUALLY IS -- and a correction to the design.
+
+10 says "weighted robust regression of `dx` on `y`". That is not available,
+because a single seam observation is not a `dx`. `seam_metric` can only fit
+structures that span the whole blend window in x, which means near-horizontal
+ones, and a near-horizontal line of slope `m` displaced horizontally by `dx`
+moves *vertically* at the seam:
+
+    r_y  =  dy  +  m * dx(y)
+
+`dy` is the constant vertical mismatch (a relative lens roll produces one, 2).
+So a flat line sees nothing of `dx`, one line under-determines it, and `dx` is
+recoverable only jointly, from structures of *differing slope*. There is no
+per-observation `dx` to regress on `y`.
+
+The solver therefore fits one joint model over every accumulated observation.
+Taking the physical model of 2 -- a relative lens roll gives `dx` exactly
+linear in y -- as `dx(y) = a + b*(y - y_ref)`:
+
+    r_y  =  dy  +  a*m  +  b*m*(y - y_ref)
+
+three unknowns, design row `[1, m, m*(y - y_ref)]`. Identifiability follows
+from the design matrix, not from the observation count:
+
+  * spread in `m` separates `dy` from `a`. Lines that all share one slope leave
+    the two collinear and `dx` is simply not observable, at any n.
+  * spread in `m*(y - y_ref)` separates `a` from `b`. Observations at a single
+    height leave the shear unobservable, again at any n.
+
+which is why the refusal gate below is a *standard error on dx*, not a count.
+Thirteen observations in one row band produce an enormous error bar, and that
+is the honest reason to refuse them.
+
+WHAT THE FIT CAN AND CANNOT SEPARATE.
+
+  * It separates translate (`a`) from shear (`b`), given the spread above.
+  * It does NOT separate a rigid relative *rotation* of one half from a
+    linear-in-y *shear* of it: every observation is taken at one column, and at
+    one column those produce identical displacements (2). So the artifact
+    stores the curve, never `(tx, ty, rot, shear)`. `roll_theta_rad` below is
+    reported as the roll interpretation of `b`, not as a separately measured
+    quantity.
+  * It cannot attribute the misregistration to a half. `dx` is relative, which
+    is all either correction surface needs.
+  * `dy` is measured but not emitted: the downstream corrector is horizontal
+    only (`stitch_remap.py`), and 4.2 forbids inventing a field one consumer
+    silently drops. It appears in the metadata as a finding and as a
+    cross-check on the roll model.
+
+WHAT THE BLEND WINDOW COSTS.
+
+Every observation comes from the shoulders, because the 128-px-per-side blend
+window has already mixed the two sensors irreversibly. So each shoulder fit is
+*extrapolated* at least `blend_w/2` px to reach the seam, and the variance of a
+linear extrapolation grows with the square of that distance. `_observation_variance`
+computes it rather than assuming it, and it is the dominant term for short
+chains: a 384-px chain starting at the blend edge extrapolates from a centroid
+320 px away, inflating its variance by ~9x over the in-span case.
+
+That bounds precision, not correctness. What is irrecoverable is the ghosting
+already baked into the fused pixels -- a correction measured this way can
+register the shoulders, but no post-fusion operation un-mixes the window
+(that is what SSR measures, and why the camera-side mesh exists).
+
+SIGN. `dx(y)` is the pixels the RIGHT half must move to the RIGHT at row y to
+register with the left, matching `stitch_remap.build_dx_lookup` and 4.4.
+Note that `seam_metric.ScrResult.implied_dx` is reported in the OPPOSITE sense
+-- it models `r_y = dy - m*dx`, so its `dx` is the misregistration the right
+half currently carries, not the correction for it. This module does not use it;
+`tests/test_stitch_solver.py` pins the relationship so the trap stays visible.
+
+CLI:
+    python stitch_solver.py <frame.jpg> [more.jpg ...] [--seam-x=N] [--json]
+                            [--validate]
+Exit 0 on a fit, 1 on a refusal (with the measurement report), 2 on usage.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lut2d import FRAC_SCALE, MAX_ABS_DX_PX  # noqa: E402
+from seam_metric import (  # noqa: E402
+    BLEND_W,
+    SEAM_X,
+    SHOULDER_W,
+    default_band,
+    measure,
+    seam_continuity_residual,
+)
+
+TOOL_VERSION = "stitch_anchor_solver/1"
+
+# Anchor count. 4.2's example artifact carries five, 10 says "sample that
+# line at 5 rows", and five is already more than a straight line needs -- the
+# redundancy is there so a later curved fit can reuse the same slots.
+N_ANCHORS = 5
+
+# Coverage floors, mirroring 9.3 so a solve that passes here cannot be
+# rejected by `seam_metric.check_acceptance` on coverage grounds afterwards.
+MIN_OBSERVATIONS = 8
+MIN_ROW_BANDS = 3
+MIN_HEIGHT_COVERAGE = 0.60
+
+# `dx` enters every observation multiplied by the structure's slope, so with no
+# slope spread the translate term is collinear with the vertical offset. This
+# threshold only catches the degenerate case; the standard-error gate below
+# does the quantitative work. Matches the value `seam_metric` uses before it
+# will report `implied_dx` at all.
+MIN_SLOPE_SPREAD = 0.02
+
+# The gate that matters. 10 stops iterating at `SCR p90 < 1.0 px`; a fit whose
+# own uncertainty exceeds the target it is aiming at has not measured anything.
+MAX_DX_STDERR_PX = 1.0
+
+# Sub-pixel edge localisation floor. `seam_metric._edge_positions` refines each
+# peak with a parabola through three samples, which is good to well under a
+# pixel but not to zero -- and a fit_rms of exactly 0 (synthetic input) would
+# otherwise claim infinite weight.
+MIN_FIT_SIGMA_PX = 0.05
+
+
+class SolverRefused(Exception):
+    """The evidence does not support a calibration.
+
+    Carries `.reasons` (every failed condition, not just the first) and
+    `.report` (the 10 measurement report: coverage plus every observation
+    found, so the operator can start Workflow B from real numbers).
+    """
+
+    def __init__(self, reasons: list[str], report: dict):
+        super().__init__("; ".join(reasons))
+        self.reasons = reasons
+        self.report = report
+
+
+@dataclass
+class Observation:
+    """One structure crossing the seam, in one frame."""
+
+    y: float
+    slope: float
+    residual_y: float
+    span_px: int
+    fit_rms: float
+    variance: float
+    frame: int = 0
+
+
+@dataclass
+class SolveResult:
+    anchors: list[tuple[int, float]] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+
+# -- observations -------------------------------------------------------------
+
+
+def _observation_variance(span_px: float, fit_rms: float, blend_w: int) -> float:
+    """Variance of one `r_y`, dominated by extrapolation across the blend window.
+
+    For an OLS line fitted to N points uniformly spanning length L, evaluated a
+    distance D from the span's centroid, `Var = sigma^2 * (1/N + D^2/Sxx)` with
+    `Sxx = N*L^2/12`. `seam_metric._chains` seeds at the blend edge and walks
+    outward one column at a time, so N ~ L and the centroid sits `L/2` beyond
+    the blend edge: `D = blend_w/2 + L/2`. Both shoulders contribute, and
+    `r_y` is their difference, so the variances add.
+
+    This is why a short chain is nearly worthless even when it fits perfectly:
+    halving L doubles `1/L` and quadruples `D^2/L^2`.
+    """
+    sigma = max(float(fit_rms), MIN_FIT_SIGMA_PX)
+    length = max(float(span_px), 2.0)
+    d = blend_w / 2.0 + length / 2.0
+    per_side = (sigma * sigma / length) * (1.0 + 12.0 * d * d / (length * length))
+    return 2.0 * per_side
+
+
+def collect_observations(
+    frames: list[np.ndarray],
+    *,
+    seam_x: int = SEAM_X,
+    blend_w: int = BLEND_W,
+    shoulder_w: int = SHOULDER_W,
+    band: tuple[int, int] | None = None,
+    **scr_kwargs,
+) -> tuple[list[Observation], list[int], tuple[int, int]]:
+    """Run `seam_continuity_residual` over every frame and pool the results.
+
+    Pooling across frames rather than within one is the whole point (10): a
+    90-minute game is ~108,000 frames and no single frame needs to be good. It
+    also means per-frame coverage is irrelevant -- only the pooled design
+    matters -- and it lets the robust loss see a moving object as the outlier
+    it is, because a player contributes an observation that disagrees with the
+    static structure around it.
+    """
+    if not frames:
+        raise ValueError("no frames")
+    shapes = {f.shape[:2] for f in frames}
+    if len(shapes) != 1:
+        raise ValueError(f"frames must share one geometry, got {sorted(shapes)}")
+    height = frames[0].shape[0]
+    band = band or default_band(height)
+
+    obs: list[Observation] = []
+    per_frame: list[int] = []
+    for i, frame in enumerate(frames):
+        scr = seam_continuity_residual(
+            frame,
+            seam_x=seam_x,
+            blend_w=blend_w,
+            shoulder_w=shoulder_w,
+            band=band,
+            **scr_kwargs,
+        )
+        per_frame.append(scr.n)
+        for o in scr.observations:
+            obs.append(
+                Observation(
+                    y=0.5 * (o.y_left + o.y_right),
+                    slope=o.slope,
+                    residual_y=o.residual_y,
+                    span_px=o.span_px,
+                    fit_rms=o.fit_rms,
+                    variance=_observation_variance(o.span_px, o.fit_rms, blend_w),
+                    frame=i,
+                )
+            )
+    return obs, per_frame, band
+
+
+def coverage_of(
+    observations: list[Observation],
+    band: tuple[int, int],
+    n_frames: int,
+    per_frame: list[int],
+) -> dict:
+    """Per-band coverage, so a caller can see *why* a fit was taken or refused.
+
+    Row bands and height coverage use the same definitions as
+    `seam_metric.ScrResult`, so the numbers here and the ones
+    `check_acceptance` gates on are the same numbers.
+    """
+    y0, y1 = band
+    height = y1 - y0
+    ys = np.array([o.y for o in observations], dtype=float)
+    slopes = np.array([o.slope for o in observations], dtype=float)
+    counts = [0] * MIN_ROW_BANDS
+    for y in ys:
+        idx = int((y - y0) / height * MIN_ROW_BANDS)
+        counts[min(max(idx, 0), MIN_ROW_BANDS - 1)] += 1
+    return {
+        "n": len(observations),
+        "n_frames": n_frames,
+        "n_frames_contributing": sum(1 for c in per_frame if c),
+        "observations_per_frame": per_frame,
+        "band": [int(y0), int(y1)],
+        "row_band_counts": counts,
+        "row_bands_covered": sum(1 for c in counts if c),
+        "row_bands": MIN_ROW_BANDS,
+        "height_coverage": float((ys.max() - ys.min()) / height)
+        if len(ys) > 1
+        else 0.0,
+        "y_min": float(ys.min()) if len(ys) else None,
+        "y_max": float(ys.max()) if len(ys) else None,
+        "slope_min": float(slopes.min()) if len(ys) else None,
+        "slope_max": float(slopes.max()) if len(ys) else None,
+        "slope_spread": float(slopes.max() - slopes.min()) if len(ys) > 1 else 0.0,
+        "median_span_px": float(np.median([o.span_px for o in observations]))
+        if observations
+        else None,
+    }
+
+
+# -- the joint robust fit -----------------------------------------------------
+
+
+def _design(observations: list[Observation], y_ref: float, y_half: float) -> np.ndarray:
+    m = np.array([o.slope for o in observations], dtype=float)
+    t = np.array([(o.y - y_ref) / y_half for o in observations], dtype=float)
+    return np.column_stack([np.ones_like(m), m, m * t])
+
+
+def _irls(
+    a: np.ndarray, r: np.ndarray, prior_w: np.ndarray, iters: int = 20
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+    """Weighted least squares with a Huber redescent on top of the prior weights.
+
+    The prior weights are true inverse variances from `_observation_variance`,
+    so the robust scale is estimated in *standardised* units and floored at 1.0:
+    if the residuals already sit inside the noise the model predicts, nothing is
+    down-weighted. Without that floor a synthetic fixture (or a genuinely clean
+    game) collapses the scale to ~0 and the loss starts rejecting good data.
+
+    The returned scale is the dispersion estimate the covariance uses. It has to
+    be the *robust* one: a plain reduced chi-square counts each rejected
+    observation's full residual, so three players crossing the seam would widen
+    the error bar until the solver refused data it had correctly cleaned. A
+    median-based scale ignores them, which is the entire point of rejecting
+    them, while still growing when the *bulk* of the data misfits the model.
+    """
+    sigma = 1.0 / np.sqrt(prior_w)
+    w = prior_w.copy()
+    beta = np.zeros(a.shape[1])
+    resid = r.copy()
+    scale = 1.0
+    for _ in range(iters):
+        aw = a * w[:, None]
+        beta, *_ = np.linalg.lstsq(a.T @ aw, aw.T @ r, rcond=None)
+        resid = r - a @ beta
+        z = resid / sigma
+        scale = max(1.4826 * float(np.median(np.abs(z))), 1.0)
+        huber = np.clip(1.345 * scale / np.maximum(np.abs(z), 1e-9), 0.0, 1.0)
+        w = prior_w * huber
+    return beta, resid, w, scale
+
+
+def solve(
+    observations: list[Observation],
+    *,
+    source_width: int,
+    source_height: int,
+    seam_x: int = SEAM_X,
+    blend_w: int = BLEND_W,
+    band: tuple[int, int] | None = None,
+    n_frames: int = 1,
+    per_frame: list[int] | None = None,
+    frame_labels: list[str] | None = None,
+    n_anchors: int = N_ANCHORS,
+    min_observations: int = MIN_OBSERVATIONS,
+    min_row_bands: int = MIN_ROW_BANDS,
+    min_height_coverage: float = MIN_HEIGHT_COVERAGE,
+    min_slope_spread: float = MIN_SLOPE_SPREAD,
+    max_dx_stderr: float = MAX_DX_STDERR_PX,
+    max_abs_dx: float = MAX_ABS_DX_PX,
+) -> SolveResult:
+    """Fit `dx(y) = a + b*(y - y_ref)` jointly, or refuse and say what was missing.
+
+    Raises `SolverRefused` -- never returns a curve it cannot support. A
+    warning printed into a log no chain reads is not a guard, and a fabricated
+    calibration is worse than none because it gets applied to the camera and
+    then trusted.
+    """
+    band = band or default_band(source_height)
+    per_frame = per_frame if per_frame is not None else [len(observations)]
+    cov_info = (
+        coverage_of(observations, band, n_frames, per_frame)
+        if observations
+        else {
+            "n": 0,
+            "n_frames": n_frames,
+            "n_frames_contributing": 0,
+            "observations_per_frame": per_frame,
+            "band": [int(band[0]), int(band[1])],
+            "row_band_counts": [0] * MIN_ROW_BANDS,
+            "row_bands_covered": 0,
+            "row_bands": MIN_ROW_BANDS,
+            "height_coverage": 0.0,
+            "y_min": None,
+            "y_max": None,
+            "slope_min": None,
+            "slope_max": None,
+            "slope_spread": 0.0,
+            "median_span_px": None,
+        }
+    )
+
+    base = {
+        "solver": TOOL_VERSION,
+        "source_width": int(source_width),
+        "source_height": int(source_height),
+        "seam_x": int(seam_x),
+        "blend_window": [seam_x - blend_w // 2, seam_x + blend_w // 2],
+        "coverage": cov_info,
+        "provenance": {
+            "workflow": "automated",
+            "frames": frame_labels or [],
+            "created_utc": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "tool_version": TOOL_VERSION,
+        },
+    }
+
+    reasons: list[str] = []
+    if cov_info["n"] < min_observations:
+        reasons.append(
+            f"only {cov_info['n']} accepted structures across {n_frames} frame(s) "
+            f"(need {min_observations})"
+        )
+    if cov_info["row_bands_covered"] < min_row_bands:
+        reasons.append(
+            f"structures span {cov_info['row_bands_covered']} of {min_row_bands} row "
+            f"bands (counts {cov_info['row_band_counts']})"
+        )
+    if cov_info["height_coverage"] < min_height_coverage:
+        reasons.append(
+            f"structures cover {cov_info['height_coverage'] * 100:.0f}% of the field "
+            f"band, need {min_height_coverage * 100:.0f}%"
+        )
+    if cov_info["slope_spread"] <= min_slope_spread:
+        reasons.append(
+            f"every structure found has effectively the same slope (spread "
+            f"{cov_info['slope_spread']:.3f}); dx enters each observation only "
+            "through the slope, so it is not observable from this data at any n"
+        )
+    if reasons:
+        raise SolverRefused(
+            reasons, {**base, "observations": [asdict(o) for o in observations]}
+        )
+
+    y_ref = source_height / 2.0
+    y_half = source_height / 2.0
+    a = _design(observations, y_ref, y_half)
+    r = np.array([o.residual_y for o in observations], dtype=float)
+    prior_w = np.array([1.0 / o.variance for o in observations], dtype=float)
+
+    normal = a.T @ (a * prior_w[:, None])
+    cond = float(np.linalg.cond(normal))
+    if not np.isfinite(cond) or cond > 1e12:
+        raise SolverRefused(
+            [
+                f"the observation geometry is singular (condition number {cond:.3g}); "
+                "the structures found do not constrain a translate and a shear "
+                "independently"
+            ],
+            {**base, "observations": [asdict(o) for o in observations]},
+        )
+
+    beta, resid, w, scale = _irls(a, r, prior_w)
+    dof = max(len(observations) - a.shape[1], 1)
+    chi2 = float(np.sum(w * resid * resid))
+    # Floored at 1.0: if the data fit *better* than the noise model predicts,
+    # that is not licence to claim more precision than the model supports.
+    s2 = max(scale * scale, 1.0)
+    try:
+        cov_beta = s2 * np.linalg.inv(a.T @ (a * w[:, None]))
+    except np.linalg.LinAlgError as exc:  # pragma: no cover - cond gate catches it
+        raise SolverRefused(
+            [f"normal equations are not invertible: {exc}"],
+            {**base, "observations": [asdict(o) for o in observations]},
+        ) from exc
+
+    dy_px, a_px, b_scaled = (float(v) for v in beta)
+    b_px_per_row = b_scaled / y_half
+
+    rows = np.unique(np.round(np.linspace(0, source_height - 1, n_anchors)).astype(int))
+    dx_raw = [a_px + b_scaled * ((y - y_ref) / y_half) for y in rows]
+    stderr = []
+    for y in rows:
+        c = np.array([0.0, 1.0, (y - y_ref) / y_half])
+        stderr.append(float(np.sqrt(max(c @ cov_beta @ c, 0.0))))
+
+    # Quantise to the mesh's own resolution. Q14.2 is a quarter pixel
+    # (`lut2d.FRAC_BITS`); anything finer cannot reach the camera, and pretending
+    # otherwise only makes the artifact look more precise than the surface it
+    # drives.
+    dx_q = [round(v * FRAC_SCALE) / FRAC_SCALE for v in dx_raw]
+    anchors = [(int(y), float(d)) for y, d in zip(rows, dx_q, strict=True)]
+
+    ss_res = float(np.sum(w * resid * resid))
+    r_mean = float(np.sum(w * r) / np.sum(w))
+    ss_tot = float(np.sum(w * (r - r_mean) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+
+    findings: list[str] = []
+    # 5.2 / 10: is `dx(y)` actually linear in y? A relative lens roll says it
+    # must be, and if it is the mesh's 8.44-row control spacing loses nothing.
+    # A significant quadratic term is a finding about the camera, not licence
+    # for this solver to fit a curve -- that needs a human look first.
+    quad_t = None
+    if len(observations) >= 8:
+        t = np.array([(o.y - y_ref) / y_half for o in observations])
+        m = np.array([o.slope for o in observations])
+        a4 = np.column_stack([a, m * t * t])
+        try:
+            xtwx4 = a4.T @ (a4 * w[:, None])
+            beta4 = np.linalg.solve(xtwx4, (a4 * w[:, None]).T @ r)
+            resid4 = r - a4 @ beta4
+            z4 = resid4 * np.sqrt(prior_w)
+            s2_4 = max((1.4826 * float(np.median(np.abs(z4)))) ** 2, 1.0)
+            se4 = float(np.sqrt(s2_4 * np.linalg.inv(xtwx4)[3, 3]))
+            quad_t = float(beta4[3]) / se4 if se4 > 0 else None
+        except np.linalg.LinAlgError:
+            quad_t = None
+    if quad_t is not None and abs(quad_t) > 3.0:
+        findings.append(
+            f"dx(y) may not be linear in y: a quadratic term is {abs(quad_t):.1f} sigma "
+            "from zero. A rigid relative roll cannot do that (2), so this is a "
+            "finding about the camera and needs explaining before it ships. The "
+            "emitted anchors are still the straight-line fit."
+        )
+
+    # The roll cross-check, free from the same fit. 2: a relative roll theta
+    # displaces a point at (X, Y) by theta*(-Y, +X), so at the seam column
+    # X = source_width/4 from the half's optical centre the same theta that
+    # produces the shear must also produce a constant `dy = b * X`.
+    x_seam_from_centre = source_width / 4.0
+    dy_predicted = b_px_per_row * x_seam_from_centre
+    dy_se = float(np.sqrt(max(cov_beta[0, 0], 0.0)))
+    if dy_se > 0 and abs(dy_px - dy_predicted) > 3.0 * dy_se + 1.0:
+        findings.append(
+            f"the measured vertical offset ({dy_px:+.2f} px) disagrees with the "
+            f"{dy_predicted:+.2f} px a pure relative roll of this shear would "
+            "produce. Something other than roll contributes -- relative pitch, "
+            "or parallax at a depth away from the stitch calibration (12.1). "
+            "dx is still what the surfaces correct; dy is not emitted (4.2)."
+        )
+
+    max_stderr = max(stderr)
+    worst_dx = max(abs(d) for d in dx_q)
+    late: list[str] = []
+    if max_stderr > max_dx_stderr:
+        late.append(
+            f"dx is uncertain to +/-{max_stderr:.2f} px at the anchor rows (limit "
+            f"{max_dx_stderr:.2f} px). The structures found do not pin the curve: "
+            f"{cov_info['n']} observations, slope spread "
+            f"{cov_info['slope_spread']:.3f}, row-band counts "
+            f"{cov_info['row_band_counts']}, condition number {cond:.3g}"
+        )
+    if worst_dx > max_abs_dx:
+        late.append(
+            f"fitted |dx| reaches {worst_dx:.1f} px, past the {max_abs_dx:.0f} px "
+            "limit nothing physical needs -- treat this as a detector failure, "
+            "not a badly aligned camera"
+        )
+    if any(anchors[i][0] <= anchors[i - 1][0] for i in range(1, len(anchors))):
+        late.append("anchor rows are not strictly increasing")
+
+    fit = {
+        "model": "dx(y) = a + b*(y - y_ref)",
+        "y_ref": y_ref,
+        "a_px": a_px,
+        "b_px_per_row": b_px_per_row,
+        "roll_theta_rad": b_px_per_row,
+        "dy_px": dy_px,
+        "dy_predicted_from_roll_px": dy_predicted,
+        "stderr_a_px": float(np.sqrt(max(cov_beta[1, 1], 0.0))),
+        "stderr_b_px_per_row": float(np.sqrt(max(cov_beta[2, 2], 0.0))) / y_half,
+        "stderr_dy_px": dy_se,
+        "max_anchor_stderr_px": max_stderr,
+        "condition_number": cond,
+        # Both dispersions are reported. The robust one sets the error bars; a
+        # chi2/dof much larger than robust_scale^2 is the signature of a few
+        # wild observations rather than a bad model, and is worth seeing.
+        "robust_scale": scale,
+        "chi2_per_dof": chi2 / dof,
+        "weighted_r2": float(r2),
+        "residual_rms_px": float(np.sqrt(np.mean(resid**2))),
+        "max_residual_px": float(np.max(np.abs(resid))),
+        "n_downweighted": int(np.sum(w < 0.5 * prior_w)),
+        "quadratic_term_sigma": quad_t,
+    }
+    meta = {
+        **base,
+        "sense": {
+            "dx_means": (
+                "px the RIGHT half must move right, at row y, to register with the left"
+            ),
+            "downstream_moves": "right_half",
+            "camera_mesh_moves": "left_half_with_opposite_sense",
+        },
+        "units": (
+            "anchors are [row, dx] in the source-pixel units of the frames measured "
+            f"({source_width}x{source_height}); build_dx_lookup rescales them to the "
+            "actual frame"
+        ),
+        "quantum_px": 1.0 / FRAC_SCALE,
+        "fit": fit,
+        "anchor_stderr_px": stderr,
+        "downstream_projection": [[int(y), int(round(d))] for y, d in anchors],
+        "findings": findings,
+        "refused": None,
+    }
+
+    if late:
+        raise SolverRefused(
+            late,
+            {
+                **meta,
+                "refused": late,
+                "provisional_anchors": [[y, d] for y, d in anchors],
+                "observations": [asdict(o) for o in observations],
+            },
+        )
+    return SolveResult(anchors=anchors, metadata=meta)
+
+
+def solve_from_frames(
+    frames: list[np.ndarray],
+    *,
+    seam_x: int = SEAM_X,
+    blend_w: int = BLEND_W,
+    shoulder_w: int = SHOULDER_W,
+    band: tuple[int, int] | None = None,
+    frame_labels: list[str] | None = None,
+    scr_kwargs: dict | None = None,
+    **solve_kwargs,
+) -> SolveResult:
+    """`collect_observations` then `solve`, which is the whole of Workflow A."""
+    obs, per_frame, band = collect_observations(
+        frames,
+        seam_x=seam_x,
+        blend_w=blend_w,
+        shoulder_w=shoulder_w,
+        band=band,
+        **(scr_kwargs or {}),
+    )
+    h, w = frames[0].shape[:2]
+    return solve(
+        obs,
+        source_width=w,
+        source_height=h,
+        seam_x=seam_x,
+        blend_w=blend_w,
+        band=band,
+        n_frames=len(frames),
+        per_frame=per_frame,
+        frame_labels=frame_labels,
+        **solve_kwargs,
+    )
+
+
+# -- validating the downstream projection -------------------------------------
+
+
+def holdout_split(n: int, every: int = 4) -> tuple[list[int], list[int]]:
+    """Deterministic solve/hold-out split. 9.3 condition 4.
+
+    Every `every`-th frame is held out. Deterministic rather than random so a
+    re-run of the same footage reproduces the same numbers; taking a stride
+    rather than a contiguous tail so the hold-out spans the same span of the
+    game as the solve set, and not just its last minutes.
+    """
+    hold = list(range(0, n, every))
+    solve_idx = [i for i in range(n) if i not in set(hold)]
+    return solve_idx, hold
+
+
+def apply_anchors_downstream(
+    frame: np.ndarray,
+    anchors: list[tuple[int, float]],
+    *,
+    source_width: int,
+    source_height: int,
+    seam_x: int,
+) -> np.ndarray:
+    """Apply the anchors with the *shipped* downstream corrector.
+
+    Deliberately the real `video_grouper.utils.stitch_remap` and not a local
+    reimplementation: this is the check that the emitted sign is the sign that
+    module consumes, and a private copy of the shift would prove nothing. The
+    import is lazy and path-relative for the same reason `stitch_apply.py`
+    reaches into `runtime/` -- this directory is a standalone script tree, not
+    a package, and must stay importable without the app installed.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from video_grouper.utils.stitch_remap import (
+        StitchProfile,
+        apply_shift_to_frame_rgb,
+        build_dx_lookup,
+    )
+
+    profile = StitchProfile(
+        source_width=source_width,
+        source_height=source_height,
+        seam_x=seam_x,
+        dx_anchors=[(int(y), int(round(d))) for y, d in anchors],
+    )
+    h, w = frame.shape[:2]
+    lookup = build_dx_lookup(profile, w, h)
+    scaled_seam = int(round(seam_x * w / source_width))
+    return apply_shift_to_frame_rgb(frame, lookup, scaled_seam)
+
+
+def _pool(measures: list[dict]) -> dict:
+    """Pool per-frame `seam_metric.measure` reports into one before/after dict.
+
+    Percentiles are recomputed over the pooled observation count rather than
+    averaged, because averaging p90s across frames is not a p90 of anything.
+    """
+    n = sum(m["scr"]["n"] for m in measures)
+    weighted = [m for m in measures if m["scr"]["n"]]
+    if weighted:
+        p50 = float(np.median([m["scr"]["p50"] for m in weighted]))
+        p90 = float(np.percentile([m["scr"]["p90"] for m in weighted], 90))
+        mx = float(max(m["scr"]["max"] for m in weighted))
+        bands = max(m["scr"]["row_bands_covered"] for m in weighted)
+        covh = float(max(m["scr"]["height_coverage"] for m in weighted))
+    else:
+        p50 = p90 = mx = float("nan")
+        bands, covh = 0, 0.0
+    return {
+        "scr": {
+            "n": n,
+            "p50": p50,
+            "p90": p90,
+            "max": mx,
+            "row_bands_covered": bands,
+            "height_coverage": covh,
+        },
+        "ssr": {
+            "abs_ln_ssr": float(np.mean([m["ssr"]["abs_ln_ssr"] for m in measures])),
+            "noise_floor": measures[0]["ssr"]["noise_floor"],
+        },
+    }
+
+
+def validate_downstream(
+    frames: list[np.ndarray],
+    anchors: list[tuple[int, float]],
+    *,
+    source_width: int,
+    source_height: int,
+    seam_x: int = SEAM_X,
+    blend_w: int = BLEND_W,
+) -> dict:
+    """Measure hold-out frames before and after the downstream projection.
+
+    Returns the two dicts `seam_metric.check_acceptance` wants. Call it with
+    `camera_side_owner=False`: a post-fusion shift genuinely improves SCR but
+    cannot restore gradient energy the blend already destroyed, so demanding an
+    SSR improvement from *this* surface would fail a correct correction. Only a
+    camera-side owner is held to that.
+    """
+    before = [measure(f, seam_x=seam_x, blend_w=blend_w) for f in frames]
+    after = [
+        measure(
+            apply_anchors_downstream(
+                f,
+                anchors,
+                source_width=source_width,
+                source_height=source_height,
+                seam_x=seam_x,
+            ),
+            seam_x=seam_x,
+            blend_w=blend_w,
+        )
+        for f in frames
+    ]
+    return {"before": _pool(before), "after": _pool(after)}
+
+
+# -- CLI ----------------------------------------------------------------------
+
+
+def _print_report(report: dict) -> None:
+    cov = report["coverage"]
+    print("  coverage")
+    print(
+        f"    {cov['n']} observation(s) from {cov['n_frames_contributing']}"
+        f"/{cov['n_frames']} frame(s); per frame {cov['observations_per_frame']}"
+    )
+    print(
+        f"    row bands {cov['row_bands_covered']}/{cov['row_bands']}"
+        f"  counts {cov['row_band_counts']}"
+        f"  height {cov['height_coverage'] * 100:.0f}%"
+    )
+    if cov["slope_min"] is not None:
+        print(
+            f"    slopes {cov['slope_min']:+.3f}..{cov['slope_max']:+.3f}"
+            f"  (spread {cov['slope_spread']:.3f})"
+            f"  median span {cov['median_span_px']:.0f} px"
+        )
+    obs = report.get("observations") or []
+    if obs:
+        print("  observations (row, slope, seam break px, span, fit rms, frame)")
+        for o in sorted(obs, key=lambda d: d["y"]):
+            print(
+                f"    {o['y']:8.1f}  {o['slope']:+.4f}  {o['residual_y']:+7.2f}"
+                f"  {o['span_px']:4d}  {o['fit_rms']:.2f}  f{o['frame']}"
+            )
+
+
+def main(argv: list[str]) -> int:
+    paths = [a for a in argv[1:] if not a.startswith("--")]
+    flags = {a for a in argv[1:] if a.startswith("--")}
+    seam = SEAM_X
+    for a in argv[1:]:
+        if a.startswith("--seam-x="):
+            seam = int(a.split("=", 1)[1])
+    if not paths:
+        print(__doc__)
+        return 2
+
+    frames, labels = [], []
+    for p in paths:
+        img = cv2.imread(p, cv2.IMREAD_COLOR)
+        if img is None:
+            print(f"cannot read {p}")
+            return 2
+        frames.append(img)
+        labels.append(Path(p).name)
+
+    try:
+        result = solve_from_frames(frames, seam_x=seam, frame_labels=labels)
+    except SolverRefused as exc:
+        if "--json" in flags:
+            print(json.dumps({"refused": exc.reasons, "report": exc.report}, indent=2))
+            return 1
+        print("REFUSED -- no calibration emitted")
+        for why in exc.reasons:
+            print(f"  * {why}")
+        _print_report(exc.report)
+        print(
+            "\n  This is the measurement report (10, step 3): start Workflow B "
+            "from these numbers, or place a deliberate target across the seam "
+            "and re-shoot."
+        )
+        return 1
+
+    out = {"dx_anchors": [[y, d] for y, d in result.anchors], **result.metadata}
+    if "--validate" in flags and len(frames) >= 4:
+        _, hold = holdout_split(len(frames))
+        out["validation"] = validate_downstream(
+            [frames[i] for i in hold],
+            result.anchors,
+            source_width=result.metadata["source_width"],
+            source_height=result.metadata["source_height"],
+            seam_x=seam,
+        )
+        out["validation"]["surface"] = "downstream"
+        out["validation"]["frames_holdout"] = [labels[i] for i in hold]
+
+    if "--json" in flags:
+        print(json.dumps(out, indent=2))
+        return 0
+
+    fit = result.metadata["fit"]
+    print(f"dx_anchors  {[[y, d] for y, d in result.anchors]}")
+    print(
+        f"  dx(y) = {fit['a_px']:+.2f} {fit['b_px_per_row']:+.5f}*(y - "
+        f"{fit['y_ref']:.0f})  +/-{fit['max_anchor_stderr_px']:.2f} px"
+    )
+    print(
+        f"  roll {fit['roll_theta_rad'] * 1000:+.3f} mrad   dy {fit['dy_px']:+.2f} px "
+        f"(roll predicts {fit['dy_predicted_from_roll_px']:+.2f})"
+    )
+    print(
+        f"  weighted r2 {fit['weighted_r2']:.3f}  residual rms "
+        f"{fit['residual_rms_px']:.2f} px  chi2/dof {fit['chi2_per_dof']:.2f}"
+        f"  downweighted {fit['n_downweighted']}"
+    )
+    _print_report({**result.metadata, "observations": []})
+    for f in result.metadata["findings"]:
+        print(f"  FINDING: {f}")
+    if "validation" in out:
+        v = out["validation"]
+        print(
+            f"  hold-out (downstream projection): SCR p90 "
+            f"{v['before']['scr']['p90']:.2f} -> {v['after']['scr']['p90']:.2f} px"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/reolink-firmware-patching/vpe/stitch_solver.py
+++ b/reolink-firmware-patching/vpe/stitch_solver.py
@@ -77,9 +77,32 @@ Note that `seam_metric.ScrResult.implied_dx` is reported in the OPPOSITE sense
 half currently carries, not the correction for it. This module does not use it;
 `tests/test_stitch_solver.py` pins the relationship so the trap stays visible.
 
+MEASURED VERDICT ON THIS OBJECTIVE (27 archived Duo 3 games, 2026-08-17).
+
+It does not work on fused game footage, and the reason is structural rather than
+a matter of tuning. On a soccer field almost everything crossing a vertical seam
+runs horizontally, and a horizontal edge is invariant under a horizontal shift:
+over 4239 archived observations the median |slope| is 0.034, so a 10 px
+misregistration moves the median observation 0.34 px -- under its own noise. A
+structure has to span the blend window in x to be usable at all, which is
+exactly what forces it to be near-horizontal, so the admissible features and the
+informative features barely overlap.
+
+Swept on real frames, the objective moves 4-22% across +/-32 px, usually with
+its best score at a sweep endpoint, and on one frame a deliberate 32 px break
+scored BETTER than the untouched frame. Selecting frames rich in vertical
+structure at the seam does not help: a person at the seam sits INSIDE the blend
+window, where the two sensors' views are already superposed, so there is no
+left/right pair to extrapolate and compare. That information is real but it is
+an echo-separation problem, not this one. See docs/STITCH_CALIBRATION.md 10.2.
+
+Hence `sweep_dx` / `require_responsive_objective` below: no curve is trustworthy
+until the objective is shown to respond to the parameter being solved for, and
+no count-and-coverage gate can stand in for that.
+
 CLI:
     python stitch_solver.py <frame.jpg> [more.jpg ...] [--seam-x=N] [--json]
-                            [--validate]
+                            [--validate] [--sweep]
 Exit 0 on a fit, 1 on a refusal (with the measurement report), 2 on usage.
 """
 
@@ -87,6 +110,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -119,6 +143,24 @@ MIN_OBSERVATIONS = 8
 MIN_ROW_BANDS = 3
 MIN_HEIGHT_COVERAGE = 0.60
 
+# ...and one floor 9.3 does not have, added because 27 games of real footage
+# walked straight through the ones it does. `height_coverage` is a RANGE --
+# (y_max - y_min) / band -- so two stragglers at the extremes satisfy it while
+# every other observation sits in one place. Measured on the archive: range
+# coverage read 81-98% on 24 of 27 games while 73-98% of the observation MASS
+# was in the top row band, and the smallest band's share never exceeded 9.2%.
+# Leverage comes from mass, not from extremes, so the gate has to weigh mass.
+MIN_ROW_BAND_FRACTION = 0.10
+
+# Two frames minimum, so the estimate can be asked twice. The failure that
+# actually bites on game footage is not too little structure -- it is too much
+# false structure: `seam_metric`'s matcher pairs any left/right pair whose
+# extrapolations land within 40 px, and a crowd at mixed depths supplies plenty.
+# Those pass every count-and-coverage condition. They do NOT repeat across
+# frames, because they are re-drawn each time, so cross-frame agreement is the
+# cheap discriminator (see `_frame_consistency`).
+MIN_CONTRIBUTING_FRAMES = 2
+
 # `dx` enters every observation multiplied by the structure's slope, so with no
 # slope spread the translate term is collinear with the vertical offset. This
 # threshold only catches the degenerate case; the standard-error gate below
@@ -129,6 +171,11 @@ MIN_SLOPE_SPREAD = 0.02
 # The gate that matters. 10 stops iterating at `SCR p90 < 1.0 px`; a fit whose
 # own uncertainty exceeds the target it is aiming at has not measured anything.
 MAX_DX_STDERR_PX = 1.0
+
+# Each half of the cross-frame check carries about half the data, so allow it a
+# looser bar than the full fit -- but only a looser one. Past this the halves
+# are not estimates, and comparing them proves nothing (see `_frame_consistency`).
+MAX_HALF_STDERR_PX = 3.0
 
 # Sub-pixel edge localisation floor. `seam_metric._edge_positions` refines each
 # peak with a parabola through three samples, which is good to well under a
@@ -269,10 +316,16 @@ def coverage_of(
     return {
         "n": len(observations),
         "n_frames": n_frames,
-        "n_frames_contributing": sum(1 for c in per_frame if c),
+        # Counted from the observations themselves, not from the caller's
+        # per-frame tally: `solve` can be handed observations directly, and a
+        # gate that depends on a bookkeeping argument is a gate that can be
+        # satisfied by passing the right argument.
+        "n_frames_contributing": len({o.frame for o in observations}),
         "observations_per_frame": per_frame,
         "band": [int(y0), int(y1)],
         "row_band_counts": counts,
+        "row_band_fractions": [round(c / max(len(ys), 1), 4) for c in counts],
+        "min_row_band_fraction": min(counts) / max(len(ys), 1),
         "row_bands_covered": sum(1 for c in counts if c),
         "row_bands": MIN_ROW_BANDS,
         "height_coverage": float((ys.max() - ys.min()) / height)
@@ -332,6 +385,177 @@ def _irls(
     return beta, resid, w, scale
 
 
+def _constant_dx(
+    observations: list[Observation], residuals: np.ndarray | None = None
+) -> tuple[float, float] | None:
+    """Fit a single whole-frame `dx` to a subset: `r_y = dy + m*dx`.
+
+    Two parameters, so it needs slope spread but no y spread at all. That is
+    exactly what the split-half depth check needs: each half spans too few rows
+    to determine a shear, but each can say what the seam offset *is* over its
+    own rows. Returns `(dx, stderr)`, or None if the subset cannot support even
+    that.
+    """
+    if len(observations) < 4:
+        return None
+    m = np.array([o.slope for o in observations], dtype=float)
+    if float(m.max() - m.min()) <= MIN_SLOPE_SPREAD:
+        return None
+    a = np.column_stack([np.ones_like(m), m])
+    r = (
+        np.array([o.residual_y for o in observations], dtype=float)
+        if residuals is None
+        else np.asarray(residuals, dtype=float)
+    )
+    prior_w = np.array([1.0 / o.variance for o in observations], dtype=float)
+    try:
+        beta, _resid, w, scale = _irls(a, r, prior_w)
+        cov = max(scale * scale, 1.0) * np.linalg.inv(a.T @ (a * w[:, None]))
+    except np.linalg.LinAlgError:
+        return None
+    return float(beta[1]), float(np.sqrt(max(cov[1, 1], 0.0)))
+
+
+def _frame_consistency(
+    observations: list[Observation],
+    *,
+    b_scaled: float = 0.0,
+    y_ref: float = 0.0,
+    y_half: float = 1.0,
+) -> dict | None:
+    """Do independent halves of the footage agree on the seam offset?
+
+    The gate that catches the failure the coverage conditions cannot. On a busy
+    scene at mixed depths, `seam_metric`'s matcher pairs any left and right
+    structure whose extrapolations land within `max_gap` (40 px) of each other,
+    and a crowd, a treeline and a car park supply plenty of pairs that are not
+    the same structure. Those false observations pass every count-and-coverage
+    condition in 9.3 -- there are lots of them, they are spread over the
+    height, they have varied slopes -- and they are *noise dressed as data*.
+
+    Formal standard errors do not always catch that, because they are computed
+    against a noise model that assumes the pairings are real. Splitting by FRAME
+    does: false pairings are re-drawn independently in every frame, so their
+    contribution does not repeat, while a genuine seam offset is the same in
+    every frame of a fixed camera. Two subsets that disagree by more than their
+    error bars mean the estimate does not survive being asked twice.
+
+    This is 9.3 condition 4 -- "measured on held-out frames" -- applied to the
+    solve rather than only to the acceptance check, and it is why a single frame
+    is not enough to calibrate from.
+
+    A constant-`dx` fit is used per half: it needs slope spread but no y spread,
+    both halves see the same scene so the comparison is like for like, and it
+    cannot fail for want of leverage the way the three-parameter model can.
+    """
+    frames = sorted({o.frame for o in observations})
+    if len(frames) < 2:
+        return None
+    rank = {f: i for i, f in enumerate(frames)}
+
+    def half(parity):
+        sel = [o for o in observations if rank[o.frame] % 2 == parity]
+        # Remove the pooled shear before fitting a constant offset. Both halves
+        # see the same rows, so the bias would cancel in the difference anyway
+        # -- but leaving it in inflates each half's own robust scale, and the
+        # precision precondition below would then reject a perfectly consistent
+        # pair for a misfit the model already explains.
+        res = np.array(
+            [o.residual_y - b_scaled * o.slope * ((o.y - y_ref) / y_half) for o in sel],
+            dtype=float,
+        )
+        return sel, _constant_dx(sel, res)
+
+    even, a = half(0)
+    odd, b = half(1)
+    if a is None or b is None:
+        return {
+            "checked": False,
+            "why": "one half of the frames cannot support even a constant dx",
+            "n_even": len(even),
+            "n_odd": len(odd),
+        }
+    # Agreement between two numbers that are each unconstrained is not evidence
+    # of anything, and reporting it as agreement turns this gate into a rubber
+    # stamp. Measured on the archive: 22 of 23 games "agreed" while the two
+    # halves differed by up to 242 px, purely because their own error bars ran
+    # to +-100 px. So precision is a precondition for the comparison, not a
+    # separate concern.
+    if max(a[1], b[1]) > MAX_HALF_STDERR_PX:
+        return {
+            "checked": False,
+            "why": (
+                f"each half's own estimate is uncertain to "
+                f"+/-{max(a[1], b[1]):.1f} px (limit {MAX_HALF_STDERR_PX:.1f}); "
+                "two unconstrained numbers agree with each other by default"
+            ),
+            "even_dx_px": a[0],
+            "even_stderr_px": a[1],
+            "odd_dx_px": b[0],
+            "odd_stderr_px": b[1],
+            "n_even": len(even),
+            "n_odd": len(odd),
+        }
+    diff = a[0] - b[0]
+    se = float(np.hypot(a[1], b[1]))
+    return {
+        "checked": True,
+        "even_dx_px": a[0],
+        "even_stderr_px": a[1],
+        "even_n": len(even),
+        "odd_dx_px": b[0],
+        "odd_stderr_px": b[1],
+        "odd_n": len(odd),
+        "difference_px": diff,
+        "difference_stderr_px": se,
+        "agrees": bool(abs(diff) <= 3.0 * se + 1.0),
+    }
+
+
+def _depth_split(observations: list[Observation]) -> dict | None:
+    """What the seam offset is over the far rows, and over the near rows.
+
+    Section 10 asks for observations to be down-weighted by depth mismatch from
+    the field homography. There is no homography here, but on a sideline mount
+    row *is* a proxy for depth -- the far touchline near the top of the frame,
+    the near touchline metres from the lens at the bottom -- so splitting by row
+    gives the operator the two numbers a depth choice needs (12.1), computed
+    rather than guessed.
+
+    Informational only, and it must never be reported as evidence of parallax:
+    a genuine lens roll makes these two halves differ too, because that is
+    precisely what a shear is. The roll/parallax discriminator is `dy`, in
+    `solve`.
+
+    A constant-`dx` fit is used per half deliberately: two parameters need slope
+    spread but no y spread, and neither half spans enough rows to determine a
+    shear of its own.
+    """
+    if len(observations) < 12:
+        return None
+    ys = np.array([o.y for o in observations])
+    cut = float(np.median(ys))
+    far = [o for o in observations if o.y <= cut]
+    near = [o for o in observations if o.y > cut]
+    f, n = _constant_dx(far), _constant_dx(near)
+    if f is None or n is None:
+        return None
+    diff = n[0] - f[0]
+    se = float(np.hypot(f[1], n[1]))
+    return {
+        "cut_row": cut,
+        "far_dx_px": f[0],
+        "far_stderr_px": f[1],
+        "far_n": len(far),
+        "near_dx_px": n[0],
+        "near_stderr_px": n[1],
+        "near_n": len(near),
+        "difference_px": diff,
+        "difference_stderr_px": se,
+        "significant": bool(abs(diff) > 3.0 * se + 1.0),
+    }
+
+
 def solve(
     observations: list[Observation],
     *,
@@ -347,6 +571,8 @@ def solve(
     min_observations: int = MIN_OBSERVATIONS,
     min_row_bands: int = MIN_ROW_BANDS,
     min_height_coverage: float = MIN_HEIGHT_COVERAGE,
+    min_row_band_fraction: float = MIN_ROW_BAND_FRACTION,
+    min_contributing_frames: int = MIN_CONTRIBUTING_FRAMES,
     min_slope_spread: float = MIN_SLOPE_SPREAD,
     max_dx_stderr: float = MAX_DX_STDERR_PX,
     max_abs_dx: float = MAX_ABS_DX_PX,
@@ -370,6 +596,8 @@ def solve(
             "observations_per_frame": per_frame,
             "band": [int(band[0]), int(band[1])],
             "row_band_counts": [0] * MIN_ROW_BANDS,
+            "row_band_fractions": [0.0] * MIN_ROW_BANDS,
+            "min_row_band_fraction": 0.0,
             "row_bands_covered": 0,
             "row_bands": MIN_ROW_BANDS,
             "height_coverage": 0.0,
@@ -412,6 +640,27 @@ def solve(
         reasons.append(
             f"structures cover {cov_info['height_coverage'] * 100:.0f}% of the field "
             f"band, need {min_height_coverage * 100:.0f}%"
+        )
+    if (
+        cov_info["n"]
+        and cov_info["row_bands_covered"] >= min_row_bands
+        and cov_info["min_row_band_fraction"] < min_row_band_fraction
+    ):
+        reasons.append(
+            f"observations reach all {min_row_bands} row bands but are piled into "
+            f"one: shares {[f'{f * 100:.0f}%' for f in cov_info['row_band_fractions']]} "
+            f"(need every band above {min_row_band_fraction * 100:.0f}%). Leverage on "
+            "the shear comes from mass at differing heights, not from two stragglers "
+            "stretching the range"
+        )
+    if cov_info["n"] and cov_info["n_frames_contributing"] < min_contributing_frames:
+        reasons.append(
+            f"only {cov_info['n_frames_contributing']} frame(s) contributed "
+            f"observations (need {min_contributing_frames}). A single frame cannot "
+            "be cross-checked, and the failure that matters on game footage is "
+            "false structure pairings that look like data -- those are re-drawn "
+            "per frame, so agreement across frames is what separates them from a "
+            "real seam offset"
         )
     if cov_info["slope_spread"] <= min_slope_spread:
         reasons.append(
@@ -506,25 +755,87 @@ def solve(
             "emitted anchors are still the straight-line fit."
         )
 
-    # The roll cross-check, free from the same fit. 2: a relative roll theta
-    # displaces a point at (X, Y) by theta*(-Y, +X), so at the seam column
-    # X = source_width/4 from the half's optical centre the same theta that
-    # produces the shear must also produce a constant `dy = b * X`.
+    # WHAT CAUSED THE SHEAR, and why the answer is not in the curve.
+    #
+    # Two mechanisms produce a `dx` linear in y and the curve cannot tell them
+    # apart. Section 2's relative lens roll is one. The other is ground-plane
+    # parallax on a sideline mount: subject distance falls monotonically down
+    # the frame, and for a ground plane `f*b/d` is very nearly linear in row, so
+    # parallax wears the same shape. Section 12.1 has the parallax arithmetic
+    # but does not say it mimics the roll signature; it does, exactly.
+    #
+    # The vertical offset separates them, and it is free. The two lenses sit
+    # side by side, so their parallax is horizontal: it produces dx and NO dy.
+    # A roll `theta` displaces a point at (X, Y) by theta*(-Y, +X), so the same
+    # theta that shears dx must also produce `dy = b * X` at the seam column,
+    # X = source_width/4 from the half's optical centre. Which one the data
+    # supports changes what the calibration MEANS -- a roll correction is valid
+    # at every depth, a parallax correction only at the depth each row happens
+    # to image.
     x_seam_from_centre = source_width / 4.0
     dy_predicted = b_px_per_row * x_seam_from_centre
     dy_se = float(np.sqrt(max(cov_beta[0, 0], 0.0)))
-    if dy_se > 0 and abs(dy_px - dy_predicted) > 3.0 * dy_se + 1.0:
+    shear_px = b_px_per_row * (source_height - 1)
+    shear_se = float(np.sqrt(max(cov_beta[2, 2], 0.0))) / y_half * (source_height - 1)
+    split = _depth_split(observations)
+    consistency = _frame_consistency(
+        observations, b_scaled=b_scaled, y_ref=y_ref, y_half=y_half
+    )
+    mechanism = None
+    if abs(shear_px) > 3.0 * shear_se + 1.0:
+        if abs(dy_px - dy_predicted) <= 3.0 * dy_se + 1.0:
+            mechanism = "roll"
+            verdict = (
+                f"consistent with a relative lens roll, which predicts "
+                f"{dy_predicted:+.2f} px. A roll correction is valid at every depth."
+            )
+        elif abs(dy_px) <= 3.0 * dy_se + 1.0:
+            mechanism = "parallax"
+            verdict = (
+                f"consistent with PARALLAX, not roll: a roll of this shear would "
+                f"need {dy_predicted:+.2f} px of vertical offset and there is "
+                "none. The correction is then valid only at the depth each row "
+                "images -- a subject at a different depth in the same row is not "
+                "corrected. Set `calibrated_for.subject_distance_m` deliberately "
+                "and restrict `band` to the rows at that depth."
+            )
+        else:
+            mechanism = "mixed"
+            verdict = (
+                f"consistent with neither a pure roll ({dy_predicted:+.2f} px "
+                "predicted) nor pure horizontal parallax (0 px predicted); "
+                "relative pitch or a mixture contributes."
+            )
         findings.append(
-            f"the measured vertical offset ({dy_px:+.2f} px) disagrees with the "
-            f"{dy_predicted:+.2f} px a pure relative roll of this shear would "
-            "produce. Something other than roll contributes -- relative pitch, "
-            "or parallax at a depth away from the stitch calibration (12.1). "
-            "dx is still what the surfaces correct; dy is not emitted (4.2)."
+            f"dx varies by {shear_px:+.2f} +/-{shear_se:.2f} px from the top of "
+            f"the frame to the bottom. Roll and ground-plane parallax both produce "
+            f"a dx linear in y and the curve cannot separate them (2, 12.1); the "
+            f"vertical offset can. Measured dy {dy_px:+.2f} +/-{dy_se:.2f} px is "
+            f"{verdict} dy itself is not emitted (4.2)."
         )
 
     max_stderr = max(stderr)
     worst_dx = max(abs(d) for d in dx_q)
     late: list[str] = []
+    if consistency and consistency.get("checked") and not consistency["agrees"]:
+        late.append(
+            f"the footage does not agree with itself: alternate frames give seam "
+            f"offsets of {consistency['even_dx_px']:+.2f} "
+            f"+/-{consistency['even_stderr_px']:.2f} px "
+            f"({consistency['even_n']} obs) and {consistency['odd_dx_px']:+.2f} "
+            f"+/-{consistency['odd_stderr_px']:.2f} px ({consistency['odd_n']} obs), "
+            f"a {consistency['difference_px']:+.2f} px gap against a combined "
+            f"{consistency['difference_stderr_px']:.2f} px. A real seam offset is "
+            "the same in every frame of a fixed camera; a matcher pairing "
+            "unrelated structures across the seam is not"
+        )
+    elif consistency and not consistency.get("checked"):
+        late.append(
+            f"the cross-frame check could not run ({consistency['why']}), so the "
+            "estimate is unverified. On game footage the dominant failure is "
+            "false pairings that pass every coverage condition, and agreement "
+            "across frames is the only cheap thing that catches them"
+        )
     if max_stderr > max_dx_stderr:
         late.append(
             f"dx is uncertain to +/-{max_stderr:.2f} px at the anchor rows (limit "
@@ -565,6 +876,14 @@ def solve(
         "max_residual_px": float(np.max(np.abs(resid))),
         "n_downweighted": int(np.sum(w < 0.5 * prior_w)),
         "quadratic_term_sigma": quad_t,
+        "shear_px_top_to_bottom": shear_px,
+        "stderr_shear_px": shear_se,
+        "shear_mechanism": mechanism,
+        "frame_consistency": consistency,
+        # Informational, never a finding on its own: a genuine roll ALSO makes
+        # these two halves differ, because that is what a shear is. It is here so
+        # a depth choice can be made with numbers instead of a guess.
+        "depth_split": split,
     }
     meta = {
         **base,
@@ -721,6 +1040,141 @@ def _pool(measures: list[dict]) -> dict:
     }
 
 
+def sweep_dx(
+    frames: list[np.ndarray],
+    dx_values: Sequence[float] = (-32, -24, -16, -8, -4, 0, 4, 8, 16, 24, 32),
+    *,
+    source_width: int,
+    source_height: int,
+    seam_x: int = SEAM_X,
+    blend_w: int = BLEND_W,
+    shoulder_w: int = SHOULDER_W,
+) -> list[dict]:
+    """Apply each constant `dx` and re-measure. The objective, actually plotted.
+
+    Every gate above is computed from ONE detection pass, so all of them share
+    its assumptions. This does not: it shifts the pixels, re-detects, and asks
+    whether the score moves. If the metric is measuring registration, the curve
+    has a floor near the truth and rises on both sides. If it is measuring
+    something else, the curve is flat, or its minimum sits at whichever endpoint
+    the noise favoured.
+
+    That distinction cannot be inferred from coverage, and it is the one that
+    decides whether descending this objective means anything.
+    """
+    out = []
+    for dx in dx_values:
+        shifted = (
+            frames
+            if dx == 0
+            else [
+                apply_anchors_downstream(
+                    f,
+                    [(0, float(dx)), (source_height - 1, float(dx))],
+                    source_width=source_width,
+                    source_height=source_height,
+                    seam_x=seam_x,
+                )
+                for f in frames
+            ]
+        )
+        rs = [
+            seam_continuity_residual(
+                f, seam_x=seam_x, blend_w=blend_w, shoulder_w=shoulder_w
+            )
+            for f in shifted
+        ]
+        live = [r for r in rs if r.n]
+        out.append(
+            {
+                "dx": float(dx),
+                "n": sum(r.n for r in rs),
+                "p50": float(np.median([r.p50 for r in live]))
+                if live
+                else float("nan"),
+                "p90": float(np.median([r.p90 for r in live]))
+                if live
+                else float("nan"),
+            }
+        )
+    return out
+
+
+def assess_sweep(points: list[dict], *, min_depth_fraction: float = 0.25) -> dict:
+    """Does the swept objective have a real, interior minimum?
+
+    Three conditions, each of which a flat or noise-driven curve fails:
+
+    * the best score is not at an endpoint -- an endpoint argmin means the
+      curve is still falling when the sweep ran out, i.e. no minimum was found;
+    * the trough is deep relative to the value -- a 4% dip on a 37 px score is
+      noise, not a signal;
+    * the curve is single-troughed -- two minima mean the optimiser's answer
+      depends on where it started.
+
+    Thresholds are deliberately loose. This is meant to catch objectives that
+    say nothing, not to certify good ones.
+    """
+    p90 = np.array([p["p90"] for p in points], dtype=float)
+    dxs = [p["dx"] for p in points]
+    ok = np.isfinite(p90)
+    if ok.sum() < 5:
+        return {
+            "responds": False,
+            "why": "too few usable sweep points",
+            "points": points,
+        }
+    best = int(np.nanargmin(p90))
+    depth = float(np.nanmax(p90) - np.nanmin(p90))
+    frac = depth / float(np.nanmax(p90)) if np.nanmax(p90) > 0 else 0.0
+    interior = 0 < best < len(p90) - 1
+    # Count sign changes of the first difference: one trough means exactly one
+    # transition from falling to rising.
+    d = np.sign(np.diff(p90[ok]))
+    d = d[d != 0]
+    turns = int(np.sum(d[1:] != d[:-1]))
+    reasons = []
+    if not interior:
+        reasons.append(f"the best score is at the sweep endpoint dx={dxs[best]:+.0f}")
+    if frac < min_depth_fraction:
+        reasons.append(
+            f"the objective moves only {depth:.2f} px ({frac * 100:.0f}%) across the "
+            f"whole sweep (need {min_depth_fraction * 100:.0f}%)"
+        )
+    if turns > 1:
+        reasons.append(f"the curve has {turns + 1} troughs, not one")
+    return {
+        "responds": not reasons,
+        "why": "; ".join(reasons),
+        "best_dx": dxs[best],
+        "p90_min": float(np.nanmin(p90)),
+        "p90_max": float(np.nanmax(p90)),
+        "depth_px": depth,
+        "depth_fraction": frac,
+        "interior_minimum": interior,
+        "turning_points": turns,
+        "points": points,
+    }
+
+
+def require_responsive_objective(assessment: dict) -> None:
+    """Raise unless the swept objective actually responds to `dx`.
+
+    Separate from `solve` because it costs a re-detection per sweep point, but
+    it is the check with teeth: a curve that does not respond means any anchors
+    derived from it are noise wearing a calibration's clothes, however healthy
+    the coverage numbers looked.
+    """
+    if not assessment.get("responds"):
+        raise SolverRefused(
+            [
+                "the objective does not respond to dx: "
+                + assessment.get("why", "unknown")
+            ],
+            {"sweep": assessment},
+        )
+
+
 def validate_downstream(
     frames: list[np.ndarray],
     anchors: list[tuple[int, float]],
@@ -808,6 +1262,15 @@ def main(argv: list[str]) -> int:
         labels.append(Path(p).name)
 
     try:
+        if "--sweep" in flags:
+            # Cheapest way to be told the objective is worthless before reading
+            # anything else it says.
+            h, w = frames[0].shape[:2]
+            require_responsive_objective(
+                assess_sweep(
+                    sweep_dx(frames, source_width=w, source_height=h, seam_x=seam)
+                )
+            )
         result = solve_from_frames(frames, seam_x=seam, frame_labels=labels)
     except SolverRefused as exc:
         if "--json" in flags:

--- a/tests/test_stitch_solver.py
+++ b/tests/test_stitch_solver.py
@@ -43,12 +43,16 @@ from stitch_solver import (  # noqa: E402
     MAX_DX_STDERR_PX,
     Observation,
     SolverRefused,
+    _frame_consistency,
     _observation_variance,
     apply_anchors_downstream,
+    assess_sweep,
     holdout_split,
     main,
+    require_responsive_objective,
     solve,
     solve_from_frames,
+    sweep_dx,
 )
 
 W, H = 1200, 800
@@ -183,26 +187,70 @@ def test_recovers_a_pure_translation_as_a_flat_curve():
     assert result.metadata["fit"]["b_px_per_row"] == pytest.approx(0.0, abs=0.0005)
 
 
-def test_the_vertical_offset_cross_checks_the_roll_model():
-    """A relative roll that shears dx must also produce a specific dy.
+# A shear big enough that the roll's predicted dy (= b * source_width/4) is
+# resolvable on this small fixture. At the real 7680-px panorama width X_seam is
+# 1920 rather than 300, so the discriminator is 6.4x more sensitive there than
+# it is here.
+B_SHEAR = 0.02
 
-    Section 2: a roll theta displaces a point at (X, Y) by theta*(-Y, +X), so
-    the same theta that gives `dx` its slope in y must give a constant vertical
-    offset of `theta * X_seam`, with X_seam = source_width/4 from the half's
-    optical centre. Injecting exactly that and confirming the solver finds it
-    is a free consistency check on the physics, not just on the algebra -- and
-    it is the check that fires when something other than a roll is present.
+
+def test_a_shear_with_the_matching_dy_is_diagnosed_as_a_lens_roll():
+    """Section 2: a roll theta displaces a point at (X, Y) by theta*(-Y, +X).
+
+    So the theta that gives `dx` its slope in y must ALSO give a constant
+    vertical offset of `theta * X_seam`, X_seam = source_width/4 from the
+    half's optical centre. The fit estimates dy anyway as a nuisance parameter,
+    so the check is free -- and it is a check on the physics, not the algebra.
     """
-    b = 0.006
-    result = _solve(frames(a=-4.0, b=b, dy=b * (W / 4.0)))
+    result = _solve(frames(a=-4.0, b=B_SHEAR, dy=B_SHEAR * (W / 4.0)))
     fit = result.metadata["fit"]
-    assert fit["dy_px"] == pytest.approx(fit["dy_predicted_from_roll_px"], abs=0.4)
-    assert not any("vertical offset" in f for f in result.metadata["findings"])
+    assert fit["dy_px"] == pytest.approx(fit["dy_predicted_from_roll_px"], abs=0.5)
+    assert fit["shear_mechanism"] == "roll"
+    assert any("relative lens roll" in f for f in result.metadata["findings"])
 
 
-def test_a_dy_inconsistent_with_the_roll_is_reported_as_a_finding():
-    result = _solve(frames(a=-4.0, b=0.006, dy=6.0))
-    assert any("vertical offset" in f for f in result.metadata["findings"])
+def test_a_shear_with_no_dy_is_diagnosed_as_parallax_not_roll():
+    """The correction that changed how this result must be read.
+
+    Ground-plane parallax on a sideline mount produces a dx that is very nearly
+    linear in row, because subject distance falls monotonically down the frame.
+    That is the SAME shape a lens roll produces, so the curve cannot tell them
+    apart -- and the design does not say so. The vertical offset can: the two
+    lenses sit side by side, so parallax is horizontal and carries no dy.
+
+    It matters because it changes what the calibration means. A roll correction
+    is valid at every depth; a parallax correction is valid only at the depth
+    each row happens to image.
+    """
+    result = _solve(frames(a=-4.0, b=B_SHEAR, dy=0.0))
+    assert result.metadata["fit"]["shear_mechanism"] == "parallax"
+    assert any("PARALLAX" in f for f in result.metadata["findings"])
+
+
+def test_a_dy_matching_neither_mechanism_is_reported_as_mixed():
+    result = _solve(frames(a=-4.0, b=B_SHEAR, dy=-9.0))
+    assert result.metadata["fit"]["shear_mechanism"] == "mixed"
+    assert any("neither" in f for f in result.metadata["findings"])
+
+
+def test_no_shear_means_no_mechanism_claim():
+    """With no shear to explain there is nothing for dy to discriminate."""
+    result = _solve(frames(a=-5.0, b=0.0))
+    assert result.metadata["fit"]["shear_mechanism"] is None
+
+
+def test_the_depth_split_is_reported_but_never_claimed_as_evidence():
+    """It is two numbers for choosing a calibration depth, not a diagnosis.
+
+    A genuine roll makes the near and far halves differ as well -- that is what
+    a shear is -- so a finding drawn from this split alone would fire on every
+    correctly-diagnosed roll.
+    """
+    result = _solve(frames(a=-4.0, b=B_SHEAR, dy=B_SHEAR * (W / 4.0)))
+    split = result.metadata["fit"]["depth_split"]
+    assert split["far_n"] > 0 and split["near_n"] > 0
+    assert split["near_dx_px"] != split["far_dx_px"]
+    assert not any("near rows" in f for f in result.metadata["findings"])
 
 
 # -- the sign, end to end through the shipped corrector ----------------------
@@ -301,6 +349,50 @@ def test_refuses_thin_row_coverage_which_is_the_case_the_live_frame_hits():
     cov = e.value.report["coverage"]
     assert cov["row_bands_covered"] == 1
     assert sum(cov["row_band_counts"]) == cov["n"]
+
+
+def test_refuses_when_all_three_bands_are_reached_but_the_mass_is_piled_in_one():
+    """The shape 27 archived games actually had, and the gate 9.3 was missing.
+
+    `height_coverage` is a RANGE -- (y_max - y_min) / band -- so two stragglers
+    at the extremes satisfy it while everything else sits in one place. On the
+    Duo 3 archive that is not a corner case, it is the norm: usable
+    near-horizontal structure lives on the far touchline and the crowd behind
+    it, and mid-field is grass. Range coverage read 81-98% on 24 of 27 games
+    while 73-98% of the observations were in the top band.
+
+    Leverage on a shear comes from mass at differing heights. Two points do not
+    provide it, however far apart they are.
+    """
+    var = _observation_variance(384, 0.3, BLEND)
+    obs = [
+        Observation(
+            y=y,
+            slope=-0.25 + 0.1 * k,
+            residual_y=(-0.25 + 0.1 * k) * -4.0,
+            span_px=384,
+            fit_rms=0.3,
+            variance=var,
+        )
+        # 18 observations on the far touchline, one straggler in each of the
+        # other two bands: 90% / 5% / 5%, which is the archive's median shape.
+        for y, n in ((200.0, 18), (500.0, 1), (760.0, 1))
+        for k in range(n)
+    ]
+    with pytest.raises(SolverRefused) as e:
+        solve(obs, source_width=W, source_height=H, seam_x=SEAM, blend_w=BLEND)
+    assert any("piled into" in r for r in e.value.reasons)
+    cov = e.value.report["coverage"]
+    assert cov["row_bands_covered"] == 3, "the old gate would have passed this"
+    assert cov["height_coverage"] > 0.60, "and so would the old coverage gate"
+    assert cov["min_row_band_fraction"] < 0.10
+
+
+def test_a_balanced_solve_reports_its_band_shares():
+    result = _solve(frames())
+    cov = result.metadata["coverage"]
+    assert min(cov["row_band_fractions"]) >= 0.10
+    assert sum(cov["row_band_fractions"]) == pytest.approx(1.0, abs=1e-3)
 
 
 def test_refuses_when_every_structure_shares_one_slope():
@@ -461,6 +553,9 @@ def _synthetic_obs(a: float, b: float, n_each: int = 6) -> list[Observation]:
                     span_px=384,
                     fit_rms=0.3,
                     variance=var,
+                    # Spread over frames: a solve from a single frame cannot be
+                    # cross-checked and the solver refuses it.
+                    frame=k % 3,
                 )
             )
     return obs
@@ -471,16 +566,18 @@ def test_the_robust_loss_survives_a_minority_of_wild_observations():
 
     Section 10 rejects players by policy, but a policy is not a filter -- some
     get through, and each one contributes a residual that has nothing to do
-    with the seam. Three corrupted observations in twelve must not move the
-    answer.
+    with the seam. Three corrupted observations in 27 must not move the answer.
+
+    One per frame, deliberately: the cross-frame check refuses when a third of
+    a half is corrupt, and it is right to -- so this test measures the robust
+    loss, not the accident of which frame a synthetic outlier landed in.
     """
     a, b = -4.0, 0.006
-    clean = _synthetic_obs(a, b)
+    clean = _synthetic_obs(a, b, n_each=9)
     dirty = list(clean)
-    for i, bad in zip(
-        (1, len(clean) // 2, len(clean) - 2), (14.0, -11.0, 9.0), strict=True
-    ):
+    for i, bad in zip((1, 12, 23), (14.0, -11.0, 9.0), strict=True):
         dirty[i] = Observation(**{**vars(clean[i]), "residual_y": bad})
+    assert len({dirty[i].frame for i in (1, 12, 23)}) == 3
 
     ref = solve(clean, source_width=W, source_height=H, seam_x=SEAM, blend_w=BLEND)
     got = solve(dirty, source_width=W, source_height=H, seam_x=SEAM, blend_w=BLEND)
@@ -491,6 +588,66 @@ def test_the_robust_loss_survives_a_minority_of_wild_observations():
     # wrecked by three wild points while the robust dispersion stays near 1.
     assert got.metadata["fit"]["chi2_per_dof"] > 10
     assert got.metadata["fit"]["robust_scale"] < 2.0
+
+
+def test_refuses_a_single_frame_because_it_cannot_be_cross_checked():
+    """The failure on game footage is too MUCH false structure, not too little.
+
+    `seam_metric`'s matcher pairs any left/right structures whose extrapolations
+    land within 40 px, and a crowd at mixed depths supplies plenty of pairs that
+    are not the same structure. Those pass every count-and-coverage condition in
+    9.3 -- there are many, spread over the height, with varied slopes. What they
+    do not do is repeat: they are re-drawn in every frame. So one frame is never
+    enough, however healthy its coverage numbers look.
+    """
+    obs = [Observation(**{**vars(o), "frame": 0}) for o in _synthetic_obs(-4.0, 0.006)]
+    with pytest.raises(SolverRefused) as e:
+        solve(obs, source_width=W, source_height=H, seam_x=SEAM, blend_w=BLEND)
+    assert any("frame(s) contributed" in r for r in e.value.reasons)
+
+
+def test_refuses_when_alternate_frames_disagree():
+    """A real seam offset is the same in every frame of a fixed camera."""
+    obs = _synthetic_obs(-4.0, 0.006)
+    poisoned = [
+        Observation(**{**vars(o), "residual_y": o.residual_y + 6.0 * o.slope})
+        if o.frame == 1
+        else o
+        for o in obs
+    ]
+    with pytest.raises(SolverRefused) as e:
+        solve(poisoned, source_width=W, source_height=H, seam_x=SEAM, blend_w=BLEND)
+    assert any("does not agree with itself" in r for r in e.value.reasons)
+
+
+def test_agreement_between_two_unconstrained_halves_is_not_agreement():
+    """The rubber-stamp failure, caught before it could ship.
+
+    Measured on the archive with the precision precondition absent: 22 of 23
+    games "agreed" while their two halves differed by up to 242 px, purely
+    because each half's own error bar ran to +-100 px. A cross-check that
+    passes on numbers it cannot constrain is worse than no cross-check, because
+    it appears in the artifact as evidence.
+    """
+    var = _observation_variance(384, 0.3, BLEND)
+    rng = np.random.default_rng(11)
+    obs = [
+        Observation(
+            y=400.0,
+            # Slope varies WITHIN each frame -- otherwise a half cannot fit at
+            # all and the check bails for the wrong reason.
+            slope=-0.012 + 0.008 * (k % 4),
+            residual_y=rng.normal(0.0, 12.0),
+            span_px=70,
+            fit_rms=1.0,
+            variance=var,
+            frame=k // 6,
+        )
+        for k in range(24)
+    ]
+    c = _frame_consistency(obs)
+    assert c["checked"] is False
+    assert "unconstrained" in c["why"]
 
 
 def test_holdout_split_is_deterministic_and_spans_the_footage():
@@ -542,3 +699,63 @@ def test_cli_refusal_json_carries_the_reasons(tmp_path, capsys):
 
 def test_cli_reports_usage_without_frames(capsys):
     assert main(["stitch_solver.py"]) == 2
+
+
+# -- the discriminative sweep ------------------------------------------------
+
+
+def test_the_swept_objective_has_a_real_minimum_when_the_seam_is_misregistered():
+    """The check with teeth, and the one no coverage number can stand in for.
+
+    Every other gate is computed from one detection pass and shares its
+    assumptions. This one shifts the pixels, re-detects, and asks whether the
+    score actually moves. On a fixture with a known 6 px misregistration it must
+    find an interior trough near it.
+    """
+    fs = list(frames(a=-6.0, b=0.0, n=2))
+    pts = sweep_dx(
+        fs,
+        (-12, -9, -6, -3, 0, 3, 6),
+        source_width=W,
+        source_height=H,
+        seam_x=SEAM,
+        blend_w=BLEND,
+        shoulder_w=SHOULDER,
+    )
+    a = assess_sweep(pts)
+    assert a["responds"], (
+        f"{a['why']}  curve={[(p['dx'], round(p['p90'], 2)) for p in pts]}"
+    )
+    assert a["best_dx"] == pytest.approx(-6.0, abs=3.5), (
+        f"trough at dx={a['best_dx']}, truth -6"
+    )
+    require_responsive_objective(a)  # must not raise
+
+
+def test_a_flat_swept_objective_is_refused():
+    """What 27 games of real footage produced, in one assertion.
+
+    Measured on the archive: p90 moved 4-22% across a +/-32 px sweep with the
+    best score usually at an endpoint, and on one frame deliberately breaking
+    the seam by 32 px made the score BETTER. A solver descending that returns a
+    confident curve made of noise.
+    """
+    flat = [
+        {"dx": dx, "n": 50, "p50": 12.0, "p90": 31.0 + 0.3 * (dx / 32.0)}
+        for dx in (-32, -24, -16, -8, 0, 8, 16, 24, 32)
+    ]
+    a = assess_sweep(flat)
+    assert not a["responds"]
+    assert "endpoint" in a["why"] or "moves only" in a["why"]
+    with pytest.raises(SolverRefused, match="does not respond"):
+        require_responsive_objective(a)
+
+
+def test_a_two_troughed_sweep_is_refused():
+    curve = [31.0, 24.0, 30.0, 25.0, 31.0, 33.0, 34.0, 35.0, 36.0]
+    pts = [
+        {"dx": dx, "n": 50, "p50": 12.0, "p90": v}
+        for dx, v in zip((-32, -24, -16, -8, 0, 8, 16, 24, 32), curve, strict=True)
+    ]
+    a = assess_sweep(pts)
+    assert not a["responds"] and "troughs" in a["why"]

--- a/tests/test_stitch_solver.py
+++ b/tests/test_stitch_solver.py
@@ -1,0 +1,544 @@
+"""Gates on the automatic stitch-anchor solver.
+
+Two kinds of test, and the distinction matters for how much they prove.
+
+  * **Ground truth.** A known shear is applied to a synthetic panorama and the
+    solver has to recover it. This is the only place the true answer is known,
+    so it is the only place an accuracy number means anything. Tolerances are
+    stated in the assertions, not hidden in a helper.
+
+  * **Refusal.** Every way the evidence can be too thin, each checked to raise
+    rather than return a plausible curve. This is the half that matters most:
+    the seam sits mid-field, mid-field is featureless grass, and a fabricated
+    calibration is worse than none because it gets applied to the camera and
+    then trusted.
+
+The fixture blends two shifted views across a 256-px window exactly as
+VIDEOPROC 2 does, so the solver sees what it will see in the field: evidence
+only on the shoulders, with the window itself already irreversibly mixed.
+
+Real frames are not committed (a Duo 3 still is 730 KB and is calibration data
+for one physical unit). What the live camera *did* show while this was written
+is recorded in `docs/STITCH_CALIBRATION.md` and in the branch commit message:
+an indoor 0.3 m scene with one lens occluded, on which the solver refuses --
+which is the correct behaviour, not a gap in the test suite.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from functools import cache
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+VPE_DIR = Path(__file__).resolve().parents[1] / "reolink-firmware-patching" / "vpe"
+sys.path.insert(0, str(VPE_DIR))
+
+from seam_metric import seam_continuity_residual  # noqa: E402
+from stitch_solver import (  # noqa: E402
+    MAX_DX_STDERR_PX,
+    Observation,
+    SolverRefused,
+    _observation_variance,
+    apply_anchors_downstream,
+    holdout_split,
+    main,
+    solve,
+    solve_from_frames,
+)
+
+W, H = 1200, 800
+SEAM, BLEND, SHOULDER = 600, 256, 256
+KW = {"seam_x": SEAM, "blend_w": BLEND, "shoulder_w": SHOULDER}
+
+# Six straight edges crossing the seam. Slopes fan from -0.25 to +0.25 and the
+# seam-crossing rows are spaced 96 px apart, which puts every pairwise crossing
+# ~1000 px from the seam -- well outside the +/-384 px the detector looks at, so
+# no two structures can be confused for one another inside the analysis band.
+# Alternating polarity keeps the cumulative brightness inside 8 bits; six
+# same-signed steps would saturate the lower half of the frame and the bottom
+# structures would simply vanish.
+FANNED = tuple(
+    (-0.25 + 0.10 * k, 220.0 + 96.0 * k, 50.0 if k % 2 == 0 else -50.0)
+    for k in range(6)
+)
+
+
+def _render(
+    lines: tuple, *, e_of_y=None, dy: float = 0.0, seed: int = 0, noise: float = 1.5
+) -> np.ndarray:
+    yy = np.arange(H, dtype=np.float32)[:, None]
+    xx = np.arange(W, dtype=np.float32)[None, :]
+    if e_of_y is None:
+        e = np.zeros((H, 1), dtype=np.float32)
+    else:
+        e = e_of_y(np.arange(H, dtype=np.float32))[:, None].astype(np.float32)
+    xs = xx - e
+    img = np.full((H, W), 100.0, dtype=np.float32)
+    for m, y0, amp in lines:
+        d = (yy - dy) - (m * (xs - SEAM) + y0)
+        img += amp * 0.5 * (1.0 + np.tanh(d / 1.2))
+    rng = np.random.default_rng(seed)
+    return img + rng.normal(0.0, noise, img.shape).astype(np.float32)
+
+
+def _fuse(lines: tuple, e_of_y, dy: float, seed: int) -> np.ndarray:
+    """One scene seen by two sensors, butt-joined with a 256-px linear blend.
+
+    `e_of_y(y)` is the *misregistration*: how far right the right sensor's view
+    of the world sits at row y. The correction the solver must emit is its
+    negative, per the sign convention of section 4.4.
+    """
+    left = _render(lines, seed=seed)
+    right = _render(lines, e_of_y=e_of_y, dy=dy, seed=seed + 1000)
+    out = left.copy()
+    lo, hi = SEAM - BLEND // 2, SEAM + BLEND // 2
+    alpha = np.linspace(0.0, 1.0, hi - lo, dtype=np.float32)[None, :]
+    out[:, hi:] = right[:, hi:]
+    out[:, lo:hi] = left[:, lo:hi] * (1 - alpha) + right[:, lo:hi] * alpha
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+def _dx_truth(a: float, b: float):
+    """The correction: dx(y) = a + b*(y - H/2)."""
+    return lambda y: a + b * (np.asarray(y, dtype=float) - H / 2.0)
+
+
+@cache
+def frames(
+    a: float = -4.0,
+    b: float = 0.006,
+    quad: float = 0.0,
+    dy: float = 0.0,
+    n: int = 3,
+    lines: tuple = FANNED,
+) -> tuple[np.ndarray, ...]:
+    """`n` frames of the same static scene, differing only in detector noise.
+
+    Static scene, independent noise, which is what accumulating across a game
+    actually gives you: the field lines do not move, so extra frames buy
+    averaging and nothing else. They do not improve the design matrix, and the
+    solver must not pretend they do.
+    """
+
+    def e_of_y(y):
+        y = np.asarray(y, dtype=float)
+        return -(a + b * (y - H / 2.0) + quad * (y - H / 2.0) ** 2)
+
+    return tuple(_fuse(lines, e_of_y, dy, seed=s) for s in range(1, n + 1))
+
+
+def _solve(fs, **kw):
+    return solve_from_frames(list(fs), **KW, **kw)
+
+
+# -- ground truth: recover a shear we put there ------------------------------
+
+
+def test_recovers_a_known_shear_to_a_third_of_a_pixel():
+    a, b = -4.0, 0.006
+    truth = _dx_truth(a, b)
+    result = _solve(frames(a=a, b=b))
+
+    errs = [abs(dx - float(truth(y))) for y, dx in result.anchors]
+    assert max(errs) < 0.35, (
+        f"recovered {result.anchors} against truth "
+        f"{[(y, round(float(truth(y)), 2)) for y, _ in result.anchors]}"
+    )
+    fit = result.metadata["fit"]
+    assert fit["a_px"] == pytest.approx(a, abs=0.3)
+    assert fit["b_px_per_row"] == pytest.approx(b, abs=0.0008)
+
+
+def test_the_reported_uncertainty_actually_bounds_the_error():
+    """The stderr is the refusal gate, so it has to mean something.
+
+    Checked on two fixtures with very different conditioning -- a well-fanned
+    one and a barely-fanned one -- because an error bar that is only right when
+    the data is good is not an error bar.
+    """
+    shallow = tuple(
+        (-0.02 if k % 2 else 0.02, 220.0 + 96.0 * k, 50.0 if k % 2 == 0 else -50.0)
+        for k in range(6)
+    )
+    for lines, tol_mult in ((FANNED, 3.0), (shallow, 3.0)):
+        truth = _dx_truth(-4.0, 0.006)
+        result = _solve(frames(lines=lines))
+        for (y, dx), se in zip(
+            result.anchors, result.metadata["anchor_stderr_px"], strict=True
+        ):
+            err = abs(dx - float(truth(y)))
+            assert err <= tol_mult * se + 0.25, (
+                f"row {y}: error {err:.2f} px against a claimed +/-{se:.2f} px"
+            )
+
+
+def test_recovers_a_pure_translation_as_a_flat_curve():
+    result = _solve(frames(a=-5.0, b=0.0))
+    assert all(dx == pytest.approx(-5.0, abs=0.35) for _, dx in result.anchors)
+    assert result.metadata["fit"]["b_px_per_row"] == pytest.approx(0.0, abs=0.0005)
+
+
+def test_the_vertical_offset_cross_checks_the_roll_model():
+    """A relative roll that shears dx must also produce a specific dy.
+
+    Section 2: a roll theta displaces a point at (X, Y) by theta*(-Y, +X), so
+    the same theta that gives `dx` its slope in y must give a constant vertical
+    offset of `theta * X_seam`, with X_seam = source_width/4 from the half's
+    optical centre. Injecting exactly that and confirming the solver finds it
+    is a free consistency check on the physics, not just on the algebra -- and
+    it is the check that fires when something other than a roll is present.
+    """
+    b = 0.006
+    result = _solve(frames(a=-4.0, b=b, dy=b * (W / 4.0)))
+    fit = result.metadata["fit"]
+    assert fit["dy_px"] == pytest.approx(fit["dy_predicted_from_roll_px"], abs=0.4)
+    assert not any("vertical offset" in f for f in result.metadata["findings"])
+
+
+def test_a_dy_inconsistent_with_the_roll_is_reported_as_a_finding():
+    result = _solve(frames(a=-4.0, b=0.006, dy=6.0))
+    assert any("vertical offset" in f for f in result.metadata["findings"])
+
+
+# -- the sign, end to end through the shipped corrector ----------------------
+
+
+def _pooled_p90(fs) -> float:
+    ps = [seam_continuity_residual(f, **KW) for f in fs]
+    return float(np.median([r.p90 for r in ps if r.n]))
+
+
+def test_the_emitted_sign_is_the_one_the_shipped_corrector_consumes():
+    """The one test that makes a sign error impossible to ship.
+
+    A sign error here does not fail loudly: it doubles the seam break instead
+    of closing it and presents as "the tool does not work". So the recovered
+    anchors are fed to the real `stitch_remap` applier -- not a local copy --
+    and the metric has to improve; the same anchors negated have to make it
+    worse. Both directions are asserted, because "it got better" alone is also
+    satisfied by a correction of half the right size.
+    """
+    fs = list(frames(a=-4.0, b=0.006))
+    result = _solve(fs)
+    before = _pooled_p90(fs)
+
+    def applied(anchors):
+        return [
+            apply_anchors_downstream(
+                f, anchors, source_width=W, source_height=H, seam_x=SEAM
+            )
+            for f in fs
+        ]
+
+    after = _pooled_p90(applied(result.anchors))
+    flipped = _pooled_p90(applied([(y, -dx) for y, dx in result.anchors]))
+    assert after < before * 0.5, f"SCR p90 {before:.2f} -> {after:.2f} px"
+    assert flipped > before, f"negating the anchors must hurt: {flipped:.2f} px"
+
+
+def test_anchors_are_in_the_pixel_units_of_the_frames_measured():
+    """Solve on a half-size frame; the anchors must be half-size too.
+
+    `build_dx_lookup` rescales anchors by `actual/source`, so getting this
+    wrong scales every correction downstream. Solving the same scene at half
+    resolution must give half the dx, at half the row.
+    """
+    full = frames(a=-4.0, b=0.006)
+    small = [
+        cv2.resize(f, (W // 2, H // 2), interpolation=cv2.INTER_AREA) for f in full
+    ]
+    result = solve_from_frames(
+        small, seam_x=SEAM // 2, blend_w=BLEND // 2, shoulder_w=SHOULDER // 2
+    )
+    assert result.metadata["source_width"] == W // 2
+    assert result.metadata["source_height"] == H // 2
+
+    truth = _dx_truth(-4.0, 0.006)
+    for y, dx in result.anchors:
+        # y and dx are both in half-size units; scale both back up.
+        assert dx * 2.0 == pytest.approx(float(truth(y * 2.0)), abs=0.6)
+
+
+# -- refusal -----------------------------------------------------------------
+
+
+def test_refuses_a_seam_with_no_structure_at_all():
+    blank = [np.full((H, W), 120, dtype=np.uint8)] * 2
+    with pytest.raises(SolverRefused) as e:
+        _solve(blank)
+    assert "0 accepted structures" in str(e.value)
+    assert e.value.report["coverage"]["n"] == 0
+
+
+def test_refuses_too_few_structures():
+    one = ((0.22, 400.0, 50.0),)
+    with pytest.raises(SolverRefused) as e:
+        _solve(frames(lines=one))
+    assert any("accepted structures" in r for r in e.value.reasons)
+
+
+def test_refuses_thin_row_coverage_which_is_the_case_the_live_frame_hits():
+    """Structures all bunched at one height.
+
+    This is exactly what `seam_metric` reported on the live indoor frame: a
+    handful of observations in one of three row bands over a fifth of the
+    height. A shear fitted to that is an extrapolation dressed as a
+    measurement.
+    """
+    bunched = tuple(
+        (-0.25 + 0.10 * k, 380.0 + 7.0 * k, 50.0 if k % 2 == 0 else -50.0)
+        for k in range(6)
+    )
+    with pytest.raises(SolverRefused) as e:
+        _solve(frames(lines=bunched))
+    assert any("row band" in r for r in e.value.reasons)
+    assert any("field band" in r for r in e.value.reasons)
+    cov = e.value.report["coverage"]
+    assert cov["row_bands_covered"] == 1
+    assert sum(cov["row_band_counts"]) == cov["n"]
+
+
+def test_refuses_when_every_structure_shares_one_slope():
+    """dx enters each observation only as `m * dx`.
+
+    With one slope the translate term is collinear with the vertical offset, so
+    no number of observations makes dx observable -- which is why this refuses
+    on geometry and not on count.
+    """
+    parallel = tuple(
+        (0.22, 220.0 + 96.0 * k, 50.0 if k % 2 == 0 else -50.0) for k in range(6)
+    )
+    with pytest.raises(SolverRefused) as e:
+        _solve(frames(lines=parallel))
+    assert any("same slope" in r for r in e.value.reasons)
+
+
+def test_refuses_when_the_slope_lever_is_too_weak_to_pin_dx():
+    """Coverage passes, precision does not -- the gate doing independent work.
+
+    Every count-and-coverage condition of 9.3 is satisfied here: 18
+    observations, all three row bands, 70% of the height. Only the error bar
+    says no. Without this gate the solver would emit a confident-looking curve
+    that is wrong by more than the correction it is trying to make.
+    """
+    barely = tuple(
+        (-0.011 if k % 2 else 0.011, 220.0 + 96.0 * k, 50.0 if k % 2 == 0 else -50.0)
+        for k in range(6)
+    )
+    with pytest.raises(SolverRefused) as e:
+        _solve(frames(lines=barely))
+    assert any("uncertain to" in r for r in e.value.reasons)
+    cov = e.value.report["coverage"]
+    assert cov["n"] >= 8 and cov["row_bands_covered"] == 3
+    assert cov["height_coverage"] > 0.60
+    assert e.value.report["fit"]["max_anchor_stderr_px"] > MAX_DX_STDERR_PX
+
+
+def test_refuses_a_physically_implausible_shear():
+    with pytest.raises(SolverRefused) as e:
+        _solve(frames(a=-80.0, b=0.0))
+    assert any("64 px limit" in r for r in e.value.reasons)
+
+
+def test_a_refusal_carries_the_measurement_report():
+    """Section 10 step 3: emit the observations, not just a shrug.
+
+    The operator's next move is Workflow B, and starting it from real rows and
+    real residuals is the difference between a two-minute fix and a guess.
+    """
+    bunched = tuple(
+        (-0.25 + 0.10 * k, 380.0 + 7.0 * k, 50.0 if k % 2 == 0 else -50.0)
+        for k in range(6)
+    )
+    with pytest.raises(SolverRefused) as e:
+        _solve(frames(lines=bunched))
+    report = e.value.report
+    assert len(report["observations"]) == report["coverage"]["n"]
+    for o in report["observations"]:
+        assert {"y", "slope", "residual_y", "span_px", "fit_rms", "frame"} <= set(o)
+    json.dumps(report)  # must survive serialisation
+
+
+def test_no_anchors_are_returned_alongside_a_refusal():
+    """A refusal must not be recoverable into a calibration by a careless caller.
+
+    `provisional_anchors` exists only on the late (post-fit) refusals and is
+    deliberately named so that nothing mistakes it for `dx_anchors`.
+    """
+    with pytest.raises(SolverRefused) as e:
+        _solve(frames(a=-80.0, b=0.0))
+    assert "dx_anchors" not in e.value.report
+    assert e.value.report["refused"] == e.value.reasons
+
+
+# -- reporting ---------------------------------------------------------------
+
+
+def test_reports_per_band_coverage_so_a_caller_can_see_why():
+    result = _solve(frames())
+    cov = result.metadata["coverage"]
+    assert cov["row_bands_covered"] == 3
+    assert len(cov["row_band_counts"]) == 3
+    assert sum(cov["row_band_counts"]) == cov["n"]
+    assert cov["n_frames"] == 3 and cov["n_frames_contributing"] == 3
+    assert len(cov["observations_per_frame"]) == 3
+    assert cov["height_coverage"] > 0.60
+
+
+def test_flags_a_nonlinear_dx_as_a_finding_without_fitting_a_curve():
+    """Section 5.2 / 10: the mesh's y-coarseness is lossless *if* dx is linear.
+
+    A rigid relative roll cannot produce curvature, so curvature is a finding
+    about the camera. The solver reports it and still emits the straight line;
+    fitting a curve to it is a decision for a human with the report in hand.
+    """
+    result = _solve(frames(a=-4.0, b=0.006, quad=3.0e-5))
+    assert result.metadata["fit"]["quadratic_term_sigma"] > 3.0
+    assert any("not be linear in y" in f for f in result.metadata["findings"])
+    assert len(result.anchors) == 5
+    diffs = np.diff([dx for _, dx in result.anchors])
+    assert np.allclose(diffs, diffs[0], atol=0.3), "emitted curve must stay straight"
+
+
+def test_metadata_is_serialisable_and_states_the_sign_convention():
+    result = _solve(frames())
+    json.dumps({"dx_anchors": result.anchors, **result.metadata})
+    sense = result.metadata["sense"]
+    assert sense["dx_means"].startswith("px the RIGHT half must move right")
+    assert sense["downstream_moves"] == "right_half"
+    assert result.metadata["quantum_px"] == 0.25
+    assert all(abs(dx * 4 - round(dx * 4)) < 1e-9 for _, dx in result.anchors), (
+        "anchors must be whole quarter-pixels, the mesh's own resolution"
+    )
+
+
+def test_anchor_rows_are_strictly_increasing_and_span_the_frame():
+    result = _solve(frames())
+    rows = [y for y, _ in result.anchors]
+    assert rows == sorted(set(rows))
+    assert rows[0] == 0 and rows[-1] == H - 1
+
+
+# -- the pieces, unit-tested -------------------------------------------------
+
+
+def test_short_chains_are_penalised_for_extrapolating_further():
+    """Weight comes from extrapolation variance, and it is steeply non-linear.
+
+    A chain seeded at the blend edge has its centroid `blend_w/2 + L/2` from the
+    seam, so halving its length both halves the sample count and roughly
+    quadruples the leverage term. Treating a 96-px chain like a 384-px one is
+    how a handful of scraps outvote the good data.
+    """
+    long_v = _observation_variance(384, 0.5, BLEND)
+    short_v = _observation_variance(96, 0.5, BLEND)
+    assert short_v > 10 * long_v, f"{short_v:.3f} vs {long_v:.3f}"
+    assert _observation_variance(384, 1.0, BLEND) == pytest.approx(4 * long_v)
+    # A zero-rms fit must not claim infinite weight.
+    assert np.isfinite(_observation_variance(384, 0.0, BLEND))
+    assert _observation_variance(384, 0.0, BLEND) > 0
+
+
+def _synthetic_obs(a: float, b: float, n_each: int = 6) -> list[Observation]:
+    """Observations straight from the model, with the noise the weights assume."""
+    var = _observation_variance(384, 0.3, BLEND)
+    rng = np.random.default_rng(5)
+    obs = []
+    for y in (150.0, 400.0, 650.0):
+        for k in range(n_each):
+            m = -0.25 + 0.5 * k / max(n_each - 1, 1)
+            r = m * (a + b * (y - H / 2.0)) + rng.normal(0.0, np.sqrt(var))
+            obs.append(
+                Observation(
+                    y=y,
+                    slope=m,
+                    residual_y=r,
+                    span_px=384,
+                    fit_rms=0.3,
+                    variance=var,
+                )
+            )
+    return obs
+
+
+def test_the_robust_loss_survives_a_minority_of_wild_observations():
+    """Moving objects straddle depths and cannot be excluded by detection alone.
+
+    Section 10 rejects players by policy, but a policy is not a filter -- some
+    get through, and each one contributes a residual that has nothing to do
+    with the seam. Three corrupted observations in twelve must not move the
+    answer.
+    """
+    a, b = -4.0, 0.006
+    clean = _synthetic_obs(a, b)
+    dirty = list(clean)
+    for i, bad in zip(
+        (1, len(clean) // 2, len(clean) - 2), (14.0, -11.0, 9.0), strict=True
+    ):
+        dirty[i] = Observation(**{**vars(clean[i]), "residual_y": bad})
+
+    ref = solve(clean, source_width=W, source_height=H, seam_x=SEAM, blend_w=BLEND)
+    got = solve(dirty, source_width=W, source_height=H, seam_x=SEAM, blend_w=BLEND)
+    for (_, want), (_, have) in zip(ref.anchors, got.anchors, strict=True):
+        assert have == pytest.approx(want, abs=0.5)
+    assert got.metadata["fit"]["n_downweighted"] >= 3
+    # The diagnostic that says "outliers, not a bad model": a reduced chi-square
+    # wrecked by three wild points while the robust dispersion stays near 1.
+    assert got.metadata["fit"]["chi2_per_dof"] > 10
+    assert got.metadata["fit"]["robust_scale"] < 2.0
+
+
+def test_holdout_split_is_deterministic_and_spans_the_footage():
+    solve_idx, hold = holdout_split(12, every=4)
+    assert hold == [0, 4, 8]
+    assert set(solve_idx) & set(hold) == set()
+    assert sorted(solve_idx + hold) == list(range(12))
+
+
+def test_seam_metric_implied_dx_is_the_opposite_sense_to_the_artifact():
+    """A landmine pinned in code rather than left in prose.
+
+    `seam_metric` models `r_y = dy - m*dx` and this solver models
+    `r_y = dy + m*dx`, because the first is measuring how far the right half
+    has drifted and the second is emitting how far it must be moved back. Same
+    magnitude, opposite sign, both correct for what they mean. Nothing in
+    either module's signature says so, so it is asserted here.
+    """
+    result = _solve(frames(a=-4.0, b=0.0))
+    scr = seam_continuity_residual(frames(a=-4.0, b=0.0)[0], **KW)
+    assert scr.slope_spread > 0.02, "the fixture must give implied_dx meaning"
+    mean_dx = float(np.mean([dx for _, dx in result.anchors]))
+    assert scr.implied_dx == pytest.approx(-mean_dx, abs=0.6)
+
+
+# -- CLI ---------------------------------------------------------------------
+
+
+def test_cli_exits_non_zero_when_it_refuses(tmp_path, capsys):
+    """A guard that warns and continues is not a guard.
+
+    In an automated chain the only thing downstream reads is the exit code.
+    """
+    p = tmp_path / "blank.png"
+    cv2.imwrite(str(p), np.full((H, W, 3), 120, dtype=np.uint8))
+    assert main(["stitch_solver.py", str(p), f"--seam-x={SEAM}"]) == 1
+    out = capsys.readouterr().out
+    assert "REFUSED" in out and "accepted structures" in out
+
+
+def test_cli_refusal_json_carries_the_reasons(tmp_path, capsys):
+    p = tmp_path / "blank.png"
+    cv2.imwrite(str(p), np.full((H, W, 3), 120, dtype=np.uint8))
+    assert main(["stitch_solver.py", str(p), f"--seam-x={SEAM}", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["refused"]
+    assert payload["report"]["coverage"]["n"] == 0
+
+
+def test_cli_reports_usage_without_frames(capsys):
+    assert main(["stitch_solver.py"]) == 2


### PR DESCRIPTION
Implements Workflow A from `docs/STITCH_CALIBRATION.md` §10: derive `dx_anchors`
from panorama frames instead of from a human dragging handles. It works on
synthetic ground truth, and it **refuses on all 27 archived games** — which is
the finding, not a failure.

### The headline: SCR cannot be the solver's objective

On a soccer field, almost everything crossing a **vertical** seam runs
**horizontally** — touchlines, painted banners, the treeline. **A horizontal
edge is invariant under horizontal shift.** Over **4239 archived observations
the median |slope| is 0.034**: a 10 px misregistration moves the median
observation 0.34 px, under its own ~1.3 px noise. This is structural, not a
tuning problem — spanning the blend window in x *forces* a structure to be
near-horizontal.

Independently reproduced before merging: on a separate game frame, 56
observations, median |slope| **0.0216**, so 10 px of error moves the median
observation 0.22 px.

Sweeps (inject a constant dx, re-detect) on the three frames richest in
vertical-edge energy at the seam:

| dx | rich A | rich B | control |
|---|---|---|---|
| −32 | 26.12 | 30.29 | 36.63 |
| 0 | 29.15 | 27.51 | 37.17 |
| +32 | **23.47** | 27.03 | 37.71 |

**Breaking rich A by 32 px scored better than leaving it alone.** `implied_dx`
wandered −0.8…−53 px across a single frame's sweep. A coordinator sweep on a
fourth frame agreed: p90 moved <3 px across ±32 px, best at +24, worst at −16.

**Why a person in the seam does not rescue it** — and this is the subtle part.
A person standing at the seam is *inside* the 128 px blend window, where the two
sensors are already superposed. There is no left/right pair to extrapolate from.
Tested: the 12 frames richest in vertical-edge energy gave `implied_dx` spanning
−55…+141 px for one fixed camera, and 4 of 12 produced zero observations. A
human eye reads a torn body instantly; this metric cannot, because it works by
matching structures on the two *shoulders* outside the window.

### Design corrections, all measured

1. **§10's "regression of dx on y" does not exist.** A single observation is not
   a `dx`. Usable structures span the window in x, hence are near-horizontal,
   and such a line displaced by `dx` moves *vertically*: `r_y = dy + m·dx(y)`.
   Recoverable only jointly, from differing slopes.
2. **§9.3's counts are necessary but not sufficient.** 18 observations, 3/3
   bands, 70% height, slopes ±0.011 still leaves dx uncertain to ±1.35 px. The
   governing gate is the **standard error on dx**, refused above 1.0 px.
3. **`height_coverage` is a range, so two stragglers satisfy it** — it read
   81–98% on the archive while 73–98% of the mass sat in a single band. Added
   `MIN_ROW_BAND_FRACTION`.
4. **Ground-plane parallax on a sideline mount is also linear in y**, so it is
   shape-indistinguishable from lens roll. `dy` discriminates, since side-by-side
   lenses give parallax no `dy` component.
5. `seam_metric.implied_dx` carries the **opposite sign** to `dx_anchors`.

### What is tested

Synthetic shear recovered to **<0.35 px** at all five anchors (roll slope within
0.0008 px/row). The reported standard error bounds the actual error on both
well- and barely-conditioned fixtures. Sign verified end-to-end through the
shipped `stitch_remap` applier — p90 halves with the anchors, and negating them
makes it worse. Every refusal path. Units survive solving at half resolution.
37 tests; suite 1881 passing; ruff clean.

**Argued, not tested:** that echo separation inside the blend window could
recover `dx` (named as the next step, unbuilt), and that the pre-stitch
`VIDEOPROC 2` port would sidestep this entirely (§14 Q1).

### A near-miss worth recording

The cross-frame check initially "agreed" on 22 of 23 games whose halves differed
by up to **242 px** — because each half's error bar was ±100 px. Agreement
between two useless numbers is not evidence. It now requires precision before it
compares, and that rubber stamp is now a test.

### What this means

96 frames across 27 games: 23 refuse on band imbalance, 4 on zero observations,
weighted r² 0.00–0.24 everywhere. Separately, **52 of 96 frames sit below the SSR
noise floor** — it is not established that these placements have a
misregistration worth correcting at all. Visual inspection agrees: players
straddling the seam are continuous through it.

So the automatic path is parked with its reasons recorded, and the
human-in-the-loop tool is the one that works — a person in the seam makes a
20 px error obvious to the eye that this metric cannot see.