### PR TITLE
feat(stitch): calibrate the seam from a phone, against a person standing in it

### DIFF
--- a/VideoGrouperService.spec
+++ b/VideoGrouperService.spec
@@ -8,11 +8,23 @@
 # onnxruntime/cv2/av to its excludes because it only drives the autocam (GUI)
 # step and must stay light.
 
+# The seam-calibration tool at /stitch reaches the firmware-side toolkit
+# (seam_metric, stitch_apply, lut2d, camsh) by path rather than by import --
+# `reolink-firmware-patching/` is excluded from the wheel and from mypy because
+# it is firmware territory, not application code. Carrying the two directories
+# in as data keeps that separation while letting the installed service run the
+# calibration UI; `stitch_calibration._vpe_dir()` looks for them under
+# sys._MEIPASS, and stitch_apply's own `parents[1]/"runtime"` lookup lands
+# correctly given this layout. Service spec only: the tray excludes cv2/av, so
+# these modules could not import there anyway.
 a = Analysis(
     ['video_grouper\\service\\main.py'],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=[
+        ('reolink-firmware-patching\\vpe', 'vpe'),
+        ('reolink-firmware-patching\\runtime', 'runtime'),
+    ],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/VideoGrouperService.spec
+++ b/VideoGrouperService.spec
@@ -9,7 +9,8 @@
 # step and must stay light.
 
 # The seam-calibration tool at /stitch reaches the firmware-side toolkit
-# (seam_metric, stitch_apply, lut2d, camsh) by path rather than by import --
+# (seam_metric, seam_vertical, stitch_apply, lut2d, camsh) by path rather than
+# by import --
 # `reolink-firmware-patching/` is excluded from the wheel and from mypy because
 # it is firmware territory, not application code. Carrying the two directories
 # in as data keeps that separation while letting the installed service run the

--- a/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
+++ b/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
@@ -1022,6 +1022,78 @@ scalars; the §6.2 push plus §7 install for the mesh; nothing at all for downst
 re-fetches a fresh `Snap` and re-scores, so the operator sees the before/after numbers, not a
 promise.
 
+### 11.1 Two corrections to the above, from Mark, 2026-08-17
+
+Both change the shape of the tool, so they are recorded here rather than only in the code.
+
+**The client is a phone, at the pitch side.** *"I will connect to the camera from my phone while on
+the field, so setting this up in the camera manager app will work."* An earlier reading of this
+section assumed the field ruled out a live view and made the file door primary; that inference was
+wrong. The live `Snap` is the primary door and the loop is: tripod → aim → snap → adjust → apply →
+re-snap. Consequences, all implemented in `video_grouper/web/stitch_calibration.py`: touch gestures
+(axis-locked one-finger drag, pinch zoom, thumb-sized roll and nudge controls) rather than
+mouse-and-keyboard; a single-column layout for a 390 px viewport with everything secondary folded
+away, because a pair of 640×2160 strips and a tall curve widget do not fit by shrinking; no external
+font or CDN request; every score request bounded by a 9 s timeout, with numbers that go visibly
+stale the instant the curve moves and a backoff retry that recovers them. Reaching the app from a
+phone needs `[TTT] auth_server_bind` set to the machine's LAN address — the host allowlist is
+loopback plus that value, and `0.0.0.0` does not widen it **[R]**. A new `POST /stitch/aim` returns
+a 1/8-scale panorama (~35 KB) with the seam marked, cheap enough to press repeatedly while someone
+walks into position, and it never disturbs a scored session.
+
+**The calibration target is a person standing in the seam.** *"It's easy to see misregistration if
+there's a person in the seam."* This is the answer to the anomaly in §9.1: SCR fits **near-horizontal**
+structures and `r_y = -m·dx`, so a horizontal edge is *invariant* under the horizontal shift being
+tuned. On a sideline mount almost everything crossing the vertical seam runs horizontally — far
+touchline, treeline, painted banners — so a frame can produce dozens of observations, pass every
+coverage gate, and carry no information at all. Measured **[M]**:
+
+- On three games, of 11, 61 and 88 accepted structures, **0, 1 and 2** were steeper than |m| = 0.15;
+  restricting the dx sweep to the subset that can see dx moved p90 by **1.3%, 2.9% and 1.8%** — no
+  better than the full set. Re-weighting does not rescue these frames; only different structure does.
+- Across 87 frames of the archived set (`F:\archive\duo3_stitch\frames`), whole-band `|ln SSR|`
+  cannot distinguish a corridor with upright structure from one without (median **0.095** against
+  **0.088**), while the same metric restricted to the rows holding that structure separates them by
+  an order of magnitude (**1.889** against **0.170**). 48 of the 87 read below the 0.10 noise floor
+  whole-band — "a perfect seam" — and 16 of those have upright structure whose own rows read a median
+  of **1.49**.
+- On one frame with a player straddling the seam, whole-band `|ln SSR|` is **0.062** and the player's
+  rows read **1.180** (2.188 over the strongest band alone).
+
+So the UI makes standing in the seam a numbered **step**, shows where the seam falls before the snap
+so the operator can place the person, detects whether anything upright is actually in the corridor
+(`vpe/seam_vertical.py`, ~60 ms) and says *put a person in the seam* when nothing is, reports SCR's
+steerable subset beside the whole-set number rather than redefining it, and reports `|ln SSR|` over
+the target's rows as well as over the field band. Per §12.1 the person stands where play happens, not
+beside the tripod, and `calibrated_for.subject_distance_m` records which depth that was.
+
+**The eye is the instrument; the numbers are aids.** The automatic solver (#136) refuses on all 27
+archived games for the same geometric reason — median |slope| over 4239 observations is 0.034, so a
+10 px error moves the median observation 0.34 px, under its own ~1.3 px noise — and it establishes
+the part that bears on this UI: a person standing in the seam is *inside* the blend window, where
+the two sensors are already superposed, so there is no separated pair to extrapolate from and no
+shoulder-matching estimator can score them (12 vertical-structure-rich frames from one camera gave
+`implied_dx` spanning −55..+141 px, 4 of them producing no observations at all) **[M]**. What does
+work is a human looking at whether the body is continuous: with ±20 px injected the tearing is
+unmistakable at 4× and invisible to the metric **[M]**. The UI is therefore the path that works, not
+the fallback, and it says so — every number is presented as secondary to the picture.
+
+**This is a check-and-correct tool, and "nothing to change" is the common answer.** 52 of 96
+archived frames sit below the SSR noise floor (#136's sample; 48 of 87 in the independent sample
+above, same conclusion) and players straddling the seam look continuous, so it is not established
+that these placements are misregistered at all **[M]**. The job is the knocked
+tripod, the remount, the new field. The UI states that in the lede, and when `|ln SSR|` is at or
+below the noise floor it says so as a verdict in its own right rather than leaving an operator to
+hunt for a correction that is not there.
+
+Two honest limits. `|ln SSR|` on the target is raised by the object *existing* inside the window as
+well as by misregistration (§9.2 says the same of the 0.3 m live frame), so it is a before/after
+comparator on a fixed scene, not an absolute — the UI says so, and the separation figures above are
+evidence that the *metric responds to upright structure*, never evidence that those frames are
+broken. And note the deliberate difference from §10, which rejects players: that is the automatic
+solver accumulating observations across a game where players move and straddle unknown depths. A
+cooperating person standing still at a stated distance is the opposite case.
+
 ---
 
 ## 12. What this does not fix

--- a/reolink-firmware-patching/vpe/seam_metric.py
+++ b/reolink-firmware-patching/vpe/seam_metric.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
 
 import cv2
@@ -267,7 +268,60 @@ def _fit(xs: np.ndarray, ys: np.ndarray) -> tuple[float, float, float]:
     return float(m), float(c), rms
 
 
-def seam_continuity_residual(
+def interp_dx_anchors(anchors: Sequence[tuple[float, float]], y: float) -> float:
+    """Linear interpolation of `[y, dx]` anchors, clamped outside their range.
+
+    `np.interp`, deliberately: it is what the shipped downstream corrector uses
+    (`stitch_remap.build_dx_lookup`) and what `lut2d.interp_dx` reproduces for
+    the camera. One anchor list has to mean one curve on every surface, or the
+    number an operator tunes against is not the number that gets applied.
+    """
+    if not anchors:
+        return 0.0
+    ys = [float(a[0]) for a in anchors]
+    ds = [float(a[1]) for a in anchors]
+    return float(np.interp(y, ys, ds))
+
+
+@dataclass
+class ShoulderChains:
+    """Structures detected on each shoulder, kept so a *candidate* dx can be
+    scored without re-running the detector.
+
+    Detection is the whole cost of SCR -- linking per-column edge points into
+    chains is a Python loop over hundreds of columns and, on a noisy frame,
+    hundreds of points per column (13 s on a 7680x2160 still). Scoring a fitted
+    chain against a candidate dx is arithmetic on a handful of numbers.
+
+    That split is what makes an interactive tool possible: the operator drags,
+    and every candidate curve is scored against the SAME objective the solver
+    minimises, at interactive rates, because the expensive half was done once
+    when the frame was fetched.
+
+    The chains are stored as raw point arrays rather than as fitted lines
+    because a dx that varies with y *shears* a structure -- it changes the
+    slope, not just the intercept -- so the fit has to be redone against the
+    displaced points. `residual_from_chains` does exactly that.
+
+    What this cannot model: re-detection. A shear changes the gradient field
+    slightly, so a marginal structure could in principle appear or vanish. The
+    displaced-refit path holds the detected set fixed. See
+    `tests/test_seam_metric_incremental.py`, which pins the agreement against a
+    genuinely shifted image rather than asserting it.
+    """
+
+    left: list[tuple[np.ndarray, np.ndarray]] = field(default_factory=list)
+    right: list[tuple[np.ndarray, np.ndarray]] = field(default_factory=list)
+    y0: int = 0
+    y1: int = 0
+    seam_x: int = SEAM_X
+
+    @property
+    def band(self) -> tuple[int, int]:
+        return self.y0, self.y1
+
+
+def detect_shoulder_chains(
     image: np.ndarray,
     seam_x: int = SEAM_X,
     blend_w: int = BLEND_W,
@@ -275,34 +329,10 @@ def seam_continuity_residual(
     band: tuple[int, int] | None = None,
     min_strength: float = 3.0,
     max_slope: float = 0.35,
-    max_slope_diff: float = 0.06,
-    max_gap: float = 40.0,
-    max_fit_rms: float = 1.2,
     min_len: int = 60,
-) -> ScrResult:
-    """Fit near-horizontal structures on both shoulders, extrapolate, compare.
-
-    Only near-horizontal structures can be used, because a structure has to
-    span the whole blend window in x to be extrapolated to the seam from both
-    sides. That has a consequence worth stating: such a line is displaced
-    *vertically* by a horizontal misregistration, by `r_y = -m * dx` where m is
-    its slope. So a single line under-determines dx (a flat line sees nothing),
-    and the estimate comes from regressing r_y on m across lines of differing
-    slope. `implied_dx` is that regression; it is only meaningful when
-    `slope_spread` is non-trivial, which the caller must check.
-
-    SENSE, because it is the opposite of the artifact's and nothing else says
-    so. `implied_dx` here is the misregistration the right half currently
-    CARRIES -- positive means its content sits that many px too far right. The
-    profile's `dx_anchors` are the CORRECTION, "px the right half must move
-    right" (`stitch_remap.build_dx_lookup`, STITCH_CALIBRATION.md 4.4), so the
-    two are equal and opposite. `stitch_solver` fits the correction directly
-    rather than negating this, and `tests/test_stitch_solver.py` pins the
-    relationship so the trap stays visible.
-
-    `implied_dx` is also a single whole-frame number, not a curve: it assumes
-    one dx for every row. A per-row shear needs the joint fit in
-    `stitch_solver.solve`, which this deliberately is not.
+) -> ShoulderChains:
+    """The expensive half of SCR: find near-horizontal structures on both
+    shoulders. Chain x is absolute image column; chain y is relative to `y0`.
     """
     gray = to_gray(image)
     y0, y1 = band or default_band(gray.shape[0])
@@ -316,19 +346,57 @@ def seam_continuity_residual(
     right_xs = right_xs[(right_xs >= 0) & (right_xs < gray.shape[1])]
 
     max_step = max_slope * 1.5 + 1.0
-    left = _chains(grad, left_xs, min_strength, max_step, min_len)
-    right = _chains(grad, right_xs, min_strength, max_step, min_len)
+    return ShoulderChains(
+        left=_chains(grad, left_xs, min_strength, max_step, min_len),
+        right=_chains(grad, right_xs, min_strength, max_step, min_len),
+        y0=y0,
+        y1=y1,
+        seam_x=seam_x,
+    )
 
-    def usable(chs):
+
+def residual_from_chains(
+    chains: ShoulderChains,
+    dx_anchors: Sequence[tuple[float, float]] | None = None,
+    *,
+    max_slope: float = 0.35,
+    max_slope_diff: float = 0.06,
+    max_gap: float = 40.0,
+    max_fit_rms: float = 1.2,
+) -> ScrResult:
+    """The cheap half of SCR: fit, match across the seam, and summarise.
+
+    `dx_anchors` are `[y, dx]` in the coordinates of the image the chains were
+    detected on, with the sign convention of the whole project: **dx is the
+    number of pixels the RIGHT half must move right, at row y, to register with
+    the left**. Passing them scores the curve *as if* it had been applied,
+    which is what lets an operator see the objective move while dragging.
+
+    The displacement is applied to the right-hand chain points and the line is
+    refitted, not applied to the fitted intercept: a dx that varies with y is a
+    shear, and a shear rotates a sloped structure as well as translating it.
+    `y = m*x + c` sheared by `dx(y)` with local ramp `k` becomes
+    `m' = m/(1 + m*k)` -- a 1.3% slope change at the extremes of this camera's
+    range, small but free to get right.
+    """
+    y0, y1, seam_x = chains.y0, chains.y1, chains.seam_x
+
+    def fits(
+        chs: list[tuple[np.ndarray, np.ndarray]], displace: bool
+    ) -> list[tuple[float, float, float, int]]:
         out = []
         for xs, ys in chs:
+            if displace and dx_anchors:
+                xs = xs + np.array(
+                    [interp_dx_anchors(dx_anchors, float(y) + y0) for y in ys]
+                )
             m, c, rms = _fit(xs, ys)
             if abs(m) > max_slope or rms > max_fit_rms:
                 continue
             out.append((m, c, rms, len(xs)))
         return out
 
-    lfits, rfits = usable(left), usable(right)
+    lfits, rfits = fits(chains.left, False), fits(chains.right, True)
 
     obs: list[ScrObservation] = []
     taken: set[int] = set()
@@ -390,6 +458,66 @@ def seam_continuity_residual(
             w = np.clip(1.345 * scale / np.maximum(np.abs(resid), 1e-9), 0.0, 1.0)
         res.implied_dy, res.implied_dx = float(beta[0]), float(beta[1])
     return res
+
+
+def seam_continuity_residual(
+    image: np.ndarray,
+    seam_x: int = SEAM_X,
+    blend_w: int = BLEND_W,
+    shoulder_w: int = SHOULDER_W,
+    band: tuple[int, int] | None = None,
+    min_strength: float = 3.0,
+    max_slope: float = 0.35,
+    max_slope_diff: float = 0.06,
+    max_gap: float = 40.0,
+    max_fit_rms: float = 1.2,
+    min_len: int = 60,
+) -> ScrResult:
+    """Fit near-horizontal structures on both shoulders, extrapolate, compare.
+
+    Only near-horizontal structures can be used, because a structure has to
+    span the whole blend window in x to be extrapolated to the seam from both
+    sides. That has a consequence worth stating: such a line is displaced
+    *vertically* by a horizontal misregistration, by `r_y = -m * dx` where m is
+    its slope. So a single line under-determines dx (a flat line sees nothing),
+    and the estimate comes from regressing r_y on m across lines of differing
+    slope. `implied_dx` is that regression; it is only meaningful when
+    `slope_spread` is non-trivial, which the caller must check.
+
+    SENSE, because it is the opposite of the artifact's and nothing else says
+    so. `implied_dx` here is the misregistration the right half currently
+    CARRIES -- positive means its content sits that many px too far right. The
+    profile's `dx_anchors` are the CORRECTION, "px the right half must move
+    right" (`stitch_remap.build_dx_lookup`, STITCH_CALIBRATION.md 4.4), so the
+    two are equal and opposite. `stitch_solver` fits the correction directly
+    rather than negating this, and `tests/test_stitch_solver.py` pins the
+    relationship so the trap stays visible.
+
+    `implied_dx` is also a single whole-frame number, not a curve: it assumes
+    one dx for every row. A per-row shear needs the joint fit in
+    `stitch_solver.solve`, which this deliberately is not.
+
+    Detection and scoring are split (`detect_shoulder_chains` /
+    `residual_from_chains`) so an interactive caller can re-score a candidate
+    dx without paying for detection again; this function is the one-shot
+    composition of the two and is what every batch caller should use.
+    """
+    return residual_from_chains(
+        detect_shoulder_chains(
+            image,
+            seam_x=seam_x,
+            blend_w=blend_w,
+            shoulder_w=shoulder_w,
+            band=band,
+            min_strength=min_strength,
+            max_slope=max_slope,
+            min_len=min_len,
+        ),
+        max_slope=max_slope,
+        max_slope_diff=max_slope_diff,
+        max_gap=max_gap,
+        max_fit_rms=max_fit_rms,
+    )
 
 
 # -- acceptance --------------------------------------------------------------

--- a/reolink-firmware-patching/vpe/seam_vertical.py
+++ b/reolink-firmware-patching/vpe/seam_vertical.py
@@ -1,0 +1,326 @@
+"""Does anything at the seam actually *see* a horizontal misregistration?
+
+`seam_metric.SCR` fits **near-horizontal** structures (`max_slope = 0.35`) on the
+two shoulders and compares where they arrive at the seam. Write out what a
+horizontal shift does to such a structure and the problem is immediate:
+
+    r_y = -m * dx          (seam_metric.seam_continuity_residual, and section 9.1)
+
+so an observation's sensitivity to `dx`, in px of residual per px of shift, is
+
+    sensitivity = |m| / sqrt(1 + m^2)   ->  0 as the structure flattens.
+
+A perfectly horizontal edge is **invariant** under a horizontal shift. It still
+gets detected, still gets paired across the seam, still contributes an
+observation and a residual -- and that residual says nothing whatever about
+registration. On a soccer field nearly everything that crosses a vertical seam
+runs horizontally: the far touchline, the treeline, the grass/track boundary,
+painted banners. That is the mechanism behind the measured anomaly recorded in
+`video_grouper/web/stitch_calibration.py`: 40-69 observations, every coverage
+gate passed, p90 of 27-36 px, and an objective that barely moves across the
+whole plausible dx range, on frames whose seams are visibly registered.
+
+Two instruments here, neither of which redefines anything in `seam_metric`:
+
+`split_by_dx_sensitivity` sorts an existing `ScrResult`'s observations into the
+ones that can see `dx` and the ones that cannot, so a p90 can be reported over
+the steering subset instead of over a set that is mostly blind to the quantity
+being tuned.
+
+`vertical_structure` asks the *picture* the prior question: is there any
+vertical structure in the blend window at all? It is a presence detector, not a
+registration estimator -- it says "there is something upright at rows 900-1100
+that a horizontal error would break", or it says there is nothing, in which case
+the honest instruction to an operator standing at the pitch is not "this frame
+is unusable" but **put a person in the seam**. A person is upright by
+construction: torso, legs, head. That is exactly the structure a horizontal
+misregistration destroys and exactly what a horizontal edge cannot supply.
+
+**What this module does not do, deliberately.** It does not measure
+registration, and it must never be read as doing so. A person standing in the
+seam is *inside* the blend window, where the two sensors are already
+superposed; there is no separated left/right pair to extrapolate from and
+compare, so no shoulder-matching estimator can score them. The automatic solver
+established that from the other side, on the same archive: across 12
+vertical-structure-rich frames from one fixed camera, `implied_dx` spanned
+-55..+141 px and 4 of the 12 produced no observations at all. The instrument
+that works on a person in the seam is the operator's eye -- a body torn at the
+seam is unmistakable at 4x and invisible to the metric -- and this module's only
+job is to tell them whether there is a body there to look at, and where.
+
+A second thing this is not: evidence of a defect. Across the archived set 52 of
+96 frames sit below the SSR noise floor and players straddling the seam look
+continuous, so it is not established that these placements are misregistered at
+all. A high ratio here means "something upright is in the corridor", never
+"the corridor is broken".
+
+Validated as a presence detector on real frames, which is the only claim made
+for it: see `MIN_VERTICAL_RATIO` for the distribution it was calibrated against
+and the one false negative found. `split_by_dx_sensitivity` needs no validation
+beyond arithmetic -- it is the derivative of a formula `seam_metric` already
+documents -- but the conclusion drawn from it was measured: on three games,
+0, 1 and 2 of 11, 61 and 88 accepted structures were steeper than |m| = 0.15.
+
+Per section 12.1 the person has to stand where play happens. One calibration is
+exact at one depth, and a target at 2 m carries ~60 px of parallax disparity
+that has nothing to do with the lens roll being calibrated.
+
+Note the deliberate difference from section 10, which *rejects* players: the
+automatic solver accumulates observations across a whole game, where players
+move, straddle unknown depths and are the thing being detected. A cooperating
+person standing still at a stated distance, in a frame an operator chose, is
+the opposite case -- the depth is known because someone walked to it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+import cv2
+import numpy as np
+
+SEAM_X = 3840
+BLEND_W = 256
+
+#: Below this, an observation is blind to `dx` for practical purposes: at
+#: |m| = 0.05 a 20 px misregistration moves the residual by 1 px, which is the
+#: acceptance gate's whole budget. Structures flatter than this are reported
+#: separately rather than averaged into a number the operator is trying to
+#: minimise.
+MIN_DX_SENSITIVITY = 0.05
+
+
+class _Observation(Protocol):
+    """Structurally, a `seam_metric.ScrObservation`. Duck-typed on purpose so
+    this module never imports the metric it comments on."""
+
+    slope: float
+    residual_perp: float
+
+
+def dx_sensitivity(slope: float) -> float:
+    """Px of perpendicular residual per px of horizontal misregistration.
+
+    `r_y = -m*dx`, and `residual_perp = |r_y| / hypot(1, m)`, so the derivative
+    of the reported residual with respect to dx is `|m| / hypot(1, m)` -- the
+    sine of the structure's angle from horizontal. 1 for a vertical structure,
+    0 for a horizontal one.
+    """
+    return float(abs(slope) / np.hypot(1.0, slope))
+
+
+@dataclass
+class SensitivitySplit:
+    """An `ScrResult`'s observations, sorted by whether they can see `dx`."""
+
+    n_total: int = 0
+    n_steering: int = 0
+    p50_steering: float = float("nan")
+    p90_steering: float = float("nan")
+    p90_blind: float = float("nan")
+    #: Median sensitivity among the steering subset: how many px of residual one
+    #: px of misregistration actually buys on this frame.
+    median_sensitivity: float = 0.0
+    #: Worst-case: even the steepest structure here only converts this fraction
+    #: of a shift into a residual.
+    max_sensitivity: float = 0.0
+
+    @property
+    def blind_fraction(self) -> float:
+        if not self.n_total:
+            return 0.0
+        return 1.0 - self.n_steering / self.n_total
+
+
+def split_by_dx_sensitivity(
+    observations: Sequence[_Observation],
+    min_sensitivity: float = MIN_DX_SENSITIVITY,
+) -> SensitivitySplit:
+    """Summarise an observation set by whether it can steer a dx at all."""
+    if not observations:
+        return SensitivitySplit()
+    sens = np.array([dx_sensitivity(o.slope) for o in observations])
+    perp = np.array([float(o.residual_perp) for o in observations])
+    steering = sens >= min_sensitivity
+    out = SensitivitySplit(
+        n_total=len(observations),
+        n_steering=int(steering.sum()),
+        max_sensitivity=round(float(sens.max()), 4),
+    )
+    if out.n_steering:
+        out.p50_steering = float(np.percentile(perp[steering], 50))
+        out.p90_steering = float(np.percentile(perp[steering], 90))
+        out.median_sensitivity = round(float(np.median(sens[steering])), 4)
+    if out.n_steering < out.n_total:
+        out.p90_blind = float(np.percentile(perp[~steering], 90))
+    return out
+
+
+# -- presence of upright structure -------------------------------------------
+
+
+@dataclass
+class VerticalBand:
+    y0: int
+    y1: int
+    #: Vertical-edge energy in the seam corridor over the same statistic taken
+    #: across a wide reference slab at the same rows. 1.0 means the corridor is
+    #: as featureless as the rest of the row.
+    ratio: float
+    #: Column of the strongest vertical edge in the corridor, absolute x.
+    peak_x: int
+    has_structure: bool
+
+
+@dataclass
+class VerticalProfile:
+    bands: list[VerticalBand] = field(default_factory=list)
+    corridor: tuple[int, int] = (0, 0)
+    band: tuple[int, int] = (0, 0)
+    min_ratio: float = 0.0
+
+    @property
+    def n_with_structure(self) -> int:
+        return sum(1 for b in self.bands if b.has_structure)
+
+    @property
+    def best(self) -> VerticalBand | None:
+        return max(self.bands, key=lambda b: b.ratio) if self.bands else None
+
+    @property
+    def rows_with_structure(self) -> list[tuple[int, int]]:
+        """Contiguous row ranges that hold upright structure, merged."""
+        out: list[list[int]] = []
+        for b in self.bands:
+            if not b.has_structure:
+                continue
+            if out and out[-1][1] == b.y0:
+                out[-1][1] = b.y1
+            else:
+                out.append([b.y0, b.y1])
+        return [(a, b) for a, b in out]
+
+
+#: A corridor whose 90th-percentile column energy exceeds the reference slab's
+#: by this much holds something upright.
+#:
+#: Calibrated on the archived Duo 3 frame set rather than chosen: over 87 frames
+#: spanning 28 tripod placements the band ratio runs p25 0.94, p50 1.23, p75
+#: 4.36, max 59.3, and the threshold sits in the gap. Bare grass reads 0.80-0.82;
+#: a player straddling the seam reads 20.6, and the rows the detector returns for
+#: that frame (404-609) are the rows the player occupies, checked against the
+#: image at 4x. 31 of the 87 frames are flagged, 56 are not.
+#:
+#: Known false negative: a painted line running near-vertically through the
+#: corridor read 1.78 on one placement and was not flagged. It is real upright
+#: structure and the detector missed it, which is the conservative direction --
+#: the cost is a "put a person in the seam" prompt the operator did not need.
+MIN_VERTICAL_RATIO = 2.2
+
+
+def vertical_structure(
+    image: np.ndarray,
+    seam_x: int = SEAM_X,
+    blend_w: int = BLEND_W,
+    band: tuple[int, int] | None = None,
+    n_bands: int = 18,
+    ref_w: int = 1200,
+    min_ratio: float = MIN_VERTICAL_RATIO,
+) -> VerticalProfile:
+    """Where, if anywhere, upright structure crosses the seam corridor.
+
+    Measured on |dI/dx|^2 -- the gradient a *horizontal* misregistration
+    displaces -- per column, then compared against the same statistic over a
+    wide slab at the same rows. Normalising against the frame's own texture at
+    the same rows is what makes the number mean "unusual here" rather than
+    "bright scene": grass reads ~1 whatever the light.
+
+    Deliberately not the blend window's *damage*, which is what
+    `seam_metric.seam_sharpness_ratio` measures. This is presence: it answers
+    "is there anything here for a misregistration to break", which is the
+    question an operator has *before* they trust any registration number.
+    """
+    gray = image
+    if gray.ndim == 3:
+        gray = cv2.cvtColor(gray, cv2.COLOR_BGR2GRAY)
+    gray = gray.astype(np.float32)
+    h, w = gray.shape
+    y0, y1 = band or (int(h * 0.14), int(h * 0.995))
+    half = blend_w // 2
+    c0, c1 = max(0, seam_x - half), min(w, seam_x + half)
+    r0, r1 = max(0, seam_x - ref_w), min(w, seam_x + ref_w)
+
+    slab = cv2.GaussianBlur(gray[y0:y1, r0:r1], (0, 0), 1.0)
+    energy = cv2.Sobel(slab, cv2.CV_32F, 1, 0, ksize=3) ** 2
+    cor_lo, cor_hi = c0 - r0, c1 - r0
+
+    profile = VerticalProfile(corridor=(c0, c1), band=(y0, y1), min_ratio=min_ratio)
+    rows = y1 - y0
+    if rows < n_bands or cor_hi <= cor_lo:
+        return profile
+    edges = np.linspace(0, rows, n_bands + 1).astype(int)
+    for i in range(n_bands):
+        a, b = edges[i], edges[i + 1]
+        if b <= a:
+            continue
+        col = energy[a:b].mean(axis=0)
+        corridor = col[cor_lo:cor_hi]
+        reference = np.concatenate([col[:cor_lo], col[cor_hi:]])
+        if reference.size < 64 or corridor.size < 8:
+            continue
+        # p90 against p90: the corridor is 256 px of a 2400 px slab, so a person
+        # occupying 30 columns is a tenth of the corridor and a hundredth of the
+        # reference. Comparing like with like keeps a textured frame at ~1
+        # instead of manufacturing a ratio out of the tail of grass noise.
+        cor_level = float(np.percentile(corridor, 90))
+        ref_level = float(np.percentile(reference, 90))
+        ratio = cor_level / max(ref_level, 1e-6)
+        profile.bands.append(
+            VerticalBand(
+                y0=int(y0 + a),
+                y1=int(y0 + b),
+                ratio=round(ratio, 3),
+                peak_x=int(c0 + int(np.argmax(corridor))),
+                has_structure=bool(ratio >= min_ratio),
+            )
+        )
+    return profile
+
+
+def summarise(profile: VerticalProfile, split: SensitivitySplit | None = None) -> dict:
+    """JSON for the UI: the verdict first, the numbers behind it after."""
+    best = profile.best
+    out: dict[str, Any] = {
+        "corridor": list(profile.corridor),
+        "min_ratio": profile.min_ratio,
+        "n_bands": len(profile.bands),
+        "n_with_structure": profile.n_with_structure,
+        "rows": [list(r) for r in profile.rows_with_structure],
+        "best_ratio": None if best is None else best.ratio,
+        "best_rows": None if best is None else [best.y0, best.y1],
+        "best_x": None if best is None else best.peak_x,
+        "bands": [
+            {"y0": b.y0, "y1": b.y1, "ratio": b.ratio, "on": b.has_structure}
+            for b in profile.bands
+        ],
+    }
+    if split is not None:
+        out["scr_split"] = {
+            "n_total": split.n_total,
+            "n_steering": split.n_steering,
+            "blind_fraction": round(split.blind_fraction, 3),
+            "p50_steering": None
+            if split.p50_steering != split.p50_steering
+            else round(split.p50_steering, 3),
+            "p90_steering": None
+            if split.p90_steering != split.p90_steering
+            else round(split.p90_steering, 3),
+            "p90_blind": None
+            if split.p90_blind != split.p90_blind
+            else round(split.p90_blind, 3),
+            "median_sensitivity": split.median_sensitivity,
+            "max_sensitivity": split.max_sensitivity,
+        }
+    return out

--- a/tests/test_seam_metric_incremental.py
+++ b/tests/test_seam_metric_incremental.py
@@ -1,0 +1,256 @@
+"""Gates on the incremental SCR path, and on the sign of `dx`.
+
+Two things are pinned here, both of which the interactive calibration UI
+depends on and neither of which is safe to assume.
+
+**The fast path must equal the slow path.** `detect_shoulder_chains` +
+`residual_from_chains(anchors)` scores a candidate curve without re-running the
+detector, which is what lets an operator drag and watch the objective move.
+That is only legitimate if it agrees with running the whole metric on a frame
+that really was shifted -- so the tests below do exactly that comparison rather
+than asserting the algebra is right.
+
+**`dx` closes the seam and `-dx` opens it.** This is the signed sanity gate of
+`docs/STITCH_CALIBRATION.md` 4.4, run in simulation, where it costs a second
+instead of a camera write. It also pins the trap it exists to catch: the sign
+of `ScrResult.implied_dx` is the *opposite* of the sign of `dx_anchors`.
+
+The SSR fixture in `test_seam_metric.py` cannot be reused: its structures are
+near-horizontal steps, and a horizontal misregistration displaces a structure
+vertically by `-m * dx`, so a flat line sees nothing (the metric says so
+itself). This fixture therefore draws lines with a deliberate spread of slopes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+VPE_DIR = Path(__file__).resolve().parents[1] / "reolink-firmware-patching" / "vpe"
+sys.path.insert(0, str(VPE_DIR))
+
+from seam_metric import (  # noqa: E402
+    detect_shoulder_chains,
+    interp_dx_anchors,
+    residual_from_chains,
+    seam_continuity_residual,
+)
+
+from video_grouper.utils.stitch_remap import (  # noqa: E402
+    apply_shift_to_frame_rgb,
+)
+
+W, H = 2048, 900
+SEAM = W // 2
+BLEND = 256
+SHOULDER = 384
+
+# Slopes deliberately spread: `implied_dx` comes from regressing the vertical
+# residual on the slope, so a fixture of parallel lines would leave it
+# under-determined and the test would pass on a metric that measured nothing.
+_LINES = (
+    (-0.30, 760),
+    (-0.16, 300),
+    (-0.05, 620),
+    (0.07, 180),
+    (0.19, 500),
+    (0.30, 80),
+)
+
+
+def _scene(rng: np.random.Generator, w: int, h: int) -> np.ndarray:
+    """Smooth background plus straight lines of varying slope."""
+    img = 110 + 6 * cv2.GaussianBlur(rng.normal(0.0, 1.0, (h, w)), (0, 0), 5.0)
+    xs = np.arange(w)
+    for m, y0 in _LINES:
+        ys = y0 + m * (xs - w / 2)
+        for offset, amp in ((-1, 30), (0, 55), (1, 30)):
+            yy = np.clip(np.round(ys + offset).astype(int), 0, h - 1)
+            img[yy, xs] += amp
+    return np.clip(img, 0, 255)
+
+
+def build_panorama(disparity: int = 0, seed: int = 3) -> np.ndarray:
+    """One scene seen by two sensors, butt-joined with a 256-px linear blend.
+
+    `disparity` shifts the right sensor's view of the world left by that many
+    pixels, so its content sits `disparity` px to the LEFT of where the left
+    sensor puts it. Registering the two therefore requires moving the right
+    half RIGHT by `disparity` -- i.e. the correcting `dx` is `+disparity`, in
+    the project's sign convention.
+    """
+    rng = np.random.default_rng(seed)
+    world = _scene(rng, W + 512, H)
+    left = world[:, 256 : 256 + W]
+    right = np.roll(world, -disparity, axis=1)[:, 256 : 256 + W]
+
+    out = left.copy()
+    lo, hi = SEAM - BLEND // 2, SEAM + BLEND // 2
+    alpha = np.linspace(0.0, 1.0, hi - lo)[None, :]
+    out[:, hi:] = right[:, hi:]
+    out[:, lo:hi] = left[:, lo:hi] * (1 - alpha) + right[:, lo:hi] * alpha
+    return np.dstack([np.clip(out, 0, 255).astype(np.uint8)] * 3)
+
+
+def _scr(img: np.ndarray):
+    return seam_continuity_residual(
+        img, seam_x=SEAM, blend_w=BLEND, shoulder_w=SHOULDER
+    )
+
+
+def _apply(img: np.ndarray, anchors: list[tuple[float, float]]) -> np.ndarray:
+    """Shift the right half per-row exactly as the shipped corrector does."""
+    ys = [a[0] for a in anchors]
+    ds = [a[1] for a in anchors]
+    lut = np.round(np.interp(np.arange(H), ys, ds)).astype(np.int32)
+    return apply_shift_to_frame_rgb(img, lut, SEAM)
+
+
+def _incremental(img: np.ndarray, anchors: list[tuple[float, float]]):
+    chains = detect_shoulder_chains(
+        img, seam_x=SEAM, blend_w=BLEND, shoulder_w=SHOULDER
+    )
+    return residual_from_chains(chains, anchors)
+
+
+# -- the sign convention -----------------------------------------------------
+
+
+def test_the_fixture_is_actually_misregistered():
+    """Guard the guard: if disparity did nothing, every test below is vacuous."""
+    clean, bad = _scr(build_panorama(0)), _scr(build_panorama(6))
+    assert clean.n >= 6, f"fixture yields only {clean.n} structures"
+    assert bad.p50 > clean.p50 + 0.5, (
+        f"disparity moved SCR p50 only {clean.p50:.2f} -> {bad.p50:.2f}"
+    )
+
+
+@pytest.mark.parametrize("disparity", [4, 6, 10])
+def test_positive_dx_closes_the_seam_and_negative_dx_doubles_it(disparity):
+    """The signed sanity gate of STITCH_CALIBRATION.md 4.4, in simulation.
+
+    `dx` means "px the RIGHT half must move right to register with the left".
+    A sign error here does not merely fail to help -- it applies the
+    misregistration twice, and presents to the operator as "the tool doesn't
+    work". Running the gate against a synthetic frame costs a second and needs
+    no camera, so there is no excuse for shipping it unchecked.
+    """
+    img = build_panorama(disparity)
+    before = _scr(img).p50
+    corrected = _scr(_apply(img, [(0, disparity), (H - 1, disparity)])).p50
+    doubled = _scr(_apply(img, [(0, -disparity), (H - 1, -disparity)])).p50
+
+    assert corrected < before * 0.4, (
+        f"dx=+{disparity} should close the seam: p50 {before:.2f} -> {corrected:.2f}"
+    )
+    assert doubled > before * 1.5, (
+        f"dx=-{disparity} should roughly double the error: "
+        f"p50 {before:.2f} -> {doubled:.2f}"
+    )
+
+
+@pytest.mark.parametrize("disparity", [4, 8])
+def test_implied_dx_carries_the_opposite_sign_to_dx_anchors(disparity):
+    """A trap, pinned so nobody walks into it twice.
+
+    `ScrResult.implied_dx` comes from fitting `r_y = dy - m*dx`, and that `dx`
+    is the misregistration *present in the image*, not the correction for it.
+    It is therefore the NEGATIVE of a `dx_anchors` value. Feeding `implied_dx`
+    straight into an anchor curve is the sign error of 4.4, and it is an easy
+    one to make because both quantities are called `dx`.
+    """
+    r = _scr(build_panorama(disparity))
+    assert r.implied_dx == pytest.approx(-disparity, abs=1.0), (
+        f"implied_dx {r.implied_dx:+.2f} for a seam that needs dx=+{disparity}"
+    )
+    # And the correction derived by negating it does close the seam.
+    fixed = _scr(_apply(build_panorama(disparity), [(0, -r.implied_dx)])).p50
+    assert fixed < _scr(build_panorama(disparity)).p50 * 0.5
+
+
+# -- the incremental path ----------------------------------------------------
+
+
+@pytest.mark.parametrize("dx", [0, 3, 6, -5])
+def test_incremental_scoring_matches_a_genuinely_shifted_frame(dx):
+    """The claim the interactive UI rests on, checked rather than argued.
+
+    Scoring a candidate curve from cached chains must give the same answer as
+    detecting on the frame that curve produces. It cannot be identical -- a
+    shear perturbs the gradient field, so a marginal structure could appear or
+    vanish, and the shipped corrector rounds dx to whole pixels -- so this pins
+    agreement to a tolerance well inside the 2.0 px acceptance gate rather than
+    claiming equality.
+    """
+    img = build_panorama(6)
+    anchors = [(0.0, float(dx)), (float(H - 1), float(dx))]
+
+    truth = _scr(_apply(img, anchors))
+    fast = _incremental(img, anchors)
+
+    assert fast.n == truth.n, f"n differs: fast {fast.n} vs truth {truth.n}"
+    assert fast.p50 == pytest.approx(truth.p50, abs=0.35)
+    assert fast.p90 == pytest.approx(truth.p90, abs=0.35)
+
+
+def test_incremental_scoring_tracks_a_sloped_curve_not_just_a_constant():
+    """A roll is linear in y, so the curve that matters is not a translation.
+
+    A constant dx cannot express it, and an implementation that applied the
+    curve to the fitted intercept instead of to the points would get the slope
+    wrong. Compare against the real thing on a ramp.
+    """
+    img = build_panorama(6)
+    anchors = [(0.0, -4.0), (float(H - 1), 8.0)]
+    truth = _scr(_apply(img, anchors))
+    fast = _incremental(img, anchors)
+    assert fast.n == truth.n
+    assert fast.p50 == pytest.approx(truth.p50, abs=0.35)
+    assert fast.p90 == pytest.approx(truth.p90, abs=0.35)
+
+
+def test_incremental_reuse_is_what_makes_it_cheap():
+    """One detection, many scores -- the property, not the wall-clock time.
+
+    Timing assertions are flaky on shared CI, so this pins the structural
+    claim instead: scoring N curves does N fits and zero detections, and the
+    scores genuinely differ from one another.
+    """
+    chains = detect_shoulder_chains(
+        build_panorama(6), seam_x=SEAM, blend_w=BLEND, shoulder_w=SHOULDER
+    )
+    scores = [
+        residual_from_chains(chains, [(0.0, float(d)), (float(H - 1), float(d))]).p50
+        for d in (0, 3, 6, 9)
+    ]
+    assert scores[2] < scores[0], "dx=+6 should beat dx=0 on a +6 disparity"
+    assert len({round(s, 3) for s in scores}) == len(scores), (
+        f"scores should all differ, got {scores}"
+    )
+
+
+def test_residual_from_chains_with_no_anchors_equals_the_one_shot_metric():
+    """The refactor is a split, not a rewrite: the composed path must be
+    bit-identical to scoring the cached chains with no correction."""
+    img = build_panorama(5)
+    chains = detect_shoulder_chains(
+        img, seam_x=SEAM, blend_w=BLEND, shoulder_w=SHOULDER
+    )
+    a, b = residual_from_chains(chains), _scr(img)
+    assert (a.n, a.p50, a.p90, a.max) == (b.n, b.p50, b.p90, b.max)
+
+
+# -- the interpolator --------------------------------------------------------
+
+
+def test_anchor_interpolation_clamps_outside_its_range():
+    """Matches `np.interp` / `build_dx_lookup`, so one curve means one curve."""
+    anchors = [(100.0, -4.0), (500.0, 4.0)]
+    assert interp_dx_anchors(anchors, 0) == pytest.approx(-4.0)
+    assert interp_dx_anchors(anchors, 300) == pytest.approx(0.0)
+    assert interp_dx_anchors(anchors, 9999) == pytest.approx(4.0)
+    assert interp_dx_anchors([], 42) == 0.0

--- a/tests/test_seam_vertical.py
+++ b/tests/test_seam_vertical.py
@@ -1,0 +1,173 @@
+"""Gates on the two instruments that answer "can this picture see a shift".
+
+Both exist because of a measurement, not a hunch. On the archived Duo 3 frame
+set the seam metric reports 40-69 paired structures, passes every coverage
+gate, and returns a p90 of 27-36 px on frames whose seams are visibly
+registered -- and sliding dx across its whole plausible range moves that p90 by
+1-15%. Restricting the sweep to the observations that can see dx at all does
+not rescue it either: on three games it moved p90 by 1.3%, 2.9% and 1.8%.
+
+The reason is geometric and is pinned below. SCR fits *near-horizontal*
+structures, `r_y = -m*dx`, and a horizontal edge is invariant under a
+horizontal shift. On a soccer field almost everything crossing a vertical seam
+runs horizontally, so almost every observation is blind to the thing being
+tuned. The remedy is not a better statistic. It is upright structure in the
+seam -- a person -- and `vertical_structure` is what checks whether one is
+there.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+VPE_DIR = Path(__file__).resolve().parents[1] / "reolink-firmware-patching" / "vpe"
+sys.path.insert(0, str(VPE_DIR))
+
+from seam_vertical import (  # noqa: E402
+    MIN_VERTICAL_RATIO,
+    dx_sensitivity,
+    split_by_dx_sensitivity,
+    summarise,
+    vertical_structure,
+)
+
+W, H = 2048, 900
+SEAM = W // 2
+BLEND = 256
+PERSON = (300, 640)
+
+
+@dataclass
+class _Obs:
+    slope: float
+    residual_perp: float
+
+
+def _scene(person: bool = False, seed: int = 5) -> np.ndarray:
+    """Grass-like texture, optionally with someone standing in the seam."""
+    rng = np.random.default_rng(seed)
+    img = 110 + 9.0 * cv2.GaussianBlur(rng.normal(0.0, 1.0, (H, W)), (0, 0), 1.1)
+    img += 6.0 * cv2.GaussianBlur(rng.normal(0.0, 1.0, (H, W)), (0, 0), 5.0)
+    if person:
+        y0, y1 = PERSON
+        rows = np.arange(y0, y1)
+        half = np.where(rows < y0 + 70, 12, np.where(rows < y0 + 230, 30, 22))
+        body = rng.normal(45.0, 22.0, (y1 - y0, 60))
+        for k, row in enumerate(rows):
+            hw = int(half[k])
+            img[row, SEAM - hw : SEAM + hw] = body[k, : 2 * hw]
+    return np.dstack([np.clip(img, 0, 255).astype(np.uint8)] * 3)
+
+
+# -- sensitivity -------------------------------------------------------------
+
+
+def test_a_horizontal_structure_cannot_see_a_horizontal_shift():
+    """The whole mechanism, in one assertion.
+
+    `r_y = -m*dx` and `residual_perp = |r_y| / hypot(1, m)`, so the derivative
+    of the reported residual with respect to dx is the structure's sine from
+    horizontal.
+    """
+    assert dx_sensitivity(0.0) == 0.0
+    assert dx_sensitivity(0.05) == pytest.approx(0.0499, abs=1e-3)
+    assert dx_sensitivity(1.0) == pytest.approx(0.7071, abs=1e-4)
+    assert dx_sensitivity(-0.35) == dx_sensitivity(0.35)
+    # The detector's own ceiling: nothing steeper than 0.35 is ever accepted,
+    # so a third of a pixel of residual per pixel of shift is the best SCR can
+    # ever do on this camera.
+    assert dx_sensitivity(0.35) < 0.35
+
+
+def test_the_split_separates_what_can_steer_from_what_cannot():
+    obs = [_Obs(0.0, 30.0), _Obs(0.01, 28.0), _Obs(0.20, 4.0), _Obs(-0.30, 6.0)]
+    split = split_by_dx_sensitivity(obs)
+    assert split.n_total == 4
+    assert split.n_steering == 2
+    assert split.blind_fraction == 0.5
+    # The number an operator is trying to minimise, over the structures that
+    # can respond to the control in their hand.
+    assert split.p90_steering == pytest.approx(5.8, abs=0.3)
+    assert split.p90_blind == pytest.approx(29.8, abs=0.3)
+    assert split.max_sensitivity == pytest.approx(0.287, abs=0.01)
+
+
+def test_an_all_horizontal_set_reports_nothing_steering_rather_than_a_number():
+    """The real case: many observations, none of them evidence.
+
+    Nine paired structures, every gate an acceptance check applies would pass,
+    and a p90 of 30 px -- of which not one pixel is a statement about
+    horizontal registration, because at |m| = 0.04 a 20 px error moves the
+    residual by 0.8 px.
+    """
+    split = split_by_dx_sensitivity([_Obs(0.01 * i, 30.0) for i in range(-4, 5)])
+    assert split.n_total == 9
+    assert split.n_steering == 0
+    assert split.blind_fraction == 1.0
+    assert split.p90_steering != split.p90_steering, "no steering subset, no number"
+    assert split.p90_blind == pytest.approx(30.0)
+
+
+def test_an_empty_set_is_empty_not_an_exception():
+    split = split_by_dx_sensitivity([])
+    assert split.n_total == 0 and split.n_steering == 0
+    assert split.blind_fraction == 0.0
+
+
+# -- presence of upright structure -------------------------------------------
+
+
+def test_bare_grass_reports_no_upright_structure():
+    profile = vertical_structure(_scene(person=False), seam_x=SEAM, blend_w=BLEND)
+    assert profile.n_with_structure == 0
+    assert profile.rows_with_structure == []
+    assert profile.best.ratio < MIN_VERTICAL_RATIO
+    # Measured on 87 frames of the archived set: the median band ratio is 1.23
+    # and the 25th percentile 0.94, so a featureless corridor sits near 1.
+    assert 0.4 < profile.best.ratio < 2.0
+
+
+def test_a_person_in_the_seam_is_found_and_the_rows_are_reported():
+    profile = vertical_structure(_scene(person=True), seam_x=SEAM, blend_w=BLEND)
+    assert profile.n_with_structure >= 3
+    assert profile.best.ratio > 3 * MIN_VERTICAL_RATIO
+    covered = [
+        r for r in profile.rows_with_structure if r[0] < PERSON[1] and r[1] > PERSON[0]
+    ]
+    assert covered, profile.rows_with_structure
+    lo, hi = covered[0]
+    assert PERSON[0] - 60 <= lo and hi <= PERSON[1] + 60
+    assert abs(profile.best.peak_x - SEAM) <= BLEND // 2
+
+
+def test_a_person_beside_the_corridor_is_not_a_person_in_it():
+    """Standing near the seam is not standing in it, and the tool must not
+    say otherwise -- the whole instruction is about where they stand."""
+    img = _scene(person=True)
+    shifted = np.roll(img, 600, axis=1)  # same person, 600 px away from the seam
+    profile = vertical_structure(shifted, seam_x=SEAM, blend_w=BLEND)
+    assert profile.n_with_structure == 0
+
+
+def test_the_summary_leads_with_the_verdict_and_carries_the_numbers():
+    profile = vertical_structure(_scene(person=True), seam_x=SEAM, blend_w=BLEND)
+    out = summarise(profile, split_by_dx_sensitivity([_Obs(0.0, 9.0), _Obs(0.3, 2.0)]))
+    assert out["n_with_structure"] >= 3
+    assert out["best_rows"][0] < out["best_rows"][1]
+    assert out["corridor"] == [SEAM - BLEND // 2, SEAM + BLEND // 2]
+    assert len(out["bands"]) == out["n_bands"]
+    assert out["scr_split"]["n_steering"] == 1
+    assert out["scr_split"]["blind_fraction"] == 0.5
+
+
+def test_a_frame_too_short_to_band_returns_empty_rather_than_dividing_by_zero():
+    profile = vertical_structure(np.zeros((8, 600, 3), np.uint8), seam_x=300)
+    assert profile.bands == []
+    assert profile.best is None
+    assert summarise(profile)["n_with_structure"] == 0

--- a/tests/test_stitch_profile_v2.py
+++ b/tests/test_stitch_profile_v2.py
@@ -1,0 +1,176 @@
+"""Gates on the v2 calibration artifact.
+
+Two producers write this curve -- the interactive tool and the automatic
+solver -- and one shipped consumer reads it without knowing v2 exists. The
+tests below pin the three properties that keeps working:
+
+  * a v2 artifact is still a valid v1 profile, byte-for-byte compatible with
+    the loader that ships today;
+  * the reader takes whatever shape a producer emits, including the solver's
+    bare ``[[y, dx], ...]`` plus a metadata dict;
+  * the combinations that would double-correct are refused, not warned about.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from video_grouper.utils.stitch_remap import (
+    SCHEMA_V2,
+    SeamCalibrationError,
+    StitchProfile,
+    build_dx_lookup,
+    build_v2_profile,
+    read_dx_anchors,
+    validate_v2_profile,
+)
+
+ANCHORS = [(0.0, -6.0), (540.0, -3.0), (1080.0, 0.0), (1620.0, 3.0), (2159.0, 6.0)]
+
+
+def _v2(anchors=None, **kw):
+    base = {"correction_owner": "camera_mesh", "calibration_id": "duo3-test"}
+    base.update(kw)
+    return build_v2_profile(anchors if anchors is not None else ANCHORS, **base)
+
+
+# -- backward compatibility --------------------------------------------------
+
+
+def test_a_v2_artifact_is_still_a_v1_profile():
+    """The whole reason the schema extends in place instead of wrapping."""
+    profile = StitchProfile.from_dict(_v2())
+    assert profile.source_width == 7680
+    assert profile.seam_x == 3840
+    assert profile.dx_anchors == [(0, -6), (540, -3), (1080, 0), (1620, 3), (2159, 6)]
+
+
+def test_sub_pixel_anchors_round_rather_than_truncate():
+    """The mesh is quarter-pixel; `int()` would bias every anchor toward zero.
+
+    -6.75 truncates to -6 and 6.75 to 6 -- a systematic under-correction of up
+    to a pixel, applied before `build_dx_lookup` does its own rounding, on
+    exactly the small objects at the seam this exists to help.
+    """
+    d = _v2(anchors=[(0.0, -6.75), (2159.0, 6.75)])
+    assert StitchProfile.from_dict(d).dx_anchors == [(0, -7), (2159, 7)]
+
+
+def test_the_curve_survives_the_round_trip_into_the_shipped_lookup():
+    profile = StitchProfile.from_dict(_v2())
+    lut = build_dx_lookup(profile, 7680, 2160)
+    assert lut[0] == -6
+    assert lut[1080] == 0
+    assert lut[2159] == 6
+    # monotone, because the authored curve is
+    assert all(b >= a for a, b in zip(lut, lut[1:], strict=False))
+
+
+# -- the permissive reader ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [[0, -4], [2159, 4]],
+        {"dx_anchors": [[0, -4], [2159, 4]]},
+        {
+            "dx_anchors": [[0, -4], [2159, 4]],
+            "metadata": {"solver": "huber", "r2": 0.98},
+        },
+        {"source_width": 7680, "seam_x": 3840, "dx_anchors": [(0, -4), (2159, 4)]},
+    ],
+)
+def test_the_reader_accepts_whatever_shape_a_producer_emits(payload):
+    """The automatic solver was told not to touch the schema; it emits plain
+    pairs plus a metadata dict. That has to just work."""
+    assert read_dx_anchors(payload) == [(0.0, -4.0), (2159.0, 4.0)]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {},
+        {"dx_anchors": []},
+        [[0, 1], [0, 2]],  # np.interp goes silently wrong on unsorted x
+        [[100, 1], [50, 2]],
+        [[0, 1, 2]],
+        [["a", 1]],
+    ],
+)
+def test_the_reader_refuses_what_would_silently_misbehave(payload):
+    with pytest.raises(SeamCalibrationError):
+        read_dx_anchors(payload)
+
+
+# -- the anti-double-correction rules ----------------------------------------
+
+
+def test_a_curve_under_an_owner_that_cannot_apply_it_is_refused():
+    with pytest.raises(SeamCalibrationError, match="cannot express a per-row shear"):
+        build_v2_profile(ANCHORS, correction_owner="camera_scalars", calibration_id="x")
+
+
+def test_a_zero_curve_under_the_scalars_owner_is_fine():
+    """Scalars can own the correction; they just cannot own a *shear*."""
+    d = build_v2_profile(
+        [(0.0, 0.0), (2159.0, 0.0)],
+        correction_owner="camera_scalars",
+        calibration_id="x",
+    )
+    assert d["correction_owner"] == "camera_scalars"
+
+
+def test_downstream_ownership_with_an_applied_mesh_stage_is_refused():
+    """The double-correct: the camera already fixed it and the pipeline is
+    about to fix it again. This is the one case that must never be a warning."""
+    d = _v2(correction_owner="downstream")
+    d["stages"] = [{"surface": "camera_mesh", "state": "applied"}]
+    with pytest.raises(SeamCalibrationError, match="double-correction"):
+        validate_v2_profile(d)
+
+
+def test_an_unknown_owner_is_refused():
+    with pytest.raises(SeamCalibrationError):
+        build_v2_profile(ANCHORS, correction_owner="magic", calibration_id="x")
+
+
+def test_dropping_dy_downstream_has_to_be_recorded():
+    """The downstream corrector is horizontal-only. Silently discarding a
+    measured vertical component is how calibrations become mysterious."""
+    d = _v2(correction_owner="downstream")
+    d["dy_anchors"] = [[0, 1.5]]
+    with pytest.raises(SeamCalibrationError, match="dropped"):
+        validate_v2_profile(d)
+    d["dropped"] = ["dy_anchors"]
+    validate_v2_profile(d)
+
+
+def test_a_legacy_v1_profile_is_not_second_guessed():
+    """No schema, no correction_owner: it means downstream and always did."""
+    validate_v2_profile(
+        {
+            "source_width": 7680,
+            "source_height": 2160,
+            "seam_x": 3840,
+            "dx_anchors": [[0, -10], [2159, 5]],
+        }
+    )
+
+
+# -- the sign convention, carried in the artifact ----------------------------
+
+
+def test_the_artifact_states_its_own_sign_convention():
+    """One paragraph that prevents a sign error, and a sign error here applies
+    the misregistration twice instead of removing it."""
+    d = _v2()
+    assert d["schema"] == SCHEMA_V2
+    assert d["sense"]["dx_means"] == (
+        "px the RIGHT half must move right, at row y, to register with the left"
+    )
+    assert d["sense"]["downstream_moves"] == "right_half"
+    assert d["sense"]["camera_mesh_moves"] == "left_half_with_opposite_sense"
+    assert d["geometry"]["warped_half"] == "left"
+    assert d["geometry"]["blend_window"] == [3712, 3968]

--- a/tests/web/test_stitch_calibration.py
+++ b/tests/web/test_stitch_calibration.py
@@ -32,6 +32,7 @@ VPE_DIR = Path(__file__).resolve().parents[2] / "reolink-firmware-patching" / "v
 sys.path.insert(0, str(VPE_DIR))
 
 import seam_metric  # noqa: E402
+import seam_vertical  # noqa: E402
 
 # Small enough that detection is ~1 s instead of the 37-50 s a real
 # 7680x2160 game frame costs, and still a genuine
@@ -49,15 +50,41 @@ _LINES = (
 )
 
 
-def _panorama(disparity: int = 6) -> np.ndarray:
+#: Rows the stand-in for a person occupies. Upright is the one shape a
+#: horizontal misregistration visibly breaks, and it is painted into the scene
+#: *before* the two halves are cut, so both sensors carry it and the fused
+#: frame ghosts it exactly as the camera does.
+#:
+#: Shaped and textured rather than a plain bar, because both instruments care.
+#: A bar 26 px wide has four hot columns in a 256 px corridor and slips under a
+#: 90th-percentile statistic that a real 60 px player with limbs and a kit sails
+#: past; and SSR detrends by column mean, so a body that is constant down the
+#: rows is subtracted away by construction. A person is neither.
+_UPRIGHT = (300, 640)
+
+
+def _panorama(disparity: int = 6, upright: bool = False) -> np.ndarray:
     rng = np.random.default_rng(3)
     w = W + 512
     img = 110 + 6 * cv2.GaussianBlur(rng.normal(0.0, 1.0, (H, w)), (0, 0), 5.0)
+    # Fine texture, so the frame has the horizontal-gradient floor real grass
+    # has. Without it a synthetic scene is so clean that the step a
+    # misregistration puts in a painted line reads as "upright structure".
+    img = img + 8.0 * cv2.GaussianBlur(rng.normal(0.0, 1.0, (H, w)), (0, 0), 1.0)
     xs = np.arange(w)
     for m, y0 in _LINES:
         ys = y0 + m * (xs - w / 2)
         for off, amp in ((-1, 30), (0, 55), (1, 30)):
             img[np.clip(np.round(ys + off).astype(int), 0, H - 1), xs] += amp
+    if upright:
+        y0, y1 = _UPRIGHT
+        cx = 256 + SEAM  # source column that lands on the seam of the left half
+        rows = np.arange(y0, y1)
+        half = np.where(rows < y0 + 70, 12, np.where(rows < y0 + 230, 30, 22))
+        body = rng.normal(45.0, 22.0, (y1 - y0, 60))
+        for k, row in enumerate(rows):
+            hw = int(half[k])
+            img[row, cx - hw : cx + hw] = body[k, : 2 * hw]
     img = np.clip(img, 0, 255)
     left = img[:, 256 : 256 + W]
     right = np.roll(img, -disparity, axis=1)[:, 256 : 256 + W]
@@ -156,7 +183,12 @@ def client(tmp_path, calls, monkeypatch):
     # Real metric, fake transport.
     sc._toolkit_cache.clear()
     sc._toolkit_cache.update(
-        {"metric": seam_metric, "camera": _fake_camera(calls), "errors": []}
+        {
+            "metric": seam_metric,
+            "vertical": seam_vertical,
+            "camera": _fake_camera(calls),
+            "errors": [],
+        }
     )
     sc._session.__init__()  # type: ignore[misc] -- fresh session per test
     app = FastAPI()
@@ -195,6 +227,80 @@ def test_page_renders_and_states_the_constraints_it_must_state(client):
     assert "already a mixture" in body, "the fused-JPEG caveat must be UI text"
     assert "the window is inference" in body.lower()
     assert "camera can only move the left" in body.lower()
+
+
+def test_the_page_is_built_for_the_phone_that_will_actually_run_it(client):
+    """The client is a phone held at the pitch side, and that is structural.
+
+    Every assertion here is a decision that a desktop-first page gets wrong,
+    and each was verified live in Chrome at 390x844 before being pinned:
+
+    * Pointer Events, so one implementation serves a thumb and a mouse. A drag
+      is axis-locked -- across is the calibration, down is navigation -- and
+      two fingers zoom. Verified: a 40 px horizontal drag moved the curve to
+      exactly -31.90 px (40 / 1.2539 px-per-source-px, negated because the
+      camera surface moves the left half), a 120 px vertical drag moved the row
+      cursor and left the curve at -31.90, and a synthetic two-pointer spread
+      halved the span from 256 to 128 source px.
+    * `touch-action: none` on the canvases, or the browser eats the gesture and
+      scrolls the page instead.
+    * No webfont link, and no external request of any kind. A field link should
+      not be spent on a font CDN before the operator can read anything.
+    * Every score request is bounded. Verified by making fetch hang: the badge
+      went to "offline x1" with "no answer in 9 s", the numbers dimmed and kept
+      saying which curve they belonged to, and a backoff retry recovered them
+      with no user action once fetch was restored.
+    """
+    body = client.get("/stitch").text
+    assert '<meta name="viewport" content="width=device-width' in body
+    assert "<link " not in body, "no external stylesheet or font on a field link"
+    assert "https://" not in body, "the page fetches nothing off this machine"
+    assert "addEventListener('pointerdown'" in body
+    assert "start.mode = Math.abs(dx) >= Math.abs(dy) ? 'shift' : 'row';" in body
+    assert "pinch = { d: pdist(pts), span: S.spanX }" in body
+    assert "touch-action:none" in body
+    assert "AbortController" in body and "MEASURE_TIMEOUT_MS = 9000" in body
+    # The dock is fixed to the bottom of a phone viewport, in thumb reach.
+    assert ".dock { position:fixed" in body
+    # And the way in from a phone at all, which is a config fact, not a wish.
+    assert "auth_server_bind" in body
+
+
+def test_the_page_makes_standing_in_the_seam_a_step_rather_than_a_tip(client):
+    """The procedure, in the interface.
+
+    "It's easy to see misregistration if there's a person in the seam" is the
+    answer to a frame that measures well and looks broken, so it is numbered
+    and it carries the depth qualifier from section 12.1 -- one calibration is
+    exact at one depth, and a target beside the tripod is calibrating for the
+    tripod.
+    """
+    body = client.get("/stitch").text
+    assert 'id="step-stand"' in body
+    assert "Put someone in the seam" in body
+    assert "not beside the tripod" in body
+    assert "one depth" in body
+    # And the aiming door that makes step 2 possible: you cannot stand someone
+    # in the seam without being shown where the seam falls.
+    assert 'id="step-aim"' in body and "the orange line is the seam" in body
+
+
+def test_the_page_says_that_changing_nothing_is_a_valid_outcome(client):
+    """A tool that can only ever propose a correction will manufacture one.
+
+    The automatic solver refuses on all 27 archived games; 52 of 96 frames sit
+    below the SSR noise floor; players straddling the seam look continuous. So
+    the job is the knocked tripod and the remount, not a known defect, and the
+    page has to be able to say "leave it alone" without that reading as a
+    failure. `renderFloor` makes it a verdict of its own.
+    """
+    body = client.get("/stitch").text
+    assert "nothing to change here" in body.lower()
+    assert "check</b>-and-correct" in body
+    assert "This seam is already at the measurement floor." in body
+    # And the numbers are subordinate to the picture, in the page's own words.
+    assert "refuses on all 27 archived games" in body
+    assert "The picture is the\n      evidence, and it should overrule them." in body
 
 
 def test_the_surface_selector_flips_the_presentation_and_only_the_presentation(client):
@@ -336,27 +442,174 @@ def test_the_frame_is_asked_whether_it_can_constrain_anything(client):
 def test_an_unconstraining_frame_says_so_instead_of_reporting_a_number(
     client, tmp_path
 ):
-    """Flat texture: structures get paired, a score comes out, and it is junk."""
+    """Flat texture: structures get paired, a score comes out, and it is junk.
+
+    And the verdict has to carry the one instruction that changes the answer.
+    Re-weighting does not rescue a frame like this -- measured on three real
+    games, restricting the dx sweep to the observations that can see dx moved
+    p90 by 1.3-2.9%, no better than the full set -- so what the operator needs
+    back is a change to the scene, not a smaller number.
+    """
     flat = np.dstack([np.full((H, W), 120, np.uint8)] * 3)
     rng = np.random.default_rng(1)
     flat = np.clip(flat + rng.normal(0, 6, flat.shape), 0, 255).astype(np.uint8)
     path = tmp_path / "flat.png"
     cv2.imwrite(str(path), flat)
 
-    r = client.post("/stitch/open", json={"path": str(path)})
-    assert r.status_code == 200
-    for _ in range(200):
+    st = _open(client, path)
+    assert st["quality"]["usable"] is False
+    assert "stand in the seam" in st["quality"]["remedy"]
+    assert st["quality"]["has_upright"] is False
+    assert st["vertical"]["n_with_structure"] == 0
+
+
+def _open(client, path, **body) -> dict:
+    r = client.post("/stitch/open", json={"path": str(path), **body})
+    assert r.status_code == 200, r.text
+    for _ in range(300):
         st = client.get("/stitch/state").json()
         if st["metric_state"] in ("ready", "failed"):
-            break
+            return st
         import time
 
         time.sleep(0.1)
-    assert st["quality"]["usable"] is False
-    assert (
-        "does not constrain" in st["quality"]["reason"]
-        or "no structure" in (st["quality"]["reason"])
+    raise AssertionError("baseline detection never finished")
+
+
+# -- the calibration target: a person standing in the seam -------------------
+
+
+def test_a_frame_with_nothing_upright_in_the_seam_asks_for_a_person(client):
+    """The bare-grass case, which is what a seam mid-field always looks like.
+
+    Every structure crossing a *vertical* seam on a soccer field runs
+    horizontally -- touchline, treeline, painted banner -- and `r_y = -m*dx`
+    makes a horizontal edge invariant under the shift being tuned. So the
+    honest output is an instruction about the scene.
+    """
+    st = _snap(client)  # the fixture panorama: sloped lines, nothing upright
+    assert st["vertical"] is not None
+    assert st["vertical"]["n_with_structure"] == 0
+    assert st["baseline"]["ssr_target"] is None, "nothing to measure damage on"
+
+
+def test_upright_structure_in_the_seam_is_found_and_located(client, tmp_path):
+    """A person in the seam is detected, and the rows they occupy are reported.
+
+    Those rows are the whole point: they are where the operator should look,
+    and they are the band the damage number is computed over.
+    """
+    path = tmp_path / "with_person.png"
+    cv2.imwrite(str(path), _panorama(upright=True))
+    st = _open(client, path)
+
+    v = st["vertical"]
+    assert v["n_with_structure"] >= 1, v
+    y0, y1 = _UPRIGHT[0], _UPRIGHT[1]
+    covered = [r for r in v["rows"] if r[0] < y1 and r[1] > y0]
+    assert covered, f"upright bar at rows {y0}-{y1} not among {v['rows']}"
+    assert y0 - 120 <= v["best_rows"][0] <= y1
+    assert v["best_ratio"] > v["min_ratio"]
+    assert st["quality"]["has_upright"] is True
+
+
+def test_damage_is_measured_where_the_target_stands_not_over_the_whole_frame(
+    client, tmp_path
+):
+    """The number a person in the seam exists to produce.
+
+    |ln SSR| over a field band is an average over mostly grass, and a
+    misregistration cannot damage grass because there is nothing there to
+    break. Measured on a real Duo 3 frame with a player straddling the seam:
+    0.062 over the field band -- below the 0.10 noise floor, i.e. reading as a
+    perfect seam -- against 1.180 over the 285 rows the player occupies (2.188
+    over the strongest band alone). Over
+    87 frames of the archived set the whole-band figure is blind to the
+    difference (median 0.095 with upright structure against 0.088 without) and
+    the banded figure is not (1.889 against 0.170).
+
+    It is a before/after comparator, not an absolute: an object living only
+    inside the window raises SSR by existing. The tool says so on screen.
+    """
+    path = tmp_path / "with_person.png"
+    cv2.imwrite(str(path), _panorama(upright=True))
+    st = _open(client, path)
+
+    tgt = st["baseline"]["ssr_target"]
+    assert tgt is not None
+    assert tgt["band"][0] <= _UPRIGHT[0] and tgt["band"][1] >= _UPRIGHT[1] - 40
+    assert tgt["abs_ln_ssr"] > st["baseline"]["ssr"]["abs_ln_ssr"], (
+        "the rows holding the target must show more seam damage than the "
+        "average over a band that is mostly featureless"
     )
+    # And it survives into the live path, so it is on screen while dragging.
+    scored = client.post("/stitch/measure", json={"dx_anchors": _flat(0)}).json()
+    assert scored["ssr_target"]["band"] == tgt["band"]
+
+
+def test_the_score_says_how_many_structures_can_see_a_horizontal_shift(client):
+    """`r_y = -m*dx`: a structure's sensitivity to dx is |m|/hypot(1,m).
+
+    Reported beside SCR rather than folded into it. Silently redefining the
+    shared metric would leave this tool and the automatic solver minimising two
+    different things under one name.
+    """
+    st = _snap(client)
+    split = st["baseline"]["split"]
+    assert split["n_total"] == st["baseline"]["scr"]["n"]
+    # The fixture's lines run to +/-0.30, so most of them can steer.
+    assert split["n_steering"] >= 4
+    assert 0.28 <= split["max_sensitivity"] <= 0.32
+    assert split["p90_steering"] is not None
+
+    scored = client.post("/stitch/measure", json={"dx_anchors": _flat(6)}).json()
+    assert scored["split"]["n_steering"] >= 4
+    assert scored["split"]["p90_steering"] < split["p90_steering"]
+    # Every observation carries its own sensitivity, so the view can draw the
+    # blind ones as the hints they are rather than as evidence.
+    assert all("sens" in o for o in scored["observations"])
+
+
+def test_a_horizontal_structure_is_reported_as_blind_not_as_evidence():
+    """The mechanism itself, at the unit level."""
+    assert seam_vertical.dx_sensitivity(0.0) == 0.0
+    assert seam_vertical.dx_sensitivity(0.30) == pytest.approx(0.287, abs=0.01)
+    assert seam_vertical.dx_sensitivity(1e9) == pytest.approx(1.0, abs=1e-6)
+
+
+# -- aiming: where the seam falls, before the calibration snapshot -----------
+
+
+def test_aim_returns_a_scene_overview_without_disturbing_the_session(client, calls):
+    """The step before the measurement, and it must be safe to repeat.
+
+    An operator presses this while someone walks into the seam. If it reset the
+    scored session each time, the loop would be unusable.
+    """
+    st = _snap(client)
+    version, baseline = st["version"], st["baseline"]
+
+    r = client.post("/stitch/aim")
+    assert r.status_code == 200, r.text
+    aimed = r.json()
+    assert aimed["scene"]["has"] is True
+    assert aimed["version"] == version, "aiming must not adopt a new frame"
+    assert aimed["baseline"] == baseline, "aiming must not lose the measurement"
+    assert aimed["aim"]["seam_x"] == SEAM
+    assert aimed["aim"]["vertical"]["n_bands"] > 0
+
+    scene = client.get("/stitch/scene.jpg")
+    assert scene.status_code == 200
+    assert scene.headers["content-type"] == "image/jpeg"
+    # Small enough to cross a field's worth of link, unlike the panorama.
+    assert len(scene.content) < 120_000
+    img = cv2.imdecode(np.frombuffer(scene.content, np.uint8), cv2.IMREAD_COLOR)
+    assert img.shape[1] == sc.SCENE_W
+    assert len([c for c in calls if c[0] == "snap"]) == 2
+
+
+def test_the_scene_before_any_snapshot_is_a_404_not_a_blank(client):
+    assert client.get("/stitch/scene.jpg").status_code == 404
 
 
 # -- the second door: a frame from a recorded game ---------------------------
@@ -591,7 +844,12 @@ def test_a_non_reolink_camera_is_refused_with_a_reason(tmp_path, calls):
     )
     sc._toolkit_cache.clear()
     sc._toolkit_cache.update(
-        {"metric": seam_metric, "camera": _fake_camera(calls), "errors": []}
+        {
+            "metric": seam_metric,
+            "vertical": seam_vertical,
+            "camera": _fake_camera(calls),
+            "errors": [],
+        }
     )
     sc._session.__init__()  # type: ignore[misc]
     app = FastAPI()

--- a/tests/web/test_stitch_calibration.py
+++ b/tests/web/test_stitch_calibration.py
@@ -1,0 +1,603 @@
+"""Tests for the seam-calibration tool at ``/stitch``.
+
+The camera transport is faked; the *metric* is not. `seam_metric` runs for
+real against a synthetic panorama, because the whole claim of the tool is that
+an operator descends the same objective the automatic solver does, and a
+mocked score would test nothing.
+
+`apply_calibration` is faked deliberately and permanently: the write path is
+hardware-verified in its own right (#135), it sets vendor scalars and writes a
+warp mesh, and a unit test has no business doing either. What is tested here is
+that the button reaches it with the operator's curve, in the right shape, and
+refuses the cases that would double-correct.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from video_grouper.utils.stitch_remap import StitchProfile
+from video_grouper.web import stitch_calibration as sc
+
+VPE_DIR = Path(__file__).resolve().parents[2] / "reolink-firmware-patching" / "vpe"
+sys.path.insert(0, str(VPE_DIR))
+
+import seam_metric  # noqa: E402
+
+# Small enough that detection is ~1 s instead of the 37-50 s a real
+# 7680x2160 game frame costs, and still a genuine
+# two-sensor butt-join with a 256-px blend and sloped structure across it.
+W, H = 2048, 900
+SEAM = W // 2
+BLEND = 256
+_LINES = (
+    (-0.30, 760),
+    (-0.16, 300),
+    (-0.05, 620),
+    (0.07, 180),
+    (0.19, 500),
+    (0.30, 80),
+)
+
+
+def _panorama(disparity: int = 6) -> np.ndarray:
+    rng = np.random.default_rng(3)
+    w = W + 512
+    img = 110 + 6 * cv2.GaussianBlur(rng.normal(0.0, 1.0, (H, w)), (0, 0), 5.0)
+    xs = np.arange(w)
+    for m, y0 in _LINES:
+        ys = y0 + m * (xs - w / 2)
+        for off, amp in ((-1, 30), (0, 55), (1, 30)):
+            img[np.clip(np.round(ys + off).astype(int), 0, H - 1), xs] += amp
+    img = np.clip(img, 0, 255)
+    left = img[:, 256 : 256 + W]
+    right = np.roll(img, -disparity, axis=1)[:, 256 : 256 + W]
+    out = left.copy()
+    lo, hi = SEAM - BLEND // 2, SEAM + BLEND // 2
+    alpha = np.linspace(0.0, 1.0, hi - lo)[None, :]
+    out[:, hi:] = right[:, hi:]
+    out[:, lo:hi] = left[:, lo:hi] * (1 - alpha) + right[:, lo:hi] * alpha
+    return np.dstack([np.clip(out, 0, 255).astype(np.uint8)] * 3)
+
+
+class _Scalars:
+    def __init__(self, distance, x, y):
+        self._d = {"distance": distance, "stitchXMove": x, "stitchYMove": y}
+
+    def to_api(self):
+        return dict(self._d)
+
+
+def _fake_camera(calls: list) -> types.ModuleType:
+    """A stand-in for `stitch_apply` that records instead of transmitting."""
+    mod = types.ModuleType("fake_stitch_apply")
+
+    def snap(host, user, password, out: Path):
+        calls.append(("snap", host, user))
+        cv2.imwrite(str(out), _panorama())
+        return out
+
+    def get_stitch(host, user, password):
+        calls.append(("get_stitch", host, user))
+        return _Scalars(8.0, 3, 0), _Scalars(8.0, 0, 0)
+
+    def apply_calibration(anchors, **kw):
+        calls.append(("apply", list(anchors), kw))
+        return {
+            "host": kw.get("host"),
+            "stages": [{"surface": "camera_mesh", "state": "applied"}],
+        }
+
+    mod.snap = snap  # type: ignore[attr-defined]
+    mod.get_stitch = get_stitch  # type: ignore[attr-defined]
+    mod.apply_calibration = apply_calibration  # type: ignore[attr-defined]
+    return mod
+
+
+CONFIG = """\
+[CAMERA.duo3]
+type = reolink
+device_ip = 10.0.0.9
+username = admin
+password = hunter2
+
+[STORAGE]
+path = {storage}
+min_free_gb = 2.0
+
+[RECORDING]
+min_duration = 60
+max_duration = 3600
+
+[PROCESSING]
+max_concurrent_downloads = 2
+
+[LOGGING]
+level = INFO
+log_dir = logs
+
+[APP]
+check_interval_seconds = 60
+
+[TEAMSNAP]
+enabled = false
+
+[PLAYMETRICS]
+enabled = false
+
+[NTFY]
+enabled = false
+server_url = https://ntfy.sh
+topic =
+
+[YOUTUBE]
+enabled = false
+"""
+
+
+@pytest.fixture
+def calls() -> list:
+    return []
+
+
+@pytest.fixture
+def client(tmp_path, calls, monkeypatch):
+    config_path = tmp_path / "config.ini"
+    config_path.write_text(CONFIG.format(storage=str(tmp_path).replace("\\", "/")))
+    # Real metric, fake transport.
+    sc._toolkit_cache.clear()
+    sc._toolkit_cache.update(
+        {"metric": seam_metric, "camera": _fake_camera(calls), "errors": []}
+    )
+    sc._session.__init__()  # type: ignore[misc] -- fresh session per test
+    app = FastAPI()
+    app.include_router(sc.build_router(config_path, tmp_path))
+    with TestClient(app) as c:
+        yield c
+    sc._toolkit_cache.clear()
+
+
+def _snap(client) -> dict:
+    r = client.post("/stitch/snap")
+    assert r.status_code == 200, r.text
+    # Detection runs in a background thread; wait for it the way the page does.
+    for _ in range(200):
+        st = client.get("/stitch/state").json()
+        if st["metric_state"] in ("ready", "failed"):
+            return st
+        import time
+
+        time.sleep(0.1)
+    raise AssertionError("baseline detection never finished")
+
+
+def _flat(dx: float) -> list[list[float]]:
+    return [[0, dx], [225, dx], [450, dx], [675, dx], [899, dx]]
+
+
+# -- page + session ----------------------------------------------------------
+
+
+def test_page_renders_and_states_the_constraints_it_must_state(client):
+    body = client.get("/stitch").text
+    assert body.startswith("<!DOCTYPE html>")
+    # The two things the design says must be visible in the interface, not
+    # merely true of the code.
+    assert "already a mixture" in body, "the fused-JPEG caveat must be UI text"
+    assert "the window is inference" in body.lower()
+    assert "camera can only move the left" in body.lower()
+
+
+def test_the_surface_selector_flips_the_presentation_and_only_the_presentation(client):
+    """The client half of the contract, pinned in the page source.
+
+    The stored-anchors half is covered by
+    `test_the_stored_curve_does_not_depend_on_the_chosen_surface`; this pins
+    the sign rule that decides which half the operator sees move. `dx` means
+    "the right half moves right", so the camera surface -- which can only warp
+    the LEFT half -- has to realise the same relative displacement with the
+    opposite sign. Getting that backwards would show the operator a correction
+    moving the wrong way while storing a curve that is right, which is the
+    hardest kind of bug to see.
+
+    (Verified live in Chrome as well: with the camera surface the right half
+    dims and signFor is left=-1 / right=0; switching to downstream dims the
+    left half and gives left=0 / right=+1, with byte-identical anchors.)
+    """
+    body = client.get("/stitch").text
+    assert (
+        "function movingSide() { return S.surface === 'downstream' ? 'right' : 'left'; }"
+        in body
+    )
+    assert "return side === 'right' ? 1 : -1;" in body
+    # Both directional captions must exist, or the flip is invisible.
+    assert "You are moving the <b>LEFT</b> image" in body
+    assert "You are moving the <b>RIGHT</b> image" in body
+
+
+def test_state_before_any_snapshot_is_honest_about_having_nothing(client):
+    st = client.get("/stitch/state").json()
+    assert st["has_snapshot"] is False
+    assert st["metric_state"] == "idle"
+    assert st["baseline"] is None
+
+
+def test_snap_fetches_the_still_and_both_scalar_blocks(client, calls):
+    st = _snap(client)
+    assert st["has_snapshot"] is True
+    assert st["camera"] == "duo3"
+    assert st["host"] == "10.0.0.9"
+    assert ("snap", "10.0.0.9", "admin") in calls
+    # Both the live values AND the factory block -- "confirm what the camera
+    # already decided" is not a real action without the second one.
+    assert st["scalars"]["current"] == {
+        "distance": 8.0,
+        "stitchXMove": 3,
+        "stitchYMove": 0,
+    }
+    assert st["scalars"]["factory"]["stitchXMove"] == 0
+
+
+def test_only_the_seam_strips_cross_the_wire_not_the_panorama(client):
+    _snap(client)
+    left = client.get("/stitch/half.jpg?side=left&v=1")
+    right = client.get("/stitch/half.jpg?side=right&v=1")
+    assert left.status_code == right.status_code == 200
+    assert left.headers["content-type"] == "image/jpeg"
+    img = cv2.imdecode(np.frombuffer(left.content, np.uint8), cv2.IMREAD_COLOR)
+    assert img.shape == (H, sc.STRIP_W, 3)
+    # The point of the split: a fraction of the frame, not the frame.
+    assert len(left.content) + len(right.content) < 400_000
+
+
+def test_half_before_a_snapshot_is_a_404_not_a_stale_frame(client):
+    assert client.get("/stitch/half.jpg?side=left").status_code == 404
+
+
+# -- the live score ----------------------------------------------------------
+
+
+def test_measure_scores_a_candidate_curve_against_the_real_metric(client):
+    st = _snap(client)
+    assert st["metric_state"] == "ready", st["metric_error"]
+    base = st["baseline"]
+    assert base["scr"]["n"] >= 6, "fixture must present structure to measure"
+
+    good = client.post("/stitch/measure", json={"dx_anchors": _flat(6)}).json()
+    bad = client.post("/stitch/measure", json={"dx_anchors": _flat(-6)}).json()
+
+    assert good["scr"]["p50"] < base["scr"]["p50"], "dx=+6 must close a +6 seam"
+    assert bad["scr"]["p50"] > base["scr"]["p50"], "dx=-6 must open it further"
+    assert good["baseline"]["scr"]["p50"] == base["scr"]["p50"]
+
+
+def test_measure_suggests_a_dx_in_the_sign_the_curve_uses(client):
+    """The trap this exists to defuse.
+
+    `ScrResult.implied_dx` is the misregistration in the image, which is the
+    opposite sense to a `dx_anchors` value. Handed over unnegated it would
+    double the error, which presents as "the tool doesn't work".
+    """
+    st = _snap(client)
+    suggested = st["baseline"]["scr"]["suggested_dx"]
+    assert suggested == pytest.approx(6, abs=1.5), suggested
+    scored = client.post(
+        "/stitch/measure", json={"dx_anchors": _flat(suggested)}
+    ).json()
+    assert scored["scr"]["p50"] < st["baseline"]["scr"]["p50"] * 0.5
+
+
+def test_measure_before_a_snapshot_refuses_rather_than_inventing_numbers(client):
+    r = client.post("/stitch/measure", json={"dx_anchors": _flat(0)})
+    assert r.status_code == 409
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"dx_anchors": []},
+        {"dx_anchors": [[0, 0], [0, 3]]},  # non-increasing rows
+        {"dx_anchors": [[0, 0], [10, "x"]]},
+        {"dx_anchors": _flat(200)},  # beyond anything physical
+        {},
+    ],
+)
+def test_a_curve_that_cannot_be_applied_is_refused_at_authoring_time(client, payload):
+    _snap(client)
+    assert client.post("/stitch/measure", json=payload).status_code == 400
+
+
+def test_the_frame_is_asked_whether_it_can_constrain_anything(client):
+    """A number that does not move with the curve is not a measurement.
+
+    On real Duo 3 tripod frames SCR sits at 27-36 px and shifts by 1-15% as dx
+    sweeps its whole plausible range, while the seam is visibly registered --
+    and every coverage gate passes while that happens. So the frame gets swept
+    once and the verdict leads the panel. Here the fixture *is* misregistered,
+    so the verdict must be the positive one.
+    """
+    st = _snap(client)
+    q = st["quality"]
+    assert q["usable"] is True, q["reason"]
+    assert q["best_dx"] == pytest.approx(6, abs=2)
+    assert q["gain"] > 0.2
+    assert len(q["sweep"]) == 17
+
+
+def test_an_unconstraining_frame_says_so_instead_of_reporting_a_number(
+    client, tmp_path
+):
+    """Flat texture: structures get paired, a score comes out, and it is junk."""
+    flat = np.dstack([np.full((H, W), 120, np.uint8)] * 3)
+    rng = np.random.default_rng(1)
+    flat = np.clip(flat + rng.normal(0, 6, flat.shape), 0, 255).astype(np.uint8)
+    path = tmp_path / "flat.png"
+    cv2.imwrite(str(path), flat)
+
+    r = client.post("/stitch/open", json={"path": str(path)})
+    assert r.status_code == 200
+    for _ in range(200):
+        st = client.get("/stitch/state").json()
+        if st["metric_state"] in ("ready", "failed"):
+            break
+        import time
+
+        time.sleep(0.1)
+    assert st["quality"]["usable"] is False
+    assert (
+        "does not constrain" in st["quality"]["reason"]
+        or "no structure" in (st["quality"]["reason"])
+    )
+
+
+# -- the second door: a frame from a recorded game ---------------------------
+
+
+def test_a_frame_can_be_opened_from_a_file_not_only_from_the_camera(client, tmp_path):
+    """The door most calibrations will actually use.
+
+    A camera indoors on a bench sees a scene 0.3 m away, where parallax is tens
+    of pixels; a still from a game is the representative input, and it needs no
+    camera access at all.
+    """
+    path = tmp_path / "game_frame.jpg"
+    cv2.imwrite(str(path), _panorama())
+    r = client.post(
+        "/stitch/open",
+        json={"path": str(path), "deployment": "heat-fairport-2025.07.22"},
+    )
+    assert r.status_code == 200, r.text
+    st = r.json()
+    assert st["has_snapshot"] is True
+    assert st["camera"] == "heat-fairport-2025.07.22"
+    assert st["source_path"] == str(path)
+    # No camera was touched to get here.
+    assert st["scalars"]["current"] is None
+    assert client.get("/stitch/half.jpg?side=right").status_code == 200
+
+
+def test_opening_a_missing_or_undecodable_file_says_which(client, tmp_path):
+    assert client.post("/stitch/open", json={"path": ""}).status_code == 400
+    assert (
+        client.post(
+            "/stitch/open", json={"path": str(tmp_path / "nope.jpg")}
+        ).status_code
+        == 404
+    )
+    junk = tmp_path / "junk.jpg"
+    junk.write_bytes(b"not a jpeg")
+    assert client.post("/stitch/open", json={"path": str(junk)}).status_code == 415
+
+
+def test_a_frame_too_narrow_to_carry_a_seam_is_refused(client, tmp_path):
+    tiny = tmp_path / "tiny.png"
+    cv2.imwrite(str(tiny), np.zeros((64, 200, 3), np.uint8))
+    r = client.post("/stitch/open", json={"path": str(tiny)})
+    assert r.status_code == 415
+    assert "too narrow" in r.json()["detail"]
+
+
+def test_frames_can_be_listed_so_the_operator_picks_a_name(client, tmp_path):
+    d = tmp_path / "frames"
+    d.mkdir()
+    for name in ("a.jpg", "b.png", "c.mp4", "notes.txt"):
+        (d / name).write_bytes(b"x")
+    got = client.get("/stitch/frames", params={"dir": str(d)}).json()
+    assert got["files"] == ["a.jpg", "b.png", "c.mp4"]
+    assert client.get("/stitch/frames", params={"dir": ""}).status_code == 400
+    assert (
+        client.get("/stitch/frames", params={"dir": str(tmp_path / "nope")}).status_code
+        == 404
+    )
+
+
+# -- the artifact ------------------------------------------------------------
+
+
+def test_save_writes_a_v2_artifact_a_v1_reader_still_understands(client, tmp_path):
+    _snap(client)
+    r = client.post(
+        "/stitch/save",
+        json={
+            "dx_anchors": _flat(6.25),
+            "correction_owner": "camera_mesh",
+            "subject_distance_m": 45,
+            "basis": "far touchline midpoint",
+        },
+    )
+    assert r.status_code == 200, r.text
+    written = json.loads((tmp_path / "stitch_profile.json").read_text())
+
+    assert written["schema"] == "seam_calibration/2"
+    assert written["correction_owner"] == "camera_mesh"
+    assert written["sense"]["dx_means"].startswith("px the RIGHT half must move right")
+    # Geometry recorded is the geometry measured, not a hardcoded panorama --
+    # build_dx_lookup rescales by it, so a lie here scales the correction.
+    assert written["source_width"] == W and written["source_height"] == H
+    assert written["calibrated_for"]["subject_distance_m"] == 45
+
+    # The whole point of extending v1 in place.
+    profile = StitchProfile.from_dict(written)
+    assert profile.seam_x == SEAM
+    assert profile.dx_anchors[0][1] == 6, "sub-pixel anchors round, they don't truncate"
+
+
+def test_every_save_is_also_filed_under_its_deployment(client, tmp_path):
+    """Whether the seam offset is per-camera or per-tripod-placement is still
+    being measured. A single overwritten profile answers it never; an
+    append-only history keyed by deployment answers it either way."""
+    _snap(client)
+    for label in ("dome-2026.03.21", "fairport-2025.07.22"):
+        r = client.post(
+            "/stitch/save",
+            json={
+                "dx_anchors": _flat(4),
+                "correction_owner": "downstream",
+                "deployment": label,
+            },
+        )
+        assert r.status_code == 200, r.text
+    archived = sorted(p.name for p in (tmp_path / "stitch_calibrations").iterdir())
+    assert len(archived) == 2
+    assert archived[0].startswith("dome-2026.03.21-")
+    assert archived[1].startswith("fairport-2025.07.22-")
+    latest = json.loads((tmp_path / "stitch_profile.json").read_text())
+    assert latest["provenance"]["deployment"] == "fairport-2025.07.22"
+
+
+def test_the_stored_curve_does_not_depend_on_the_chosen_surface(client, tmp_path):
+    """The surface selector changes presentation, never the artifact.
+
+    Flipping which half is draggable and inverting the displayed sense is a UI
+    affordance; if it leaked into the stored anchors, the same physical
+    correction would be recorded two different ways and one of them would be
+    wrong.
+    """
+    _snap(client)
+    stored = {}
+    for owner in ("camera_mesh", "downstream", "camera_scalars+downstream"):
+        client.post(
+            "/stitch/save", json={"dx_anchors": _flat(4.5), "correction_owner": owner}
+        )
+        stored[owner] = json.loads((tmp_path / "stitch_profile.json").read_text())[
+            "dx_anchors"
+        ]
+    assert len({json.dumps(v) for v in stored.values()}) == 1, stored
+
+
+def test_save_refuses_an_owner_that_cannot_carry_a_curve(client):
+    _snap(client)
+    r = client.post(
+        "/stitch/save",
+        json={"dx_anchors": _flat(6), "correction_owner": "camera_scalars"},
+    )
+    assert r.status_code == 400
+    assert "cannot express a per-row shear" in r.json()["detail"]
+
+
+# -- apply -------------------------------------------------------------------
+
+
+def test_apply_hands_the_operators_curve_to_the_ordered_sequence(client, calls):
+    _snap(client)
+    r = client.post(
+        "/stitch/apply",
+        json={"dx_anchors": _flat(3.5), "correction_owner": "camera_mesh"},
+    )
+    assert r.status_code == 200, r.text
+    applied = [c for c in calls if c[0] == "apply"]
+    assert len(applied) == 1
+    anchors, kw = applied[0][1], applied[0][2]
+    assert anchors == [
+        (0.0, 3.5),
+        (225.0, 3.5),
+        (450.0, 3.5),
+        (675.0, 3.5),
+        (899.0, 3.5),
+    ]
+    assert kw["host"] == "10.0.0.9"
+    assert kw["password"] == "hunter2"
+    # Never guessed at: the scalars are the operator's to change explicitly.
+    assert kw["scalars"] is None
+    assert kw["calibration_id"].startswith("duo3-")
+
+
+def test_apply_refuses_the_downstream_owner_because_that_is_the_double_correct(client):
+    _snap(client)
+    r = client.post(
+        "/stitch/apply", json={"dx_anchors": _flat(3), "correction_owner": "downstream"}
+    )
+    assert r.status_code == 400
+    assert "double-correction" in r.json()["detail"]
+
+
+def test_apply_dry_run_is_passed_through_rather_than_simulated_here(client, calls):
+    _snap(client)
+    client.post(
+        "/stitch/apply",
+        json={
+            "dx_anchors": _flat(2),
+            "correction_owner": "camera_mesh",
+            "dry_run": True,
+        },
+    )
+    assert [c for c in calls if c[0] == "apply"][0][2]["dry_run"] is True
+
+
+def test_apply_surfaces_a_refusal_instead_of_reporting_success(client, tmp_path, calls):
+    _snap(client)
+
+    def boom(anchors, **kw):
+        raise RuntimeError("the live mesh changed between the dump and the write")
+
+    sc._toolkit_cache["camera"].apply_calibration = boom
+    r = client.post(
+        "/stitch/apply",
+        json={"dx_anchors": _flat(3), "correction_owner": "camera_mesh"},
+    )
+    assert r.status_code == 502
+    assert "live mesh changed" in r.json()["detail"]
+
+
+# -- degradation -------------------------------------------------------------
+
+
+def test_without_the_toolkit_the_page_still_loads_and_says_why(client):
+    sc._toolkit_cache.clear()
+    sc._toolkit_cache.update(
+        {"metric": None, "camera": None, "errors": ["seam_metric: nope"]}
+    )
+    body = client.get("/stitch").text
+    assert "Calibration toolkit unavailable" in body
+    assert "seam_metric: nope" in body
+    assert client.post("/stitch/snap").status_code == 503
+
+
+def test_a_non_reolink_camera_is_refused_with_a_reason(tmp_path, calls):
+    config_path = tmp_path / "config.ini"
+    config_path.write_text(
+        CONFIG.format(storage=str(tmp_path).replace("\\", "/")).replace(
+            "type = reolink", "type = dahua"
+        )
+    )
+    sc._toolkit_cache.clear()
+    sc._toolkit_cache.update(
+        {"metric": seam_metric, "camera": _fake_camera(calls), "errors": []}
+    )
+    sc._session.__init__()  # type: ignore[misc]
+    app = FastAPI()
+    app.include_router(sc.build_router(config_path, tmp_path))
+    with TestClient(app) as c:
+        r = c.post("/stitch/snap")
+    assert r.status_code == 400
+    assert "dual-lens" in r.json()["detail"]
+    sc._toolkit_cache.clear()

--- a/video_grouper/utils/stitch_remap.py
+++ b/video_grouper/utils/stitch_remap.py
@@ -42,7 +42,14 @@ class StitchProfile:
 
     @classmethod
     def from_dict(cls, d: dict) -> StitchProfile:
-        anchors = [(int(a[0]), int(a[1])) for a in d["dx_anchors"]]
+        # round(), not int(): a v2 calibration carries sub-pixel anchors (the
+        # camera's warp mesh is quarter-pixel), and int() truncates toward
+        # zero. Truncation would bias every non-integer anchor toward the
+        # seam by up to a pixel *before* build_dx_lookup does its own
+        # rounding -- a silent under-correction on exactly the small objects
+        # at the seam this module exists to help. Rounding here matches what
+        # build_dx_lookup does downstream, so the two agree.
+        anchors = [(round(float(a[0])), round(float(a[1]))) for a in d["dx_anchors"]]
         return cls(
             source_width=int(d["source_width"]),
             source_height=int(d["source_height"]),
@@ -57,6 +64,226 @@ class StitchProfile:
             "seam_x": self.seam_x,
             "dx_anchors": [list(a) for a in self.dx_anchors],
         }
+
+
+SCHEMA_V2 = "seam_calibration/2"
+
+# Who owns the correction. Exactly one surface does; the others contribute
+# nothing. See docs/STITCH_CALIBRATION.md 3.1 for why summing them is a trap:
+# the camera's mesh is runtime state that dies on reboot, so a split
+# correction silently becomes a partial one at the next power cycle and
+# nothing in the video says so. A single owner degrades to *no* correction,
+# which is detectable.
+CORRECTION_OWNERS = frozenset(
+    {
+        "camera_mesh",
+        "camera_scalars",
+        "camera_scalars+downstream",
+        "downstream",
+    }
+)
+
+# Only these two author a per-row curve. `camera_scalars` alone cannot express
+# a shear at all -- it is three whole-frame integers -- so a curve stored under
+# it would be a curve nothing applies.
+CURVE_OWNERS = frozenset({"camera_mesh", "camera_scalars+downstream", "downstream"})
+
+
+class SeamCalibrationError(ValueError):
+    """A calibration artifact that must not be written or applied."""
+
+
+def read_dx_anchors(obj: object) -> list[tuple[float, float]]:
+    """Pull the `[y, dx]` curve out of whatever shape the producer emitted.
+
+    Deliberately permissive on the way in and strict on the way out, because
+    two independent producers write this curve -- the interactive tool and the
+    automatic solver -- and pinning them to one envelope would couple them for
+    no benefit. Accepted:
+
+      * a bare list of pairs, ``[[y, dx], ...]``
+      * any mapping carrying ``dx_anchors`` (v1 profile, v2 profile, or the
+        solver's ``{"dx_anchors": [...], "metadata": {...}}``)
+
+    Values stay floats. The mesh is quarter-pixel and the downstream corrector
+    is whole-pixel; rounding is the consumer's business, not the reader's.
+    """
+    raw: object = obj
+    if isinstance(obj, dict):
+        if "dx_anchors" not in obj:
+            raise SeamCalibrationError("no dx_anchors in calibration payload")
+        raw = obj["dx_anchors"]
+    if not isinstance(raw, list | tuple) or not raw:
+        raise SeamCalibrationError(f"dx_anchors must be a non-empty list, got {raw!r}")
+
+    anchors: list[tuple[float, float]] = []
+    for pair in raw:
+        if not isinstance(pair, list | tuple) or len(pair) != 2:
+            raise SeamCalibrationError(f"anchor must be a [y, dx] pair, got {pair!r}")
+        try:
+            anchors.append((float(pair[0]), float(pair[1])))
+        except (TypeError, ValueError) as exc:
+            raise SeamCalibrationError(f"non-numeric anchor {pair!r}") from exc
+
+    if any(b[0] <= a[0] for a, b in zip(anchors, anchors[1:], strict=False)):
+        # np.interp (and therefore build_dx_lookup, and therefore the camera's
+        # composer) silently produces nonsense for unsorted x. Refuse instead.
+        raise SeamCalibrationError(f"anchor rows must strictly increase: {anchors}")
+    return anchors
+
+
+def validate_v2_profile(d: dict) -> None:
+    """Raise unless the artifact is internally consistent.
+
+    These are the anti-double-correction rules of STITCH_CALIBRATION.md 3.2,
+    and they are refusals rather than warnings on purpose: the one failure
+    this format cannot afford is a profile that names the camera as owner
+    while also carrying a downstream payload, because then the correction is
+    applied twice and the seam ends up worse than uncorrected.
+
+    A legacy v1 profile -- no ``schema``, no ``correction_owner`` -- is not
+    checked here at all. It means ``downstream`` and applies as it always has.
+    """
+    if d.get("schema") != SCHEMA_V2:
+        return
+
+    owner = d.get("correction_owner")
+    if owner not in CORRECTION_OWNERS:
+        raise SeamCalibrationError(
+            f"correction_owner {owner!r} is not one of {sorted(CORRECTION_OWNERS)}"
+        )
+
+    anchors = read_dx_anchors(d)
+    nonzero = any(dx != 0.0 for _y, dx in anchors)
+
+    if owner not in CURVE_OWNERS and nonzero:
+        raise SeamCalibrationError(
+            f"correction_owner is {owner!r}, which cannot express a per-row "
+            "shear, but dx_anchors is non-zero. A curve nothing applies is a "
+            "packaging bug, not a calibration."
+        )
+
+    stages = d.get("stages") or []
+    applied = {
+        s.get("surface") for s in stages if s.get("state") in ("applied", "would_set")
+    }
+    if "downstream" in owner and "camera_mesh" in applied:
+        raise SeamCalibrationError(
+            "correction_owner names downstream but a camera_mesh stage is "
+            "recorded as applied. That is the double-correction, and it is "
+            "the one case that must never be a warning."
+        )
+
+    if d.get("dy_anchors") is not None and "downstream" in owner:
+        # The downstream corrector is horizontal-only by construction. Dropping
+        # a field silently is how calibrations become mysterious.
+        if "dy_anchors" not in (d.get("dropped") or []):
+            raise SeamCalibrationError(
+                "dy_anchors is set but the downstream surface cannot apply it; "
+                'record the loss explicitly with "dropped": ["dy_anchors"]'
+            )
+
+
+def build_v2_profile(
+    anchors: list[tuple[float, float]],
+    *,
+    correction_owner: str,
+    calibration_id: str,
+    source_width: int = 7680,
+    source_height: int = 2160,
+    seam_x: int = 3840,
+    blend_w: int = 128,
+    scalars: dict | None = None,
+    factory_scalars: dict | None = None,
+    stages: list[dict] | None = None,
+    validation: dict | None = None,
+    calibrated_for: dict | None = None,
+    provenance: dict | None = None,
+) -> dict:
+    """Build the on-disk calibration artifact.
+
+    Not a new format wrapping the old one: this **is** a `StitchProfile` JSON
+    with optional keys added, and `StitchProfile.from_dict` ignores every one
+    of them. A v1 consumer keeps working with no code change, which is the
+    whole reason the schema is shaped this way.
+
+    The `sense` block is not decoration. It is the one paragraph that stops a
+    sign error, and a sign error here applies the misregistration twice rather
+    than removing it.
+    """
+    if correction_owner not in CORRECTION_OWNERS:
+        raise SeamCalibrationError(
+            f"correction_owner {correction_owner!r} is not one of "
+            f"{sorted(CORRECTION_OWNERS)}"
+        )
+    half = blend_w
+    profile = {
+        # v1 core -- read by the shipped downstream corrector, unchanged.
+        "source_width": source_width,
+        "source_height": source_height,
+        "seam_x": seam_x,
+        "dx_anchors": [[float(y), round(float(dx), 4)] for y, dx in anchors],
+        # v2 additions -- ignored by v1 readers.
+        "schema": SCHEMA_V2,
+        "calibration_id": calibration_id,
+        "correction_owner": correction_owner,
+        "sense": {
+            "dx_means": (
+                "px the RIGHT half must move right, at row y, to register with the left"
+            ),
+            "downstream_moves": "right_half",
+            "camera_mesh_moves": "left_half_with_opposite_sense",
+        },
+        "geometry": {
+            "panorama": [source_width, source_height],
+            "half": [source_width // 2, source_height],
+            "blend_w": blend_w,
+            "blend_window": [seam_x - half, seam_x + half],
+            "warped_half": "left",
+            "mesh": {"n": 257, "stride": 260, "frac_bits": 2},
+        },
+        "dy_anchors": None,
+        "calibrated_for": calibrated_for
+        or {
+            "subject_distance_m": None,
+            "basis": None,
+            "fb_px_m": None,
+            "residual_px_at": {},
+        },
+        "stages": stages
+        if stages is not None
+        else _default_stages(correction_owner, scalars, factory_scalars),
+        "validation": validation or {},
+        "provenance": provenance or {},
+    }
+    validate_v2_profile(profile)
+    return profile
+
+
+def _default_stages(
+    owner: str, scalars: dict | None, factory: dict | None
+) -> list[dict]:
+    """The `stages[]` witness for a calibration that has not been applied yet."""
+    stages: list[dict] = []
+    if scalars is not None or factory is not None:
+        stages.append(
+            {
+                "surface": "camera_scalars",
+                "state": "baseline",
+                "values": scalars,
+                "factory": factory,
+            }
+        )
+    if owner == "camera_mesh":
+        stages.append({"surface": "camera_mesh", "state": "pending", "vpe_id": 0})
+        stages.append(
+            {
+                "surface": "downstream",
+                "state": "disabled",
+                "reason": "owned by camera_mesh",
+            }
+        )
+    return stages
 
 
 def load_profile(path: str | Path) -> StitchProfile | None:

--- a/video_grouper/web/auth_server.py
+++ b/video_grouper/web/auth_server.py
@@ -137,6 +137,7 @@ form.inline { display: inline; margin-left: 0.5rem; }
 <nav style="margin: 0 0 1rem;">
 <a class="btn btn-ghost" href="/config">Configure</a>
 <a class="btn btn-ghost" href="/setup">Setup wizard</a>
+<a class="btn btn-ghost" href="/stitch">Seam calibration</a>
 </nav>
 
 __AUTH_FLAGS_BANNER__
@@ -880,6 +881,15 @@ def create_app(
         from video_grouper.web.setup.router import build_router as _build_setup
 
         app.include_router(_build_setup(config_path))
+
+        # And the stitch-seam calibration tool at /stitch/*. Same trigger
+        # again -- it reads the camera credentials out of config.ini and
+        # writes the calibration profile next to it.
+        from video_grouper.web.stitch_calibration import (
+            build_router as _build_stitch,
+        )
+
+        app.include_router(_build_stitch(config_path, storage))
 
     # Phase 4: master nodes expose the worker-coordination API.
     if node_role == "master":

--- a/video_grouper/web/stitch_calibration.py
+++ b/video_grouper/web/stitch_calibration.py
@@ -6,13 +6,27 @@ while the seam metric scores every candidate curve, and send the result back.
 The curve the operator authors **is** the calibration artifact -- there is no
 export step and no parameter that lives only in the UI.
 
-Two doors, one editor: a live `Snap` over HTTP, or a frame opened from a file
-or seeked out of a recording. The second is the one most calibrations will come
-through. Nobody stands at the touchline with a laptop mid-match, and a camera
-indoors on a bench is looking at a scene 0.3 m away, where parallax runs to
-tens of pixels and swamps the lens roll this exists to correct.
+**The client is a phone, held at the pitch side.** Mark's plan, in his words:
+*"I will connect to the camera from my phone while on the field, so setting
+this up in the camera manager app will work."* That is not a nice-to-have
+responsive pass over a desktop tool; it decides the layout, the gestures and
+the network behaviour. A pair of 640x2160 strips and a tall curve widget do not
+fit a 390 px viewport by shrinking, a mouse-only drag is unreachable, and the
+link at a field is whatever the field has. So: one primary canvas with pinch
+zoom and an axis-locked drag, a thumb-sized roll control, everything else
+folded away, every score request bounded by a timeout, and numbers that are
+visibly stale the instant the curve moves rather than silently wrong.
 
-Four things about this file are load-bearing and easy to get wrong.
+Reaching it from a phone at all needs ``[TTT].auth_server_bind`` set to the
+machine's LAN address -- the app's host allowlist is loopback plus that value
+(``web/auth_server.py``), and ``0.0.0.0`` deliberately does *not* widen it. The
+page says so where an operator will read it.
+
+**The live `Snap` is the primary door.** The field loop is: tripod, snap,
+adjust, apply, re-snap to confirm. Opening a frame from an archived game stays,
+because a calibration can also be recovered from footage after the fact.
+
+Six things about this file are load-bearing and easy to get wrong.
 
 **Only one half moves, and it is the LEFT one.** The camera's warp mesh lives
 in VPE 0, which warps the left half; measured on hardware (#135), a requested
@@ -36,6 +50,18 @@ the whole plausible dx range while the seam is visibly registered, and every
 coverage gate passes while it happens. So each frame is swept once and the
 verdict -- can this picture steer the calibration at all -- leads the panel,
 ahead of any number. See `_frame_quality`.
+
+**The calibration target is a person standing in the seam.** Mark: *"it's easy
+to see misregistration if there's a person in the seam."* That is the answer to
+the anomaly above, and the mechanism is in `seam_vertical`: the seam is a
+vertical line, SCR is built from *near-horizontal* structures, and a horizontal
+edge is invariant under a horizontal shift. Touchlines, treelines and painted
+banners therefore supply observation after observation carrying no information
+about the quantity being tuned. A person is upright -- torso, legs, head -- and
+is exactly what a horizontal error breaks. So "have someone stand in the seam"
+is a *step* in this interface, not a tip, the tool checks whether they actually
+are in it before believing any number, and the reported residual leads with the
+subset of structures that can see `dx` at all.
 
 **The picture is a fused JPEG, so parts of it are already a mixture.** The
 camera blends the two sensors over a 256-px window, so nothing inside it is
@@ -124,16 +150,21 @@ _toolkit_cache: dict[str, Any] = {}
 
 
 def load_toolkit() -> dict[str, Any]:
-    """Import `seam_metric` / `stitch_apply`, or explain why not.
+    """Import `seam_metric` / `seam_vertical` / `stitch_apply`, or explain why not.
 
-    Returns a dict with ``metric`` and ``camera`` (module or None) plus
-    ``errors``. The page degrades rather than 500s: the metric and the camera
-    surface fail independently, and an operator with neither can still read the
-    documentation the page carries.
+    Returns a dict with ``metric``, ``vertical`` and ``camera`` (module or None)
+    plus ``errors``. The page degrades rather than 500s: the metric and the
+    camera surface fail independently, and an operator with neither can still
+    read the documentation the page carries.
     """
     if _toolkit_cache:
         return _toolkit_cache
-    out: dict[str, Any] = {"metric": None, "camera": None, "errors": []}
+    out: dict[str, Any] = {
+        "metric": None,
+        "camera": None,
+        "vertical": None,
+        "errors": [],
+    }
     vpe = _vpe_dir()
     if vpe is None:
         out["errors"].append(
@@ -144,7 +175,11 @@ def load_toolkit() -> dict[str, Any]:
         return out
     if str(vpe) not in sys.path:
         sys.path.insert(0, str(vpe))
-    for key, name in (("metric", "seam_metric"), ("camera", "stitch_apply")):
+    for key, name in (
+        ("metric", "seam_metric"),
+        ("vertical", "seam_vertical"),
+        ("camera", "stitch_apply"),
+    ):
         try:
             out[key] = importlib.import_module(name)
         except Exception as exc:  # noqa: BLE001 -- any import failure degrades
@@ -185,6 +220,17 @@ class _Session:
     baseline: dict | None = None
     quality: dict | None = None
     last_apply: dict | None = None
+    # The aiming loop, which is cheap and runs ahead of the expensive one: a
+    # downscaled whole-panorama JPEG plus "is anything upright in the seam
+    # corridor". Kept separate from the calibration frame so pressing Aim
+    # repeatedly -- while someone walks into the seam -- never disturbs a
+    # session that is already scored.
+    scene: bytes = b""
+    scene_version: int = 0
+    scene_at: float = 0.0
+    scene_source: str = ""
+    scene_vertical: dict | None = None
+    vertical: dict | None = None
 
     lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -234,6 +280,83 @@ def _encode_halves(frame: Any, seam_x: int) -> dict[str, bytes]:
     return out
 
 
+#: The whole panorama, small enough to cross a field's worth of link. 960 px of
+#: a 7680 px frame is 1/8 scale -- useless for judging registration and exactly
+#: right for judging *aim*: where the seam falls in the scene, and whether the
+#: person you asked to stand in it is standing in it.
+SCENE_W = 960
+SCENE_QUALITY = 68
+
+
+def _encode_scene(frame: Any) -> bytes:
+    import cv2
+
+    h, w = frame.shape[:2]
+    small = cv2.resize(
+        frame, (SCENE_W, max(1, round(h * SCENE_W / w))), interpolation=cv2.INTER_AREA
+    )
+    ok, buf = cv2.imencode(".jpg", small, [cv2.IMWRITE_JPEG_QUALITY, SCENE_QUALITY])
+    if not ok:
+        raise HTTPException(500, "could not encode the scene overview")
+    return bytes(buf.tobytes())
+
+
+def _vertical_profile(frame: Any, seam_x: int) -> dict | None:
+    """Where upright structure crosses the seam corridor, if anywhere.
+
+    ~60 ms on a 7680x2160 frame against the 37-50 s SCR detection, which is why
+    it can run on every aiming snapshot: the operator finds out whether the
+    person is in the seam *before* committing to a measurement.
+    """
+    vertical = load_toolkit().get("vertical")
+    if vertical is None:
+        return None
+    try:
+        profile = vertical.vertical_structure(frame, seam_x=seam_x, blend_w=2 * BLEND_W)
+        return vertical.summarise(profile)
+    except Exception as exc:  # noqa: BLE001 -- an aiming aid never 500s
+        logger.warning("STITCH: vertical-structure scan failed: %s", exc)
+        return None
+
+
+def _target_band(
+    upright: dict | None, height: int, pad: int = 40
+) -> tuple[int, int] | None:
+    """The rows the calibration target actually occupies, padded.
+
+    SSR over the whole field band answers "is the seam damaged on average",
+    and mid-field average is grass, which a misregistration cannot damage
+    because there is nothing there to break. Measured on a real frame with a
+    player straddling the seam: |ln SSR| over the field band reads 0.062 --
+    below the 0.10 noise floor, i.e. indistinguishable from a perfect seam --
+    while over the 285 rows this function hands back for that player it reads
+    1.180, and over the strongest 183-row band alone 2.188. Across 87
+    frames sampled from the archived set, the whole-band figure cannot tell the
+    two cases apart at all (median 0.095 with upright structure in the corridor
+    against 0.088 without), while the banded figure separates them by an order
+    of magnitude (1.889 against 0.170).
+
+    One honest limit, and the UI states it: SSR is a ratio against a background
+    fitted on the *shoulders*, so an object that exists only inside the window
+    raises it whether or not it is misregistered (section 9.2 says the same of
+    the live frame at 0.3 m). This is therefore a before/after comparator on a
+    fixed scene -- the same person standing in the same place across an Apply
+    and a re-snap -- not an absolute measure of damage.
+    """
+    if not upright or not upright.get("rows"):
+        return None
+    best = upright.get("best_rows")
+    rows = [tuple(r) for r in upright["rows"]]
+    chosen = rows[0]
+    if best:
+        for r in rows:
+            if r[0] <= best[0] < r[1]:
+                chosen = r
+                break
+    lo, hi = max(0, chosen[0] - pad), min(height, chosen[1] + pad)
+    return (lo, hi) if hi - lo >= 64 else None
+
+
 def _detect_chains_async(session: _Session, version: int) -> None:
     """Run the expensive SCR detection off the request thread.
 
@@ -256,7 +379,17 @@ def _detect_chains_async(session: _Session, version: int) -> None:
         )
         scr = metric.residual_from_chains(chains)
         ssr = metric.seam_sharpness_ratio(frame, seam_x=seam, blend_w=2 * BLEND_W)
-        quality = _frame_quality(metric, chains, frame.shape[0])
+        with session.lock:
+            upright = session.vertical
+        band = _target_band(upright, frame.shape[0])
+        ssr_target = (
+            None
+            if band is None
+            else metric.seam_sharpness_ratio(
+                frame, seam_x=seam, blend_w=2 * BLEND_W, band=band
+            )
+        )
+        quality = _frame_quality(metric, chains, frame.shape[0], upright)
     except Exception as exc:  # noqa: BLE001 -- surfaced to the operator instead
         logger.warning("STITCH: baseline detection failed: %s", exc)
         with session.lock:
@@ -269,7 +402,7 @@ def _detect_chains_async(session: _Session, version: int) -> None:
             return
         session.chains = chains
         session.chains_state = "ready"
-        session.baseline = _score_payload(scr, ssr)
+        session.baseline = _score_payload(scr, ssr, ssr_target, band)
         session.quality = quality
 
 
@@ -285,8 +418,11 @@ _MATCH_GAP_PX = 40.0
 _MIN_USEFUL_GAIN = 0.20
 
 
-def _frame_quality(metric: Any, chains: Any, height: int) -> dict:
-    """Ask the frame whether it can constrain the calibration at all.
+def _frame_quality(
+    metric: Any, chains: Any, height: int, upright: dict | None = None
+) -> dict:
+    """Ask the frame whether it can constrain the calibration at all, and if
+    not, say what to change about the picture.
 
     This exists because of what real material does. On three separate Duo 3
     tripod placements -- an indoor dome and two outdoor pitches -- SCR reports
@@ -295,15 +431,23 @@ def _frame_quality(metric: Any, chains: Any, height: int) -> dict:
     coverage gate passes (40-69 structures, 3 row bands, 69-79% height), so
     nothing in the acceptance check flags it.
 
-    What is happening: the matcher pairs a left structure with any right
-    structure within 40 px at the seam, and a busy scene at mixed depths
-    offers plenty. The resulting "observations" are unrelated edges, and their
-    residuals describe the matching tolerance rather than the registration.
+    Two things are happening, and only the second one has a remedy.
 
-    So a number alone is not honest. Sweeping dx once per frame answers the
-    question the operator actually has -- *can this picture tell me anything*
-    -- and it is the same question the automatic solver has to answer before
-    it trusts a fit.
+    The matcher pairs a left structure with any right structure within 40 px at
+    the seam, and a busy scene at mixed depths offers plenty; those pairs are
+    unrelated edges whose residuals describe the matching tolerance.
+
+    And underneath that, the structures being paired are the wrong shape. SCR
+    fits *near-horizontal* lines, and `r_y = -m*dx` means a horizontal line is
+    invariant under the horizontal shift being tuned. Measured across the
+    archived Duo 3 frame set on three games (see `seam_vertical`): of 11, 61 and
+    88 accepted structures, 0, 1 and 2 respectively were steeper than |m| = 0.15,
+    and restricting the dx sweep to the subset that can see dx at all moved the
+    p90 by 1.3-2.9% -- no better than the full set. Re-weighting does not rescue
+    these frames. Only different structure does, which is why the remedy this
+    returns is an instruction about the scene rather than a smaller number:
+    **put a person in the seam.** A person is upright, and upright is precisely
+    what a horizontal error breaks.
     """
     sweep = []
     for dx in range(-16, 17, 2):
@@ -312,37 +456,66 @@ def _frame_quality(metric: Any, chains: Any, height: int) -> dict:
         )
         if r.n:
             sweep.append({"dx": dx, "p50": round(r.p50, 3), "p90": round(r.p90, 3)})
+
+    base = metric.residual_from_chains(chains)
+    split = _sensitivity_split(base.observations)
+    has_upright = bool(upright and upright.get("n_with_structure"))
+    upright_rows = (upright or {}).get("rows") or []
+
     if not sweep:
-        return {"usable": False, "reason": "no structure crosses the seam", "sweep": []}
+        return {
+            "usable": False,
+            "reason": "no structure crosses the seam at all",
+            "remedy": _PERSON_REMEDY,
+            "has_upright": has_upright,
+            "upright_rows": upright_rows,
+            "split": split,
+            "sweep": [],
+        }
 
     at_zero = next((s for s in sweep if s["dx"] == 0), sweep[0])
     best = min(sweep, key=lambda s: s["p90"])
     gain = 0.0 if at_zero["p90"] <= 0 else 1.0 - best["p90"] / at_zero["p90"]
 
-    base = metric.residual_from_chains(chains)
     saturated = [o for o in base.observations if o.residual_perp > 0.8 * _MATCH_GAP_PX]
     sat_frac = len(saturated) / base.n if base.n else 0.0
 
     usable = gain >= _MIN_USEFUL_GAIN
+    remedy = ""
     if usable:
         reason = (
             f"sliding dx across +/-16 px moves SCR p90 by {gain * 100:.0f}%, "
             f"best at dx={best['dx']:+d}"
         )
+    elif split["n_steering"] == 0:
+        reason = (
+            f"every one of the {split['n_total']} structures crossing the seam is "
+            "within 3 degrees of horizontal, and a horizontal edge does not move "
+            "when the halves shift horizontally -- SCR here is measuring its own "
+            "pairing tolerance"
+        )
+        remedy = _PERSON_REMEDY
     elif sat_frac > 0.4:
         reason = (
             f"{sat_frac * 100:.0f}% of matched structures sit near the "
             f"{_MATCH_GAP_PX:.0f} px pairing limit, so the score is dominated by "
             "unrelated edges paired across the seam, not by misregistration"
         )
+        remedy = _PERSON_REMEDY
     else:
         reason = (
             f"sliding dx across the whole plausible range moves SCR p90 by only "
-            f"{gain * 100:.0f}% -- this frame does not constrain the seam offset"
+            f"{gain * 100:.0f}%; the steepest structure here converts a shift into "
+            f"only {split['max_sensitivity']:.2f} px of residual per px"
         )
+        remedy = _PERSON_REMEDY
     return {
         "usable": usable,
         "reason": reason,
+        "remedy": remedy,
+        "has_upright": has_upright,
+        "upright_rows": upright_rows,
+        "split": split,
         "best_dx": best["dx"] if usable else None,
         "gain": round(gain, 4),
         "saturated_fraction": round(sat_frac, 3),
@@ -350,7 +523,40 @@ def _frame_quality(metric: Any, chains: Any, height: int) -> dict:
     }
 
 
-def _score_payload(scr: Any, ssr: Any) -> dict:
+#: The one instruction that changes the answer. Everything else -- re-weighting,
+#: tighter gates, a better regression -- is arithmetic on structure that cannot
+#: see the quantity being measured.
+_PERSON_REMEDY = (
+    "Have someone stand in the seam, out where play actually happens rather "
+    "than beside the tripod, and snap again. A person is upright, which is the "
+    "one thing a horizontal misregistration visibly breaks."
+)
+
+
+def _sensitivity_split(observations: Any) -> dict:
+    """How many of these structures can see a horizontal shift at all."""
+    vertical = load_toolkit().get("vertical")
+    if vertical is None or not observations:
+        return {
+            "n_total": len(observations or []),
+            "n_steering": 0,
+            "blind_fraction": 1.0,
+            "p90_steering": None,
+            "p90_blind": None,
+            "median_sensitivity": 0.0,
+            "max_sensitivity": 0.0,
+        }
+    return vertical.summarise(
+        vertical.VerticalProfile(), vertical.split_by_dx_sensitivity(observations)
+    )["scr_split"]
+
+
+def _score_payload(
+    scr: Any,
+    ssr: Any,
+    ssr_target: Any = None,
+    target_band: tuple[int, int] | None = None,
+) -> dict:
     return {
         "scr": {
             "n": scr.n,
@@ -370,11 +576,28 @@ def _score_payload(scr: Any, ssr: Any) -> dict:
                 else round(-scr.implied_dx, 3)
             ),
         },
+        # How much of that residual comes from structure that can actually see
+        # a horizontal shift. Reported beside the headline number rather than
+        # folded into it: silently redefining SCR would leave this tool and the
+        # automatic solver minimising two different things under one name.
+        "split": _sensitivity_split(scr.observations),
         "ssr": {
             "ssr": round(ssr.ssr, 4),
             "abs_ln_ssr": round(ssr.abs_ln_ssr, 4),
             "noise_floor": ssr.noise_floor,
         },
+        # The same metric, restricted to the rows the calibration target
+        # occupies. Grass cannot be broken by a misregistration, so averaging
+        # over a field band of it hides the damage: 0.062 whole-band against
+        # 1.180 on the player's rows, on one real frame verified in the UI.
+        "ssr_target": (
+            None
+            if ssr_target is None
+            else {
+                "abs_ln_ssr": round(ssr_target.abs_ln_ssr, 4),
+                "band": list(target_band or ssr_target.band),
+            }
+        ),
         # The structures the score is computed from, so the picture and the
         # number are the same evidence. Each is one structure fitted
         # independently on the two shoulders and extrapolated to the seam;
@@ -383,12 +606,17 @@ def _score_payload(scr: Any, ssr: Any) -> dict:
         # and it is honest in a way extrapolating pixels is not: the metric
         # really does extrapolate lines, and a line drawn on screen cannot be
         # mistaken for photographic evidence the fused frame does not contain.
+        # `sens` is px of residual per px of horizontal shift -- the structure's
+        # sine from horizontal. The view draws near-zero ones muted, because a
+        # bright confident line that cannot respond to the control the operator
+        # is holding is a lie told in a picture.
         "observations": [
             {
                 "y_left": round(o.y_left, 2),
                 "y_right": round(o.y_right, 2),
                 "slope": round(o.slope, 5),
                 "residual": round(o.residual_perp, 2),
+                "sens": round(abs(o.slope) / (1.0 + o.slope * o.slope) ** 0.5, 3),
             }
             for o in sorted(scr.observations, key=lambda o: o.fit_rms)[:60]
         ],
@@ -450,7 +678,10 @@ def _adopt_frame(
     the operator should be looking at the picture long before the numbers do.
     """
     metric = load_toolkit()["metric"]
-    halves = _encode_halves(frame, frame.shape[1] // 2)
+    seam_x = frame.shape[1] // 2
+    halves = _encode_halves(frame, seam_x)
+    scene = _encode_scene(frame)
+    upright = _vertical_profile(frame, seam_x)
     with _session.lock:
         _session.version += 1
         version = _session.version
@@ -459,6 +690,12 @@ def _adopt_frame(
         _session.source_path = source_path
         _session.frame = frame
         _session.halves = halves
+        _session.scene = scene
+        _session.scene_version = version
+        _session.scene_at = time.time()
+        _session.scene_source = source_path or "camera"
+        _session.scene_vertical = upright
+        _session.vertical = upright
         _session.height, _session.width = frame.shape[0], frame.shape[1]
         _session.snapped_at = time.time()
         _session.scalars_current, _session.scalars_factory = scalars
@@ -505,16 +742,10 @@ def build_router(config_path: Path, storage_path: Path | None = None) -> APIRout
         with _session.lock:
             return JSONResponse(_state_payload())
 
-    @router.post("/stitch/snap")
-    def post_snap() -> JSONResponse:
-        """Fetch a fresh still and the camera's own scalars, in one action.
-
-        `GetStitch` returns both the live values and the factory `initial`
-        block, so "confirm what the camera's auto-adjustment already found" is
-        a real comparison rather than a leap of faith.
-        """
+    def _live_frame() -> tuple[Any, CameraConfig, str]:
+        """One `Snap` off the camera, decoded. Read-only, every time."""
         toolkit = load_toolkit()
-        camera_mod, metric = toolkit["camera"], toolkit["metric"]
+        camera_mod = toolkit["camera"]
         if camera_mod is None:
             raise HTTPException(503, "; ".join(toolkit["errors"]) or "toolkit missing")
         cam = _reolink_camera(config_path)
@@ -533,7 +764,68 @@ def build_router(config_path: Path, storage_path: Path | None = None) -> APIRout
             frame = cv2.imread(str(path), cv2.IMREAD_COLOR)
         if frame is None:
             raise HTTPException(502, "the camera returned something that is not a JPEG")
+        return frame, cam, host
 
+    @router.post("/stitch/aim")
+    def post_aim() -> JSONResponse:
+        """Where does the seam fall in the scene, and is anyone standing in it?
+
+        The step before the calibration snapshot, and the reason it is a
+        separate endpoint: it must be cheap enough to press repeatedly while
+        someone walks into position. A downscaled panorama (~35 KB) plus a
+        60 ms upright-structure scan, and nothing that touches the scored
+        session -- pressing this cannot lose a calibration in progress.
+
+        A phone at a pitch cannot see a live video stream from a camera it is
+        not on the same link as, and does not need to: what the operator has to
+        establish before spending 40 s on detection is only *where the seam
+        lands in the scene* and *whether the target is in it*.
+        """
+        frame, cam, host = _live_frame()
+        seam_x = frame.shape[1] // 2
+        scene = _encode_scene(frame)
+        upright = _vertical_profile(frame, seam_x)
+        with _session.lock:
+            _session.scene = scene
+            _session.scene_version += 1
+            _session.scene_at = time.time()
+            _session.scene_source = f"aim {host}"
+            _session.scene_vertical = upright
+            if not _session.camera_name:
+                _session.camera_name = cam.name
+                _session.host = host
+            payload = _state_payload()
+        payload["aim"] = {
+            "width": frame.shape[1],
+            "height": frame.shape[0],
+            "seam_x": seam_x,
+            "vertical": upright,
+        }
+        return JSONResponse(payload)
+
+    @router.get("/stitch/scene.jpg")
+    def get_scene(v: int = 0) -> Response:
+        with _session.lock:
+            data, version = _session.scene, _session.scene_version
+        if not data:
+            raise HTTPException(404, "no scene overview yet")
+        del v  # cache-buster only
+        return Response(
+            data,
+            media_type="image/jpeg",
+            headers={"Cache-Control": "no-store", "X-Stitch-Scene": str(version)},
+        )
+
+    @router.post("/stitch/snap")
+    def post_snap() -> JSONResponse:
+        """Fetch a fresh still and the camera's own scalars, in one action.
+
+        `GetStitch` returns both the live values and the factory `initial`
+        block, so "confirm what the camera's auto-adjustment already found" is
+        a real comparison rather than a leap of faith.
+        """
+        frame, cam, host = _live_frame()
+        camera_mod = load_toolkit()["camera"]
         try:
             current, factory = camera_mod.get_stitch(host, cam.username, cam.password)
             scalars = (current.to_api(), factory.to_api())
@@ -541,7 +833,6 @@ def build_router(config_path: Path, storage_path: Path | None = None) -> APIRout
             logger.warning("STITCH: GetStitch failed: %s", exc)
             scalars = (None, None)
 
-        del metric
         return _adopt_frame(
             frame,
             camera_name=cam.name,
@@ -647,13 +938,15 @@ def build_router(config_path: Path, storage_path: Path | None = None) -> APIRout
             chains, frame = _session.chains, _session.frame
             width, height = _session.width, _session.height
             baseline = _session.baseline
+            upright = _session.vertical
         if chains is None or frame is None:
             raise HTTPException(409, "no measured snapshot yet")
 
         seam = width // 2
+        band = _target_band(upright, height)
         scr = metric.residual_from_chains(chains, anchors)
-        ssr = _ssr_for_anchors(metric, frame, seam, height, anchors)
-        payload = _score_payload(scr, ssr)
+        ssr, ssr_target = _ssr_for_anchors(metric, frame, seam, height, anchors, band)
+        payload = _score_payload(scr, ssr, ssr_target, band)
         payload["baseline"] = baseline
         return JSONResponse(payload)
 
@@ -781,9 +1074,18 @@ def build_router(config_path: Path, storage_path: Path | None = None) -> APIRout
 
 
 def _ssr_for_anchors(
-    metric: Any, frame: Any, seam: int, height: int, anchors: list[tuple[float, float]]
-) -> Any:
-    """SSR of the frame as the candidate curve would leave it.
+    metric: Any,
+    frame: Any,
+    seam: int,
+    height: int,
+    anchors: list[tuple[float, float]],
+    band: tuple[int, int] | None = None,
+) -> tuple[Any, Any]:
+    """SSR of the frame as the candidate curve would leave it, twice.
+
+    Once over the whole field band and once over the rows the calibration
+    target occupies, because those are different questions and on a real frame
+    they differ by two orders of magnitude.
 
     Computed on a 1280-px crop around the seam rather than the whole panorama:
     SSR only ever reads the blend window and the two shoulders, so the rest of
@@ -799,7 +1101,15 @@ def _ssr_for_anchors(
     ds = [a[1] for a in anchors]
     lut = np.round(np.interp(np.arange(height), ys, ds)).astype(np.int32)
     shifted = apply_shift_to_frame_rgb(crop, lut, seam - lo)
-    return metric.seam_sharpness_ratio(shifted, seam_x=seam - lo, blend_w=2 * BLEND_W)
+    whole = metric.seam_sharpness_ratio(shifted, seam_x=seam - lo, blend_w=2 * BLEND_W)
+    target = (
+        None
+        if band is None
+        else metric.seam_sharpness_ratio(
+            shifted, seam_x=seam - lo, blend_w=2 * BLEND_W, band=band
+        )
+    )
+    return whole, target
 
 
 def _state_payload() -> dict:
@@ -825,6 +1135,15 @@ def _state_payload() -> dict:
         "metric_error": _session.chains_error,
         "baseline": _session.baseline,
         "quality": _session.quality,
+        "vertical": _session.vertical,
+        "scene": {
+            "has": bool(_session.scene),
+            "version": _session.scene_version,
+            "at": _session.scene_at,
+            "source": _session.scene_source,
+            "vertical": _session.scene_vertical,
+            "width": SCENE_W,
+        },
         "last_apply": _session.last_apply,
     }
 
@@ -851,121 +1170,196 @@ _STYLE = """
   --rule:#2a2c34; --rule-strong:#3b3e48; --text:#e6e7ec; --text-mute:#94969f;
   --text-faint:#5e616b; --accent:#fb923c; --signal-on:#22c55e; --signal-off:#6b7280;
   --signal-warn:#fbbf24; --signal-bad:#f43f5e;
-  --display:'Barlow Condensed','Bebas Neue',sans-serif;
-  --body:'IBM Plex Sans',system-ui,sans-serif;
-  --mono:'IBM Plex Mono',ui-monospace,monospace;
+  /* System stacks, no webfont link. A phone at a pitch should not be waiting on
+     a webfont CDN over whatever link the field has. */
+  --display:'Bahnschrift','DIN Alternate','Roboto Condensed',system-ui,sans-serif;
+  --body:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+  --mono:ui-monospace,'SF Mono','Cascadia Mono','Segoe UI Mono',monospace;
 }
 * { box-sizing:border-box; }
+html { -webkit-text-size-adjust:100%; }
 body {
-  margin:0; font-family:var(--body); font-size:14px; line-height:1.55;
-  color:var(--text); background:var(--bg-base);
+  margin:0; font-family:var(--body); font-size:15px; line-height:1.5;
+  color:var(--text); background:var(--bg-base); padding-bottom:76px;
+  overscroll-behavior-y:contain;
 }
-.topbar { border-bottom:1px solid var(--rule); background:rgba(10,11,15,.72); }
+.topbar { border-bottom:1px solid var(--rule); background:rgba(10,11,15,.94);
+  position:sticky; top:0; z-index:30; backdrop-filter:blur(6px); }
 .topbar-inner {
-  max-width:1400px; margin:0 auto; padding:14px 24px;
-  display:flex; align-items:center; justify-content:space-between;
+  max-width:1400px; margin:0 auto; padding:9px 12px;
+  display:flex; align-items:center; justify-content:space-between; gap:10px;
 }
 .brand {
-  font-family:var(--display); font-weight:700; letter-spacing:.18em;
-  font-size:18px; text-transform:uppercase;
+  font-family:var(--display); font-weight:700; letter-spacing:.16em;
+  font-size:14px; text-transform:uppercase; white-space:nowrap;
 }
 .brand .dot { color:var(--accent); }
 .crumb {
-  font-family:var(--mono); font-size:11px; letter-spacing:.16em;
-  text-transform:uppercase; color:var(--text-mute);
+  font-family:var(--mono); font-size:11px; letter-spacing:.1em;
+  text-transform:uppercase; color:var(--text-mute); text-align:right;
 }
 .crumb a { color:var(--text-mute); text-decoration:none; }
-.crumb a:hover { color:var(--accent); }
-.shell { max-width:1400px; margin:0 auto; padding:24px 24px 80px; }
+.shell { max-width:1400px; margin:0 auto; padding:12px 12px 24px; }
 .headline {
   font-family:var(--display); font-weight:700; text-transform:uppercase;
-  letter-spacing:.04em; font-size:clamp(32px,4vw,48px); line-height:.95; margin:0 0 6px;
+  letter-spacing:.03em; font-size:clamp(21px,5.5vw,44px); line-height:1; margin:0 0 4px;
 }
-.lede { color:var(--text-mute); max-width:70ch; margin:0 0 20px; }
+.lede { color:var(--text-mute); max-width:70ch; margin:0 0 12px; font-size:13.5px; }
 h2.sec {
   font-family:var(--display); font-weight:700; text-transform:uppercase;
-  letter-spacing:.06em; font-size:19px; margin:0 0 12px;
+  letter-spacing:.05em; font-size:16px; margin:0 0 9px;
 }
 h2.sec .accent { color:var(--accent); }
-.grid { display:grid; grid-template-columns:minmax(0,1fr) 380px; gap:24px; align-items:start; }
-@media (max-width:1080px) { .grid { grid-template-columns:minmax(0,1fr); } }
+.grid { display:flex; flex-direction:column; gap:12px; }
+.col { display:contents; }
 .panel {
   background:var(--bg-surface); border:1px solid var(--rule);
-  padding:16px 18px; margin-bottom:18px;
+  padding:12px 13px; margin:0;
 }
+details.panel > summary {
+  cursor:pointer; list-style:none; font-family:var(--display); font-weight:700;
+  text-transform:uppercase; letter-spacing:.05em; font-size:16px;
+  display:flex; justify-content:space-between; align-items:center; gap:8px;
+}
+details.panel > summary::-webkit-details-marker { display:none; }
+details.panel > summary::after { content:'+'; color:var(--accent); font-size:19px; }
+details.panel[open] > summary::after { content:'\\2212'; }
+details.panel > summary .accent { color:var(--accent); }
+details.panel[open] > summary { margin-bottom:10px; }
 .mono { font-family:var(--mono); font-size:12px; }
 .muted { color:var(--text-mute); }
-.faint { color:var(--text-faint); font-size:12px; }
+.faint { color:var(--text-faint); font-size:12.5px; }
 .btn {
-  font-family:var(--display); text-transform:uppercase; letter-spacing:.09em;
-  font-weight:600; font-size:14px; padding:8px 16px; cursor:pointer;
-  background:var(--accent); color:#141414; border:0;
+  font-family:var(--display); text-transform:uppercase; letter-spacing:.07em;
+  font-weight:600; font-size:15px; padding:11px 15px; cursor:pointer;
+  background:var(--accent); color:#141414; border:0; min-height:44px;
+  touch-action:manipulation;
 }
-.btn:hover { filter:brightness(1.12); }
+.btn:active { filter:brightness(1.2); }
 .btn[disabled] { background:var(--rule-strong); color:var(--text-faint); cursor:not-allowed; }
 .btn-ghost { background:transparent; color:var(--accent); border:1px solid var(--accent); }
-.btn-ghost:hover { background:rgba(251,146,60,.12); }
 .btn-danger { background:transparent; color:var(--signal-bad); border:1px solid var(--signal-bad); }
-.btn-row { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
-canvas { display:block; background:#000; image-rendering:pixelated; }
-#viewwrap { border:1px solid var(--rule); position:relative; }
-#view { width:100%; height:auto; cursor:ew-resize; }
-#zoomwrap { border:1px solid var(--rule); margin-top:12px; position:relative; }
-#zoom { width:100%; height:auto; }
-.modes { display:flex; gap:6px; flex-wrap:wrap; margin:12px 0 8px; }
-.modes button {
-  font-family:var(--mono); font-size:11px; letter-spacing:.1em; text-transform:uppercase;
-  padding:6px 11px; background:var(--bg-elev); color:var(--text-mute);
-  border:1px solid var(--rule); cursor:pointer;
+.btn-sm { font-size:12px; padding:7px 10px; min-height:36px; }
+.btn-row { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
+
+/* The procedure. It is the spine of the page, not a tip box. */
+ol.steps { list-style:none; margin:0 0 12px; padding:0; border:1px solid var(--rule);
+  background:var(--bg-surface); }
+ol.steps li { display:flex; gap:9px; padding:8px 11px; border-bottom:1px solid var(--rule);
+  color:var(--text-faint); font-size:13px; align-items:flex-start; }
+ol.steps li:last-child { border-bottom:0; }
+ol.steps li .n { font-family:var(--mono); font-size:11px; width:17px; flex:none;
+  border:1px solid var(--rule-strong); text-align:center; line-height:16px; height:18px; }
+ol.steps li .t { font-weight:600; color:var(--text-mute); }
+ol.steps li .d { display:none; }
+ol.steps li.on { color:var(--text); background:var(--bg-elev);
+  border-left:3px solid var(--accent); padding-left:8px; }
+ol.steps li.on .t { color:var(--accent); }
+ol.steps li.on .d { display:block; color:var(--text-mute); font-size:12.5px; }
+ol.steps li.done .n { border-color:var(--signal-on); color:var(--signal-on); }
+
+/* Bottom action bar: the two live-camera doors, in thumb reach. */
+.dock { position:fixed; left:0; right:0; bottom:0; z-index:40;
+  background:rgba(10,11,15,.96); border-top:1px solid var(--rule);
+  padding:8px 10px calc(8px + env(safe-area-inset-bottom)); display:flex; gap:8px;
+  align-items:center; backdrop-filter:blur(6px); }
+.dock .btn { flex:1 1 0; }
+.dock .st { font-family:var(--mono); font-size:11px; color:var(--text-mute);
+  flex:2 1 0; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+
+canvas { display:block; background:#000; image-rendering:pixelated; width:100%;
+  touch-action:none; -webkit-user-select:none; user-select:none; }
+#zoomwrap, #viewwrap { border:1px solid var(--rule); position:relative; }
+#zoomwrap { margin-bottom:8px; }
+.modes { display:flex; gap:5px; flex-wrap:wrap; margin:9px 0 6px; }
+.modes button, .seg button {
+  font-family:var(--mono); font-size:11px; letter-spacing:.06em; text-transform:uppercase;
+  padding:8px 9px; background:var(--bg-elev); color:var(--text-mute); min-height:38px;
+  border:1px solid var(--rule); cursor:pointer; touch-action:manipulation;
 }
-.modes button.on { color:var(--accent); border-color:var(--accent); }
+.modes button.on, .seg button.on { color:var(--accent); border-color:var(--accent); }
+.seg { display:flex; gap:5px; }
+.seg button { flex:1; }
 .caption {
-  font-family:var(--mono); font-size:12px; letter-spacing:.04em;
-  padding:9px 12px; margin-top:10px;
+  font-family:var(--mono); font-size:12px; letter-spacing:.02em;
+  padding:8px 10px; margin-top:8px;
   border-left:3px solid var(--accent); background:var(--bg-elev); color:var(--text);
 }
 .caveat {
-  font-size:12.5px; padding:10px 12px; margin-top:10px;
+  font-size:12.5px; padding:9px 11px; margin-top:8px;
   border-left:3px solid var(--signal-warn); background:rgba(251,191,36,.07);
   color:var(--text-mute);
 }
 .caveat strong { color:var(--signal-warn); }
-label.row { display:block; margin:14px 0 4px; }
+.do { font-size:13.5px; padding:10px 12px; margin-top:8px;
+  border-left:3px solid var(--signal-on); background:rgba(34,197,94,.09); color:var(--text); }
+.do strong { color:var(--signal-on); }
+label.row { display:block; margin:11px 0 3px; }
 label.row .lbl {
-  font-family:var(--mono); font-size:11px; letter-spacing:.12em;
+  font-family:var(--mono); font-size:11px; letter-spacing:.09em;
   text-transform:uppercase; color:var(--text-mute);
-  display:flex; justify-content:space-between; align-items:baseline;
+  display:flex; justify-content:space-between; align-items:baseline; gap:8px;
 }
 label.row .val { color:var(--accent); font-weight:600; }
-input[type=range] { width:100%; margin:6px 0 0; accent-color:var(--accent); }
-input[type=number], select {
+input[type=range] { width:100%; margin:2px 0 0; accent-color:var(--accent); height:38px; }
+input[type=number], input[type=text], select {
   background:var(--bg-input); color:var(--text); border:1px solid var(--rule);
-  padding:5px 7px; font-family:var(--mono); font-size:12px; width:100%;
+  padding:9px 8px; font-family:var(--mono); font-size:15px; width:100%; min-height:42px;
 }
-input[type=number]:focus, select:focus { outline:1px solid var(--accent); border-color:var(--accent); }
+select { -webkit-appearance:none; appearance:none; }
 table { border-collapse:collapse; width:100%; font-family:var(--mono); font-size:12px; }
-th, td { padding:5px 7px; border-bottom:1px solid var(--rule); text-align:left; }
-th { color:var(--text-faint); font-weight:600; text-transform:uppercase; letter-spacing:.1em; font-size:10px; }
+th, td { padding:5px 6px; border-bottom:1px solid var(--rule); text-align:left; }
+th { color:var(--text-faint); font-weight:600; text-transform:uppercase; letter-spacing:.08em; font-size:10px; }
 td.num { text-align:right; }
-.kpi { display:grid; grid-template-columns:repeat(2,1fr); gap:10px; margin-bottom:8px; }
-.kpi div { background:var(--bg-elev); border:1px solid var(--rule); padding:8px 10px; }
+.kpi { display:grid; grid-template-columns:repeat(2,1fr); gap:8px; margin-bottom:8px; }
+.kpi div { background:var(--bg-elev); border:1px solid var(--rule); padding:7px 9px; }
 .kpi .k {
-  font-family:var(--mono); font-size:10px; letter-spacing:.12em;
+  font-family:var(--mono); font-size:10px; letter-spacing:.1em;
   text-transform:uppercase; color:var(--text-faint);
 }
-.kpi .v { font-family:var(--display); font-size:26px; line-height:1.1; }
-.kpi .d { font-family:var(--mono); font-size:11px; }
-.better { color:var(--signal-on); }
-.worse { color:var(--signal-bad); }
+.kpi .v { font-family:var(--display); font-size:25px; line-height:1.1; }
+.kpi.stale .v, .kpi.stale .d { opacity:.42; }
+.better { color:var(--signal-on); } .worse { color:var(--signal-bad); }
 .flat { color:var(--text-faint); }
-.flash { padding:10px 14px; margin:0 0 16px; border-left:3px solid var(--signal-bad);
+.flash { padding:9px 12px; margin:0 0 12px; border-left:3px solid var(--signal-bad);
   background:rgba(244,63,94,.08); font-size:13px; }
-.flash ul { margin:6px 0 0 16px; padding:0; }
-.flash-ok { border-left-color:var(--signal-on); background:rgba(34,197,94,.08); }
-.dot { display:inline-block; width:8px; height:8px; border-radius:50%; margin-right:6px; }
+.flash ul { margin:5px 0 0 16px; padding:0; }
+.dot { display:inline-block; width:8px; height:8px; border-radius:50%; margin-right:5px; }
 .dot.on { background:var(--signal-on); } .dot.off { background:var(--signal-off); }
 .dot.warn { background:var(--signal-warn); } .dot.bad { background:var(--signal-bad); }
-.locked { color:var(--text-faint); }
+.badge { font-family:var(--mono); font-size:10.5px; letter-spacing:.08em; padding:2px 6px;
+  border:1px solid var(--rule-strong); color:var(--text-mute); text-transform:uppercase; }
+.badge.live { border-color:var(--signal-on); color:var(--signal-on); }
+.badge.stale { border-color:var(--signal-warn); color:var(--signal-warn); }
+.badge.off { border-color:var(--signal-bad); color:var(--signal-bad); }
+#scenewrap { position:relative; border:1px solid var(--rule); background:#000; }
+#scene { display:block; width:100%; height:auto; }
+#sceneseam { position:absolute; top:0; bottom:0; left:50%; width:2px; margin-left:-1px;
+  background:var(--accent); box-shadow:0 0 6px rgba(251,146,60,.9); pointer-events:none; }
+#scenehint { position:absolute; left:0; right:0; bottom:0; padding:3px 6px;
+  font-family:var(--mono); font-size:10.5px; background:rgba(10,11,15,.72); color:var(--text-mute); }
+.nudge { display:flex; gap:6px; margin:8px 0 0; }
+.nudge button { flex:1; font-family:var(--mono); font-size:14px; min-height:46px;
+  background:var(--bg-elev); color:var(--text); border:1px solid var(--rule-strong);
+  cursor:pointer; touch-action:manipulation; }
+.nudge button:active { border-color:var(--accent); color:var(--accent); }
+.dxread { font-family:var(--display); font-size:30px; line-height:1.05; }
+.dxread span { font-family:var(--mono); font-size:12px; color:var(--text-mute); }
+
+@media (min-width:980px) {
+  body { padding-bottom:0; font-size:14px; }
+  .shell { padding:20px 24px 60px; }
+  .grid { display:grid; grid-template-columns:minmax(0,1fr) 400px; gap:18px;
+    align-items:start; }
+  .col { display:flex; flex-direction:column; gap:14px; }
+  .dock { position:static; border-top:0; border:1px solid var(--rule);
+    background:var(--bg-surface); margin-bottom:12px; padding:10px 12px; }
+  .dock .btn { flex:0 0 auto; }
+  ol.steps { display:flex; }
+  ol.steps li { flex:1; border-bottom:0; border-right:1px solid var(--rule);
+    flex-direction:column; }
+  ol.steps li:last-child { border-right:0; }
+}
 """
 
 
@@ -973,21 +1367,25 @@ _SCRIPT = r"""
 'use strict';
 // ---------------------------------------------------------------------------
 // Model. The anchor curve is the ONLY authored state: the translate and roll
-// sliders are a decomposition of it (mean, best-fit ramp), recomputed whenever
+// controls are a decomposition of it (mean, best-fit ramp), recomputed whenever
 // the curve changes by any route. Nothing the operator can move exists outside
 // the artifact.
 // ---------------------------------------------------------------------------
 var S = {
   st: null, anchors: [], surface: 'camera_mesh', mode: 'blink',
-  imgs: {}, blink: 0, cursorRow: 1080, dragging: null, ready: false,
-  metrics: null, baseline: null, busy: false, pending: false
+  imgs: {}, blink: 0, cursorRow: 1080, ready: false,
+  metrics: null, baseline: null, quality: null, vertical: null,
+  busy: false, pending: false, stale: false, scoredAt: null, netFails: 0,
+  spanX: 256, grab: 'curve', narrow: true, retry: null
 };
 // Geometry is taken from the frame the server actually fetched, never assumed.
 // These are only the pre-snapshot defaults.
-var H = 2160, STRIP = 640, BLENDH = 128, ZOOM = 4, ZOOM_ROWS = 400;
+var H = 2160, STRIP = 640, BLENDH = 128;
+var MEASURE_TIMEOUT_MS = 9000;
 
 function $(id) { return document.getElementById(id); }
 function fmt(v, d) { return (v === null || v === undefined || isNaN(v)) ? '--' : v.toFixed(d === undefined ? 2 : d); }
+function clamp(v, a, b) { return v < a ? a : (v > b ? b : v); }
 
 function dxAt(y) {
   var A = S.anchors;
@@ -1005,7 +1403,8 @@ function dxAt(y) {
 
 // Piecewise-linear segments of the curve, as (y0, y1, slope, intercept). A
 // linear-in-y horizontal offset is exactly a canvas shear, so each segment is
-// one GPU-composited draw call instead of 2160 per-row blits.
+// one GPU-composited draw call instead of 2160 per-row blits -- which is what
+// keeps a drag smooth on a phone with no round trip to the server.
 function bands() {
   var A = S.anchors, out = [];
   if (A[0][0] > 0) out.push([0, A[0][0], 0, A[0][1]]);
@@ -1075,9 +1474,13 @@ function emitStrip(ctx, img) { ctx.drawImage(img, 0, 0); }
 // does instead is fit each structure independently on the two shoulders and
 // extrapolate both to the seam column -- so drawing those extrapolations is
 // both the most sensitive comparator available and exactly the evidence the
-// score is computed from. A gap between a red line and its cyan partner at the
-// seam IS that structure's residual, to sub-pixel precision, and no smear of
-// replicated columns comes close to showing it that clearly.
+// score is computed from.
+//
+// Drawn by sensitivity, not uniformly. `sens` is px of residual per px of
+// horizontal shift: a structure at 0.02 is within a degree of horizontal and
+// will not move whatever the operator does with the control in their hand.
+// Painting it as brightly as one that responds would be a lie told in a
+// picture, so it is drawn as a faint grey hint instead.
 function drawShoulders(view, which) {
   var obs = (S.metrics && S.metrics.observations) || [];
   if (!obs.length) return;
@@ -1086,10 +1489,9 @@ function drawShoulders(view, which) {
   ctx.lineWidth = Math.max(1, view.sy * 1.5);
   var seam = STRIP, reach = BLENDH * 2;
   for (var i = 0; i < obs.length; i++) {
-    var o = obs[i];
-    // slope is dy/dx in source px; the view scales the axes differently, so
-    // the drawn slope has to be scaled too or the lines would lie.
-    [['left', o.y_left, '#ff5a5a'], ['right', o.y_right, '#48e0ff']].forEach(function (t) {
+    var o = obs[i], blind = (o.sens !== undefined && o.sens < 0.05);
+    [['left', o.y_left, blind ? '#6b7280' : '#ff5a5a'],
+     ['right', o.y_right, blind ? '#4b5563' : '#48e0ff']].forEach(function (t) {
       if (which && which !== t[0]) return;
       var side = t[0], yAt = t[1];
       var x0 = side === 'left' ? seam - reach : seam;
@@ -1097,12 +1499,11 @@ function drawShoulders(view, which) {
       var X = function (x) { return (x - view.ox) * view.sx; };
       var Y = function (x) { return (yAt + o.slope * (x - seam) - view.oy) * view.sy; };
       ctx.strokeStyle = t[2];
-      ctx.globalAlpha = 0.9;
+      ctx.globalAlpha = blind ? 0.30 : 0.9;
       ctx.beginPath(); ctx.moveTo(X(x0), Y(x0)); ctx.lineTo(X(x1), Y(x1)); ctx.stroke();
-      // dashed continuation across the window: this part is extrapolation.
-      ctx.setLineDash([4, 4]); ctx.globalAlpha = 0.55;
+      ctx.setLineDash([4, 4]); ctx.globalAlpha = blind ? 0.18 : 0.55;
       var x2 = side === 'left' ? seam + reach : seam - reach;
-      ctx.beginPath(); ctx.moveTo(X(x1 === seam ? seam : seam), Y(seam));
+      ctx.beginPath(); ctx.moveTo(X(seam), Y(seam));
       ctx.lineTo(X(x2), Y(x2)); ctx.stroke();
       ctx.setLineDash([]);
     });
@@ -1110,16 +1511,21 @@ function drawShoulders(view, which) {
   ctx.globalAlpha = 1;
 }
 
-function paint(view, grid) {
+function paint(view, grid, locator) {
   var ctx = view.ctx;
   ctx.setTransform(1, 0, 0, 1, 0, 0);
   ctx.clearRect(0, 0, view.c.width, view.c.height);
   ctx.fillStyle = '#000'; ctx.fillRect(0, 0, view.c.width, view.c.height);
-  if (!S.imgs.left || !S.imgs.right) return;
+  var sxOf = function (x) { return (x - view.ox) * view.sx; };
+  if (!S.imgs.left || !S.imgs.right) {
+    ctx.fillStyle = '#5e616b'; ctx.font = '13px ui-monospace, monospace';
+    ctx.fillText(S.st && S.st.has_snapshot ? 'strips still loading' : 'no frame yet', 10, 22);
+    return;
+  }
 
-  // Both halves are always drawn at their true positions. Only the 256-px
-  // blend window changes between views -- blanking a whole half would be a
-  // flash, and what a blink has to reveal is a few pixels of jump.
+  // Both halves are always drawn at their true positions. Only the blend
+  // window changes between views -- blanking a whole half would be a flash,
+  // and what a blink has to reveal is a few pixels of jump.
   view.half('left', emitStrip, {});
   view.half('right', emitStrip, {});
 
@@ -1133,7 +1539,6 @@ function paint(view, grid) {
 
   // seam + blend window
   ctx.setTransform(1, 0, 0, 1, 0, 0);
-  var sxOf = function (x) { return (x - view.ox) * view.sx; };
   ctx.fillStyle = 'rgba(251,146,60,.10)';
   ctx.fillRect(sxOf(STRIP - BLENDH), 0, 2 * BLENDH * view.sx, view.c.height);
   ctx.strokeStyle = 'rgba(251,146,60,.85)'; ctx.lineWidth = 1;
@@ -1141,7 +1546,7 @@ function paint(view, grid) {
 
   if (grid) {
     ctx.strokeStyle = 'rgba(255,255,255,.13)';
-    for (var x = STRIP - BLENDH; x <= STRIP + BLENDH; x++) {
+    for (var x = Math.ceil(view.ox); x <= view.ox + view.c.width / view.sx; x++) {
       var px = Math.round(sxOf(x)) + .5;
       ctx.beginPath(); ctx.moveTo(px, 0); ctx.lineTo(px, view.c.height); ctx.stroke();
     }
@@ -1151,38 +1556,70 @@ function paint(view, grid) {
   ctx.fillStyle = 'rgba(0,0,0,.42)';
   ctx.fillRect(lockedLeft ? 0 : sxOf(STRIP), 0,
     lockedLeft ? sxOf(STRIP) : view.c.width - sxOf(STRIP), view.c.height);
-  // row cursor
-  ctx.strokeStyle = 'rgba(34,197,94,.8)';
+
+  if (locator) {
+    // Rows that hold upright structure -- the only rows where a horizontal
+    // error is visible at all. Marked so the operator can jump to the person
+    // they just put in the seam instead of scrubbing 2160 rows for them.
+    var rows = (S.vertical && S.vertical.rows) || [];
+    ctx.fillStyle = 'rgba(34,197,94,.30)';
+    for (var r = 0; r < rows.length; r++) {
+      ctx.fillRect(0, (rows[r][0] - view.oy) * view.sy, view.c.width,
+        (rows[r][1] - rows[r][0]) * view.sy);
+    }
+    // what the zoom view is currently showing
+    var span = zoomRows();
+    ctx.strokeStyle = 'rgba(255,255,255,.55)'; ctx.lineWidth = 1;
+    ctx.strokeRect(0.5, (S.cursorRow - span / 2 - view.oy) * view.sy + .5,
+      view.c.width - 1, span * view.sy);
+  }
+  ctx.strokeStyle = 'rgba(34,197,94,.8)'; ctx.lineWidth = 1;
   var cy = (S.cursorRow - view.oy) * view.sy;
   ctx.beginPath(); ctx.moveTo(0, cy); ctx.lineTo(view.c.width, cy); ctx.stroke();
 }
 
+function zoomCssH() {
+  return S.narrow ? Math.round(clamp(window.innerHeight * 0.44, 210, 430)) : 430;
+}
+function zoomScale() {           // CSS px per source px
+  var z = $('zoom');
+  return (z.clientWidth || 360) / S.spanX;
+}
+function zoomRows() { return zoomCssH() / zoomScale(); }
+function zoomTop() {
+  return clamp(S.cursorRow - zoomRows() / 2, 0, Math.max(0, H - zoomRows()));
+}
+
+function fitCanvas(c, cssH) {
+  var dpr = Math.min(window.devicePixelRatio || 1, 2);
+  c.width = Math.max(1, Math.round((c.clientWidth || 360) * dpr));
+  c.height = Math.max(1, Math.round(cssH * dpr));
+  c.style.height = cssH + 'px';
+  return dpr;
+}
+
 function draw() {
   var v = $('view'), z = $('zoom');
-  var dpr = Math.min(window.devicePixelRatio || 1, 2);
-  var cssW = v.clientWidth || 900;
-  v.width = Math.round(cssW * dpr); v.height = Math.round(660 * dpr);
-  v.style.height = '660px';
-  paint(new View(v, 0, 0, v.width / (2 * STRIP), v.height / H), false);
+  var zh = zoomCssH();
+  var dpr = fitCanvas(z, zh);
+  var scale = z.width / S.spanX;             // device px per source px
+  var top = zoomTop();
+  paint(new View(z, STRIP - S.spanX / 2, top, scale, scale), scale / dpr >= 2.2, false);
 
-  var zw = z.clientWidth || 900;
-  z.width = Math.round(zw * dpr);
-  var zs = z.width / (2 * BLENDH * ZOOM);          // display px per (source px * ZOOM)
-  var scale = zs * ZOOM;                            // display px per source px
-  z.height = Math.round(ZOOM_ROWS * scale);
-  z.style.height = Math.round(z.height / dpr) + 'px';
-  var top = Math.max(0, Math.min(H - ZOOM_ROWS, S.cursorRow - ZOOM_ROWS / 2));
-  paint(new View(z, STRIP - BLENDH, top, scale, scale), true);
-  $('zoomlabel').textContent = 'rows ' + Math.round(top) + '-' + Math.round(top + ZOOM_ROWS)
-    + ' @ ' + ZOOM + 'x, true aspect';
-  $('viewscale').textContent = (v.width / dpr / (2 * STRIP)).toFixed(2);
+  var lh = S.narrow ? 120 : 430;
+  fitCanvas(v, lh);
+  paint(new View(v, 0, 0, v.width / (2 * STRIP), v.height / H), false, true);
+
+  $('zoomlabel').textContent = 'rows ' + Math.round(top) + '-' + Math.round(top + zoomRows())
+    + ' \u00b7 ' + (zoomScale()).toFixed(1) + 'x \u00b7 ' + Math.round(S.spanX) + ' px wide';
 }
 
 // ---------------------------------------------------------------------------
 // Curve editing
 // ---------------------------------------------------------------------------
 function setAnchors(a, why) {
-  S.anchors = a.map(function (p) { return [p[0], Math.max(-64, Math.min(64, p[1]))]; });
+  S.anchors = a.map(function (p) { return [p[0], clamp(p[1], -64, 64)]; });
+  S.stale = true;
   syncControls(); draw(); scheduleMeasure();
   if (why) $('curvewhy').textContent = why;
 }
@@ -1204,13 +1641,14 @@ function rollAmp() {
 }
 function syncControls() {
   var t = meanDx(), r = rollAmp();
-  $('translate').value = t.toFixed(2); $('translateV').textContent = fmt(t) + ' px';
-  $('roll').value = r.toFixed(2); $('rollV').textContent = fmt(r) + ' px top-to-bottom';
-  var rows = S.st ? S.st.anchor_rows : [0, 540, 1080, 1620, 2159];
+  $('roll').value = r.toFixed(2); $('rollV').textContent = fmt(r) + ' px';
+  $('dxnow').innerHTML = (t >= 0 ? '+' : '') + t.toFixed(2)
+    + ' <span>px mean \u00b7 dx at row ' + Math.round(S.cursorRow) + ' = '
+    + fmt(dxAt(S.cursorRow)) + '</span>';
   var html = '';
   for (var i = 0; i < S.anchors.length; i++) {
     html += '<tr><td class="muted">y ' + S.anchors[i][0] + '</td><td>'
-      + '<input type="number" step="0.25" data-i="' + i + '" class="anch" value="'
+      + '<input type="number" step="0.25" inputmode="decimal" data-i="' + i + '" class="anch" value="'
       + S.anchors[i][1].toFixed(2) + '"></td></tr>';
   }
   $('curverows').innerHTML = html;
@@ -1224,12 +1662,11 @@ function syncControls() {
   }
   $('curvejson').textContent = JSON.stringify(
     S.anchors.map(function (p) { return [p[0], Math.round(p[1] * 1000) / 1000]; }));
-  void rows;
 }
 
 function nudge(delta) {
   setAnchors(S.anchors.map(function (p) { return [p[0], p[1] + delta]; }),
-    'translate ' + (delta > 0 ? '+' : '') + delta.toFixed(2) + ' px');
+    'whole curve ' + (delta > 0 ? '+' : '') + delta.toFixed(2) + ' px');
 }
 function setRoll(amp) {
   var cur = rollAmp(), d = amp - cur, mid = (H - 1) / 2;
@@ -1237,31 +1674,78 @@ function setRoll(amp) {
     return [p[0], p[1] + d * (p[0] - mid) / (H - 1)];
   }), 'roll set to ' + fmt(amp) + ' px top-to-bottom');
 }
+function nearestAnchor(row) {
+  var best = 0, bd = 1e9;
+  for (var i = 0; i < S.anchors.length; i++) {
+    var d = Math.abs(S.anchors[i][0] - row);
+    if (d < bd) { bd = d; best = i; }
+  }
+  return best;
+}
 
 // ---------------------------------------------------------------------------
-// Metrics
+// Metrics. Every request is bounded and every number says which curve it
+// belongs to: on a field link a request that never returns must degrade into a
+// visible "stale", never into numbers that quietly stop moving.
 // ---------------------------------------------------------------------------
 var measureTimer = null;
 function scheduleMeasure() {
   if (measureTimer) clearTimeout(measureTimer);
-  measureTimer = setTimeout(measure, 160);
+  measureTimer = setTimeout(measure, 180);
+  renderFreshness();
 }
 function measure() {
-  if (!S.ready) return;
+  if (!S.ready) { renderFreshness(); return; }
   if (S.busy) { S.pending = true; return; }
-  S.busy = true; $('metricstate').textContent = 'scoring...';
+  S.busy = true;
+  var sent = JSON.stringify(S.anchors), sentMean = meanDx();
+  var ctl = ('AbortController' in window) ? new AbortController() : null;
+  var timer = setTimeout(function () { if (ctl) ctl.abort(); }, MEASURE_TIMEOUT_MS);
+  renderFreshness();
   fetch('/stitch/measure', {
     method: 'POST', credentials: 'same-origin',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ dx_anchors: S.anchors })
+    body: sent === '[]' ? '{}' : '{"dx_anchors":' + sent + '}',
+    signal: ctl ? ctl.signal : undefined
   }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
     .then(function (res) {
-      S.busy = false;
-      if (!res.ok) { $('metricstate').textContent = res.j.detail || 'scoring failed'; return; }
+      clearTimeout(timer); S.busy = false;
+      if (!res.ok) { S.netFails++; renderFreshness(res.j.detail || 'scoring refused'); return; }
+      S.netFails = 0;
       S.metrics = res.j; S.baseline = res.j.baseline || S.baseline;
-      renderMetrics(); $('metricstate').textContent = '';
+      S.scoredAt = sentMean;
+      S.stale = (sent !== JSON.stringify(S.anchors));
+      renderMetrics(); renderFreshness();
       if (S.pending) { S.pending = false; measure(); }
-    }).catch(function (e) { S.busy = false; $('metricstate').textContent = String(e); });
+    }).catch(function (e) {
+      clearTimeout(timer); S.busy = false; S.netFails++;
+      renderFreshness(String(e && e.name === 'AbortError'
+        ? 'no answer in ' + (MEASURE_TIMEOUT_MS / 1000) + ' s' : e));
+      // Keep trying, with backoff: a phone at a pitch loses the link for a few
+      // seconds at a time, and the operator should not have to know to poke it.
+      if (S.retry) clearTimeout(S.retry);
+      S.retry = setTimeout(measure, Math.min(8000, 1000 * Math.pow(2, Math.min(3, S.netFails))));
+    });
+}
+// One line that says whether the numbers on screen describe the curve on
+// screen. Everything else about the network is noise to an operator.
+function renderFreshness(err) {
+  var b = $('fresh');
+  if (!S.ready) {
+    b.className = 'badge'; b.textContent = S.st && S.st.has_snapshot ? 'measuring frame' : 'no frame';
+  } else if (S.netFails) {
+    b.className = 'badge off';
+    b.textContent = 'offline \u00d7' + S.netFails;
+  } else if (S.busy || S.stale) {
+    b.className = 'badge stale'; b.textContent = 'scoring\u2026';
+  } else {
+    b.className = 'badge live'; b.textContent = 'live';
+  }
+  $('kpis').className = 'kpi' + ((S.stale || S.busy || S.netFails) ? ' stale' : '');
+  $('scoredat').textContent = S.scoredAt === null ? ''
+    : ('numbers are for dx ' + (S.scoredAt >= 0 ? '+' : '') + S.scoredAt.toFixed(2) + ' px'
+      + (S.stale || S.netFails ? ' \u2014 the curve has moved since' : ''));
+  $('neterr').textContent = err || '';
 }
 function delta(now, before, unit) {
   if (now === null || before === null || now === undefined || before === undefined) return '';
@@ -1269,65 +1753,169 @@ function delta(now, before, unit) {
   var cls = Math.abs(d) < 1e-6 ? 'flat' : (d < 0 ? 'better' : 'worse');
   return '<span class="' + cls + '">' + (d >= 0 ? '+' : '') + d.toFixed(2) + ' ' + unit + '</span>';
 }
+
 // Whether this frame can constrain the calibration at all, stated before any
-// number is. Real tripod frames routinely produce a large SCR that barely
-// responds to dx -- unrelated edges paired across the seam -- and every
-// coverage gate passes while it happens. A precise-looking number on a frame
-// that cannot steer is worse than no number.
+// number is, and -- when it cannot -- what to do about it. Real tripod frames
+// routinely produce a large SCR that barely responds to dx, because SCR is
+// built from near-horizontal structures and a horizontal edge does not move
+// when the halves shift horizontally. The remedy is not a better number. It is
+// a person standing in the seam.
 function renderQuality(q) {
   var el = $('quality');
   if (!q) { el.style.display = 'none'; return; }
   el.style.display = '';
   S.quality = q;
+  var sp = q.split || {};
+  var blind = (sp.n_total && sp.n_steering !== undefined)
+    ? (sp.n_total - sp.n_steering) : 0;
+  var blindLine = sp.n_total
+    ? ' <span class="faint">' + sp.n_total + ' structures crossing the seam, ' + blind
+      + ' of them within 3&deg; of horizontal and therefore blind to a horizontal shift'
+      + (sp.max_sensitivity ? '; the steepest converts a shift into '
+        + sp.max_sensitivity.toFixed(2) + ' px of residual per px' : '') + '.</span>'
+    : '';
   if (q.usable) {
     el.className = 'caption';
     el.innerHTML = '<b>This frame can steer the calibration.</b> ' + q.reason
-      + '. Drag until SCR p90 stops falling.';
+      + '. Drag until SCR p90 stops falling.' + blindLine;
   } else {
-    el.className = 'caveat';
-    el.innerHTML = '<strong>This frame cannot steer the calibration.</strong> ' + q.reason
-      + '. Read SCR here as a bound, not as the seam offset, and do not trust a curve '
-      + 'tuned against it &mdash; find a frame with a clear structure crossing the seam '
-      + '(a field line, a goal frame, a fence) at roughly the depth you care about.';
+    el.className = 'do';
+    el.innerHTML = '<strong>The picture cannot steer this calibration.</strong> '
+      + q.reason + '.' + (q.remedy ? ' <b>' + q.remedy + '</b>' : '') + blindLine;
   }
   $('suggest').disabled = (q.best_dx === null || q.best_dx === undefined);
+}
+
+// The prior question, answered from the picture rather than from the metric:
+// is there anything upright in the blend window for a horizontal error to
+// break? Cheap enough (~60 ms) to run on every aiming snapshot.
+function renderVertical(v, where) {
+  var el = $(where);
+  if (!el) return;
+  if (!v) { el.style.display = 'none'; return; }
+  el.style.display = '';
+  if (v.n_with_structure) {
+    var r = v.rows && v.rows.length ? v.rows[0] : null;
+    el.className = 'do';
+    el.innerHTML = '<strong>Upright structure is in the seam</strong> at '
+      + (v.rows || []).map(function (x) { return 'rows ' + x[0] + '\u2013' + x[1]; }).join(', ')
+      + ' (peak ' + fmt(v.best_ratio, 1) + '\u00d7 the surrounding texture). That is what a '
+      + 'horizontal misregistration breaks. <b>Go and look at it</b>: pinch to 4&times; and ask '
+      + 'whether the body is continuous across the seam. This says only that something is '
+      + 'there \u2014 it is not a registration measurement, and nothing here can score a body '
+      + 'that sits inside the blend window, because both sensors are already mixed there.'
+      + (r ? ' <button class="btn btn-ghost btn-sm" id="jumpv">Show me</button>' : '');
+    if (r) {
+      var b = $('jumpv');
+      if (b) b.addEventListener('click', function () {
+        S.cursorRow = (r[0] + r[1]) / 2; S.spanX = Math.min(S.spanX, 320); draw(); syncControls();
+        $('zoomwrap').scrollIntoView({ block: 'center' });
+      });
+    }
+  } else {
+    el.className = 'caveat';
+    el.innerHTML = '<strong>Nothing upright crosses the seam.</strong> Everything at this seam '
+      + 'runs horizontally \u2014 the far touchline, the treeline, the painted banners \u2014 and a '
+      + 'horizontal edge does not move when the halves shift horizontally. '
+      + '<b>Have someone stand on the orange line</b>, out where play actually happens rather than '
+      + 'beside the tripod, and snap again.';
+  }
+}
+
+// "Nothing to change here" is an outcome, not a failure, and it is the common
+// one: across the archived games 52 of 96 frames sit below the SSR noise floor
+// and players straddling the seam are continuous. A tool that can only ever say
+// "here is a correction" will manufacture one.
+function renderFloor(ssr) {
+  var el = $('floor');
+  if (!ssr || ssr.abs_ln_ssr === undefined) { el.style.display = 'none'; return; }
+  var atFloor = ssr.abs_ln_ssr <= ssr.noise_floor;
+  el.style.display = '';
+  el.className = atFloor ? 'do' : 'caption';
+  el.innerHTML = atFloor
+    ? '<strong>This seam is already at the measurement floor.</strong> |ln SSR| '
+      + fmt(ssr.abs_ln_ssr, 3) + ' is at or below the ' + ssr.noise_floor.toFixed(2)
+      + ' floor, which is where a seam with nothing wrong with it reads. Unless the body '
+      + 'in the seam looks torn to you, the right answer here is to change nothing.'
+    : '|ln SSR| ' + fmt(ssr.abs_ln_ssr, 3) + ' is above the ' + ssr.noise_floor.toFixed(2)
+      + ' floor, so there is something to see &mdash; but this metric saturates and cannot '
+      + 'tell you how much. Go and look at the person in the seam.';
 }
 
 function renderMetrics() {
   var m = S.metrics, b = S.baseline;
   if (!m) return;
-  var scr = m.scr, ssr = m.ssr;
-  $('scrn').textContent = scr.n;
+  var scr = m.scr, ssr = m.ssr, sp = m.split || {}, tg = m.ssr_target;
+  $('scrn').textContent = sp.n_steering === undefined
+    ? scr.n : (sp.n_steering + '/' + scr.n);
   if (!scr.n) {
-    $('scrp50').textContent = '--'; $('scrp90').textContent = '--';
-    $('scrnote').textContent =
-      'No structure crosses the seam in this frame. That is the expected case '
-      + 'mid-field: point the camera at something with lines through the seam, '
-      + 'or walk a high-contrast edge across it, then re-snap.';
-  } else {
-    $('scrp50').textContent = fmt(scr.p50);
-    $('scrp90').textContent = fmt(scr.p90);
+    $('scrp90').textContent = '--';
     $('scrnote').innerHTML =
-      'p50 ' + delta(scr.p50, b && b.scr ? b.scr.p50 : null, 'px')
-      + ' &middot; p90 ' + delta(scr.p90, b && b.scr ? b.scr.p90 : null, 'px')
-      + ' &middot; ' + scr.row_bands_covered + '/3 row bands, '
+      'No structure crosses the seam in this frame. That is the expected case mid-field: '
+      + '<b>have someone stand in the seam</b> at the depth play happens, then snap again.';
+  } else {
+    var p90 = (sp.p90_steering === null || sp.p90_steering === undefined)
+      ? scr.p90 : sp.p90_steering;
+    $('scrp90').textContent = fmt(p90);
+    $('scrnote').innerHTML =
+      'p90 shown is over the <b>' + (sp.n_steering || 0) + '</b> structures steep enough to see a '
+      + 'horizontal shift; over all ' + scr.n + ' it is ' + fmt(scr.p90) + ' px '
+      + delta(scr.p90, b && b.scr ? b.scr.p90 : null, 'px')
+      + ', p50 ' + fmt(scr.p50) + ' px. ' + scr.row_bands_covered + '/3 row bands, '
       + Math.round(scr.height_coverage * 100) + '% height'
-      // Only offered when the frame was shown to respond to the curve at all.
-      // `implied_dx` is a regression that returns confident nonsense on a
-      // contaminated observation set -- it read -17, +159 and -7 px on three
-      // real frames whose seams were all fine.
       + (S.quality && !S.quality.usable ? ''
         : scr.suggested_dx === null ? ''
           : ' &middot; measurement suggests dx &asymp; <b>' + fmt(scr.suggested_dx) + ' px</b>');
   }
+  // The number the person in the seam exists to produce: seam damage measured
+  // over the rows they occupy rather than averaged across a field band of
+  // grass, which a misregistration cannot damage because there is nothing
+  // there to break.
+  $('ssrtarget').textContent = tg ? fmt(tg.abs_ln_ssr, 2) : '--';
   $('ssrv').textContent = fmt(ssr.abs_ln_ssr, 3);
-  $('ssrnote').innerHTML =
-    delta(ssr.abs_ln_ssr, b && b.ssr ? b.ssr.abs_ln_ssr : null, '')
-    + ' &middot; noise floor ' + ssr.noise_floor.toFixed(2)
-    + ' &mdash; a post-fusion shift cannot move this; only a camera-side '
-    + 'correction applied before the blend can, and that shows up after Apply.';
+  renderFloor(ssr);
+  $('ssrnote').innerHTML = tg
+    ? '<b>|ln SSR| on the target</b> is the same metric over rows ' + tg.band[0] + '-'
+      + tg.band[1] + ' only &mdash; the rows something upright occupies '
+      + delta(tg.abs_ln_ssr, b && b.ssr_target ? b.ssr_target.abs_ln_ssr : null, '')
+      + '. Over the whole field band the same frame reads ' + fmt(ssr.abs_ln_ssr, 3)
+      + ', because most of a field band is grass and a misregistration cannot break grass. '
+      + 'Read it as a <b>before/after</b> number, not as an absolute: SSR is a ratio against a '
+      + 'background fitted on the shoulders, so an object that exists only inside the window '
+      + 'raises it even when registration is perfect. Keep the same person standing in the same '
+      + 'place, Apply, snap again, and a drop is registration improving. Noise floor '
+      + ssr.noise_floor.toFixed(2) + '. Dragging cannot move either number: only a camera-side '
+      + 'correction applied before the blend can.'
+    : delta(ssr.abs_ln_ssr, b && b.ssr ? b.ssr.abs_ln_ssr : null, '')
+      + ' &middot; noise floor ' + ssr.noise_floor.toFixed(2)
+      + ' &mdash; averaged over the whole field band, which is mostly grass. Put something '
+      + 'upright in the seam and this is measured where it stands instead. A post-fusion shift '
+      + 'cannot move it either way; only a camera-side correction can.';
   if (!S.quality) {
     $('suggest').disabled = (scr.suggested_dx === null || scr.suggested_dx === undefined);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The procedure. Five steps, and which one you are on is derived from evidence
+// -- a frame exists, something upright is in the seam, the curve has moved --
+// never from a button someone pressed.
+// ---------------------------------------------------------------------------
+function currentStep() {
+  var st = S.st || {};
+  if (!st.has_snapshot) return st.scene && st.scene.has ? 'stand' : 'aim';
+  var v = S.vertical;
+  if (v && !v.n_with_structure) return 'stand';
+  if (Math.abs(meanDx()) < 0.001 && Math.abs(rollAmp()) < 0.001) return 'adjust';
+  return 'ship';
+}
+function renderSteps() {
+  var order = ['aim', 'stand', 'snap', 'adjust', 'ship'], cur = currentStep();
+  var at = order.indexOf(cur);
+  for (var i = 0; i < order.length; i++) {
+    var li = $('step-' + order[i]);
+    if (!li) continue;
+    li.className = (i === at ? 'on' : (i < at ? 'done' : ''));
   }
 }
 
@@ -1338,7 +1926,6 @@ function applyState(st) {
   S.st = st;
   if (st.height) {
     H = st.height; STRIP = st.strip_w; BLENDH = st.blend_w;
-    ZOOM_ROWS = Math.min(400, H);
     if (st.anchor_rows && st.anchor_rows.length && !S.anchorsPinned) {
       var rows = st.anchor_rows.filter(function (r) { return r < H; });
       if (rows[rows.length - 1] !== H - 1) rows.push(H - 1);
@@ -1360,17 +1947,30 @@ function applyState(st) {
       : ms === 'running' ? 'detecting structures and sweeping dx (25-60 s at 7680x2160)...'
         : ms === 'failed' ? ('detection failed: ' + (st.metric_error || '?'))
           : 'no snapshot yet';
+  S.vertical = st.vertical || (st.scene ? st.scene.vertical : null) || null;
+  renderVertical(S.vertical, 'vertical');
+  renderVertical((st.scene && st.scene.vertical) || S.vertical, 'aimverdict');
   renderQuality(st.quality);
+  if (st.scene && st.scene.has) {
+    var img = $('scene');
+    if (img.getAttribute('data-v') !== String(st.scene.version)) {
+      img.setAttribute('data-v', String(st.scene.version));
+      img.src = '/stitch/scene.jpg?v=' + st.scene.version;
+      $('scenewrap').style.display = '';
+    }
+  }
   if (st.baseline) { S.baseline = st.baseline; S.metrics = S.metrics || st.baseline; renderMetrics(); }
   S.ready = (ms === 'ready');
-  if (ms === 'running') setTimeout(pollState, 1500);
+  if (ms === 'running') setTimeout(pollState, 2000);
   $('apply').disabled = !st.has_snapshot;
   $('save').disabled = !st.has_snapshot;
+  renderSteps(); renderFreshness(); draw();
 }
 function pollState() {
   fetch('/stitch/state', { credentials: 'same-origin' })
     .then(function (r) { return r.json(); })
-    .then(function (st) { applyState(st); if (st.metric_state === 'ready') measure(); });
+    .then(function (st) { applyState(st); if (st.metric_state === 'ready') measure(); })
+    .catch(function (e) { S.netFails++; renderFreshness(String(e)); });
 }
 function renderScalars(cur, fac) {
   var t = $('scalars');
@@ -1391,23 +1991,41 @@ function renderScalars(cur, fac) {
     + 'auto-adjustment. The factory column is recoverable from the camera itself.';
 }
 
+// The aiming loop: cheap, repeatable, and the step where the operator finds out
+// where the seam actually falls in the scene before spending 40 s measuring one.
+function aim() {
+  $('aim').disabled = true; $('dockstate').textContent = 'aiming\u2026';
+  fetch('/stitch/aim', { method: 'POST', credentials: 'same-origin' })
+    .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      $('aim').disabled = false;
+      if (!res.ok) { $('dockstate').textContent = res.j.detail || 'aim failed'; return; }
+      $('dockstate').textContent = 'aimed ' + new Date().toLocaleTimeString();
+      applyState(res.j);
+    }).catch(function (e) { $('aim').disabled = false; $('dockstate').textContent = String(e); });
+}
+
 function snap() {
-  $('snap').disabled = true; $('snapstate').textContent = 'fetching 7680x2160 still...';
+  $('snap').disabled = true; $('dockstate').textContent = 'fetching 7680x2160 still\u2026';
   fetch('/stitch/snap', { method: 'POST', credentials: 'same-origin' })
     .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
     .then(function (res) {
       $('snap').disabled = false;
-      if (!res.ok) { $('snapstate').textContent = res.j.detail || 'snapshot failed'; return; }
-      $('snapstate').textContent = 'live snapshot ' + new Date().toLocaleTimeString();
+      if (!res.ok) { $('dockstate').textContent = res.j.detail || 'snapshot failed'; return; }
+      $('dockstate').textContent = 'live snapshot ' + new Date().toLocaleTimeString();
       loadFrame(res.j);
-    }).catch(function (e) { $('snap').disabled = false; $('snapstate').textContent = String(e); });
+    }).catch(function (e) { $('snap').disabled = false; $('dockstate').textContent = String(e); });
 }
 
 function loadFrame(res) {
   var v = res.version, n = 0;
+  S.imgs = {};
   ['left', 'right'].forEach(function (side) {
     var im = new Image();
     im.onload = function () { S.imgs[side] = im; if (++n === 2) draw(); };
+    im.onerror = function () {
+      $('dockstate').textContent = 'the ' + side + ' strip did not load \u2014 snap again';
+    };
     im.src = '/stitch/half.jpg?side=' + side + '&v=' + v;
   });
   applyState(res);
@@ -1446,7 +2064,7 @@ function openFrame() {
     .then(function (res) {
       if (!res.ok) { $('openstate').textContent = res.j.detail || 'open failed'; return; }
       $('openstate').textContent = 'loaded ' + f;
-      $('snapstate').textContent = 'frame from file';
+      $('dockstate').textContent = 'frame from file';
       loadFrame(res.j);
     }).catch(function (e) { $('openstate').textContent = String(e); });
 }
@@ -1467,7 +2085,7 @@ function save() {
       $('savestate').innerHTML = res.ok
         ? '<span class="better">written to ' + res.j.path + '</span>'
         : '<span class="worse">' + (res.j.detail || 'save failed') + '</span>';
-    });
+    }).catch(function (e) { $('savestate').innerHTML = '<span class="worse">' + e + '</span>'; });
 }
 
 function applyToCamera(dry) {
@@ -1487,15 +2105,114 @@ function applyToCamera(dry) {
         : '<span class="worse">' + (res.j.detail || 'apply failed') + '</span>';
       $('applyreport').textContent = JSON.stringify(res.j, null, 2);
       if (res.ok && !dry) snap();   // re-score against a fresh frame, not a promise
-    });
+    }).catch(function (e) { $('applystate').innerHTML = '<span class="worse">' + e + '</span>'; });
+}
+
+// ---------------------------------------------------------------------------
+// Gestures. Pointer Events, so one implementation serves a thumb and a mouse.
+// One finger is axis-locked -- across is the calibration, down is navigation --
+// and two fingers zoom. Nothing here touches the network.
+// ---------------------------------------------------------------------------
+function geomFor(kind, c) {
+  if (kind === 'zoom') {
+    return { scale: zoomScale(), left: STRIP - S.spanX / 2, top: zoomTop(), rows: zoomRows() };
+  }
+  var s = (c.clientWidth || 360) / (2 * STRIP);
+  return { scale: s, left: 0, top: 0, rows: H };
+}
+function pdist(pts) {
+  var a = [];
+  pts.forEach(function (v) { a.push(v); });
+  return Math.hypot(a[0].x - a[1].x, a[0].y - a[1].y);
+}
+function setSpan(v) {
+  S.spanX = clamp(v, 48, 2 * STRIP);
+  draw();
+}
+function bindGestures(c, kind) {
+  var pts = new Map(), start = null, pinch = null;
+  function rowAt(ev) {
+    var g = geomFor(kind, c), rect = c.getBoundingClientRect();
+    return clamp((ev.clientY - rect.top) / rect.height * g.rows + g.top, 0, H - 1);
+  }
+  function srcXAt(ev) {
+    var g = geomFor(kind, c), rect = c.getBoundingClientRect();
+    return (ev.clientX - rect.left) / rect.width * (rect.width / g.scale) + g.left;
+  }
+  c.addEventListener('pointerdown', function (ev) {
+    try { c.setPointerCapture(ev.pointerId); } catch (e) { void e; }
+    pts.set(ev.pointerId, { x: ev.clientX, y: ev.clientY });
+    if (pts.size === 2) { pinch = { d: pdist(pts), span: S.spanX }; start = null; return; }
+    if (pts.size !== 1) return;
+    var row = rowAt(ev);
+    S.cursorRow = row;
+    start = {
+      x: ev.clientX, y: ev.clientY, row: row, mode: null,
+      onMoving: (srcXAt(ev) < STRIP) === (movingSide() === 'left'),
+      i: nearestAnchor(row), before: S.anchors.slice()
+    };
+    syncControls(); draw();
+  });
+  c.addEventListener('pointermove', function (ev) {
+    if (!pts.has(ev.pointerId)) return;
+    pts.set(ev.pointerId, { x: ev.clientX, y: ev.clientY });
+    if (pinch && pts.size >= 2) {
+      var d = pdist(pts);
+      if (d > 6 && pinch.d > 6) setSpan(pinch.span * pinch.d / d);
+      return;
+    }
+    if (!start) return;
+    var dx = ev.clientX - start.x, dy = ev.clientY - start.y;
+    if (!start.mode) {
+      if (Math.hypot(dx, dy) < 7) return;
+      start.mode = Math.abs(dx) >= Math.abs(dy) ? 'shift' : 'row';
+      if (start.mode === 'shift' && !start.onMoving) {
+        // A grab only moves the half that can actually move. The other one is
+        // drawn dimmed and labelled locked; letting it be dragged anyway would
+        // make "locked" a decoration rather than a statement about hardware.
+        start.mode = 'blocked';
+        $('curvewhy').textContent = 'That half is locked. ' + (movingSide() === 'left'
+          ? 'The camera can only warp the left half -- drag that one.'
+          : 'The downstream corrector only rolls the right half -- drag that one.');
+      }
+    }
+    var g = geomFor(kind, c);
+    if (start.mode === 'row') {
+      S.cursorRow = clamp(start.row - dy / g.scale, 0, H - 1);
+      syncControls(); draw();
+    } else if (start.mode === 'shift') {
+      var sgn = signFor(movingSide()) || 1;
+      var moved = (dx / g.scale) * sgn;
+      if (S.grab === 'curve') {
+        setAnchors(start.before.map(function (p) { return [p[0], p[1] + moved]; }),
+          'whole curve dragged ' + (moved >= 0 ? '+' : '') + moved.toFixed(2) + ' px');
+      } else {
+        var a = start.before.slice(), i = start.i;
+        a[i] = [a[i][0], a[i][1] + moved];
+        setAnchors(a, 'anchor at y=' + a[i][0] + ' dragged directly');
+      }
+    }
+  });
+  function release(ev) {
+    pts.delete(ev.pointerId);
+    if (pts.size < 2) pinch = null;
+    if (pts.size === 0) start = null;
+  }
+  c.addEventListener('pointerup', release);
+  c.addEventListener('pointercancel', release);
+  c.addEventListener('lostpointercapture', release);
+  // Desktop convenience only; the primary path is the pinch.
+  c.addEventListener('wheel', function (ev) {
+    if (kind !== 'zoom') return;
+    ev.preventDefault(); setSpan(S.spanX * (ev.deltaY > 0 ? 1.12 : 0.89));
+  }, { passive: false });
 }
 
 // ---------------------------------------------------------------------------
 // Wiring
 // ---------------------------------------------------------------------------
 function surfaceChanged() {
-  S.surface = $('owner').value === 'downstream' ? 'downstream'
-    : ($('owner').value === 'camera_mesh' ? 'camera_mesh' : 'downstream');
+  S.surface = $('owner').value === 'camera_mesh' ? 'camera_mesh' : 'downstream';
   var moving = movingSide();
   $('caption').innerHTML = moving === 'left'
     ? 'You are moving the <b>LEFT</b> image relative to the right. '
@@ -1509,31 +2226,16 @@ function surfaceChanged() {
   draw();
 }
 
-function onViewDrag(ev, canvas, view) {
-  var rect = canvas.getBoundingClientRect();
-  var y = (ev.clientY - rect.top) / rect.height * (view.rows) + view.top;
-  S.cursorRow = Math.max(0, Math.min(H - 1, y));
-  if (S.dragging === null) return;
-  var dxPx = (ev.clientX - S.dragging.x0) / rect.width * (view.cols);
-  var sgn = signFor(movingSide());
-  var target = S.dragging.base + dxPx * (sgn === 0 ? 1 : sgn);
-  // The nearest anchor follows the grab; the rest of the curve is untouched.
-  var i = S.dragging.i, a = S.anchors.slice();
-  a[i] = [a[i][0], target];
-  setAnchors(a, 'anchor at y=' + a[i][0] + ' grabbed directly');
-}
-function nearestAnchor(row) {
-  var best = 0, bd = 1e9;
-  for (var i = 0; i < S.anchors.length; i++) {
-    var d = Math.abs(S.anchors[i][0] - row);
-    if (d < bd) { bd = d; best = i; }
-  }
-  return best;
+function onResize() {
+  S.narrow = window.innerWidth < 980;
+  draw();
 }
 
 function init() {
+  S.narrow = window.innerWidth < 980;
   S.anchors = [[0, 0], [540, 0], [1080, 0], [1620, 0], [2159, 0]];
   syncControls();
+  $('aim').addEventListener('click', aim);
   $('snap').addEventListener('click', snap);
   $('browse').addEventListener('click', browse);
   $('open').addEventListener('click', openFrame);
@@ -1555,59 +2257,49 @@ function init() {
       'set to the swept minimum, dx=' + s + ' px');
   });
   $('owner').addEventListener('change', surfaceChanged);
-  $('translate').addEventListener('input', function (e) { nudge(parseFloat(e.target.value) - meanDx()); });
   $('roll').addEventListener('input', function (e) { setRoll(parseFloat(e.target.value)); });
+  var nudges = document.querySelectorAll('.nudge button');
+  for (var n = 0; n < nudges.length; n++) {
+    nudges[n].addEventListener('click', function (e) {
+      nudge(parseFloat(e.currentTarget.getAttribute('data-d')));
+    });
+  }
+  var segs = document.querySelectorAll('#grabseg button');
+  for (var s2 = 0; s2 < segs.length; s2++) {
+    segs[s2].addEventListener('click', function (e) {
+      S.grab = e.currentTarget.getAttribute('data-grab');
+      for (var k = 0; k < segs.length; k++) segs[k].classList.remove('on');
+      e.currentTarget.classList.add('on');
+    });
+  }
   var modes = document.querySelectorAll('.modes button');
   for (var i = 0; i < modes.length; i++) {
     modes[i].addEventListener('click', function (e) {
-      S.mode = e.target.getAttribute('data-mode');
+      S.mode = e.currentTarget.getAttribute('data-mode');
       for (var k = 0; k < modes.length; k++) modes[k].classList.remove('on');
-      e.target.classList.add('on');
+      e.currentTarget.classList.add('on');
       draw();
     });
   }
-  ['view', 'zoom'].forEach(function (id) {
-    var c = $(id);
-    var geom = function () {
-      return id === 'view'
-        ? { cols: 2 * STRIP, rows: H, top: 0, left: 0 }
-        : {
-          cols: 2 * BLENDH, rows: ZOOM_ROWS, left: STRIP - BLENDH,
-          top: Math.max(0, Math.min(H - ZOOM_ROWS, S.cursorRow - ZOOM_ROWS / 2))
-        };
-    };
-    c.addEventListener('mousedown', function (ev) {
-      var g = geom(), rect = c.getBoundingClientRect();
-      var row = (ev.clientY - rect.top) / rect.height * g.rows + g.top;
-      S.cursorRow = row;
-      // A grab only starts on the half that can actually move. The other one
-      // is drawn dimmed and labelled locked, and letting it be dragged anyway
-      // would make "locked" a decoration rather than a statement about the
-      // hardware.
-      var srcX = (ev.clientX - rect.left) / rect.width * g.cols + (g.left || 0);
-      var onMoving = (srcX < STRIP) === (movingSide() === 'left');
-      if (!onMoving) {
-        $('curvewhy').textContent =
-          'That half is locked. ' + (movingSide() === 'left'
-            ? 'The camera can only warp the left half -- drag that one.'
-            : 'The downstream corrector only rolls the right half -- drag that one.');
-        draw(); return;
-      }
-      var i = nearestAnchor(row);
-      S.dragging = { x0: ev.clientX, base: S.anchors[i][1], i: i };
-      draw();
-    });
-    c.addEventListener('mousemove', function (ev) { onViewDrag(ev, c, geom()); });
-    window.addEventListener('mouseup', function () { S.dragging = null; });
-  });
+  bindGestures($('zoom'), 'zoom');
+  bindGestures($('view'), 'view');
   document.addEventListener('keydown', function (ev) {
+    if (/^(INPUT|SELECT|TEXTAREA)$/.test((ev.target || {}).tagName || '')) return;
     var step = ev.shiftKey ? 1 : 0.25;
     if (ev.key === 'ArrowLeft') { nudge(-step); ev.preventDefault(); }
     if (ev.key === 'ArrowRight') { nudge(step); ev.preventDefault(); }
+    if (ev.key === 'ArrowUp') { S.cursorRow = clamp(S.cursorRow - 20, 0, H - 1); draw(); ev.preventDefault(); }
+    if (ev.key === 'ArrowDown') { S.cursorRow = clamp(S.cursorRow + 20, 0, H - 1); draw(); ev.preventDefault(); }
   });
-  setInterval(function () { if (S.mode === 'blink') { S.blink ^= 1; draw(); } }, 250);
-  window.addEventListener('resize', draw);
+  setInterval(function () { if (S.mode === 'blink' && S.imgs.left) { S.blink ^= 1; draw(); } }, 250);
+  window.addEventListener('resize', onResize);
+  window.addEventListener('orientationchange', onResize);
+  if (!S.narrow) {
+    var ds = document.querySelectorAll('details.panel');
+    for (var d = 0; d < ds.length; d++) ds[d].open = true;
+  }
   surfaceChanged();
+  renderFreshness();
   pollState();
 }
 document.addEventListener('DOMContentLoaded', init);
@@ -1618,75 +2310,90 @@ _PAGE = """<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="color-scheme" content="dark">
 <title>Soccer-Cam &middot; Seam Calibration</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
 <style>__STYLE__</style>
 </head>
 <body>
 <div class="topbar"><div class="topbar-inner">
 <div class="brand">SOCCER<span class="dot">&middot;</span>CAM</div>
-<div class="crumb"><a href="/">Dashboard</a> / <a href="/config">Config</a> / Seam calibration</div>
+<div class="crumb"><a href="/">Dashboard</a> / <a href="/config">Config</a> / Seam</div>
 </div></div>
 
 <div class="shell">
 <h1 class="headline">Stitch seam calibration</h1>
-<p class="lede">Pull a still off the camera, slide the halves into registration by eye, and
-send the geometry back. The curve you author below <em>is</em> the calibration artifact &mdash;
-there is no separate export, and nothing you can move here exists outside it.</p>
+<p class="lede">Built for a phone at the touchline: aim, put someone in the seam, snap,
+judge the seam by eye, send the geometry back. The curve you author <em>is</em> the
+calibration artifact &mdash; there is no separate export. This is a <b>check</b>-and-correct
+tool for after a knock or a remount: on the archived games 52 of 96 frames sit below the
+measurement floor and players straddling the seam are continuous, so
+<b>&ldquo;nothing to change here&rdquo; is a common and perfectly good answer</b>.</p>
 
 __BANNER__
 
-<div class="panel">
-  <div class="btn-row">
-    <button class="btn" id="snap">Fetch live snapshot</button>
-    <span class="mono muted" id="snapstate">no frame loaded</span>
-    <span style="flex:1"></span>
-    <span class="mono faint">source <b id="camname">--</b> &middot; <b id="camhost">--</b></span>
-  </div>
-  <p class="faint">Two doors into the same editor. A live <span class="mono">Snap</span> is
-    right when the camera is already looking at the field; most calibrations will come from a
-    recorded game instead, because nobody stands at the touchline with a laptop mid-match and a
-    camera on a bench indoors is looking at a scene 0.3&nbsp;m away &mdash; where parallax runs to
-    tens of pixels and drowns the lens roll this tool corrects.</p>
-  <div class="btn-row" style="margin-top:8px">
-    <input type="text" id="framedir" placeholder="folder of frames or recordings"
-      style="flex:2;min-width:240px">
-    <button class="btn btn-ghost" id="browse">List</button>
-    <select id="framelist" style="flex:2;min-width:200px"></select>
-    <input type="number" id="atsec" placeholder="sec" step="1" style="width:80px" title="seconds into a video file">
-    <button class="btn" id="open">Open frame</button>
-  </div>
-  <div class="btn-row" style="margin-top:8px">
-    <input type="text" id="deployment" placeholder="deployment / tripod placement label"
-      style="flex:1;min-width:240px">
-    <span class="mono faint" id="openstate"></span>
-  </div>
-  <p class="faint">A calibration belongs to a camera <em>and where it was standing</em>. Whether
-    the seam offset actually differs between tripod placements is still being measured, so every
-    save is also filed under this label in
-    <span class="mono">stitch_calibrations/</span> &mdash; if it turns out to be per-deployment,
-    the evidence is already there instead of having been overwritten.</p>
+<ol class="steps" id="steps">
+  <li id="step-aim"><span class="n">1</span><span><span class="t">Aim</span>
+    <span class="d">Tap Aim. The orange line is the seam. It is free to repeat, so use it
+    to see where the seam lands in the scene.</span></span></li>
+  <li id="step-stand"><span class="n">2</span><span><span class="t">Put someone in the seam</span>
+    <span class="d">Stand them on the orange line, out where play actually happens &mdash;
+    not beside the tripod. One calibration is exact at one depth, and a target at 2&nbsp;m
+    carries tens of pixels of parallax that have nothing to do with the lens roll.</span></span></li>
+  <li id="step-snap"><span class="n">3</span><span><span class="t">Snap</span>
+    <span class="d">The full 7680&times;2160 still. Detection takes 25-60 s; the picture
+    arrives first.</span></span></li>
+  <li id="step-adjust"><span class="n">4</span><span><span class="t">Look at the person, then slide</span>
+    <span class="d">Pinch to 4&times; and ask one question: is the body continuous across the
+    seam? A tear is unmistakable. Drag across the picture to move the half; drag up and
+    down to travel the rows. Your eye is the instrument here &mdash; the numbers beside it
+    are aids, and none of them can see a person in the blend window.</span></span></li>
+  <li id="step-ship"><span class="n">5</span><span><span class="t">Apply only if you saw a tear</span>
+    <span class="d">Then snap again and confirm on a fresh frame rather than on a promise.
+    If the body was continuous, leave the camera alone.</span></span></li>
+</ol>
+
+<div class="dock">
+  <button class="btn btn-ghost" id="aim">Aim</button>
+  <button class="btn" id="snap">Snap</button>
+  <span class="st" id="dockstate">no frame loaded</span>
 </div>
 
 <div class="grid">
-<div>
+<div class="col">
+
+  <div class="panel" id="scenepanel">
+    <h2 class="sec">Where the seam <span class="accent">falls</span></h2>
+    <div id="scenewrap" style="display:none">
+      <img id="scene" alt="scene overview with the seam marked">
+      <div id="sceneseam"></div>
+      <div id="scenehint">the orange line is the seam &mdash; stand your target on it</div>
+    </div>
+    <div id="aimverdict" style="display:none"></div>
+    <p class="faint">Aim re-snaps the camera and redraws this at 1/8 scale (~35&nbsp;KB), which is
+      useless for judging registration and exactly right for judging aim. It never disturbs a
+      measured session, so press it as often as you like while someone walks into position.</p>
+  </div>
+
   <div class="panel">
-    <h2 class="sec">Seam <span class="accent">view</span></h2>
+    <h2 class="sec">The <span class="accent">seam</span></h2>
+    <div id="zoomwrap"><canvas id="zoom"></canvas></div>
+    <p class="faint mono" id="zoomlabel"></p>
     <div class="modes">
-      <button data-mode="blink" class="on">Blink 2Hz</button>
+      <button data-mode="blink" class="on">Blink</button>
       <button data-mode="anaglyph">Anaglyph</button>
       <button data-mode="mirror">Mirror</button>
       <button data-mode="split">Plain</button>
     </div>
+    <p class="faint">Drag <b>across</b> to move the half you are allowed to move; drag
+      <b>up and down</b> to travel the rows; <b>pinch</b> to zoom. Arrow keys nudge by
+      0.25&nbsp;px (shift = 1&nbsp;px) if you are on a laptop.</p>
     <div id="viewwrap"><canvas id="view"></canvas></div>
-    <p class="faint mono">Full height, horizontal <b id="viewscale">1.00</b>&times; and vertical
-      0.31&times; &mdash; deliberately anisotropic: what you are judging is horizontal, and
-      squashing the rows keeps all 2160 of them on screen without shrinking a 4&nbsp;px error
-      to nothing. Drag anywhere to grab the nearest anchor; arrow keys nudge (shift = 1&nbsp;px).</p>
+    <p class="faint mono">Whole frame, squashed vertically: a locator, not a judge. Green bands
+      are rows where something upright crosses the seam; the white box is what the view above is
+      showing.</p>
     <div class="caption" id="caption"></div>
+    <div id="vertical" style="display:none"></div>
     <div class="caveat"><strong>What these views can and cannot show.</strong>
       The camera fuses the two sensors before it hands out a JPEG, blending them over the
       256&nbsp;px window shaded above. Every pixel in there is already a mixture of both, so
@@ -1694,18 +2401,71 @@ __BANNER__
       therefore draw the <em>fitted</em> structures instead: each one measured independently on
       the left shoulder (red) and the right shoulder (cyan) and extrapolated to the seam, solid
       where there is real image behind it and dashed where it is extrapolation. A gap between a
-      red line and its cyan partner at the seam is that structure's residual. The shoulders
-      either side of the window are real; the window is inference.</div>
-
-    <div id="zoomwrap"><canvas id="zoom"></canvas></div>
-    <p class="faint mono">Blend window at 4&times;, true aspect, 1&nbsp;px grid &mdash;
-      <span id="zoomlabel"></span>. Follows the green row cursor.</p>
+      red line and its cyan partner at the seam is that structure's residual. Structures too
+      near horizontal to respond to a horizontal shift are drawn grey, because they cannot tell
+      you anything about what you are adjusting. The shoulders either side of the window are
+      real; the window is inference.</div>
   </div>
-</div>
 
-<div>
   <div class="panel">
-    <h2 class="sec">Correction <span class="accent">surface</span></h2>
+    <h2 class="sec">The <span class="accent">curve</span></h2>
+    <div class="dxread" id="dxnow"></div>
+    <div class="nudge">
+      <button data-d="-1">&minus;1</button>
+      <button data-d="-0.25">&minus;&frac14;</button>
+      <button data-d="0.25">+&frac14;</button>
+      <button data-d="1">+1</button>
+    </div>
+    <label class="row"><span class="lbl">Roll &mdash; linear in y, top to bottom
+      <span class="val" id="rollV"></span></span>
+      <input type="range" id="roll" min="-40" max="40" step="0.25" value="0"></label>
+    <div class="seg" id="grabseg">
+      <button data-grab="curve" class="on">Drag moves the whole curve</button>
+      <button data-grab="anchor">Drag moves this row</button>
+    </div>
+    <p class="faint">Roll is the shape the physics predicts: two lenses rotated relative to each
+      other about their optical axes displace the seam by
+      <span class="mono">dx = -&theta;&middot;y</span>, linear in the row. With one person at one
+      depth you have one observation and can only honestly move the whole curve; a second person
+      at a different height is what earns a roll.</p>
+    <p class="faint" id="curvewhy"></p>
+    <div class="btn-row">
+      <button class="btn btn-ghost btn-sm" id="reset">Reset to zero</button>
+      <button class="btn btn-ghost btn-sm" id="suggest" disabled>Use measured dx</button>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2 class="sec">Live <span class="accent">score</span>
+      <span class="badge" id="fresh" style="float:right">no frame</span></h2>
+    <p class="mono faint"><span class="dot off" id="metricdot"></span><span id="metriclabel"></span></p>
+    <div id="floor" style="display:none"></div>
+    <div id="quality" style="display:none"></div>
+    <div class="kpi" id="kpis">
+      <div><div class="k">|ln SSR| on the target</div><div class="v" id="ssrtarget">--</div></div>
+      <div><div class="k">|ln SSR| whole frame</div><div class="v" id="ssrv">--</div></div>
+      <div><div class="k">SCR p90, steerable</div><div class="v" id="scrp90">--</div></div>
+      <div><div class="k">steerable / all</div><div class="v" id="scrn">0</div></div>
+    </div>
+    <p class="mono faint" id="scoredat"></p>
+    <p class="mono worse" id="neterr"></p>
+    <p class="faint" id="scrnote"></p>
+    <p class="faint" id="ssrnote"></p>
+    <p class="faint">These are the same numbers the automatic solver minimises, computed by the
+      same code &mdash; and that solver <b>refuses on all 27 archived games</b>, because the
+      structures able to span a vertical seam are the near-horizontal ones and their median
+      |slope| is 0.034: a 10&nbsp;px error moves the median observation 0.34&nbsp;px, under its
+      own noise. So treat every number on this panel as a secondary aid. The picture is the
+      evidence, and it should overrule them. The headline p90 is taken over the structures
+      steep enough to see a horizontal shift; the whole-set p90 is printed beside it, and
+      neither is redefined anywhere the solver would read.</p>
+  </div>
+
+</div>
+<div class="col">
+
+  <details class="panel">
+    <summary>Correction <span class="accent">surface</span></summary>
     <select id="owner">
       <option value="camera_mesh">Camera warp mesh &mdash; sub-pixel, before the blend</option>
       <option value="camera_scalars+downstream">Camera scalars + downstream residual</option>
@@ -1714,67 +2474,26 @@ __BANNER__
     <p class="faint">Exactly one surface owns the correction. Splitting it across two is how a
       reboot silently turns a full correction into half of one: the camera's mesh is runtime
       state and does not survive a power cycle, while the downstream profile always does.</p>
-  </div>
+  </details>
 
-  <div class="panel">
-    <h2 class="sec">The <span class="accent">curve</span></h2>
-    <label class="row"><span class="lbl">Translate <span class="val" id="translateV"></span></span>
-      <input type="range" id="translate" min="-40" max="40" step="0.25" value="0"></label>
-    <label class="row"><span class="lbl">Roll &mdash; linear in y <span class="val" id="rollV"></span></span>
-      <input type="range" id="roll" min="-40" max="40" step="0.25" value="0"></label>
-    <p class="faint">Roll is the shape the physics predicts: two lenses rotated relative to each
-      other about their optical axes displace the seam by <span class="mono">dx = -&theta;&middot;y</span>,
-      linear in the row. Translate and roll are a <em>view</em> of the curve, recomputed from it
-      after every edit &mdash; not stored parameters.</p>
-    <table><thead><tr><th>row</th><th>dx (px, right half moves right)</th></tr></thead>
-      <tbody id="curverows"></tbody></table>
-    <p class="mono faint" style="word-break:break-all" id="curvejson"></p>
-    <p class="faint" id="curvewhy"></p>
-    <div class="btn-row">
-      <button class="btn btn-ghost" id="reset">Reset to zero</button>
-      <button class="btn btn-ghost" id="suggest" disabled>Use measured dx</button>
-    </div>
-  </div>
-
-  <div class="panel">
-    <h2 class="sec">Live <span class="accent">score</span></h2>
-    <p class="mono faint"><span class="dot off" id="metricdot"></span><span id="metriclabel"></span>
-      <span id="metricstate"></span></p>
-    <div id="quality" style="display:none"></div>
-    <div class="kpi">
-      <div><div class="k">SCR p50</div><div class="v" id="scrp50">--</div></div>
-      <div><div class="k">SCR p90</div><div class="v" id="scrp90">--</div></div>
-      <div><div class="k">|ln SSR|</div><div class="v" id="ssrv">--</div></div>
-      <div><div class="k">structures</div><div class="v" id="scrn">0</div></div>
-    </div>
-    <p class="faint" id="scrnote"></p>
-    <p class="faint" id="ssrnote"></p>
-    <p class="faint">These are the same numbers the automatic solver minimises, computed by the
-      same code &mdash; so a calibration done by hand and one done by search are directly
-      comparable. Acceptance wants p90 below 2&nbsp;px and at least halved.</p>
-  </div>
-
-  <div class="panel">
-    <h2 class="sec">What the camera <span class="accent">already decided</span></h2>
-    <table><thead><tr><th>scalar</th><th class="num">live</th><th class="num">factory</th></tr></thead>
-      <tbody id="scalars"></tbody></table>
-    <p class="faint" id="scalarnote"></p>
-  </div>
-
-  <div class="panel">
-    <h2 class="sec">Ship <span class="accent">it</span></h2>
+  <details class="panel">
+    <summary>Ship <span class="accent">it</span></summary>
+    <label class="row"><span class="lbl">Deployment / tripod placement</span>
+      <input type="text" id="deployment" placeholder="fairport-north-2026.08"></label>
     <label class="row"><span class="lbl">Calibrated for distance (m)</span>
-      <input type="number" id="distance_m" step="1" placeholder="45"></label>
+      <input type="number" id="distance_m" step="1" inputmode="decimal" placeholder="45"></label>
     <label class="row"><span class="lbl">Basis</span>
-      <input type="text" id="basis" placeholder="far touchline midpoint"></label>
-    <p class="faint">One calibration is correct at one depth. Calibrating for the far field costs
-      a couple of pixels across the far half of the pitch and tens of pixels at the near
-      touchline &mdash; the right trade here, but a stated one.</p>
+      <input type="text" id="basis" placeholder="player standing at the far touchline"></label>
+    <p class="faint">One calibration is correct at one depth &mdash; whichever depth the person you
+      used was standing at. Calibrating for the far field costs a couple of pixels across the far
+      half of the pitch and tens of pixels at the near touchline: the right trade here, but a
+      stated one. Every save is also filed under the deployment label in
+      <span class="mono">stitch_calibrations/</span>.</p>
     <div class="btn-row">
       <button class="btn" id="save">Save profile</button>
       <span class="mono" id="savestate"></span>
     </div>
-    <div id="applywrap" style="margin-top:14px">
+    <div id="applywrap" style="margin-top:12px">
       <div class="btn-row">
         <button class="btn btn-ghost" id="dryrun">Dry run</button>
         <button class="btn btn-danger" id="apply">Apply to camera</button>
@@ -1782,12 +2501,55 @@ __BANNER__
       </div>
       <p class="faint">Apply sets the vendor scalars first and only then writes a mesh composed
         onto the baseline they produce &mdash; <span class="mono">SetStitch</span> re-runs the
-        camera's own mesh optimiser and destroys anything written before it. The baseline is
-        re-checked immediately before the write and the write is refused if it moved. Afterwards
-        a fresh snapshot is pulled and re-scored, so you see numbers rather than a promise.</p>
-      <pre class="mono faint" id="applyreport" style="white-space:pre-wrap;max-height:220px;overflow:auto"></pre>
+        camera's own mesh optimiser and destroys anything written before it. Afterwards a fresh
+        snapshot is pulled and re-scored, so you see numbers rather than a promise.</p>
+      <pre class="mono faint" id="applyreport" style="white-space:pre-wrap;max-height:200px;overflow:auto"></pre>
     </div>
-  </div>
+  </details>
+
+  <details class="panel">
+    <summary>The <span class="accent">anchors</span></summary>
+    <table><thead><tr><th>row</th><th>dx (px, right half moves right)</th></tr></thead>
+      <tbody id="curverows"></tbody></table>
+    <p class="mono faint" style="word-break:break-all" id="curvejson"></p>
+  </details>
+
+  <details class="panel">
+    <summary>What the camera <span class="accent">already decided</span></summary>
+    <table><thead><tr><th>scalar</th><th class="num">live</th><th class="num">factory</th></tr></thead>
+      <tbody id="scalars"></tbody></table>
+    <p class="faint" id="scalarnote"></p>
+    <p class="mono faint">source <b id="camname">--</b> &middot; <b id="camhost">--</b></p>
+  </details>
+
+  <details class="panel">
+    <summary>Calibrate from a <span class="accent">recorded game</span></summary>
+    <p class="faint">The other door. A calibration can be recovered after the fact from an
+      archived game &mdash; useful for footage already shot, and for checking whether the seam
+      differs between tripod placements.</p>
+    <label class="row"><span class="lbl">Folder of frames or recordings</span>
+      <input type="text" id="framedir" placeholder="F:\\archive\\duo3_stitch\\frames\\..."></label>
+    <div class="btn-row" style="margin-top:8px">
+      <button class="btn btn-ghost btn-sm" id="browse">List</button>
+      <select id="framelist" style="flex:2;min-width:160px"></select>
+      <input type="number" id="atsec" placeholder="sec" step="1" inputmode="numeric"
+        style="width:88px" title="seconds into a video file">
+      <button class="btn btn-sm" id="open">Open frame</button>
+    </div>
+    <p class="mono faint" id="openstate"></p>
+  </details>
+
+  <details class="panel">
+    <summary>Reaching this <span class="accent">from a phone</span></summary>
+    <p class="faint">The app answers on loopback by default and rejects any other
+      <span class="mono">Host</span> header, which is a deliberate DNS-rebinding defence. To use it
+      from a phone on the same network, set <span class="mono">[TTT] auth_server_bind</span> in
+      <span class="mono">config.ini</span> to this machine's LAN address and browse to
+      <span class="mono">http://&lt;that address&gt;:8765/stitch</span>. Setting it to
+      <span class="mono">0.0.0.0</span> binds everywhere but does <em>not</em> widen the allowlist,
+      so it will still refuse &mdash; name the address.</p>
+  </details>
+
 </div>
 </div>
 </div>

--- a/video_grouper/web/stitch_calibration.py
+++ b/video_grouper/web/stitch_calibration.py
@@ -1,0 +1,1797 @@
+"""Human-in-the-loop stitch-seam calibration, at ``/stitch``.
+
+Workflow B of ``reolink-firmware-patching/docs/STITCH_CALIBRATION.md``: get a
+panorama frame, let an operator slide the two halves into registration by eye
+while the seam metric scores every candidate curve, and send the result back.
+The curve the operator authors **is** the calibration artifact -- there is no
+export step and no parameter that lives only in the UI.
+
+Two doors, one editor: a live `Snap` over HTTP, or a frame opened from a file
+or seeked out of a recording. The second is the one most calibrations will come
+through. Nobody stands at the touchline with a laptop mid-match, and a camera
+indoors on a bench is looking at a scene 0.3 m away, where parallax runs to
+tens of pixels and swamps the lens roll this exists to correct.
+
+Four things about this file are load-bearing and easy to get wrong.
+
+**Only one half moves, and it is the LEFT one.** The camera's warp mesh lives
+in VPE 0, which warps the left half; measured on hardware (#135), a requested
++40 px moves the left half 40.13 px far from the seam and 40.94 px near it,
+while the right half moves 0.02 px. So the UI draws the right half locked and
+dimmed. Two draggable halves would be a nicer toy and a false model of the
+hardware. The downstream corrector is the mirror image -- it rolls the *right*
+half -- so selecting that surface flips which half is draggable and inverts the
+displayed sense. The stored anchors never change; only the presentation does.
+
+**The operator descends the same objective as the solver.** Every drag is
+scored with `seam_metric`, not with a lookalike. Detection is the expensive
+half -- 37-50 s on a real 7680x2160 game frame -- and runs once per frame in a
+background thread; scoring a candidate curve reuses those chains and takes
+~0.26 s. That is what makes a hand calibration and an automatic one directly
+comparable instead of merely similar.
+
+**A score that does not respond to the curve is not a measurement.** Measured
+on three real tripod placements, SCR sits at 27-36 px and moves 1-15% across
+the whole plausible dx range while the seam is visibly registered, and every
+coverage gate passes while it happens. So each frame is swept once and the
+verdict -- can this picture steer the calibration at all -- leads the panel,
+ahead of any number. See `_frame_quality`.
+
+**The picture is a fused JPEG, so parts of it are already a mixture.** The
+camera blends the two sensors over a 256-px window, so nothing inside it is
+evidence about registration and there is no second layer to reveal. Blink and
+anaglyph therefore draw the *fitted* structures -- the same extrapolation the
+metric performs -- rather than smearing replicated pixels across the window.
+That is stated in the interface, not just here: an honest caveat in a source
+comment is a caveat nobody reads.
+
+What crosses the wire is two 640x2160 JPEG strips (~76 KB each), not the
+730 KB panorama: the operator only ever looks at the seam, and the browser can
+shear a strip with an affine transform far more smoothly than a server can
+re-render one per drag frame.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Body, HTTPException
+from fastapi.responses import HTMLResponse, JSONResponse, Response
+
+from video_grouper.utils.config import CameraConfig, load_config
+from video_grouper.utils.stitch_remap import (
+    SeamCalibrationError,
+    build_v2_profile,
+    read_dx_anchors,
+)
+
+logger = logging.getLogger(__name__)
+
+# Panorama geometry for the Duo 3, measured from /proc/hdal/vprc/info: two
+# 3840-wide halves butt-joined at x=3840 with no crop, blended over 2*blend_w.
+PANORAMA_W = 7680
+PANORAMA_H = 2160
+SEAM_X = PANORAMA_W // 2
+BLEND_W = 128  # half-width; the mixed window is [SEAM-128, SEAM+128]
+
+# How much of each half to ship to the browser. 640 px reaches well past the
+# 384-px shoulder the metric fits on, so the operator sees the structure the
+# score is computed from, and costs ~76 KB per half at q78.
+STRIP_W = 640
+STRIP_QUALITY = 78
+
+# Rows the anchor curve is authored at. Five handles, evenly spread, matching
+# the design's worked example. A relative lens roll is linear in y, so five is
+# already more freedom than the physics needs -- the extra handles exist to
+# show the operator that the model *would* admit more, and to record it if the
+# camera turns out not to obey the roll model.
+ANCHOR_ROWS = (0, 540, 1080, 1620, 2159)
+
+_MAX_ABS_DX = 64.0  # lut2d refuses beyond this; refuse here too rather than later
+
+
+def _vpe_dir() -> Path | None:
+    """Locate the firmware-side calibration toolkit.
+
+    It lives outside the installed package (``reolink-firmware-patching/`` is
+    firmware territory and is excluded from mypy and from the wheel), so it is
+    found by path rather than imported as a module. Two layouts: a source
+    checkout, and a PyInstaller bundle that carried the directory in as data.
+    """
+    here = Path(__file__).resolve()
+    candidates = [
+        here.parents[2] / "reolink-firmware-patching" / "vpe",
+        Path(getattr(sys, "_MEIPASS", "")) / "vpe"
+        if hasattr(sys, "_MEIPASS")
+        else None,
+    ]
+    for candidate in candidates:
+        if candidate is not None and (candidate / "seam_metric.py").exists():
+            return candidate
+    return None
+
+
+_toolkit_cache: dict[str, Any] = {}
+
+
+def load_toolkit() -> dict[str, Any]:
+    """Import `seam_metric` / `stitch_apply`, or explain why not.
+
+    Returns a dict with ``metric`` and ``camera`` (module or None) plus
+    ``errors``. The page degrades rather than 500s: the metric and the camera
+    surface fail independently, and an operator with neither can still read the
+    documentation the page carries.
+    """
+    if _toolkit_cache:
+        return _toolkit_cache
+    out: dict[str, Any] = {"metric": None, "camera": None, "errors": []}
+    vpe = _vpe_dir()
+    if vpe is None:
+        out["errors"].append(
+            "the seam-calibration toolkit (reolink-firmware-patching/vpe) is not "
+            "on this install -- calibration needs a source checkout"
+        )
+        _toolkit_cache.update(out)
+        return out
+    if str(vpe) not in sys.path:
+        sys.path.insert(0, str(vpe))
+    for key, name in (("metric", "seam_metric"), ("camera", "stitch_apply")):
+        try:
+            out[key] = importlib.import_module(name)
+        except Exception as exc:  # noqa: BLE001 -- any import failure degrades
+            out["errors"].append(f"{name}: {exc}")
+    _toolkit_cache.update(out)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Session:
+    """One operator, one snapshot. Loopback tool; no multi-tenancy.
+
+    Held in memory rather than on disk because the expensive part -- the
+    detected shoulder chains -- is only meaningful for the exact frame it came
+    from, and a stale cache scored against a fresh frame would silently report
+    the wrong numbers.
+    """
+
+    camera_name: str = ""
+    host: str = ""
+    source_path: str = ""
+    snapped_at: float = 0.0
+    version: int = 0
+    frame: Any = None  # np.ndarray, full panorama BGR
+    halves: dict[str, bytes] = field(default_factory=dict)
+    width: int = 0
+    height: int = 0
+    scalars_current: dict | None = None
+    scalars_factory: dict | None = None
+    chains: Any = None
+    chains_state: str = "idle"  # idle | running | ready | failed
+    chains_error: str = ""
+    baseline: dict | None = None
+    quality: dict | None = None
+    last_apply: dict | None = None
+
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+_session = _Session()
+
+
+def _reolink_camera(config_path: Path) -> CameraConfig:
+    config = load_config(config_path)
+    if config is None:
+        raise HTTPException(500, f"could not load config from {config_path}")
+    cameras = [c for c in config.cameras if c.enabled]
+    for cam in cameras:
+        if cam.type == "reolink":
+            return cam
+    if cameras:
+        raise HTTPException(
+            400,
+            "seam calibration needs a Reolink dual-lens camera; the configured "
+            f"camera(s) are {', '.join(c.type for c in cameras)}",
+        )
+    raise HTTPException(400, "no enabled camera is configured")
+
+
+def _camera_host(cam: CameraConfig) -> str:
+    return cam.device_ip if cam.http_port == 80 else f"{cam.device_ip}:{cam.http_port}"
+
+
+def _encode_halves(frame: Any, seam_x: int) -> dict[str, bytes]:
+    """Cut the two seam strips and JPEG them.
+
+    Sent as two images rather than one so the browser can shear them
+    independently -- which is the whole trick that keeps dragging smooth
+    without a round trip per frame.
+    """
+    import cv2
+
+    lo = max(0, seam_x - STRIP_W)
+    hi = min(frame.shape[1], seam_x + STRIP_W)
+    params = [cv2.IMWRITE_JPEG_QUALITY, STRIP_QUALITY]
+    out = {}
+    for side, sl in (("left", slice(lo, seam_x)), ("right", slice(seam_x, hi))):
+        ok, buf = cv2.imencode(".jpg", frame[:, sl], params)
+        if not ok:
+            raise HTTPException(500, f"could not encode the {side} strip")
+        out[side] = buf.tobytes()
+    return out
+
+
+def _detect_chains_async(session: _Session, version: int) -> None:
+    """Run the expensive SCR detection off the request thread.
+
+    37-50 s on a real 7680x2160 game frame, plus the dx sweep. The operator
+    gets the picture immediately and
+    the numbers when they are ready; blocking the snapshot on this would make
+    the tool feel broken on the one action it always starts with.
+    """
+    metric = load_toolkit()["metric"]
+    if metric is None:
+        return
+    try:
+        with session.lock:
+            if session.version != version:
+                return
+            frame = session.frame
+            seam = session.width // 2
+        chains = metric.detect_shoulder_chains(
+            frame, seam_x=seam, blend_w=2 * BLEND_W, shoulder_w=384
+        )
+        scr = metric.residual_from_chains(chains)
+        ssr = metric.seam_sharpness_ratio(frame, seam_x=seam, blend_w=2 * BLEND_W)
+        quality = _frame_quality(metric, chains, frame.shape[0])
+    except Exception as exc:  # noqa: BLE001 -- surfaced to the operator instead
+        logger.warning("STITCH: baseline detection failed: %s", exc)
+        with session.lock:
+            if session.version == version:
+                session.chains_state = "failed"
+                session.chains_error = str(exc)
+        return
+    with session.lock:
+        if session.version != version:
+            return
+        session.chains = chains
+        session.chains_state = "ready"
+        session.baseline = _score_payload(scr, ssr)
+        session.quality = quality
+
+
+#: `seam_continuity_residual`'s pair-matching tolerance. An observation whose
+#: residual sits near it was accepted at the limit of the gate, which on a busy
+#: outdoor frame usually means two unrelated edges got paired.
+_MATCH_GAP_PX = 40.0
+
+#: Below this, sliding the curve does not move the score enough to steer by.
+#: Set against the acceptance gate, which wants SCR p90 halved: a frame that
+#: cannot produce even a fifth of that over the whole plausible dx range cannot
+#: produce the rest either.
+_MIN_USEFUL_GAIN = 0.20
+
+
+def _frame_quality(metric: Any, chains: Any, height: int) -> dict:
+    """Ask the frame whether it can constrain the calibration at all.
+
+    This exists because of what real material does. On three separate Duo 3
+    tripod placements -- an indoor dome and two outdoor pitches -- SCR reports
+    p90 between 27 and 36 px and moves by 1-15% as dx sweeps the whole
+    plausible range, while the seam is *visibly* well registered. Every
+    coverage gate passes (40-69 structures, 3 row bands, 69-79% height), so
+    nothing in the acceptance check flags it.
+
+    What is happening: the matcher pairs a left structure with any right
+    structure within 40 px at the seam, and a busy scene at mixed depths
+    offers plenty. The resulting "observations" are unrelated edges, and their
+    residuals describe the matching tolerance rather than the registration.
+
+    So a number alone is not honest. Sweeping dx once per frame answers the
+    question the operator actually has -- *can this picture tell me anything*
+    -- and it is the same question the automatic solver has to answer before
+    it trusts a fit.
+    """
+    sweep = []
+    for dx in range(-16, 17, 2):
+        r = metric.residual_from_chains(
+            chains, [(0.0, float(dx)), (height - 1.0, float(dx))]
+        )
+        if r.n:
+            sweep.append({"dx": dx, "p50": round(r.p50, 3), "p90": round(r.p90, 3)})
+    if not sweep:
+        return {"usable": False, "reason": "no structure crosses the seam", "sweep": []}
+
+    at_zero = next((s for s in sweep if s["dx"] == 0), sweep[0])
+    best = min(sweep, key=lambda s: s["p90"])
+    gain = 0.0 if at_zero["p90"] <= 0 else 1.0 - best["p90"] / at_zero["p90"]
+
+    base = metric.residual_from_chains(chains)
+    saturated = [o for o in base.observations if o.residual_perp > 0.8 * _MATCH_GAP_PX]
+    sat_frac = len(saturated) / base.n if base.n else 0.0
+
+    usable = gain >= _MIN_USEFUL_GAIN
+    if usable:
+        reason = (
+            f"sliding dx across +/-16 px moves SCR p90 by {gain * 100:.0f}%, "
+            f"best at dx={best['dx']:+d}"
+        )
+    elif sat_frac > 0.4:
+        reason = (
+            f"{sat_frac * 100:.0f}% of matched structures sit near the "
+            f"{_MATCH_GAP_PX:.0f} px pairing limit, so the score is dominated by "
+            "unrelated edges paired across the seam, not by misregistration"
+        )
+    else:
+        reason = (
+            f"sliding dx across the whole plausible range moves SCR p90 by only "
+            f"{gain * 100:.0f}% -- this frame does not constrain the seam offset"
+        )
+    return {
+        "usable": usable,
+        "reason": reason,
+        "best_dx": best["dx"] if usable else None,
+        "gain": round(gain, 4),
+        "saturated_fraction": round(sat_frac, 3),
+        "sweep": sweep,
+    }
+
+
+def _score_payload(scr: Any, ssr: Any) -> dict:
+    return {
+        "scr": {
+            "n": scr.n,
+            "p50": None if scr.n == 0 else round(scr.p50, 3),
+            "p90": None if scr.n == 0 else round(scr.p90, 3),
+            "max": None if scr.n == 0 else round(scr.max, 3),
+            "row_bands_covered": scr.row_bands_covered,
+            "height_coverage": round(scr.height_coverage, 3),
+            "slope_spread": round(scr.slope_spread, 4),
+            # Negated: `implied_dx` is the misregistration present in the
+            # image, which is the OPPOSITE sense to a dx_anchors value. Handing
+            # the raw number to an operator who then types it into the curve is
+            # the sign error of section 4.4, applied twice instead of removed.
+            "suggested_dx": (
+                None
+                if scr.n < 3 or scr.slope_spread <= 0.02
+                else round(-scr.implied_dx, 3)
+            ),
+        },
+        "ssr": {
+            "ssr": round(ssr.ssr, 4),
+            "abs_ln_ssr": round(ssr.abs_ln_ssr, 4),
+            "noise_floor": ssr.noise_floor,
+        },
+        # The structures the score is computed from, so the picture and the
+        # number are the same evidence. Each is one structure fitted
+        # independently on the two shoulders and extrapolated to the seam;
+        # `y_left` and `y_right` are where those two extrapolations arrive.
+        # Drawing them IS the "alternate the two extrapolated shoulders" view,
+        # and it is honest in a way extrapolating pixels is not: the metric
+        # really does extrapolate lines, and a line drawn on screen cannot be
+        # mistaken for photographic evidence the fused frame does not contain.
+        "observations": [
+            {
+                "y_left": round(o.y_left, 2),
+                "y_right": round(o.y_right, 2),
+                "slope": round(o.slope, 5),
+                "residual": round(o.residual_perp, 2),
+            }
+            for o in sorted(scr.observations, key=lambda o: o.fit_rms)[:60]
+        ],
+    }
+
+
+def _anchors_from_body(body: dict) -> list[tuple[float, float]]:
+    try:
+        anchors = read_dx_anchors(body)
+    except SeamCalibrationError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    worst = max(abs(dx) for _y, dx in anchors)
+    if worst > _MAX_ABS_DX:
+        # The camera-side composer refuses beyond this and calls it a corrupt
+        # file. Refuse at the point the number is authored instead, where the
+        # operator can still see what they did.
+        raise HTTPException(
+            400,
+            f"|dx| reaches {worst:.1f} px; nothing physical needs more than "
+            f"{_MAX_ABS_DX:.0f} px and the camera-side composer refuses it",
+        )
+    return anchors
+
+
+def _frame_from_video(source: Path, seconds: float) -> Any:
+    """Pull one frame out of a recording, `seconds` in.
+
+    PyAV rather than a subprocess: it is the project's convention, and it lets
+    a 7680x2160 HEVC file be seeked and decoded without a temp file.
+    """
+    import av
+    import numpy as np
+
+    with av.open(str(source)) as container:
+        stream = container.streams.video[0]
+        if seconds > 0 and stream.time_base:
+            container.seek(
+                int(seconds / float(stream.time_base)), stream=stream, backward=True
+            )
+        for frame in container.decode(stream):
+            return np.ascontiguousarray(frame.to_ndarray(format="bgr24"))
+    raise HTTPException(415, f"no decodable video frame in {source.name}")
+
+
+def _adopt_frame(
+    frame: Any,
+    *,
+    camera_name: str,
+    host: str,
+    scalars: tuple[dict | None, dict | None],
+    source_path: str,
+) -> JSONResponse:
+    """Make `frame` the session's subject, and start scoring it.
+
+    The one path by which a frame becomes the thing being calibrated, so a
+    live snapshot and a still from a recorded game land in exactly the same
+    editor with exactly the same measurement behind them. Detection runs off
+    the request thread because it takes 37-50 s on a real 7680x2160 frame and
+    the operator should be looking at the picture long before the numbers do.
+    """
+    metric = load_toolkit()["metric"]
+    halves = _encode_halves(frame, frame.shape[1] // 2)
+    with _session.lock:
+        _session.version += 1
+        version = _session.version
+        _session.camera_name = camera_name
+        _session.host = host
+        _session.source_path = source_path
+        _session.frame = frame
+        _session.halves = halves
+        _session.height, _session.width = frame.shape[0], frame.shape[1]
+        _session.snapped_at = time.time()
+        _session.scalars_current, _session.scalars_factory = scalars
+        _session.chains = None
+        _session.baseline = None
+        _session.quality = None
+        _session.chains_error = ""
+        _session.chains_state = "running" if metric is not None else "failed"
+        if metric is None:
+            _session.chains_error = "seam_metric is not importable"
+        payload = _state_payload()
+
+    if metric is not None:
+        threading.Thread(
+            target=_detect_chains_async,
+            args=(_session, version),
+            daemon=True,
+            name="stitch-detect",
+        ).start()
+    return JSONResponse(payload)
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+def build_router(config_path: Path, storage_path: Path | None = None) -> APIRouter:
+    """Build the FastAPI router for the seam-calibration tool.
+
+    Host allowlist and Origin/Referer CSRF defenses come from the parent app's
+    middleware, exactly as for the config editor.
+    """
+    router = APIRouter()
+    storage = Path(storage_path) if storage_path else config_path.parent
+
+    @router.get("/stitch", response_class=HTMLResponse)
+    def get_page() -> HTMLResponse:
+        toolkit = load_toolkit()
+        return HTMLResponse(_render_page(toolkit))
+
+    @router.get("/stitch/state")
+    def get_state() -> JSONResponse:
+        with _session.lock:
+            return JSONResponse(_state_payload())
+
+    @router.post("/stitch/snap")
+    def post_snap() -> JSONResponse:
+        """Fetch a fresh still and the camera's own scalars, in one action.
+
+        `GetStitch` returns both the live values and the factory `initial`
+        block, so "confirm what the camera's auto-adjustment already found" is
+        a real comparison rather than a leap of faith.
+        """
+        toolkit = load_toolkit()
+        camera_mod, metric = toolkit["camera"], toolkit["metric"]
+        if camera_mod is None:
+            raise HTTPException(503, "; ".join(toolkit["errors"]) or "toolkit missing")
+        cam = _reolink_camera(config_path)
+        host = _camera_host(cam)
+
+        import tempfile
+
+        import cv2
+
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "snap.jpg"
+            try:
+                camera_mod.snap(host, cam.username, cam.password, path)
+            except Exception as exc:  # noqa: BLE001 -- network/camera errors vary
+                raise HTTPException(502, f"Snap failed: {exc}") from exc
+            frame = cv2.imread(str(path), cv2.IMREAD_COLOR)
+        if frame is None:
+            raise HTTPException(502, "the camera returned something that is not a JPEG")
+
+        try:
+            current, factory = camera_mod.get_stitch(host, cam.username, cam.password)
+            scalars = (current.to_api(), factory.to_api())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("STITCH: GetStitch failed: %s", exc)
+            scalars = (None, None)
+
+        del metric
+        return _adopt_frame(
+            frame,
+            camera_name=cam.name,
+            host=host,
+            scalars=scalars,
+            source_path="",
+        )
+
+    @router.post("/stitch/open")
+    def post_open(body: dict = Body(default={})) -> JSONResponse:
+        """Load a frame from a recorded game instead of from the live camera.
+
+        This is the door most calibrations will actually come through. Nobody
+        stands at the touchline with a laptop mid-match, and a camera sitting
+        on a bench indoors is looking at a scene 0.3 m away -- where parallax
+        is tens of pixels and swamps the lens roll this tool exists to correct
+        (see 12.1). A still from the game, at tripod distance and with field
+        lines crossing the seam, is the representative input.
+
+        The consequence for the artifact is that the calibration belongs to a
+        *deployment* -- one tripod placement -- not to the camera for all time.
+        `deployment` is recorded so that stays visible whichever way the
+        per-game question falls.
+        """
+        raw = str(body.get("path") or "").strip()
+        if not raw:
+            raise HTTPException(400, "no path given")
+        source = Path(raw)
+        if not source.is_file():
+            raise HTTPException(404, f"no such file: {source}")
+
+        import cv2
+
+        suffix = source.suffix.lower()
+        if suffix in (".mp4", ".mkv", ".mov", ".dav", ".ts"):
+            frame = _frame_from_video(source, float(body.get("seconds") or 0.0))
+        else:
+            frame = cv2.imread(str(source), cv2.IMREAD_COLOR)
+        if frame is None:
+            raise HTTPException(415, f"could not decode a frame from {source}")
+        if frame.shape[1] < 4 * BLEND_W:
+            raise HTTPException(
+                415,
+                f"{source.name} is {frame.shape[1]} px wide -- too narrow to "
+                "carry a seam with shoulders either side of it",
+            )
+        return _adopt_frame(
+            frame,
+            camera_name=str(body.get("deployment") or source.stem),
+            host=f"file:{source.name}",
+            scalars=(None, None),
+            source_path=str(source),
+        )
+
+    @router.get("/stitch/frames")
+    def get_frames(dir: str = "") -> JSONResponse:  # noqa: A002 -- query name
+        """List candidate frames in a directory, so the operator picks a name
+        rather than typing a path. Read-only, and it only ever lists."""
+        if not dir.strip():
+            raise HTTPException(400, "no directory given")
+        root = Path(dir.strip())
+        if not root.is_dir():
+            raise HTTPException(404, f"no such directory: {root}")
+        exts = {".jpg", ".jpeg", ".png", ".bmp", ".mp4", ".mkv", ".mov", ".dav", ".ts"}
+        try:
+            names = sorted(
+                p.name
+                for p in root.iterdir()
+                if p.suffix.lower() in exts and p.is_file()
+            )
+        except OSError as exc:
+            raise HTTPException(502, f"could not list {root}: {exc}") from exc
+        return JSONResponse({"dir": str(root), "files": names[:500], "n": len(names)})
+
+    @router.get("/stitch/half.jpg")
+    def get_half(side: str = "left", v: int = 0) -> Response:
+        with _session.lock:
+            data = _session.halves.get(side)
+            version = _session.version
+        if data is None:
+            raise HTTPException(404, "no snapshot yet")
+        del v  # cache-buster only; the session always serves its current frame
+        return Response(
+            data,
+            media_type="image/jpeg",
+            headers={"Cache-Control": "no-store", "X-Stitch-Version": str(version)},
+        )
+
+    @router.post("/stitch/measure")
+    def post_measure(body: dict = Body(default={})) -> JSONResponse:
+        """Score a candidate curve against the metric the solver minimises.
+
+        SCR is re-scored from the cached chains, which is exact enough to be
+        the same objective (see tests/test_seam_metric_incremental.py). SSR is
+        recomputed on a genuinely shifted crop, because gradient energy is not
+        recoverable from fitted lines.
+        """
+        anchors = _anchors_from_body(body)
+        metric = load_toolkit()["metric"]
+        if metric is None:
+            raise HTTPException(503, "seam_metric is not importable")
+        with _session.lock:
+            chains, frame = _session.chains, _session.frame
+            width, height = _session.width, _session.height
+            baseline = _session.baseline
+        if chains is None or frame is None:
+            raise HTTPException(409, "no measured snapshot yet")
+
+        seam = width // 2
+        scr = metric.residual_from_chains(chains, anchors)
+        ssr = _ssr_for_anchors(metric, frame, seam, height, anchors)
+        payload = _score_payload(scr, ssr)
+        payload["baseline"] = baseline
+        return JSONResponse(payload)
+
+    @router.post("/stitch/save")
+    def post_save(body: dict = Body(default={})) -> JSONResponse:
+        """Write the calibration artifact. The curve *is* the artifact."""
+        anchors = _anchors_from_body(body)
+        owner = str(body.get("correction_owner") or "downstream")
+        with _session.lock:
+            current, factory = _session.scalars_current, _session.scalars_factory
+            camera_name = _session.camera_name or "camera"
+            validation = {"after": _session.baseline} if _session.baseline else {}
+            # Geometry of the frame this was actually measured on, not a
+            # constant. `build_dx_lookup` rescales anchors by source_width /
+            # source_height, so a profile that lies about its own frame size
+            # applies a proportionally wrong correction and nothing complains.
+            width = _session.width or PANORAMA_W
+            height = _session.height or PANORAMA_H
+            source_path = _session.source_path
+        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        deployment = str(body.get("deployment") or camera_name)
+        try:
+            profile = build_v2_profile(
+                anchors,
+                correction_owner=owner,
+                calibration_id=f"{deployment}-{stamp}",
+                source_width=width,
+                source_height=height,
+                seam_x=width // 2,
+                blend_w=BLEND_W,
+                scalars=current,
+                factory_scalars=factory,
+                validation=validation,
+                calibrated_for={
+                    "subject_distance_m": body.get("subject_distance_m"),
+                    "basis": body.get("basis") or "operator judgement",
+                    "fb_px_m": None,
+                    "residual_px_at": {},
+                },
+                provenance={
+                    "workflow": "operator",
+                    # One tripod placement is one deployment. Whether the seam
+                    # offset is a property of the camera or of the placement is
+                    # an open measurement, so the artifact records which frame
+                    # and which placement it came from either way -- a global
+                    # profile that turns out to be per-deployment is
+                    # recoverable from this; one that recorded nothing is not.
+                    "deployment": deployment,
+                    "source": source_path or f"camera snapshot {stamp}",
+                    "created_utc": datetime.now(UTC).isoformat(),
+                    "tool_version": "stitch_calibration/1",
+                },
+            )
+        except SeamCalibrationError as exc:
+            raise HTTPException(400, str(exc)) from exc
+
+        body_text = json.dumps(profile, indent=2)
+        # Two writes, on purpose. The first is the path the pipeline already
+        # reads (`seam_realign_profile_path`), so a calibration takes effect.
+        # The second is an append-only history keyed by deployment, so if the
+        # seam turns out to differ per tripod placement the evidence is already
+        # collected instead of having been overwritten one calibration at a
+        # time.
+        target = storage / "stitch_profile.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(".json.tmp")
+        tmp.write_text(body_text, encoding="utf-8")
+        tmp.replace(target)
+
+        safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in deployment)
+        archive = storage / "stitch_calibrations" / f"{safe}-{stamp}.json"
+        archive.parent.mkdir(parents=True, exist_ok=True)
+        archive.write_text(body_text, encoding="utf-8")
+
+        logger.info("STITCH: wrote %s and %s (owner=%s)", target, archive, owner)
+        return JSONResponse(
+            {"path": str(target), "archived": str(archive), "profile": profile}
+        )
+
+    @router.post("/stitch/apply")
+    def post_apply(body: dict = Body(default={})) -> JSONResponse:
+        """Send the calibration to the camera, in the one order that is correct.
+
+        Everything about sequencing lives in `apply_calibration`: scalars
+        first, because `SetStitch` re-runs the vendor's mesh optimiser and
+        destroys anything written before it; then a mesh composed onto the
+        baseline those scalars produced, with the baseline re-checked
+        immediately before the write. This endpoint does not reimplement any
+        of that, and deliberately has no path that writes a mesh on its own.
+        """
+        anchors = _anchors_from_body(body)
+        owner = str(body.get("correction_owner") or "downstream")
+        if owner == "downstream":
+            raise HTTPException(
+                400,
+                "correction_owner is 'downstream': that surface is applied by "
+                "the pipeline from the saved profile, and sending it to the "
+                "camera as well is the double-correction. Save, don't apply.",
+            )
+        camera_mod = load_toolkit()["camera"]
+        if camera_mod is None:
+            raise HTTPException(503, "stitch_apply is not importable")
+        cam = _reolink_camera(config_path)
+        with _session.lock:
+            camera_name = _session.camera_name or cam.name
+        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        try:
+            report = camera_mod.apply_calibration(
+                anchors,
+                host=_camera_host(cam),
+                user=cam.username,
+                password=cam.password,
+                scalars=None,
+                calibration_id=f"{camera_name}-{stamp}",
+                dry_run=bool(body.get("dry_run", False)),
+            )
+        except Exception as exc:  # noqa: BLE001 -- report, never half-apply
+            logger.error("STITCH: apply failed: %s", exc)
+            raise HTTPException(502, f"{type(exc).__name__}: {exc}") from exc
+        with _session.lock:
+            _session.last_apply = report
+        return JSONResponse(report)
+
+    return router
+
+
+def _ssr_for_anchors(
+    metric: Any, frame: Any, seam: int, height: int, anchors: list[tuple[float, float]]
+) -> Any:
+    """SSR of the frame as the candidate curve would leave it.
+
+    Computed on a 1280-px crop around the seam rather than the whole panorama:
+    SSR only ever reads the blend window and the two shoulders, so the rest of
+    a 7680-px frame is 200 ms of arithmetic on pixels the metric discards.
+    """
+    import numpy as np
+
+    from video_grouper.utils.stitch_remap import apply_shift_to_frame_rgb
+
+    lo, hi = max(0, seam - STRIP_W), min(frame.shape[1], seam + STRIP_W)
+    crop = np.ascontiguousarray(frame[:, lo:hi])
+    ys = [a[0] for a in anchors]
+    ds = [a[1] for a in anchors]
+    lut = np.round(np.interp(np.arange(height), ys, ds)).astype(np.int32)
+    shifted = apply_shift_to_frame_rgb(crop, lut, seam - lo)
+    return metric.seam_sharpness_ratio(shifted, seam_x=seam - lo, blend_w=2 * BLEND_W)
+
+
+def _state_payload() -> dict:
+    """Caller must hold the session lock."""
+    return {
+        "has_snapshot": _session.frame is not None,
+        "camera": _session.camera_name,
+        "host": _session.host,
+        "source_path": _session.source_path,
+        "version": _session.version,
+        "snapped_at": _session.snapped_at,
+        "width": _session.width,
+        "height": _session.height,
+        "seam_x": _session.width // 2,
+        "strip_w": STRIP_W,
+        "blend_w": BLEND_W,
+        "anchor_rows": list(ANCHOR_ROWS),
+        "scalars": {
+            "current": _session.scalars_current,
+            "factory": _session.scalars_factory,
+        },
+        "metric_state": _session.chains_state,
+        "metric_error": _session.chains_error,
+        "baseline": _session.baseline,
+        "quality": _session.quality,
+        "last_apply": _session.last_apply,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Page
+# ---------------------------------------------------------------------------
+
+
+def _render_page(toolkit: dict) -> str:
+    banner = ""
+    if toolkit["errors"]:
+        items = "".join(f"<li>{e}</li>" for e in toolkit["errors"])
+        banner = (
+            '<div class="flash flash-err"><strong>Calibration toolkit '
+            f"unavailable</strong><ul>{items}</ul></div>"
+        )
+    return _PAGE.replace("__BANNER__", banner)
+
+
+_STYLE = """
+:root {
+  --bg-base:#0a0b0f; --bg-surface:#13141a; --bg-elev:#181a22; --bg-input:#0f1015;
+  --rule:#2a2c34; --rule-strong:#3b3e48; --text:#e6e7ec; --text-mute:#94969f;
+  --text-faint:#5e616b; --accent:#fb923c; --signal-on:#22c55e; --signal-off:#6b7280;
+  --signal-warn:#fbbf24; --signal-bad:#f43f5e;
+  --display:'Barlow Condensed','Bebas Neue',sans-serif;
+  --body:'IBM Plex Sans',system-ui,sans-serif;
+  --mono:'IBM Plex Mono',ui-monospace,monospace;
+}
+* { box-sizing:border-box; }
+body {
+  margin:0; font-family:var(--body); font-size:14px; line-height:1.55;
+  color:var(--text); background:var(--bg-base);
+}
+.topbar { border-bottom:1px solid var(--rule); background:rgba(10,11,15,.72); }
+.topbar-inner {
+  max-width:1400px; margin:0 auto; padding:14px 24px;
+  display:flex; align-items:center; justify-content:space-between;
+}
+.brand {
+  font-family:var(--display); font-weight:700; letter-spacing:.18em;
+  font-size:18px; text-transform:uppercase;
+}
+.brand .dot { color:var(--accent); }
+.crumb {
+  font-family:var(--mono); font-size:11px; letter-spacing:.16em;
+  text-transform:uppercase; color:var(--text-mute);
+}
+.crumb a { color:var(--text-mute); text-decoration:none; }
+.crumb a:hover { color:var(--accent); }
+.shell { max-width:1400px; margin:0 auto; padding:24px 24px 80px; }
+.headline {
+  font-family:var(--display); font-weight:700; text-transform:uppercase;
+  letter-spacing:.04em; font-size:clamp(32px,4vw,48px); line-height:.95; margin:0 0 6px;
+}
+.lede { color:var(--text-mute); max-width:70ch; margin:0 0 20px; }
+h2.sec {
+  font-family:var(--display); font-weight:700; text-transform:uppercase;
+  letter-spacing:.06em; font-size:19px; margin:0 0 12px;
+}
+h2.sec .accent { color:var(--accent); }
+.grid { display:grid; grid-template-columns:minmax(0,1fr) 380px; gap:24px; align-items:start; }
+@media (max-width:1080px) { .grid { grid-template-columns:minmax(0,1fr); } }
+.panel {
+  background:var(--bg-surface); border:1px solid var(--rule);
+  padding:16px 18px; margin-bottom:18px;
+}
+.mono { font-family:var(--mono); font-size:12px; }
+.muted { color:var(--text-mute); }
+.faint { color:var(--text-faint); font-size:12px; }
+.btn {
+  font-family:var(--display); text-transform:uppercase; letter-spacing:.09em;
+  font-weight:600; font-size:14px; padding:8px 16px; cursor:pointer;
+  background:var(--accent); color:#141414; border:0;
+}
+.btn:hover { filter:brightness(1.12); }
+.btn[disabled] { background:var(--rule-strong); color:var(--text-faint); cursor:not-allowed; }
+.btn-ghost { background:transparent; color:var(--accent); border:1px solid var(--accent); }
+.btn-ghost:hover { background:rgba(251,146,60,.12); }
+.btn-danger { background:transparent; color:var(--signal-bad); border:1px solid var(--signal-bad); }
+.btn-row { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
+canvas { display:block; background:#000; image-rendering:pixelated; }
+#viewwrap { border:1px solid var(--rule); position:relative; }
+#view { width:100%; height:auto; cursor:ew-resize; }
+#zoomwrap { border:1px solid var(--rule); margin-top:12px; position:relative; }
+#zoom { width:100%; height:auto; }
+.modes { display:flex; gap:6px; flex-wrap:wrap; margin:12px 0 8px; }
+.modes button {
+  font-family:var(--mono); font-size:11px; letter-spacing:.1em; text-transform:uppercase;
+  padding:6px 11px; background:var(--bg-elev); color:var(--text-mute);
+  border:1px solid var(--rule); cursor:pointer;
+}
+.modes button.on { color:var(--accent); border-color:var(--accent); }
+.caption {
+  font-family:var(--mono); font-size:12px; letter-spacing:.04em;
+  padding:9px 12px; margin-top:10px;
+  border-left:3px solid var(--accent); background:var(--bg-elev); color:var(--text);
+}
+.caveat {
+  font-size:12.5px; padding:10px 12px; margin-top:10px;
+  border-left:3px solid var(--signal-warn); background:rgba(251,191,36,.07);
+  color:var(--text-mute);
+}
+.caveat strong { color:var(--signal-warn); }
+label.row { display:block; margin:14px 0 4px; }
+label.row .lbl {
+  font-family:var(--mono); font-size:11px; letter-spacing:.12em;
+  text-transform:uppercase; color:var(--text-mute);
+  display:flex; justify-content:space-between; align-items:baseline;
+}
+label.row .val { color:var(--accent); font-weight:600; }
+input[type=range] { width:100%; margin:6px 0 0; accent-color:var(--accent); }
+input[type=number], select {
+  background:var(--bg-input); color:var(--text); border:1px solid var(--rule);
+  padding:5px 7px; font-family:var(--mono); font-size:12px; width:100%;
+}
+input[type=number]:focus, select:focus { outline:1px solid var(--accent); border-color:var(--accent); }
+table { border-collapse:collapse; width:100%; font-family:var(--mono); font-size:12px; }
+th, td { padding:5px 7px; border-bottom:1px solid var(--rule); text-align:left; }
+th { color:var(--text-faint); font-weight:600; text-transform:uppercase; letter-spacing:.1em; font-size:10px; }
+td.num { text-align:right; }
+.kpi { display:grid; grid-template-columns:repeat(2,1fr); gap:10px; margin-bottom:8px; }
+.kpi div { background:var(--bg-elev); border:1px solid var(--rule); padding:8px 10px; }
+.kpi .k {
+  font-family:var(--mono); font-size:10px; letter-spacing:.12em;
+  text-transform:uppercase; color:var(--text-faint);
+}
+.kpi .v { font-family:var(--display); font-size:26px; line-height:1.1; }
+.kpi .d { font-family:var(--mono); font-size:11px; }
+.better { color:var(--signal-on); }
+.worse { color:var(--signal-bad); }
+.flat { color:var(--text-faint); }
+.flash { padding:10px 14px; margin:0 0 16px; border-left:3px solid var(--signal-bad);
+  background:rgba(244,63,94,.08); font-size:13px; }
+.flash ul { margin:6px 0 0 16px; padding:0; }
+.flash-ok { border-left-color:var(--signal-on); background:rgba(34,197,94,.08); }
+.dot { display:inline-block; width:8px; height:8px; border-radius:50%; margin-right:6px; }
+.dot.on { background:var(--signal-on); } .dot.off { background:var(--signal-off); }
+.dot.warn { background:var(--signal-warn); } .dot.bad { background:var(--signal-bad); }
+.locked { color:var(--text-faint); }
+"""
+
+
+_SCRIPT = r"""
+'use strict';
+// ---------------------------------------------------------------------------
+// Model. The anchor curve is the ONLY authored state: the translate and roll
+// sliders are a decomposition of it (mean, best-fit ramp), recomputed whenever
+// the curve changes by any route. Nothing the operator can move exists outside
+// the artifact.
+// ---------------------------------------------------------------------------
+var S = {
+  st: null, anchors: [], surface: 'camera_mesh', mode: 'blink',
+  imgs: {}, blink: 0, cursorRow: 1080, dragging: null, ready: false,
+  metrics: null, baseline: null, busy: false, pending: false
+};
+// Geometry is taken from the frame the server actually fetched, never assumed.
+// These are only the pre-snapshot defaults.
+var H = 2160, STRIP = 640, BLENDH = 128, ZOOM = 4, ZOOM_ROWS = 400;
+
+function $(id) { return document.getElementById(id); }
+function fmt(v, d) { return (v === null || v === undefined || isNaN(v)) ? '--' : v.toFixed(d === undefined ? 2 : d); }
+
+function dxAt(y) {
+  var A = S.anchors;
+  if (!A.length) return 0;
+  if (y <= A[0][0]) return A[0][1];
+  if (y >= A[A.length - 1][0]) return A[A.length - 1][1];
+  for (var i = 1; i < A.length; i++) {
+    if (y <= A[i][0]) {
+      var y0 = A[i - 1][0], d0 = A[i - 1][1], y1 = A[i][0], d1 = A[i][1];
+      return y1 === y0 ? d1 : d0 + (d1 - d0) * (y - y0) / (y1 - y0);
+    }
+  }
+  return A[A.length - 1][1];
+}
+
+// Piecewise-linear segments of the curve, as (y0, y1, slope, intercept). A
+// linear-in-y horizontal offset is exactly a canvas shear, so each segment is
+// one GPU-composited draw call instead of 2160 per-row blits.
+function bands() {
+  var A = S.anchors, out = [];
+  if (A[0][0] > 0) out.push([0, A[0][0], 0, A[0][1]]);
+  for (var i = 0; i < A.length - 1; i++) {
+    var y0 = A[i][0], d0 = A[i][1], y1 = A[i + 1][0], d1 = A[i + 1][1];
+    var a = (y1 === y0) ? 0 : (d1 - d0) / (y1 - y0);
+    out.push([y0, y1, a, d0 - a * y0]);
+  }
+  var last = A[A.length - 1];
+  if (last[0] < H) out.push([last[0], H, 0, last[1]]);
+  return out;
+}
+
+// Which half the operator sees move. The camera can only warp the LEFT half;
+// the downstream corrector only rolls the RIGHT half. Same stored dx either
+// way -- the relative registration is identical, so the picture is too.
+function movingSide() { return S.surface === 'downstream' ? 'right' : 'left'; }
+function signFor(side) {
+  // dx is "px the RIGHT half must move right". The left half realises the same
+  // relative displacement by moving LEFT, hence the negation.
+  if (side !== movingSide()) return 0;
+  return side === 'right' ? 1 : -1;
+}
+
+// ---------------------------------------------------------------------------
+// Drawing
+// ---------------------------------------------------------------------------
+function View(canvas, ox, oy, sx, sy) {
+  this.c = canvas; this.ctx = canvas.getContext('2d');
+  this.ox = ox; this.oy = oy; this.sx = sx; this.sy = sy;
+}
+// Draw one half, sheared by its share of the curve. `emit` issues the actual
+// drawImage under the transform so the same shear serves the strip, the
+// stretched shoulder extrapolation, and the mirrored overlay alike.
+View.prototype.half = function (side, emit, opt) {
+  opt = opt || {};
+  var img = S.imgs[side]; if (!img) return;
+  var ctx = this.ctx, sgn = signFor(side);
+  var base = side === 'left' ? 0 : STRIP;   // strip-space x of this half
+  var bs = bands(), mir = !!opt.mirror;
+  ctx.save();
+  ctx.globalAlpha = opt.alpha === undefined ? 1 : opt.alpha;
+  for (var i = 0; i < bs.length; i++) {
+    var y0 = bs[i][0], y1 = bs[i][1], a = bs[i][2], b = bs[i][3];
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.beginPath();
+    ctx.rect(0, (y0 - this.oy) * this.sy, this.c.width, (y1 - y0) * this.sy);
+    ctx.clip();
+    // source (x,y) -> strip x = base + x + sgn*(a*y+b); mirror reflects about
+    // the seam at strip x = STRIP.
+    var m11 = this.sx, m21 = this.sx * sgn * a, tx = this.sx * (base + sgn * b);
+    if (mir) { m11 = -this.sx; m21 = -this.sx * sgn * a; tx = this.sx * (2 * STRIP - base - sgn * b); }
+    ctx.setTransform(m11, 0, m21, this.sy, tx - this.sx * this.ox, -this.sy * this.oy);
+    emit(ctx, img);
+    ctx.restore(); ctx.save();
+    ctx.globalAlpha = opt.alpha === undefined ? 1 : opt.alpha;
+  }
+  ctx.restore();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+};
+// The half at its true position.
+function emitStrip(ctx, img) { ctx.drawImage(img, 0, 0); }
+// The two extrapolated shoulders, drawn as the lines they actually are.
+//
+// The blend window's pixels are a mixture of both sensors, so there is no
+// second layer to reveal there and no honest way to paint one. What the metric
+// does instead is fit each structure independently on the two shoulders and
+// extrapolate both to the seam column -- so drawing those extrapolations is
+// both the most sensitive comparator available and exactly the evidence the
+// score is computed from. A gap between a red line and its cyan partner at the
+// seam IS that structure's residual, to sub-pixel precision, and no smear of
+// replicated columns comes close to showing it that clearly.
+function drawShoulders(view, which) {
+  var obs = (S.metrics && S.metrics.observations) || [];
+  if (!obs.length) return;
+  var ctx = view.ctx;
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.lineWidth = Math.max(1, view.sy * 1.5);
+  var seam = STRIP, reach = BLENDH * 2;
+  for (var i = 0; i < obs.length; i++) {
+    var o = obs[i];
+    // slope is dy/dx in source px; the view scales the axes differently, so
+    // the drawn slope has to be scaled too or the lines would lie.
+    [['left', o.y_left, '#ff5a5a'], ['right', o.y_right, '#48e0ff']].forEach(function (t) {
+      if (which && which !== t[0]) return;
+      var side = t[0], yAt = t[1];
+      var x0 = side === 'left' ? seam - reach : seam;
+      var x1 = side === 'left' ? seam : seam + reach;
+      var X = function (x) { return (x - view.ox) * view.sx; };
+      var Y = function (x) { return (yAt + o.slope * (x - seam) - view.oy) * view.sy; };
+      ctx.strokeStyle = t[2];
+      ctx.globalAlpha = 0.9;
+      ctx.beginPath(); ctx.moveTo(X(x0), Y(x0)); ctx.lineTo(X(x1), Y(x1)); ctx.stroke();
+      // dashed continuation across the window: this part is extrapolation.
+      ctx.setLineDash([4, 4]); ctx.globalAlpha = 0.55;
+      var x2 = side === 'left' ? seam + reach : seam - reach;
+      ctx.beginPath(); ctx.moveTo(X(x1 === seam ? seam : seam), Y(seam));
+      ctx.lineTo(X(x2), Y(x2)); ctx.stroke();
+      ctx.setLineDash([]);
+    });
+  }
+  ctx.globalAlpha = 1;
+}
+
+function paint(view, grid) {
+  var ctx = view.ctx;
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, view.c.width, view.c.height);
+  ctx.fillStyle = '#000'; ctx.fillRect(0, 0, view.c.width, view.c.height);
+  if (!S.imgs.left || !S.imgs.right) return;
+
+  // Both halves are always drawn at their true positions. Only the 256-px
+  // blend window changes between views -- blanking a whole half would be a
+  // flash, and what a blink has to reveal is a few pixels of jump.
+  view.half('left', emitStrip, {});
+  view.half('right', emitStrip, {});
+
+  if (S.mode === 'anaglyph') {
+    drawShoulders(view, null);            // both at once; they meet or they don't
+  } else if (S.mode === 'mirror') {
+    view.half('right', emitStrip, { mirror: true, alpha: 0.5 });
+  } else if (S.mode === 'blink') {
+    drawShoulders(view, S.blink ? 'right' : 'left');
+  }
+
+  // seam + blend window
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  var sxOf = function (x) { return (x - view.ox) * view.sx; };
+  ctx.fillStyle = 'rgba(251,146,60,.10)';
+  ctx.fillRect(sxOf(STRIP - BLENDH), 0, 2 * BLENDH * view.sx, view.c.height);
+  ctx.strokeStyle = 'rgba(251,146,60,.85)'; ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.moveTo(sxOf(STRIP) + .5, 0); ctx.lineTo(sxOf(STRIP) + .5, view.c.height); ctx.stroke();
+
+  if (grid) {
+    ctx.strokeStyle = 'rgba(255,255,255,.13)';
+    for (var x = STRIP - BLENDH; x <= STRIP + BLENDH; x++) {
+      var px = Math.round(sxOf(x)) + .5;
+      ctx.beginPath(); ctx.moveTo(px, 0); ctx.lineTo(px, view.c.height); ctx.stroke();
+    }
+  }
+  // the locked half is dimmed, always, so the hardware constraint is visible
+  var lockedLeft = movingSide() === 'right';
+  ctx.fillStyle = 'rgba(0,0,0,.42)';
+  ctx.fillRect(lockedLeft ? 0 : sxOf(STRIP), 0,
+    lockedLeft ? sxOf(STRIP) : view.c.width - sxOf(STRIP), view.c.height);
+  // row cursor
+  ctx.strokeStyle = 'rgba(34,197,94,.8)';
+  var cy = (S.cursorRow - view.oy) * view.sy;
+  ctx.beginPath(); ctx.moveTo(0, cy); ctx.lineTo(view.c.width, cy); ctx.stroke();
+}
+
+function draw() {
+  var v = $('view'), z = $('zoom');
+  var dpr = Math.min(window.devicePixelRatio || 1, 2);
+  var cssW = v.clientWidth || 900;
+  v.width = Math.round(cssW * dpr); v.height = Math.round(660 * dpr);
+  v.style.height = '660px';
+  paint(new View(v, 0, 0, v.width / (2 * STRIP), v.height / H), false);
+
+  var zw = z.clientWidth || 900;
+  z.width = Math.round(zw * dpr);
+  var zs = z.width / (2 * BLENDH * ZOOM);          // display px per (source px * ZOOM)
+  var scale = zs * ZOOM;                            // display px per source px
+  z.height = Math.round(ZOOM_ROWS * scale);
+  z.style.height = Math.round(z.height / dpr) + 'px';
+  var top = Math.max(0, Math.min(H - ZOOM_ROWS, S.cursorRow - ZOOM_ROWS / 2));
+  paint(new View(z, STRIP - BLENDH, top, scale, scale), true);
+  $('zoomlabel').textContent = 'rows ' + Math.round(top) + '-' + Math.round(top + ZOOM_ROWS)
+    + ' @ ' + ZOOM + 'x, true aspect';
+  $('viewscale').textContent = (v.width / dpr / (2 * STRIP)).toFixed(2);
+}
+
+// ---------------------------------------------------------------------------
+// Curve editing
+// ---------------------------------------------------------------------------
+function setAnchors(a, why) {
+  S.anchors = a.map(function (p) { return [p[0], Math.max(-64, Math.min(64, p[1]))]; });
+  syncControls(); draw(); scheduleMeasure();
+  if (why) $('curvewhy').textContent = why;
+}
+function meanDx() {
+  var s = 0; for (var i = 0; i < S.anchors.length; i++) s += S.anchors[i][1];
+  return s / S.anchors.length;
+}
+// Best-fit ramp, expressed as the top-to-bottom amplitude. This is a *view* of
+// the curve, recomputed from it after every edit -- never a stored parameter.
+function rollAmp() {
+  var n = S.anchors.length, sy = 0, syy = 0, sd = 0, syd = 0;
+  for (var i = 0; i < n; i++) {
+    var y = S.anchors[i][0], d = S.anchors[i][1];
+    sy += y; syy += y * y; sd += d; syd += y * d;
+  }
+  var den = n * syy - sy * sy;
+  if (!den) return 0;
+  return ((n * syd - sy * sd) / den) * (H - 1);
+}
+function syncControls() {
+  var t = meanDx(), r = rollAmp();
+  $('translate').value = t.toFixed(2); $('translateV').textContent = fmt(t) + ' px';
+  $('roll').value = r.toFixed(2); $('rollV').textContent = fmt(r) + ' px top-to-bottom';
+  var rows = S.st ? S.st.anchor_rows : [0, 540, 1080, 1620, 2159];
+  var html = '';
+  for (var i = 0; i < S.anchors.length; i++) {
+    html += '<tr><td class="muted">y ' + S.anchors[i][0] + '</td><td>'
+      + '<input type="number" step="0.25" data-i="' + i + '" class="anch" value="'
+      + S.anchors[i][1].toFixed(2) + '"></td></tr>';
+  }
+  $('curverows').innerHTML = html;
+  var els = document.querySelectorAll('.anch');
+  for (var j = 0; j < els.length; j++) {
+    els[j].addEventListener('change', function (e) {
+      var i = +e.target.getAttribute('data-i');
+      var a = S.anchors.slice(); a[i] = [a[i][0], parseFloat(e.target.value) || 0];
+      setAnchors(a, 'anchor ' + i + ' set by hand');
+    });
+  }
+  $('curvejson').textContent = JSON.stringify(
+    S.anchors.map(function (p) { return [p[0], Math.round(p[1] * 1000) / 1000]; }));
+  void rows;
+}
+
+function nudge(delta) {
+  setAnchors(S.anchors.map(function (p) { return [p[0], p[1] + delta]; }),
+    'translate ' + (delta > 0 ? '+' : '') + delta.toFixed(2) + ' px');
+}
+function setRoll(amp) {
+  var cur = rollAmp(), d = amp - cur, mid = (H - 1) / 2;
+  setAnchors(S.anchors.map(function (p) {
+    return [p[0], p[1] + d * (p[0] - mid) / (H - 1)];
+  }), 'roll set to ' + fmt(amp) + ' px top-to-bottom');
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+var measureTimer = null;
+function scheduleMeasure() {
+  if (measureTimer) clearTimeout(measureTimer);
+  measureTimer = setTimeout(measure, 160);
+}
+function measure() {
+  if (!S.ready) return;
+  if (S.busy) { S.pending = true; return; }
+  S.busy = true; $('metricstate').textContent = 'scoring...';
+  fetch('/stitch/measure', {
+    method: 'POST', credentials: 'same-origin',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ dx_anchors: S.anchors })
+  }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      S.busy = false;
+      if (!res.ok) { $('metricstate').textContent = res.j.detail || 'scoring failed'; return; }
+      S.metrics = res.j; S.baseline = res.j.baseline || S.baseline;
+      renderMetrics(); $('metricstate').textContent = '';
+      if (S.pending) { S.pending = false; measure(); }
+    }).catch(function (e) { S.busy = false; $('metricstate').textContent = String(e); });
+}
+function delta(now, before, unit) {
+  if (now === null || before === null || now === undefined || before === undefined) return '';
+  var d = now - before;
+  var cls = Math.abs(d) < 1e-6 ? 'flat' : (d < 0 ? 'better' : 'worse');
+  return '<span class="' + cls + '">' + (d >= 0 ? '+' : '') + d.toFixed(2) + ' ' + unit + '</span>';
+}
+// Whether this frame can constrain the calibration at all, stated before any
+// number is. Real tripod frames routinely produce a large SCR that barely
+// responds to dx -- unrelated edges paired across the seam -- and every
+// coverage gate passes while it happens. A precise-looking number on a frame
+// that cannot steer is worse than no number.
+function renderQuality(q) {
+  var el = $('quality');
+  if (!q) { el.style.display = 'none'; return; }
+  el.style.display = '';
+  S.quality = q;
+  if (q.usable) {
+    el.className = 'caption';
+    el.innerHTML = '<b>This frame can steer the calibration.</b> ' + q.reason
+      + '. Drag until SCR p90 stops falling.';
+  } else {
+    el.className = 'caveat';
+    el.innerHTML = '<strong>This frame cannot steer the calibration.</strong> ' + q.reason
+      + '. Read SCR here as a bound, not as the seam offset, and do not trust a curve '
+      + 'tuned against it &mdash; find a frame with a clear structure crossing the seam '
+      + '(a field line, a goal frame, a fence) at roughly the depth you care about.';
+  }
+  $('suggest').disabled = (q.best_dx === null || q.best_dx === undefined);
+}
+
+function renderMetrics() {
+  var m = S.metrics, b = S.baseline;
+  if (!m) return;
+  var scr = m.scr, ssr = m.ssr;
+  $('scrn').textContent = scr.n;
+  if (!scr.n) {
+    $('scrp50').textContent = '--'; $('scrp90').textContent = '--';
+    $('scrnote').textContent =
+      'No structure crosses the seam in this frame. That is the expected case '
+      + 'mid-field: point the camera at something with lines through the seam, '
+      + 'or walk a high-contrast edge across it, then re-snap.';
+  } else {
+    $('scrp50').textContent = fmt(scr.p50);
+    $('scrp90').textContent = fmt(scr.p90);
+    $('scrnote').innerHTML =
+      'p50 ' + delta(scr.p50, b && b.scr ? b.scr.p50 : null, 'px')
+      + ' &middot; p90 ' + delta(scr.p90, b && b.scr ? b.scr.p90 : null, 'px')
+      + ' &middot; ' + scr.row_bands_covered + '/3 row bands, '
+      + Math.round(scr.height_coverage * 100) + '% height'
+      // Only offered when the frame was shown to respond to the curve at all.
+      // `implied_dx` is a regression that returns confident nonsense on a
+      // contaminated observation set -- it read -17, +159 and -7 px on three
+      // real frames whose seams were all fine.
+      + (S.quality && !S.quality.usable ? ''
+        : scr.suggested_dx === null ? ''
+          : ' &middot; measurement suggests dx &asymp; <b>' + fmt(scr.suggested_dx) + ' px</b>');
+  }
+  $('ssrv').textContent = fmt(ssr.abs_ln_ssr, 3);
+  $('ssrnote').innerHTML =
+    delta(ssr.abs_ln_ssr, b && b.ssr ? b.ssr.abs_ln_ssr : null, '')
+    + ' &middot; noise floor ' + ssr.noise_floor.toFixed(2)
+    + ' &mdash; a post-fusion shift cannot move this; only a camera-side '
+    + 'correction applied before the blend can, and that shows up after Apply.';
+  if (!S.quality) {
+    $('suggest').disabled = (scr.suggested_dx === null || scr.suggested_dx === undefined);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+function applyState(st) {
+  S.st = st;
+  if (st.height) {
+    H = st.height; STRIP = st.strip_w; BLENDH = st.blend_w;
+    ZOOM_ROWS = Math.min(400, H);
+    if (st.anchor_rows && st.anchor_rows.length && !S.anchorsPinned) {
+      var rows = st.anchor_rows.filter(function (r) { return r < H; });
+      if (rows[rows.length - 1] !== H - 1) rows.push(H - 1);
+      S.anchors = rows.map(function (r) { return [r, dxAt(r)]; });
+      S.anchorsPinned = true;
+      syncControls();
+    }
+    S.cursorRow = Math.min(S.cursorRow, H - 1);
+  }
+  $('camname').textContent = st.camera || '--';
+  $('camhost').textContent = st.host || '--';
+  var sc = st.scalars || {};
+  renderScalars(sc.current, sc.factory);
+  var ms = st.metric_state;
+  var dot = ms === 'ready' ? 'on' : (ms === 'running' ? 'warn' : (ms === 'failed' ? 'bad' : 'off'));
+  $('metricdot').className = 'dot ' + dot;
+  $('metriclabel').textContent =
+    ms === 'ready' ? 'chains detected; scoring is live'
+      : ms === 'running' ? 'detecting structures and sweeping dx (25-60 s at 7680x2160)...'
+        : ms === 'failed' ? ('detection failed: ' + (st.metric_error || '?'))
+          : 'no snapshot yet';
+  renderQuality(st.quality);
+  if (st.baseline) { S.baseline = st.baseline; S.metrics = S.metrics || st.baseline; renderMetrics(); }
+  S.ready = (ms === 'ready');
+  if (ms === 'running') setTimeout(pollState, 1500);
+  $('apply').disabled = !st.has_snapshot;
+  $('save').disabled = !st.has_snapshot;
+}
+function pollState() {
+  fetch('/stitch/state', { credentials: 'same-origin' })
+    .then(function (r) { return r.json(); })
+    .then(function (st) { applyState(st); if (st.metric_state === 'ready') measure(); });
+}
+function renderScalars(cur, fac) {
+  var t = $('scalars');
+  if (!cur) { t.innerHTML = '<tr><td class="muted">not read</td></tr>'; return; }
+  var keys = ['distance', 'stitchXMove', 'stitchYMove'], html = '', same = true;
+  for (var i = 0; i < keys.length; i++) {
+    var k = keys[i], c = cur[k], f = fac ? fac[k] : null;
+    if (f !== null && c !== f) same = false;
+    html += '<tr><td>' + k + '</td><td class="num">' + c + '</td><td class="num '
+      + (f !== null && c !== f ? 'worse' : 'muted') + '">' + (f === null ? '--' : f) + '</td></tr>';
+  }
+  t.innerHTML = html;
+  $('scalarnote').textContent = same
+    ? 'Live values match the factory block: the camera is at its own auto-adjustment, '
+    + 'and nothing here has moved it. Accepting that is a real choice -- if the seam '
+    + 'measures well, confirm it and calibrate only the residual shear.'
+    : 'Live values differ from the factory block: someone has already overridden the '
+    + 'auto-adjustment. The factory column is recoverable from the camera itself.';
+}
+
+function snap() {
+  $('snap').disabled = true; $('snapstate').textContent = 'fetching 7680x2160 still...';
+  fetch('/stitch/snap', { method: 'POST', credentials: 'same-origin' })
+    .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      $('snap').disabled = false;
+      if (!res.ok) { $('snapstate').textContent = res.j.detail || 'snapshot failed'; return; }
+      $('snapstate').textContent = 'live snapshot ' + new Date().toLocaleTimeString();
+      loadFrame(res.j);
+    }).catch(function (e) { $('snap').disabled = false; $('snapstate').textContent = String(e); });
+}
+
+function loadFrame(res) {
+  var v = res.version, n = 0;
+  ['left', 'right'].forEach(function (side) {
+    var im = new Image();
+    im.onload = function () { S.imgs[side] = im; if (++n === 2) draw(); };
+    im.src = '/stitch/half.jpg?side=' + side + '&v=' + v;
+  });
+  applyState(res);
+}
+
+function browse() {
+  var d = $('framedir').value.trim();
+  if (!d) return;
+  $('openstate').textContent = 'listing...';
+  fetch('/stitch/frames?dir=' + encodeURIComponent(d), { credentials: 'same-origin' })
+    .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      if (!res.ok) { $('openstate').textContent = res.j.detail || 'listing failed'; return; }
+      var sel = $('framelist'); sel.innerHTML = '';
+      res.j.files.forEach(function (f) {
+        var o = document.createElement('option'); o.value = f; o.textContent = f; sel.appendChild(o);
+      });
+      $('openstate').textContent = res.j.n + ' file(s)';
+    });
+}
+
+function openFrame() {
+  var d = $('framedir').value.trim(), f = $('framelist').value;
+  if (!d || !f) { $('openstate').textContent = 'pick a folder and a file first'; return; }
+  var sep = d.indexOf('\\') >= 0 ? '\\' : '/';
+  $('openstate').textContent = 'decoding...';
+  fetch('/stitch/open', {
+    method: 'POST', credentials: 'same-origin',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      path: d.replace(/[\\/]+$/, '') + sep + f,
+      seconds: parseFloat($('atsec').value) || 0,
+      deployment: $('deployment').value.trim() || null
+    })
+  }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      if (!res.ok) { $('openstate').textContent = res.j.detail || 'open failed'; return; }
+      $('openstate').textContent = 'loaded ' + f;
+      $('snapstate').textContent = 'frame from file';
+      loadFrame(res.j);
+    }).catch(function (e) { $('openstate').textContent = String(e); });
+}
+
+function save() {
+  fetch('/stitch/save', {
+    method: 'POST', credentials: 'same-origin',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      dx_anchors: S.anchors,
+      correction_owner: $('owner').value,
+      deployment: $('deployment').value.trim() || null,
+      subject_distance_m: parseFloat($('distance_m').value) || null,
+      basis: $('basis').value || null
+    })
+  }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      $('savestate').innerHTML = res.ok
+        ? '<span class="better">written to ' + res.j.path + '</span>'
+        : '<span class="worse">' + (res.j.detail || 'save failed') + '</span>';
+    });
+}
+
+function applyToCamera(dry) {
+  if (!dry && !window.confirm(
+    'This writes to the camera: vendor scalars first, then a warp mesh composed '
+    + 'onto the baseline they produce. Continue?')) return;
+  $('applystate').textContent = dry ? 'dry run...' : 'applying (this takes ~1 min)...';
+  fetch('/stitch/apply', {
+    method: 'POST', credentials: 'same-origin',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      dx_anchors: S.anchors, correction_owner: $('owner').value, dry_run: !!dry
+    })
+  }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      $('applystate').innerHTML = res.ok ? '<span class="better">done</span>'
+        : '<span class="worse">' + (res.j.detail || 'apply failed') + '</span>';
+      $('applyreport').textContent = JSON.stringify(res.j, null, 2);
+      if (res.ok && !dry) snap();   // re-score against a fresh frame, not a promise
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Wiring
+// ---------------------------------------------------------------------------
+function surfaceChanged() {
+  S.surface = $('owner').value === 'downstream' ? 'downstream'
+    : ($('owner').value === 'camera_mesh' ? 'camera_mesh' : 'downstream');
+  var moving = movingSide();
+  $('caption').innerHTML = moving === 'left'
+    ? 'You are moving the <b>LEFT</b> image relative to the right. '
+    + 'The camera can only move the left: the warp mesh lives in VPE&nbsp;0, and a '
+    + 'measured +40&nbsp;px request moved the left half 40.1-40.9&nbsp;px while the '
+    + 'right half moved 0.02&nbsp;px.'
+    : 'You are moving the <b>RIGHT</b> image relative to the left, because the '
+    + 'downstream corrector rolls the right half. The stored curve is unchanged &mdash; '
+    + 'only which half you see move, and the direction it moves, have flipped.';
+  $('applywrap').style.display = $('owner').value === 'downstream' ? 'none' : '';
+  draw();
+}
+
+function onViewDrag(ev, canvas, view) {
+  var rect = canvas.getBoundingClientRect();
+  var y = (ev.clientY - rect.top) / rect.height * (view.rows) + view.top;
+  S.cursorRow = Math.max(0, Math.min(H - 1, y));
+  if (S.dragging === null) return;
+  var dxPx = (ev.clientX - S.dragging.x0) / rect.width * (view.cols);
+  var sgn = signFor(movingSide());
+  var target = S.dragging.base + dxPx * (sgn === 0 ? 1 : sgn);
+  // The nearest anchor follows the grab; the rest of the curve is untouched.
+  var i = S.dragging.i, a = S.anchors.slice();
+  a[i] = [a[i][0], target];
+  setAnchors(a, 'anchor at y=' + a[i][0] + ' grabbed directly');
+}
+function nearestAnchor(row) {
+  var best = 0, bd = 1e9;
+  for (var i = 0; i < S.anchors.length; i++) {
+    var d = Math.abs(S.anchors[i][0] - row);
+    if (d < bd) { bd = d; best = i; }
+  }
+  return best;
+}
+
+function init() {
+  S.anchors = [[0, 0], [540, 0], [1080, 0], [1620, 0], [2159, 0]];
+  syncControls();
+  $('snap').addEventListener('click', snap);
+  $('browse').addEventListener('click', browse);
+  $('open').addEventListener('click', openFrame);
+  $('save').addEventListener('click', save);
+  $('apply').addEventListener('click', function () { applyToCamera(false); });
+  $('dryrun').addEventListener('click', function () { applyToCamera(true); });
+  $('reset').addEventListener('click', function () {
+    setAnchors(S.anchors.map(function (p) { return [p[0], 0]; }), 'curve reset to zero');
+  });
+  $('suggest').addEventListener('click', function () {
+    // The swept minimum, not `implied_dx`. The sweep descends the objective
+    // itself; the regression behind `implied_dx` returned -17, +159 and -7 px
+    // on three real frames whose seams were all visibly fine.
+    var q = S.quality;
+    var s = (q && q.best_dx !== null && q.best_dx !== undefined) ? q.best_dx
+      : (S.metrics && S.metrics.scr ? S.metrics.scr.suggested_dx : null);
+    if (s === null || s === undefined) return;
+    setAnchors(S.anchors.map(function (p) { return [p[0], s]; }),
+      'set to the swept minimum, dx=' + s + ' px');
+  });
+  $('owner').addEventListener('change', surfaceChanged);
+  $('translate').addEventListener('input', function (e) { nudge(parseFloat(e.target.value) - meanDx()); });
+  $('roll').addEventListener('input', function (e) { setRoll(parseFloat(e.target.value)); });
+  var modes = document.querySelectorAll('.modes button');
+  for (var i = 0; i < modes.length; i++) {
+    modes[i].addEventListener('click', function (e) {
+      S.mode = e.target.getAttribute('data-mode');
+      for (var k = 0; k < modes.length; k++) modes[k].classList.remove('on');
+      e.target.classList.add('on');
+      draw();
+    });
+  }
+  ['view', 'zoom'].forEach(function (id) {
+    var c = $(id);
+    var geom = function () {
+      return id === 'view'
+        ? { cols: 2 * STRIP, rows: H, top: 0, left: 0 }
+        : {
+          cols: 2 * BLENDH, rows: ZOOM_ROWS, left: STRIP - BLENDH,
+          top: Math.max(0, Math.min(H - ZOOM_ROWS, S.cursorRow - ZOOM_ROWS / 2))
+        };
+    };
+    c.addEventListener('mousedown', function (ev) {
+      var g = geom(), rect = c.getBoundingClientRect();
+      var row = (ev.clientY - rect.top) / rect.height * g.rows + g.top;
+      S.cursorRow = row;
+      // A grab only starts on the half that can actually move. The other one
+      // is drawn dimmed and labelled locked, and letting it be dragged anyway
+      // would make "locked" a decoration rather than a statement about the
+      // hardware.
+      var srcX = (ev.clientX - rect.left) / rect.width * g.cols + (g.left || 0);
+      var onMoving = (srcX < STRIP) === (movingSide() === 'left');
+      if (!onMoving) {
+        $('curvewhy').textContent =
+          'That half is locked. ' + (movingSide() === 'left'
+            ? 'The camera can only warp the left half -- drag that one.'
+            : 'The downstream corrector only rolls the right half -- drag that one.');
+        draw(); return;
+      }
+      var i = nearestAnchor(row);
+      S.dragging = { x0: ev.clientX, base: S.anchors[i][1], i: i };
+      draw();
+    });
+    c.addEventListener('mousemove', function (ev) { onViewDrag(ev, c, geom()); });
+    window.addEventListener('mouseup', function () { S.dragging = null; });
+  });
+  document.addEventListener('keydown', function (ev) {
+    var step = ev.shiftKey ? 1 : 0.25;
+    if (ev.key === 'ArrowLeft') { nudge(-step); ev.preventDefault(); }
+    if (ev.key === 'ArrowRight') { nudge(step); ev.preventDefault(); }
+  });
+  setInterval(function () { if (S.mode === 'blink') { S.blink ^= 1; draw(); } }, 250);
+  window.addEventListener('resize', draw);
+  surfaceChanged();
+  pollState();
+}
+document.addEventListener('DOMContentLoaded', init);
+"""
+
+
+_PAGE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Soccer-Cam &middot; Seam Calibration</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<style>__STYLE__</style>
+</head>
+<body>
+<div class="topbar"><div class="topbar-inner">
+<div class="brand">SOCCER<span class="dot">&middot;</span>CAM</div>
+<div class="crumb"><a href="/">Dashboard</a> / <a href="/config">Config</a> / Seam calibration</div>
+</div></div>
+
+<div class="shell">
+<h1 class="headline">Stitch seam calibration</h1>
+<p class="lede">Pull a still off the camera, slide the halves into registration by eye, and
+send the geometry back. The curve you author below <em>is</em> the calibration artifact &mdash;
+there is no separate export, and nothing you can move here exists outside it.</p>
+
+__BANNER__
+
+<div class="panel">
+  <div class="btn-row">
+    <button class="btn" id="snap">Fetch live snapshot</button>
+    <span class="mono muted" id="snapstate">no frame loaded</span>
+    <span style="flex:1"></span>
+    <span class="mono faint">source <b id="camname">--</b> &middot; <b id="camhost">--</b></span>
+  </div>
+  <p class="faint">Two doors into the same editor. A live <span class="mono">Snap</span> is
+    right when the camera is already looking at the field; most calibrations will come from a
+    recorded game instead, because nobody stands at the touchline with a laptop mid-match and a
+    camera on a bench indoors is looking at a scene 0.3&nbsp;m away &mdash; where parallax runs to
+    tens of pixels and drowns the lens roll this tool corrects.</p>
+  <div class="btn-row" style="margin-top:8px">
+    <input type="text" id="framedir" placeholder="folder of frames or recordings"
+      style="flex:2;min-width:240px">
+    <button class="btn btn-ghost" id="browse">List</button>
+    <select id="framelist" style="flex:2;min-width:200px"></select>
+    <input type="number" id="atsec" placeholder="sec" step="1" style="width:80px" title="seconds into a video file">
+    <button class="btn" id="open">Open frame</button>
+  </div>
+  <div class="btn-row" style="margin-top:8px">
+    <input type="text" id="deployment" placeholder="deployment / tripod placement label"
+      style="flex:1;min-width:240px">
+    <span class="mono faint" id="openstate"></span>
+  </div>
+  <p class="faint">A calibration belongs to a camera <em>and where it was standing</em>. Whether
+    the seam offset actually differs between tripod placements is still being measured, so every
+    save is also filed under this label in
+    <span class="mono">stitch_calibrations/</span> &mdash; if it turns out to be per-deployment,
+    the evidence is already there instead of having been overwritten.</p>
+</div>
+
+<div class="grid">
+<div>
+  <div class="panel">
+    <h2 class="sec">Seam <span class="accent">view</span></h2>
+    <div class="modes">
+      <button data-mode="blink" class="on">Blink 2Hz</button>
+      <button data-mode="anaglyph">Anaglyph</button>
+      <button data-mode="mirror">Mirror</button>
+      <button data-mode="split">Plain</button>
+    </div>
+    <div id="viewwrap"><canvas id="view"></canvas></div>
+    <p class="faint mono">Full height, horizontal <b id="viewscale">1.00</b>&times; and vertical
+      0.31&times; &mdash; deliberately anisotropic: what you are judging is horizontal, and
+      squashing the rows keeps all 2160 of them on screen without shrinking a 4&nbsp;px error
+      to nothing. Drag anywhere to grab the nearest anchor; arrow keys nudge (shift = 1&nbsp;px).</p>
+    <div class="caption" id="caption"></div>
+    <div class="caveat"><strong>What these views can and cannot show.</strong>
+      The camera fuses the two sensors before it hands out a JPEG, blending them over the
+      256&nbsp;px window shaded above. Every pixel in there is already a mixture of both, so
+      there is no second layer to reveal and no honest way to paint one. Blink and anaglyph
+      therefore draw the <em>fitted</em> structures instead: each one measured independently on
+      the left shoulder (red) and the right shoulder (cyan) and extrapolated to the seam, solid
+      where there is real image behind it and dashed where it is extrapolation. A gap between a
+      red line and its cyan partner at the seam is that structure's residual. The shoulders
+      either side of the window are real; the window is inference.</div>
+
+    <div id="zoomwrap"><canvas id="zoom"></canvas></div>
+    <p class="faint mono">Blend window at 4&times;, true aspect, 1&nbsp;px grid &mdash;
+      <span id="zoomlabel"></span>. Follows the green row cursor.</p>
+  </div>
+</div>
+
+<div>
+  <div class="panel">
+    <h2 class="sec">Correction <span class="accent">surface</span></h2>
+    <select id="owner">
+      <option value="camera_mesh">Camera warp mesh &mdash; sub-pixel, before the blend</option>
+      <option value="camera_scalars+downstream">Camera scalars + downstream residual</option>
+      <option value="downstream">Downstream corrector only &mdash; whole-pixel, after the blend</option>
+    </select>
+    <p class="faint">Exactly one surface owns the correction. Splitting it across two is how a
+      reboot silently turns a full correction into half of one: the camera's mesh is runtime
+      state and does not survive a power cycle, while the downstream profile always does.</p>
+  </div>
+
+  <div class="panel">
+    <h2 class="sec">The <span class="accent">curve</span></h2>
+    <label class="row"><span class="lbl">Translate <span class="val" id="translateV"></span></span>
+      <input type="range" id="translate" min="-40" max="40" step="0.25" value="0"></label>
+    <label class="row"><span class="lbl">Roll &mdash; linear in y <span class="val" id="rollV"></span></span>
+      <input type="range" id="roll" min="-40" max="40" step="0.25" value="0"></label>
+    <p class="faint">Roll is the shape the physics predicts: two lenses rotated relative to each
+      other about their optical axes displace the seam by <span class="mono">dx = -&theta;&middot;y</span>,
+      linear in the row. Translate and roll are a <em>view</em> of the curve, recomputed from it
+      after every edit &mdash; not stored parameters.</p>
+    <table><thead><tr><th>row</th><th>dx (px, right half moves right)</th></tr></thead>
+      <tbody id="curverows"></tbody></table>
+    <p class="mono faint" style="word-break:break-all" id="curvejson"></p>
+    <p class="faint" id="curvewhy"></p>
+    <div class="btn-row">
+      <button class="btn btn-ghost" id="reset">Reset to zero</button>
+      <button class="btn btn-ghost" id="suggest" disabled>Use measured dx</button>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2 class="sec">Live <span class="accent">score</span></h2>
+    <p class="mono faint"><span class="dot off" id="metricdot"></span><span id="metriclabel"></span>
+      <span id="metricstate"></span></p>
+    <div id="quality" style="display:none"></div>
+    <div class="kpi">
+      <div><div class="k">SCR p50</div><div class="v" id="scrp50">--</div></div>
+      <div><div class="k">SCR p90</div><div class="v" id="scrp90">--</div></div>
+      <div><div class="k">|ln SSR|</div><div class="v" id="ssrv">--</div></div>
+      <div><div class="k">structures</div><div class="v" id="scrn">0</div></div>
+    </div>
+    <p class="faint" id="scrnote"></p>
+    <p class="faint" id="ssrnote"></p>
+    <p class="faint">These are the same numbers the automatic solver minimises, computed by the
+      same code &mdash; so a calibration done by hand and one done by search are directly
+      comparable. Acceptance wants p90 below 2&nbsp;px and at least halved.</p>
+  </div>
+
+  <div class="panel">
+    <h2 class="sec">What the camera <span class="accent">already decided</span></h2>
+    <table><thead><tr><th>scalar</th><th class="num">live</th><th class="num">factory</th></tr></thead>
+      <tbody id="scalars"></tbody></table>
+    <p class="faint" id="scalarnote"></p>
+  </div>
+
+  <div class="panel">
+    <h2 class="sec">Ship <span class="accent">it</span></h2>
+    <label class="row"><span class="lbl">Calibrated for distance (m)</span>
+      <input type="number" id="distance_m" step="1" placeholder="45"></label>
+    <label class="row"><span class="lbl">Basis</span>
+      <input type="text" id="basis" placeholder="far touchline midpoint"></label>
+    <p class="faint">One calibration is correct at one depth. Calibrating for the far field costs
+      a couple of pixels across the far half of the pitch and tens of pixels at the near
+      touchline &mdash; the right trade here, but a stated one.</p>
+    <div class="btn-row">
+      <button class="btn" id="save">Save profile</button>
+      <span class="mono" id="savestate"></span>
+    </div>
+    <div id="applywrap" style="margin-top:14px">
+      <div class="btn-row">
+        <button class="btn btn-ghost" id="dryrun">Dry run</button>
+        <button class="btn btn-danger" id="apply">Apply to camera</button>
+        <span class="mono" id="applystate"></span>
+      </div>
+      <p class="faint">Apply sets the vendor scalars first and only then writes a mesh composed
+        onto the baseline they produce &mdash; <span class="mono">SetStitch</span> re-runs the
+        camera's own mesh optimiser and destroys anything written before it. The baseline is
+        re-checked immediately before the write and the write is refused if it moved. Afterwards
+        a fresh snapshot is pulled and re-scored, so you see numbers rather than a promise.</p>
+      <pre class="mono faint" id="applyreport" style="white-space:pre-wrap;max-height:220px;overflow:auto"></pre>
+    </div>
+  </div>
+</div>
+</div>
+</div>
+<script>__SCRIPT__</script>
+</body>
+</html>
+""".replace("__STYLE__", _STYLE).replace("__SCRIPT__", _SCRIPT)


### PR DESCRIPTION
Workflow B from `docs/STITCH_CALIBRATION.md` §11: the human-in-the-loop seam
calibration tool, at `/stitch` in the camera manager app, built for the browser
it will actually run in — **a phone at the side of the pitch**.

This is now the path that *works*. #136 established that the automatic solver's
objective is geometrically blind to horizontal misregistration and refuses all 28
archived games. A person standing in the seam makes a 20 px error obvious to the
eye that the metric cannot see.

### Phone-first, verified in a real viewport

Pointer Events replace mouse handlers: one finger axis-locked (across =
calibration, down = travel the rows), two fingers pinch-zoom the seam corridor.
The blend window is the primary view; the full-height strip is demoted to a
locator that green-bands rows holding upright structure. Thumb nudge pad, roll
slider, 44 px targets, camera actions docked to the bottom, secondary panels in
`<details>` that auto-open on desktop. No webfont, no external request at all.

Driven in a genuine 390x844 viewport, not inferred from CSS:

- 40 px horizontal drag -> dx exactly **-31.90** (= 40 / 1.2539 px-per-source-px,
  negated for the left half); 120 px vertical drag -> row cursor moves, **dx
  unchanged**. Axis lock works.
- Pinch 80->160 px -> span 256->128 source px.
- Hung `fetch` -> "scoring...", dimmed KPIs, then "offline x1 / no answer in 9 s";
  restoring it recovers to live **with no user action**. The previous commit had a
  real bug here: a hung fetch left `S.busy` set and scoring stopped silently
  forever. Every score request is now bounded by a 9 s `AbortController`.
- New `POST /stitch/aim` + `GET /stitch/scene.jpg`: a 1/8-scale panorama (~35 KB)
  with the seam marked, so the operator can position the person *before* snapping.
  Safe to press repeatedly; cannot disturb a scored session.

### The person in the seam is step 2, not a tip

New additive module `vpe/seam_vertical.py` — `dx_sensitivity` /
`split_by_dx_sensitivity` (pure summaries of an existing `ScrResult`) and
`vertical_structure` (a presence detector, ~60 ms, run on every aim and snap).
When nothing upright is in the corridor, **the verdict is the instruction**.

**Re-weighting does not rescue the metric, and the PR says so.** Of 11 / 61 / 88
accepted structures in three games, only **0 / 1 / 2** were steeper than
|m| = 0.15, and restricting the dx sweep to the steerable subset moved p90 by
1.3 / 2.9 / 1.8 % — no better than the full set. Sensitivity is `|m|/sqrt(1+m^2)`,
which is 0 for a horizontal edge. So the remedy shipped is an instruction about
the *scene*, not a new statistic.

**What does respond:** `|ln SSR|` banded to the target's rows separates a corridor
with upright structure from one without by an order of magnitude (**1.889 vs
0.170**) where the whole-band figure cannot (0.095 vs 0.088). On a real player
frame: **0.062 whole-frame — below the 0.10 noise floor — vs 1.180 on his rows.**
It is a before/after comparator on a fixed scene, not an absolute, and the UI
states that on screen.

### "Nothing to change here" is a first-class verdict

52 of 96 archived frames sit below the SSR noise floor, a hand-measured field line
crossing the seam gives r_y = +1.79 px, and players straddling the seam render
continuous at 8x. So this is a **check-and-correct** tool, not a repair tool, and
it can say "leave it alone" confidently. The UI states that the eye is the
instrument and the picture should overrule the numbers.

`seam_vertical`'s docstring records that it detects **presence, never
registration**, cites why (a person inside the blend window offers no separated
pair to match — #136 measured `implied_dx` spanning -55...+141 px on one fixed
camera), and logs one known false negative.

### Tested vs argued

**Tested** — 49 tests across `tests/web/test_stitch_calibration.py` and new
`tests/test_seam_vertical.py`: aim cannot disturb the session and its scene is
<120 KB; upright structure found / located / absent; the target band and its SSR
including in the live path; the sensitivity split; the phone contract pinned in
the page source (viewport meta, zero external requests, pointer/axis-lock/pinch,
`touch-action:none`, the 9 s timeout, fixed dock); the procedure steps; the
"nothing to change" copy.

**Verified by hand** — everything in the viewport section above. JS behaviour is
not reachable from pytest, so the source strings are pinned and the behaviour was
driven in Chrome.

**Argued, not tested** — that a phone on the LAN reaches the app once
`[TTT] auth_server_bind` is set (read from the middleware; no real phone tried);
and that an operator can null a tear by dragging (the tear is verified present on
real frames; the human trial is not).

### Gates

`ruff check`, `ruff format --check`, `mypy video_grouper/` green. Full unit suite
**1965 passed, 13 skipped, 1 xfailed** — run independently by the coordinator on
the rebased tree, not taken on report. #136's 37 solver tests pass against the
`seam_metric.py` conflict resolution.

Camera access was read-only throughout: `Snap` and `GetStitch` only. Apply and
Dry run were never pressed against the live unit.