### PR TITLE
fix(stitch): compose onto the true baseline; start from the camera's calibration; withdraw the echo estimator

### DIFF
--- a/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
+++ b/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
@@ -1189,10 +1189,125 @@ Not fixed here — this branch is design only — but they are real, reproduced,
    remains unmeasured on this unit. Answering it needs the deliberate target of §10 step 4, or the
    pre-stitch source images of question 1 — which would turn this from an extrapolation problem into
    a direct registration one and is now the highest-value lead in the document for this reason too.
-7. **Is there anything to correct on outdoor footage at all?** 52 of 96 archived frames sit below the
-   SSR noise floor **[M]**. SSR saturates past ~4 px so this is not proof of sub-pixel registration,
-   but before more effort goes into Workflow A it is worth establishing whether the far-field seam on
-   a tripod-mounted unit is misregistered by an amount detection cares about.
+7. ~~**Is there anything to correct on outdoor footage at all?**~~ **Answered, mostly "no" — §15.**
+   52 of 96 archived frames sat below the SSR noise floor **[M]**; §15 adds an independent instrument
+   that says the corridor at large carries no ghost on 39 of 40 placements, and explains why.
+
+---
+
+## 15. Auto-measure: what works, what does not, and the evidence for both
+
+Attempted 2026-08-19. **Outcome: the mechanism is established and shipped as an
+instrument (`vpe/seam_echo.py`); the fully automatic path is not yet reliable and
+therefore refuses rather than publishing.** The goal was an operator "Auto"
+button that reads `dx` off whatever happens to be standing in the seam, with no
+detector for any object class.
+
+### 15.1 Grey-level echo estimation fails its null — and the instrument is sound
+
+Inside the blend `s(x) = a·b(x) + (1−a)·b(x−d)` for whatever `b` is there, so a
+2-tap echo has an autocorrelation peak at lag `d` of height
+`a(1−a)/(a²+(1−a)²)` — 0.5 at `a`=0.5, independent of `b`. Estimator: horizontal
+gradient → per-row normalised autocorrelation → row-average → median-detrend in
+lag → peak.
+
+Injecting a synthetic ghost (`a`=0.5, `d`=18) into **real grass from these very
+frames** recovers lag 18 in 6/6 row bands at 0.23–0.57, against clean-control
+0.03–0.09. The instrument is not the problem.
+
+On real footage it is nonetheless flat:
+
+- Frame 1104 (`heat__2026.06.06_vs_Fairport_away`, ball at x=3846 visibly two
+  copies, required `d` = 17–19): full-height band×lag map at the seam is
+  statistically identical to controls at ±400 px; peaks 0.03–0.06, scattered
+  lags. A tight grey-level window **on the doubled ball itself** reads
+  0.029–0.058 against controls at 0.049–0.076.
+- 40 archived frames, many placements, gated by the calibrated
+  `vertical_structure`: seam median +0.050 / p90 +0.095 against control median
+  +0.039 / p90 +0.074 — **seam median ÷ control p90 = 0.68**, i.e. the seam sits
+  *below* its own controls. The single 10× outlier was checked by eye and is
+  **two players standing 16 px apart**, both sharp — the same "measured the
+  wrong thing" failure as the four detector passes.
+
+**Why:** in grey level a window on the seam is ~33 px of ghosted ball against
+~60 px of high-gradient **unghosted** grass, and the grass wins. Averaging more
+rows and frames averages more unghosted pixels, so scale does not rescue it.
+
+### 15.2 Colour changes the answer
+
+Grass has enormous luminance texture and almost no colour distinctiveness, which
+is why every gradient-energy gate let it through. Measured on the hand-verified
+frames, **chroma** distance (Lab a,b — L deliberately excluded, since mown grass
+*is* a luminance texture) from the local pitch colour:
+
+| | target | same-row grass | worst foreground grass |
+|---|---|---|---|
+| chroma distance p95 | 18.8–27.4 | 1.4–2.8 | 2.8–3.2 |
+| ratio to target | — | **9.7–13.3×** | **6.6–8.7×** |
+
+Keeping L in the distance collapses those ratios to 3.9× and 1.35×. In the
+chroma channel the grass falls to ~0 and the object's two copies are the only
+signal left. The ghost is then plainly legible: frame 1104's profile shows two
+lobes, ~45 at −14 px and ~33 at +3 px with a dip between, i.e. **separation ~17
+px at an amplitude ratio near 0.45** — matching the hand-verified 17–19 px and
+`a` = 0.451. A two-copy fit on those rows returns **d = 18.0** with the two-copy
+model halving the residual against one lobe (gain 1.99), while the same fit on
+frame 1088's ball (106 px out), frame 1120's ball, and four control corridors
+gains only 1.06–1.19.
+
+**`a` is predicted, not fitted.** `a(x) = 0.5 − (x − seam)/(2·blend_w)`, so a
+ball 106 px out sits at `a_pred` = 0.086 — an 8.6% ghost, which nothing should
+be believed on. (An earlier two-copy fit reported "separation 16.1 px" there,
+where the truth is 0.) Confining candidates to `a_pred` ∈ [0.29, 0.71] makes
+that a geometric refusal rather than a statistical one.
+
+### 15.3 What is still not reliable — the automatic path
+
+Candidate selection ranks by chroma and, on frame 1104, prefers a **walking
+person** over the ball. Its bands vote `d` = 21, 24, 28, 31, 32, 33, 34, 35,
+several pinned near the search-grid edge. A loose agreement gate published their
+median, **25.5 px, where the hand-verified answer is 17–19**. That is the single
+most important negative result here and the reason `MAX_SPREAD` is tight.
+
+The disagreement is physical, not noise. The factory mesh nulls the **ground
+plane** — grass, painted lines and feet are registered, which is what §15.1 and
+the SSR noise floor both say — so residual disparity scales with **height above
+the ground**. A walking figure is therefore not one measurement: boots, shorts
+and head sit at different heights and legitimately disagree. Two consequences:
+
+1. **Band agreement is not guaranteed even for a genuine target**, so it cannot
+   be used as the sole discriminator without also constraining target height.
+2. A per-row `dx(y)` shear cannot represent the residual anyway — at one row the
+   ground and a person's head need different `dx`. That is stronger than §12's
+   list of things the mesh does not fix.
+
+### 15.4 What would make it reliable
+
+- **A single-height target**: a board, a sign, a cone — something flat and
+  vertical whose whole extent sits at one height above the ground. The remedy
+  text says so. A person is the wrong calibration target for this measurement
+  even though they are the right one for the human-in-the-loop workflow.
+- **Widen and refine the `d` search** (fits pinning at `D_MAX` = 36 are not
+  measurements) and estimate `d` per row band rather than pooling.
+- **§14 question 1 remains the clean lead.** `VIDEOPROC 2` out port 1 (256×2160)
+  or `stitch_ori_snap` would expose the two contributions *separately*, turning
+  this from echo estimation under an unknown mixture into direct registration.
+
+### 15.5 What shipped
+
+`vpe/seam_echo.py` and `POST /stitch/auto`. The null is built into `measure()`
+and cannot be skipped: the identical fit runs at control corridors either side
+of the seam, *pretending the seam is there* (otherwise `a_pred` would refuse
+them for free and the null would be vacuous), and the seam must clear the
+controls by `NULL_MARGIN`. Chroma distance is reported on every candidate, so a
+reviewer can see the estimator ran on something actually distinct from the
+pitch — the audit trail the previous four passes lacked. On the archive the fair
+null is clean: 0 of 325 control candidates accepted against 12–18 at the seam on
+the same frames.
+
+On every hand-verified case the shipped path **refuses** and says what would fix
+it. It proposes; it never applies. Applying still goes through
+`apply_calibration()` via `/stitch/apply`, unchanged.
 
 ---
 
@@ -1223,9 +1338,9 @@ Seam profile from `snap.jpg` (numpy):
 
 ```python
 band = gray[300:2150]
-cm   = band.mean(axis=0)                          # row-independent = photometric
-res  = band - cm[None, :]                         # structural
-E    = (np.diff(res, axis=1) ** 2).mean(axis=0)   # detrended gradient energy per column
+cm = band.mean(axis=0)  # row-independent = photometric
+res = band - cm[None, :]  # structural
+E = (np.diff(res, axis=1) ** 2).mean(axis=0)  # detrended gradient energy per column
 # fit log E quadratically over x in [3328,3712) u (3968,4352]; SSR = mean(E/fit) over [3712,3968]
 ```
 

--- a/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
+++ b/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
@@ -1311,6 +1311,83 @@ it. It proposes; it never applies. Applying still goes through
 
 ---
 
+## 16. Starting the editor from the camera's current state
+
+Added 2026-08-19. Previously every session began at a flat zero curve, so an operator's first
+adjustment was a delta from nothing rather than from what is installed.
+
+### 16.1 The snapshot is already the mesh's output — do not re-warp it
+
+`cmd=Snap` returns the **fused** 7680x2160 panorama: the VPE warp and the stitcher have both run
+before the JPEG exists, which is exactly why the blend corridor and its ghost are visible in it
+(§15.2). Applying the live mesh to that image would apply the correction **twice**. So the editor
+never warps the snapshot. What the mesh can honestly contribute is its own *shape*, which is what
+`stitch_apply.seam_profile` extracts.
+
+### 16.2 What is read, and from where
+
+`stitch_apply.read_calibration(host)` — read-only; it dumps the live VPE state to a file on the SD
+card and never calls `SetStitch` or `lut2d_ioctl set`:
+
+| source | what it answers |
+|---|---|
+| `lut2d_ioctl get 0` → `baseline.bin` | the live mesh, and its crc32 |
+| `/mnt/sda/stitchcal/factory_boot.bin` | is this unit still at factory? |
+| `/mnt/sda/stitchcal/anchors.txt` | the installed calibration — **this is the starting curve** |
+| `GetStitch` current vs `initial` | the vendor scalars (already surfaced) |
+
+Both `factory_boot.bin` and `factory_vpe0.bin` exist on the unit and are **byte-identical**
+(verified live 2026-08-19, md5 `7ac18ef2988970d09fc4f5a36c6cd311`). `factory_boot.bin` is the name
+`S98_StitchCal` writes and documents, so it is tried first.
+
+**Measured on Mark's unit, live, 2026-08-19:** live mesh crc32 `8514014a`, `factory_boot.bin` crc32
+`8514014a`, no `anchors.txt`, and the camera's own hook log says
+`NOT APPLIED: no /mnt/sda/stitchcal/anchors.txt -- nothing is calibrated on this unit`. The UI says
+so in those terms rather than showing a zero curve that looks like a calibration.
+
+### 16.3 The vendor's own solution, per row
+
+The mesh maps destination grid points to **source** pixels and the seam is the left half's last
+column, so `src_x - dst_x` there is the horizontal displacement the vendor's optimiser chose for
+that row. Measured on the factory mesh:
+
+| | value |
+|---|---|
+| offset at the seam column | **-586.25 px** (row 0) to **-441.25 px** (mid frame) |
+| `s`, source-px per destination-px | 0.6002 .. 0.7168, **0.70018 at mid-row** |
+
+That `s` is an independent cross-check: `compose_correction` documents `s_at_seam` = 0.700 and the
+archived compose report measured 0.7002. `s` matters to the operator because the composer writes
+`x + dx*s` — a 10 px correction moves source pixels by ~7 px at the seam, not 10.
+
+### 16.4 `dx = 0` **is** factory, so there are two reset buttons and not three
+
+§7.1 is what makes this true: the correction is stored as anchors and composed at **every boot**
+against the mesh the firmware just generated. Anchors are therefore always relative to factory, and
+an all-zero curve leaves the vendor mesh untouched. "Reset to zero" and "back to factory" were the
+same button; there is now one, labelled **Back to factory**, plus **Back to camera current** which
+loads `anchors.txt` resampled onto the editor's rows.
+
+### 16.5 A divergence this exposed, in the existing apply path
+
+`apply_calibration` composes onto `wait_for_stable_mesh()` — the **live** mesh — while
+`S98_StitchCal` composes onto `factory_boot.bin` — the **factory** mesh. When a calibration is
+already installed those are not the same baseline:
+
+- immediately after an interactive apply: `factory ⊕ old ⊕ new`
+- after the next reboot: `factory ⊕ new`
+
+The `--require-baseline` guard does not catch it: `format_anchors` stamps the *live* crc it just
+measured, so the interactive compose trivially agrees with itself, and the boot hook deliberately
+does not set the flag (§7.3). This does not bite today — Mark's unit is at factory with no
+`anchors.txt` — but it bites the first time anyone re-calibrates an already-calibrated unit, which
+is precisely the case this feature exists to support. `read_calibration` therefore surfaces it in
+the note shown next to the loaded curve rather than leaving it to be discovered. **Fixing it belongs
+in `apply_calibration`** (compose onto the factory copy, not the live mesh) and was left alone here
+because that path is live-verified end-to-end and out of scope for a read-only change.
+
+---
+
 ## Appendix: reproducing the measurements
 
 ```sh

--- a/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
+++ b/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
@@ -1293,21 +1293,73 @@ and head sit at different heights and legitimately disagree. Two consequences:
   or `stitch_ori_snap` would expose the two contributions *separately*, turning
   this from echo estimation under an unknown mixture into direct registration.
 
-### 15.5 What shipped
+### 15.5 Withdrawn at scale: it measures a step edge, not a ghost
 
-`vpe/seam_echo.py` and `POST /stitch/auto`. The null is built into `measure()`
-and cannot be skipped: the identical fit runs at control corridors either side
-of the seam, *pretending the seam is there* (otherwise `a_pred` would refuse
-them for free and the null would be vacuous), and the seam must clear the
-controls by `NULL_MARGIN`. Chroma distance is reported on every candidate, so a
-reviewer can see the estimator ran on something actually distinct from the
-pitch — the audit trail the previous four passes lacked. On the archive the fair
-null is clean: 0 of 325 control candidates accepted against 12–18 at the seam on
-the same frames.
+The estimator of 15.2 was run unmodified over the archive and **fails**. It no longer proposes
+anchors. This is the fourth withdrawn estimator, so the reasons are recorded specifically enough to
+stop a fifth repeating them.
 
-On every hand-verified case the shipped path **refuses** and says what would fix
-it. It proposes; it never applies. Applying still goes through
-`apply_calibration()` via `/stitch/apply`, unchanged.
+**Acceptance tests, against the shipped module:**
+
+| frame | required | reported |
+|---|---|---|
+| 1104 (+6 px, real 18 px ghost) | 17-19 px | **33.0 px, published** |
+| 1088 (+106 px) | ~0 / refuse | void |
+| 1120 (-51 px) | ~0 / refuse | void |
+
+Publishing 33.0 on the one frame that carries a real ghost is worse than refusing.
+
+**The mechanism.** A **step edge** -- a shirt against grass -- is fitted better by two lobes than by
+one, so `gain` rises on exactly the objects the chromatic gate is best at finding. `gain` is
+therefore *anti-correlated with truth* on this material. On frame 1104 all three accepted candidates
+sat on a walking player's torso, shorts and leg, 37-47 px left of the seam; the ball's own row band
+ranked **15th** chromatically and `max_fits=10` never fitted it. Forced onto the ball, the fit
+returns d=1.
+
+**The null, at scale** (7,688 frames, 46,088 seam candidates, 90,609 controls, 28 games):
+
+| | value |
+|---|---|
+| seam acceptance | 7.4% |
+| control acceptance | 6.3% |
+| ratio | **1.18x**, against the module's own `NULL_MARGIN` of 3.0 |
+| `ctl-1200` | accepts **more often** than the seam |
+| d-histogram overlap | 0.85 |
+| seam / control median d | 31 / 30 px -- unchanged at 31 / 30 after matching on colour decile and row band |
+
+96 gate settings were swept; none is both quiet off-seam and correct on it.
+
+**Cross-frame agreement does not rescue it, and inverts.** Within-track IQR is *better at the
+controls* (median 1.0 px, 74% <= 1 px) than at the seam (2.0 px, 38%). The steadiest landmark in the
+corpus is a **control** reading d = 35.0 px with IQR 0.0 across 25 looks, where the truth is exactly
+zero. So agreement cannot be the acceptance criterion.
+
+**And the null as originally written was not a safeguard.** The guard read
+`if ctl_ok and seam_rate < NULL_MARGIN * ctl_rate`: on a single frame the controls frequently accept
+nothing, `ctl_ok` is empty, and the guard is skipped entirely -- inert at exactly the sample size the
+button uses. That is why the single-frame and scale runs disagreed about the same frame. **A null a
+small sample can switch off is not a null.**
+
+`HV_sheet_control_top_lab.png` is the picture of it: a page of ordinary single, unghosted players in
+*control* corridors, accepted at 19-35 px.
+
+**What a future attempt must do differently.** Colour gating was necessary and insufficient -- it
+correctly finds chromatically distinct objects, and distinct objects have step edges. Any fix has to
+discriminate a **ghost** from a **step**, which is new work with its own acceptance bar, not a
+parameter tweak. Per-candidate shards with every fitted profile are at
+`F:/archive/duo3_stitch/harvest/report_shards_dense/` (78 `.npz`), so it can be re-analysed without
+re-decoding.
+
+### 15.6 What shipped
+
+`vpe/seam_echo.py` and `POST /stitch/auto`, as **diagnostics only**. `measure()` reports its
+candidates, its control corridors and what it would have said (`provisional_dx`), and always returns
+`verdict = "withdrawn"`; `anchors_from_measurement` raises unconditionally, so no result however
+confident can become a curve. The UI has no adopt control. The chromatic gate, the control machinery
+and the plumbing are kept because they are reusable and because the numbers are the evidence.
+
+**The seam is calibrated by hand** (section 11), starting from the camera's installed state
+(section 16).
 
 ---
 
@@ -1368,23 +1420,52 @@ an all-zero curve leaves the vendor mesh untouched. "Reset to zero" and "back to
 same button; there is now one, labelled **Back to factory**, plus **Back to camera current** which
 loads `anchors.txt` resampled onto the editor's rows.
 
-### 16.5 A divergence this exposed, in the existing apply path
+### 16.5 The double-compose, and its fix
 
-`apply_calibration` composes onto `wait_for_stable_mesh()` — the **live** mesh — while
-`S98_StitchCal` composes onto `factory_boot.bin` — the **factory** mesh. When a calibration is
-already installed those are not the same baseline:
+**Found while building 16.2, fixed and verified live 2026-08-19.**
 
-- immediately after an interactive apply: `factory ⊕ old ⊕ new`
-- after the next reboot: `factory ⊕ new`
+`apply_calibration` took `wait_for_stable_mesh()` -- the **live** mesh -- as its baseline
+unconditionally. `S98_StitchCal` does not: it keeps `applied.sig`, and when the live mesh matches
+its own last write it composes from the saved `factory_boot.bin` instead (that is the idempotency
+verified on hardware in #135). So on a unit already carrying a calibration the two paths disagreed:
 
-The `--require-baseline` guard does not catch it: `format_anchors` stamps the *live* crc it just
-measured, so the interactive compose trivially agrees with itself, and the boot hook deliberately
-does not set the flag (§7.3). This does not bite today — Mark's unit is at factory with no
-`anchors.txt` — but it bites the first time anyone re-calibrates an already-calibrated unit, which
-is precisely the case this feature exists to support. `read_calibration` therefore surfaces it in
-the note shown next to the loaded curve rather than leaving it to be discovered. **Fixing it belongs
-in `apply_calibration`** (compose onto the factory copy, not the live mesh) and was left alone here
-because that path is live-verified end-to-end and out of scope for a read-only change.
+| | mesh |
+|---|---|
+| immediately after an interactive Apply | `factory (+) old (+) new` |
+| after the next reboot | `factory (+) new` |
+
+Same stored anchors, two meshes, differing only by whether the unit had been power-cycled.
+`--require-baseline` could not catch it: `format_anchors` stamps the live crc it just measured, so
+the interactive compose trivially agreed with itself.
+
+This lands squarely on 16.2 -- "load the installed calibration, nudge it by 2 px, Apply" is exactly
+the sequence that doubles.
+
+**The fix mirrors the boot hook rather than inventing a second scheme.** `apply_calibration` now
+computes `mesh_signature()` -- `md5` of the table with the 8-byte header skipped, the same byte range
+as `S98`'s `dd bs=8 skip=1` -- and if the live mesh matches `applied.sig`, composes from the saved
+factory copy. It writes `applied.sig` after a successful set (via `tail -c +9`, because `camsh`
+refuses `dd`), so the interactive and boot paths cannot drift apart. The ordering guard now compares
+the re-dump against the **live signature seen at decision time** rather than against the baseline
+crc: those are the same thing only on an uncalibrated unit, and a baseline comparison would have
+refused every legitimate re-calibration while still missing the doubling.
+
+**Verified live end-to-end on the unit, writes included.** Expected crcs were computed host-side
+*before* any write, so the doubling was falsifiable rather than assumed:
+
+| step | baseline chosen | resulting mesh crc32 | expected |
+|---|---|---|---|
+| start | — | `8514014a` | factory |
+| apply A (dx = 4 px) | live mesh | **`9604929c`** | `factory (+) A` |
+| apply A **again** | saved factory copy | **`9604929c`** unchanged | idempotent (old code: `3cdcb4aa`) |
+| apply B (dx = 8 px) | saved factory copy | **`83e3bedc`** | `factory (+) B`, **not** `f18b0999` = `factory (+) A (+) B` |
+| restore | — | `8514014a` | factory |
+
+Every write was read-back verified by the camera (`read-back matches: the mesh is live`). The unit
+was returned to exactly the state it was found in: all three mesh files back to md5
+`7ac18ef2988970d09fc4f5a36c6cd311`, `anchors.txt` / `applied.sig` / `mesh_apply.bin` /
+`recheck.bin` removed, and `read_calibration` reporting at-factory and uncalibrated. No reboot, no
+flash, no `netstate` change.
 
 ---
 

--- a/reolink-firmware-patching/vpe/seam_echo.py
+++ b/reolink-firmware-patching/vpe/seam_echo.py
@@ -1,0 +1,463 @@
+"""Automatic seam measurement: read `dx` off whatever is standing in the seam.
+
+Five passes have tried to measure this camera's stitch misregistration
+automatically. Four built a detector for an **object class** -- a ball, a person
+-- and every one of them measured something else: grass texture, a parked car, a
+player's shirt, a player's shorts. This module does not detect any object class,
+and must not be extended to.
+
+**The physics is class-agnostic.** Inside the blend the output is
+
+    s(x) = a*b(x) + (1-a)*b(x-d)
+
+for *whatever* `b` happens to be there -- a chair, a car, a person, the vertical
+stroke of a painted number. The identity of `b` is irrelevant. Only two things
+matter: the structure has horizontal gradient (a purely horizontal edge is
+invariant under a horizontal shift and carries nothing), and it sits inside the
+mixing corridor.
+
+Three things make this work where the earlier attempts failed, and all three are
+load-bearing.
+
+**1. Candidate selection is chromatic, not gradient-based.** Grass has enormous
+luminance texture and almost no colour distinctiveness, which is why every
+gradient-energy gate let it straight through -- Sobel loves mown blades.
+Measured on the hand-verified frames, distance in Lab from the local pitch
+colour -- **chroma only, excluding lightness** -- separates the ball from
+same-row grass by **9.7x** (27.4 vs 2.8) and from the worst foreground grass by
+**8.7x** (27.4 vs 3.2), while |dI/dx| p95 separates them by only 8.3x and 1.8x
+and puts foreground grass at 118, comfortably inside any gradient threshold that
+still admits real targets. Keeping L in the distance would undo most of this
+(the same ratios fall to 3.9x and 2.5x), because mown grass *is* a luminance
+texture.
+A red shirt, a blue chair, a car, a white line and a ball all pass a chromatic
+gate; grass does not. `lab` is reported on every candidate so a reviewer can see
+the estimator ran on something actually distinct from the pitch. That audit
+trail is what the previous four passes lacked.
+
+**2. Measuring in the colour-distance channel, not in grey.** This is not merely
+a better gate, it changes the estimator. In grey level a window on the seam is
+~33 px of ghosted ball against ~60 px of high-gradient **unghosted** grass, and
+the grass wins: a tight window on a visibly-doubled ball reads 0.03-0.06 by
+autocorrelation, indistinguishable from control corridors, even though the same
+estimator recovers a synthetic ghost injected into the same grass at 0.23-0.57.
+In the colour-distance channel the grass falls to ~0 and the object's two copies
+are the only signal left. The ghost is then plainly legible: on frame 1104 the
+profile shows two lobes, ~45 at -14 px and ~33 at +3 px with a dip between them,
+i.e. separation ~17 px at an amplitude ratio near 0.45.
+
+**3. `a` is predicted by geometry, not fitted freely.** The blend weight at
+column x is known:
+
+    a(x) = 0.5 - (x - seam_x) / (2 * blend_w)
+
+so mixing is not a free parameter. This is what turns the awkward cases into
+principled refusals instead of statistical ones. A ball 106 px from the seam
+sits at `a_pred` = 0.086 -- there is only an 8.6% ghost to see there, and no
+estimator should be believed on it. An earlier two-copy fit reported "separation
+16.1 px" for exactly that ball, where the true answer is zero. Requiring
+`a_pred` in [0.29, 0.71] confines the measurement to the region where a ghost
+can physically exist, and requiring the *fitted* `a` to agree with the predicted
+one is a consistency check that scene structure cannot fake.
+
+**The null is built in and cannot be skipped.** `measure` always runs the
+identical fit at control corridors either side of the seam, *pretending the seam
+is there* -- otherwise `a_pred` would refuse them for free and the null would be
+vacuous. If any control passes the same gates, the measurement is void and no
+number is published.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import cv2
+import numpy as np
+
+SEAM_X = 3840
+BLEND_W = 128  # half-width; the mixed window is [seam-128, seam+128]
+
+#: Chroma distance from the local pitch colour that marks a patch as "not
+#: grass". Measured on the hand-verified frames: grass reads 1.4-2.8 and 2.8-3.2
+#: at its worst (bright foreground), targets read 18.8-27.4. 8.0 sits well
+#: inside the gap, on the conservative side -- it costs a "stand something in
+#: the seam" prompt on a marginal target rather than admitting a patch of pitch.
+MIN_LAB_DISTANCE = 8.0
+
+#: How far from the seam a candidate may sit. +/-55 px keeps `a_pred` inside
+#: [0.29, 0.71]: nearer the corridor edge there is too little mixing for a ghost
+#: to exist, which is a statement about the blend, not about the estimator.
+MAX_OFFSET = 55
+
+#: The two-copy model has to earn its extra parameters against a single lobe.
+#: On the hand-verified frames the true ghost gains 1.99 and the three negative
+#: cases gain 1.14-1.19; control corridors gain 1.06-1.12.
+MIN_GAIN = 1.5
+
+#: Fitted `a` must agree with the geometric prediction this closely.
+MAX_A_ERROR = 0.30
+
+#: The seam must produce accepted measurements at this multiple of the control
+#: corridors' rate. Measured on the archive, a well-posed frame runs 18-26% at
+#: the seam against 0% at the controls, so this is not a tight squeeze.
+NULL_MARGIN = 3.0
+
+#: Largest IQR across accepted candidates that still counts as agreement.
+#:
+#: Deliberately tight, and the reason matters. Disparity scales with height
+#: above the ground plane (the factory mesh nulls the ground), so a *walking
+#: person* is not one measurement -- their boots, shorts and head sit at
+#: different heights and legitimately disagree. Measured on the hand-verified
+#: frame, bands on a walking figure return d = 18, 21, 25, 26, 28, 33; a looser
+#: gate published their median, 25.5 px, where the hand-verified answer is
+#: 17-19. So band agreement is not merely a nice-to-have discriminator here, it
+#: is the only thing standing between the operator and a confident wrong number.
+#: A target at a single height -- a board, a pole, a cone -- is what this gate
+#: is asking for, and the remedy text says so.
+MAX_SPREAD = 3.0
+
+D_MIN, D_MAX = 4, 36
+
+
+def blend_weight(x: float, seam_x: int = SEAM_X, blend_w: int = BLEND_W) -> float:
+    """Weight of the LEFT contribution at column x. 1 at the left edge of the
+    corridor, 0.5 at the seam, 0 at the right edge."""
+    return float(np.clip(0.5 - (x - seam_x) / (2.0 * blend_w), 0.0, 1.0))
+
+
+def colour_distance(bgr: np.ndarray, band_rows: int = 120) -> np.ndarray:
+    """Chroma distance from the *local* pitch colour at the same rows.
+
+    **Chroma only -- L is deliberately excluded.** Including lightness defeats
+    the entire point: mown grass is a luminance texture, so an L-bearing
+    distance rises with exactly the signal the gate exists to reject. Measured
+    on the hand-verified frames, dropping L moves the ball-to-grass separation
+    from 3.9x to 9.7x, and the worst case -- bright foreground grass, which is
+    what fooled the first candidate ranking -- from an unusable 1.35x to 6.6x.
+
+    Local rather than global: lighting and pitch colour change down the frame,
+    and a global median would make the far touchline look distinct everywhere.
+    """
+    lab = cv2.cvtColor(bgr, cv2.COLOR_BGR2Lab).astype(np.float32)
+    out = np.empty(lab.shape[:2], np.float32)
+    for y0 in range(0, lab.shape[0], band_rows):
+        y1 = min(lab.shape[0], y0 + band_rows)
+        med = np.median(lab[y0:y1].reshape(-1, 3), axis=0)
+        out[y0:y1] = np.linalg.norm(lab[y0:y1, :, 1:] - med[1:], axis=2)
+    return out
+
+
+_A_GRID = np.arange(0.1, 0.91, 0.1, dtype=np.float32)
+_SIGMAS = np.array([4.0, 7.0, 10.0, 13.0], np.float32)
+#: How far the lobe centre may wander from the profile centre. This must stay
+#: generous: narrowing it to +/-22 px to buy speed measurably *inflates* `gain`,
+#: because a pinned centre handicaps the one-lobe reference fit more than the
+#: two-copy one, and control corridors start passing. Speed is bought back on
+#: the sigma grid instead, which has no such asymmetry.
+_MU_REACH = 42
+
+
+def _fit_two_copy(profile: np.ndarray) -> tuple[tuple, tuple] | tuple[None, None]:
+    """Fit P(x) ~ A*[a*G(x-mu) + (1-a)*G(x-mu-d)] + c by grid search.
+
+    Amplitude and offset are linear given the shape, so only (mu, sigma, d, a)
+    are gridded, and the `a` axis is vectorised -- this runs per candidate on an
+    operator's button press, so a readable-but-quadratic version is not good
+    enough. `mu` is searched only near the profile centre because the chromatic
+    scan has already localised the candidate to that column.
+
+    Returns (best_two_copy, best_single_lobe); the caller compares their
+    residuals, because a two-copy model that does not beat one lobe has found
+    nothing.
+    """
+    n = len(profile)
+    x = np.arange(n, dtype=np.float32)
+    c0 = n // 2
+    mus = np.arange(
+        max(0, c0 - _MU_REACH), min(n, c0 + _MU_REACH) + 1, 1.0, dtype=np.float32
+    )
+    best: tuple | None = None
+    single: tuple | None = None
+    total = float(profile.sum())
+    prof = profile[None, None, :]
+    for sigma in _SIGMAS:
+        two_s2 = 2.0 * sigma * sigma
+        g1 = np.exp(-((x[None, :] - mus[:, None]) ** 2) / two_s2)
+        for d in np.arange(0, D_MAX + 1, 1.0, dtype=np.float32):
+            g2 = np.exp(-((x[None, :] - (mus[:, None] + d)) ** 2) / two_s2)
+            if d == 0:
+                model = g1[None]  # (1, mu, x)
+                a_axis = np.array([1.0], np.float32)
+            else:
+                a = _A_GRID[:, None, None]
+                model = a * g1[None] + (1.0 - a) * g2[None]
+                a_axis = _A_GRID
+            s1 = model.sum(axis=2)
+            s2 = (model * model).sum(axis=2)
+            sxy = (model * prof).sum(axis=2)
+            den = n * s2 - s1 * s1
+            den = np.where(np.abs(den) < 1e-9, 1e-9, den)
+            amp = (n * sxy - s1 * total) / den
+            off = (total - amp * s1) / n
+            resid = prof - (amp[..., None] * model + off[..., None])
+            rms = np.sqrt((resid * resid).mean(axis=2))
+            rms = np.where(amp > 0, rms, np.inf)
+            flat = int(np.argmin(rms))
+            ai, mi = divmod(flat, rms.shape[1])
+            if not np.isfinite(rms[ai, mi]):
+                continue
+            rec = (float(rms[ai, mi]), float(d), float(a_axis[ai]))
+            if d == 0:
+                if single is None or rec[0] < single[0]:
+                    single = rec
+            elif best is None or rec[0] < best[0]:
+                best = rec
+    return best, single  # type: ignore[return-value]
+
+
+@dataclass
+class Candidate:
+    """One chromatically distinct patch, fitted. `lab` is the audit trail."""
+
+    rows: tuple[int, int]
+    x: int
+    lab: float
+    d: float
+    a_fit: float
+    a_pred: float
+    gain: float
+    accepted: bool = False
+    reason: str = ""
+
+    def to_api(self) -> dict[str, Any]:
+        return {
+            "rows": list(self.rows),
+            "x": self.x,
+            "lab": round(self.lab, 1),
+            "d": round(self.d, 1),
+            "a_fit": round(self.a_fit, 2),
+            "a_pred": round(self.a_pred, 3),
+            "gain": round(self.gain, 2),
+            "accepted": self.accepted,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class EchoResult:
+    verdict: str = "refused"  # measured | refused | void
+    dx: float | None = None
+    spread: float | None = None
+    n_accepted: int = 0
+    n_candidates: int = 0
+    control_accepted: int = 0
+    seam_rate: float = 0.0
+    control_rate: float = 0.0
+    remedy: str = ""
+    candidates: list[Candidate] = field(default_factory=list)
+    controls: list[Candidate] = field(default_factory=list)
+
+    def to_api(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict,
+            "dx": None if self.dx is None else round(self.dx, 2),
+            "spread": None if self.spread is None else round(self.spread, 2),
+            "n_accepted": self.n_accepted,
+            "n_candidates": self.n_candidates,
+            "control_accepted": self.control_accepted,
+            "seam_rate": round(self.seam_rate, 3),
+            "control_rate": round(self.control_rate, 3),
+            "remedy": self.remedy,
+            "candidates": [c.to_api() for c in self.candidates[:40]],
+            "controls": [c.to_api() for c in self.controls[:20]],
+        }
+
+
+def _scan(
+    dist: np.ndarray,
+    centre: int,
+    *,
+    seam_x: int,
+    blend_w: int,
+    band: int,
+    half: int,
+    min_lab: float,
+    max_fits: int,
+) -> list[Candidate]:
+    """Fit every chromatically distinct band near `centre`.
+
+    `centre` is the column the blend is *assumed* to be centred on. For the real
+    measurement that is the seam; for the null it is a control corridor, so that
+    the same geometry gate applies there instead of refusing for free.
+    """
+    out: list[Candidate] = []
+    height, width = dist.shape
+    c = centre
+    lo, hi = c - MAX_OFFSET, c + MAX_OFFSET
+    if lo < half or hi > width - half:
+        return out
+    # Rank the bands chromatically first and fit only the most distinct ones.
+    # The fit is the expensive step and this runs on a button press; fitting
+    # every band would spend most of the budget on pitch.
+    ranked: list[tuple[float, int, int]] = []
+    for y0 in range(0, height - band + 1, band):
+        strip = dist[y0 : y0 + band, lo:hi]
+        lab = float(np.percentile(strip, 98))
+        if lab < min_lab:
+            continue
+        ranked.append((lab, y0, lo + int(np.argmax(strip.mean(axis=0)))))
+    ranked.sort(reverse=True)
+    for lab, y0, x in ranked[:max_fits]:
+        profile = dist[y0 : y0 + band, x - half : x + half].mean(axis=0)
+        best, single = _fit_two_copy(profile.astype(np.float32))
+        if best is None or single is None:
+            continue
+        a_pred = blend_weight(x, seam_x=c, blend_w=blend_w)
+        gain = single[0] / max(best[0], 1e-9)
+        cand = Candidate(
+            rows=(y0, y0 + band),
+            x=int(x),
+            lab=float(lab),
+            d=best[1],
+            a_fit=best[2],
+            a_pred=a_pred,
+            gain=gain,
+        )
+        if gain < MIN_GAIN:
+            cand.reason = f"two-copy model gains only {gain:.2f} over one lobe"
+        elif not (D_MIN <= cand.d < D_MAX):
+            cand.reason = f"d={cand.d:.0f} px is at the edge of the search band"
+        elif not 0.29 <= a_pred <= 0.71:
+            cand.reason = f"a_pred={a_pred:.2f}: too little mixing this far out"
+        elif abs(cand.a_fit - a_pred) > MAX_A_ERROR:
+            cand.reason = (
+                f"fitted a={cand.a_fit:.2f} disagrees with geometry {a_pred:.2f}"
+            )
+        else:
+            cand.accepted = True
+        out.append(cand)
+    return out
+
+
+def measure(
+    frames: list[np.ndarray],
+    *,
+    seam_x: int = SEAM_X,
+    blend_w: int = BLEND_W,
+    band: int = 26,
+    half: int = 70,
+    min_lab: float = MIN_LAB_DISTANCE,
+    control_offset: int = 500,
+    max_fits: int = 10,
+) -> EchoResult:
+    """Measure `dx` at the seam from N frames, or refuse and say why.
+
+    N frames over a couple of seconds are free -- the camera is on a tripod and
+    the operator pressed a button -- and they are what turns a single lucky
+    reading into an agreement test. Noise does not survive averaging across
+    independent row bands and independent frames; a real ghost does.
+
+    The control corridors are measured on every call, with the same geometry
+    gate applied about their own centres. If any of them passes, the instrument
+    is finding ghosts where there cannot be one and the result is **void**.
+    """
+    if not frames:
+        raise ValueError("measure() needs at least one frame")
+    result = EchoResult()
+    for frame in frames:
+        if frame.ndim != 3:
+            raise ValueError(
+                "seam echo needs colour frames; grass is separable "
+                "from a target by colour, not by luminance"
+            )
+        dist = colour_distance(frame)
+        kw = {
+            "seam_x": seam_x,
+            "blend_w": blend_w,
+            "band": band,
+            "half": half,
+            "min_lab": min_lab,
+            "max_fits": max_fits,
+        }
+        result.candidates += _scan(dist, seam_x, **kw)  # type: ignore[arg-type]
+        for off in (-control_offset, control_offset):
+            result.controls += _scan(dist, seam_x + off, **kw)  # type: ignore[arg-type]
+
+    accepted = [c for c in result.candidates if c.accepted]
+    ctl_ok = [c for c in result.controls if c.accepted]
+    result.n_candidates = len(result.candidates)
+    result.n_accepted = len(accepted)
+    result.control_accepted = len(ctl_ok)
+
+    # The null compares *rates*, not raw counts. There are far more control
+    # candidates than seam ones (two corridors, and no shortage of structure
+    # away from the seam), so a single control false positive would otherwise
+    # void every measurement. What must hold is that the seam is clearly
+    # distinguishable from a place where a ghost cannot exist.
+    seam_rate = len(accepted) / max(result.n_candidates, 1)
+    ctl_rate = len(ctl_ok) / max(len(result.controls), 1)
+    result.seam_rate = seam_rate
+    result.control_rate = ctl_rate
+    if ctl_ok and seam_rate < NULL_MARGIN * ctl_rate:
+        result.verdict = "void"
+        result.remedy = (
+            f"Control corridors produced measurements at {ctl_rate:.0%} against "
+            f"the seam's {seam_rate:.0%}, where the true answer off the seam is "
+            "zero. The scene is defeating the estimator, so no number is "
+            "published."
+        )
+        return result
+    if not result.candidates:
+        result.verdict = "refused"
+        result.remedy = (
+            "Nothing in the seam is chromatically distinct from the pitch. "
+            "Stand a person -- or anything with a vertical edge and a colour "
+            "that is not grass -- in the seam, and press Auto again."
+        )
+        return result
+    if len(accepted) < 3:
+        result.verdict = "refused"
+        best_lab = max(c.lab for c in result.candidates)
+        result.remedy = (
+            f"{len(accepted)} of {len(result.candidates)} candidates carried a "
+            f"usable echo (need 3). Brightest colour distance seen was "
+            f"{best_lab:.0f}. Move the target into the seam itself -- the ghost "
+            "only exists within ~55 px of it -- and press Auto again."
+        )
+        return result
+
+    ds = np.array([c.d for c in accepted])
+    spread = float(np.percentile(ds, 75) - np.percentile(ds, 25))
+    if spread > MAX_SPREAD:
+        result.verdict = "refused"
+        result.spread = spread
+        result.remedy = (
+            f"The {len(accepted)} usable candidates disagree (IQR {spread:.1f} px, "
+            f"lags {sorted(round(d) for d in ds)}). Agreement is the evidence, "
+            "not any single reading, so nothing is published. Disparity grows "
+            "with height above the ground, so a walking figure disagrees with "
+            "itself; stand a flat target -- a board, a sign, a cone -- in the "
+            "seam instead."
+        )
+        return result
+    result.verdict = "measured"
+    result.dx = float(np.median(ds))
+    result.spread = spread
+    result.remedy = ""
+    return result
+
+
+def anchors_from_measurement(
+    result: EchoResult, rows: tuple[int, ...]
+) -> list[tuple[float, float]]:
+    """Turn a measurement into `dx_anchors` for the existing apply path.
+
+    A flat curve, deliberately. The measurement establishes one `dx` at the rows
+    the target happened to occupy; inventing a slope from that would be reading
+    a roll model out of a single band. The operator can shape it by hand
+    afterwards -- that is what the curve editor is for.
+    """
+    if result.verdict != "measured" or result.dx is None:
+        raise ValueError("no measurement to build anchors from")
+    return [(float(y), float(result.dx)) for y in rows]

--- a/reolink-firmware-patching/vpe/seam_echo.py
+++ b/reolink-firmware-patching/vpe/seam_echo.py
@@ -1,4 +1,11 @@
-"""Automatic seam measurement: read `dx` off whatever is standing in the seam.
+"""Seam echo diagnostics. WITHDRAWN -- does not measure registration.
+
+**Read the WITHDRAWN section below before trusting anything else in this file.**
+The design notes that follow it are kept because they are the record of what was
+tried and why, but several of their claims were falsified at scale and are
+annotated where that happened.
+
+Originally: read `dx` off whatever is standing in the seam.
 
 Five passes have tried to measure this camera's stitch misregistration
 automatically. Four built a detector for an **object class** -- a ball, a person
@@ -58,13 +65,54 @@ estimator should be believed on it. An earlier two-copy fit reported "separation
 16.1 px" for exactly that ball, where the true answer is zero. Requiring
 `a_pred` in [0.29, 0.71] confines the measurement to the region where a ghost
 can physically exist, and requiring the *fitted* `a` to agree with the predicted
-one is a consistency check that scene structure cannot fake.
+one was intended as a consistency check that scene structure could not fake.
+**That last claim is false.** Ordinary single, unghosted players in *control*
+corridors fit `a` = 0.40-0.60 against predictions of 0.32-0.70 and sail through
+it, because a step edge is genuinely well described by two partially-overlapping
+lobes of comparable weight. The check constrains the *shape* of a fit; it does
+not establish that a second copy exists.
 
-**The null is built in and cannot be skipped.** `measure` always runs the
-identical fit at control corridors either side of the seam, *pretending the seam
-is there* -- otherwise `a_pred` would refuse them for free and the null would be
-vacuous. If any control passes the same gates, the measurement is void and no
-number is published.
+**WITHDRAWN 2026-08-19: this estimator does not work, and no longer proposes
+anchors.** It is kept because the plumbing, the chromatic gate and the control
+machinery are reusable and because the negative result is specific enough to stop
+a fifth attempt repeating it. `measure()` reports its numbers and always returns
+`verdict="withdrawn"`; `anchors_from_measurement` refuses unconditionally.
+
+What it actually measures is a **step edge**, not an echo. A shirt against grass
+is a step, and two lobes fit a step better than one does, so `gain` rises on
+exactly the objects the chromatic gate is best at finding. `gain` is therefore
+*anti-correlated with truth* on this material. Measured at scale over 7,688
+frames / 28 games: seam acceptance 7.4% against control acceptance 6.3%
+(**1.18x**, against the 3.0 this module itself demands), `ctl-1200` accepting
+*more often* than the seam, d-histograms overlapping 0.85, and seam/control
+medians of 31/30 px which stay 31/30 after matching on colour decile and row
+band. On the one hand-verified frame with a real 18 px ghost it published
+**33.0 px**, because all three accepted candidates sat on a walking player's
+torso, shorts and leg 37-47 px from the seam while the ball's own band ranked
+15th chromatically and `max_fits=10` never fitted it. Forced onto the ball, the
+fit returns d=1.
+
+**Cross-frame agreement cannot rescue it either**: agreement is *better* at the
+controls (within-track IQR median 1.0 px, 74% <= 1 px) than at the seam (2.0 px,
+38%), and the steadiest landmark in the corpus is a control reading d = 35.0 px
+with IQR 0.0 over 25 looks where the truth is exactly 0.
+
+**And the null as written here was not the safeguard it claimed to be.** The
+guard reads `if ctl_ok and seam_rate < NULL_MARGIN * ctl_rate`: on a single
+frame the controls frequently accept nothing, `ctl_ok` is empty, and the guard is
+skipped altogether -- inert at precisely the sample size the button uses. A null
+that a small sample can switch off is not a null. That is why the scale run and
+the single-frame run disagreed about the same frame.
+
+Any future attempt has to discriminate a **ghost** from a **step**, which is new
+work with its own acceptance bar, not a parameter tweak. Per-candidate shards are
+at `F:/archive/duo3_stitch/harvest/report_shards_dense/` (78 `.npz`) so it can
+be re-analysed without re-decoding.
+
+**The null runs on every call** -- `measure` always fits the control corridors
+either side of the seam, *pretending the seam is there*, because otherwise
+`a_pred` would refuse them for free and the null would be vacuous. Its numbers
+are reported; they are what condemned the estimator.
 """
 
 from __future__ import annotations
@@ -246,8 +294,11 @@ class Candidate:
 
 @dataclass
 class EchoResult:
-    verdict: str = "refused"  # measured | refused | void
-    dx: float | None = None
+    verdict: str = "refused"  # withdrawn | refused | void
+    #: What the estimator would have said. Reported as evidence, never as a
+    #: proposal -- see the module docstring for why it is not trustworthy.
+    provisional_dx: float | None = None
+    dx: float | None = None  # always None: this estimator does not propose
     spread: float | None = None
     n_accepted: int = 0
     n_candidates: int = 0
@@ -261,7 +312,10 @@ class EchoResult:
     def to_api(self) -> dict[str, Any]:
         return {
             "verdict": self.verdict,
-            "dx": None if self.dx is None else round(self.dx, 2),
+            "dx": None,  # this estimator does not propose a value
+            "provisional_dx": (
+                None if self.provisional_dx is None else round(self.provisional_dx, 2)
+            ),
             "spread": None if self.spread is None else round(self.spread, 2),
             "n_accepted": self.n_accepted,
             "n_candidates": self.n_candidates,
@@ -412,18 +466,18 @@ def measure(
         result.verdict = "refused"
         result.remedy = (
             "Nothing in the seam is chromatically distinct from the pitch. "
-            "Stand a person -- or anything with a vertical edge and a colour "
-            "that is not grass -- in the seam, and press Auto again."
+            "Note that this estimator is withdrawn and never proposes a curve "
+            "even when it does find something -- calibrate by hand."
         )
         return result
     if len(accepted) < 3:
         result.verdict = "refused"
         best_lab = max(c.lab for c in result.candidates)
         result.remedy = (
-            f"{len(accepted)} of {len(result.candidates)} candidates carried a "
-            f"usable echo (need 3). Brightest colour distance seen was "
-            f"{best_lab:.0f}. Move the target into the seam itself -- the ghost "
-            "only exists within ~55 px of it -- and press Auto again."
+            f"{len(accepted)} of {len(result.candidates)} candidates cleared the "
+            f"gates (brightest colour distance {best_lab:.0f}). This estimator is "
+            "withdrawn and does not propose a curve in any case: it measures a "
+            "step edge rather than a ghost. Calibrate by hand."
         )
         return result
 
@@ -434,17 +488,25 @@ def measure(
         result.spread = spread
         result.remedy = (
             f"The {len(accepted)} usable candidates disagree (IQR {spread:.1f} px, "
-            f"lags {sorted(round(d) for d in ds)}). Agreement is the evidence, "
-            "not any single reading, so nothing is published. Disparity grows "
-            "with height above the ground, so a walking figure disagrees with "
-            "itself; stand a flat target -- a board, a sign, a cone -- in the "
-            "seam instead."
+            f"lags {sorted(round(d) for d in ds)}). Nothing is published -- and "
+            "note that agreement would not earn publication either: measured at "
+            "scale, agreement is BETTER at the control corridors, where the true "
+            "answer is zero. Calibrate by hand."
         )
         return result
-    result.verdict = "measured"
-    result.dx = float(np.median(ds))
+    # Everything above this point still runs: the numbers are the evidence, and
+    # a future attempt will want them. What does not happen is a proposal.
+    result.provisional_dx = float(np.median(ds))
     result.spread = spread
-    result.remedy = ""
+    result.verdict = "withdrawn"
+    result.remedy = (
+        f"{len(accepted)} candidates agreed on {result.provisional_dx:.1f} px, but "
+        "this estimator is withdrawn and does not propose anchors. It measures a "
+        "step edge, not an echo: a shirt against grass is a step, two lobes fit a "
+        "step better than one, and at scale it accepts off-seam corridors (6.3%) "
+        "almost as often as the seam (7.4%) with the same d distribution, where "
+        "the off-seam answer is exactly zero. Calibrate by hand."
+    )
     return result
 
 
@@ -458,6 +520,9 @@ def anchors_from_measurement(
     a roll model out of a single band. The operator can shape it by hand
     afterwards -- that is what the curve editor is for.
     """
-    if result.verdict != "measured" or result.dx is None:
-        raise ValueError("no measurement to build anchors from")
-    return [(float(y), float(result.dx)) for y in rows]
+    raise ValueError(
+        "seam_echo is withdrawn and cannot propose anchors: it measures step "
+        "edges rather than ghosts, and at scale it accepts control corridors "
+        "almost as often as the seam. Calibrate by hand in /stitch. See the "
+        "module docstring for the evidence."
+    )

--- a/reolink-firmware-patching/vpe/stitch_apply.py
+++ b/reolink-firmware-patching/vpe/stitch_apply.py
@@ -38,8 +38,10 @@ from __future__ import annotations
 import json
 import sys
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -48,11 +50,17 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "runtime"))
 
 from camsh import sh  # noqa: E402
 from lut2d import (  # noqa: E402
+    DEFAULT_HALF_HEIGHT,
+    DEFAULT_HALF_WIDTH,
+    DEFAULT_PANORAMA_WIDTH,
+    FRAC_SCALE,
     Lut2D,
     Lut2DError,
     compose_from_anchors_file,
     crc32,
     format_anchors,
+    interp_dx,
+    parse_anchors,
 )
 
 CAM_DIR = "/mnt/sda/stitchcal"
@@ -205,6 +213,212 @@ def wait_for_stable_mesh(host: str, tries: int = 12, interval: float = 5.0) -> L
         f"the live mesh never stopped changing after {tries} reads -- refusing "
         "to compose onto a moving baseline"
     )
+
+
+# -- reading what is already on the camera ------------------------------------
+#
+# The editor has to start from the camera's real state rather than from a flat
+# zero curve, or the operator's first adjustment is a delta from nothing.
+#
+# One thing this deliberately does NOT do: apply the mesh to the snapshot.
+# `cmd=Snap` already returns the *fused* 7680x2160 panorama -- the VPE warp and
+# the stitcher have both run by the time the JPEG exists, which is precisely why
+# the blend corridor and its ghost are visible in it at all. Warping that image
+# by the mesh again would apply the correction twice. What the mesh can honestly
+# supply is its own *shape*, which is what `seam_profile` below extracts.
+
+#: Where the boot hook leaves this boot's dumped factory mesh. Both names are
+#: present on the unit and byte-identical (verified live 2026-08-19, md5
+#: 7ac18ef2988970d09fc4f5a36c6cd311); `factory_boot.bin` is the one
+#: `S98_StitchCal` writes and documents, so it is tried first.
+FACTORY_COPIES = ("factory_boot.bin", "factory_vpe0.bin")
+
+
+def seam_profile(
+    lut: Lut2D,
+    *,
+    dst_width: float = DEFAULT_HALF_WIDTH,
+    dst_height: float = DEFAULT_HALF_HEIGHT,
+) -> list[dict]:
+    """Per-row behaviour of a mesh at the seam column: the vendor's own solution.
+
+    The mesh maps destination grid points to *source* pixels, and the seam is
+    the left half's last column, so `src_x - dst_x` there is the horizontal
+    displacement the camera's optimiser chose for that row. `s` is the local
+    source-pixels-per-destination-pixel, computed exactly as
+    `compose_correction` computes it, because that is the factor an operator's
+    `dx` gets multiplied by: the composer writes `x + dx*s`. Showing both means
+    the operator can see the shape the camera chose *and* how far a given
+    correction will actually move things on each row.
+    """
+    n = lut.n
+    if n < 3:
+        raise Lut2DError(f"mesh too small to profile: n={n}")
+    du = (dst_width - 1.0) / (n - 1)
+    dv = (dst_height - 1.0) / (n - 1)
+    seam_col = n - 1
+    dst_x = seam_col * du
+    out: list[dict] = []
+    for row in range(n):
+        base = row * lut.stride
+        x_last = (lut.entries[base + seam_col] & 0xFFFF) / FRAC_SCALE
+        x_prev = (lut.entries[base + seam_col - 1] & 0xFFFF) / FRAC_SCALE
+        out.append(
+            {
+                "row": row,
+                "y": round(row * dv, 1),
+                "src_x": round(x_last, 3),
+                "offset_px": round(x_last - dst_x, 3),
+                "s": round((x_last - x_prev) / du, 5),
+            }
+        )
+    return out
+
+
+def _fetch_optional(host: str, sd_relative: str) -> bytes | None:
+    """Read a file off the SD card, or None if the camera does not have it.
+
+    A 404 here is information, not an error: no `anchors.txt` means this unit
+    has never been calibrated, which is a state the UI must state plainly.
+    """
+    import tempfile
+
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            p = fetch_sd(host, sd_relative, Path(td) / "f")
+            return p.read_bytes()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+    except urllib.error.URLError:
+        return None
+
+
+@dataclass
+class CameraCalibration:
+    """What is actually installed on the camera right now."""
+
+    live_crc32: int = 0
+    factory_crc32: int | None = None
+    factory_name: str = ""
+    at_factory: bool | None = None
+    anchors: list[tuple[float, float]] | None = None
+    anchors_meta: dict | None = None
+    anchors_error: str = ""
+    profile: list[dict] | None = None
+    note: str = ""
+
+    def anchors_at(
+        self,
+        rows: Sequence[float],
+        *,
+        src_width: float = DEFAULT_PANORAMA_WIDTH,
+        src_height: float = DEFAULT_HALF_HEIGHT,
+    ) -> list[tuple[float, float]] | None:
+        """The installed curve resampled onto `rows`, or None if uncalibrated.
+
+        Note the geometry: a "half" is half in *width* only, so the panorama
+        and the half share a height of `DEFAULT_HALF_HEIGHT`. Treating that
+        constant as a half-height silently halves every row.
+
+        `anchors.txt` records the geometry it was authored against, and the
+        editor works in the geometry of the frame currently loaded. Those are
+        both 7680x2160 in the shipping setup, but a calibration recovered from a
+        downscaled still is exactly the case that would otherwise apply a
+        proportionally wrong curve with nothing complaining.
+        """
+        if not self.anchors:
+            return None
+        meta = self.anchors_meta or {}
+        file_h = float(meta.get("src_height") or src_height)
+        file_w = float(meta.get("src_width") or src_width)
+        y_scale = file_h / src_height if src_height else 1.0
+        dx_scale = src_width / file_w if file_w else 1.0
+        return [
+            (float(y), interp_dx(self.anchors, y * y_scale) * dx_scale) for y in rows
+        ]
+
+    def to_api(self) -> dict:
+        return {
+            "live_crc32": f"{self.live_crc32:08x}",
+            "factory_crc32": (
+                None if self.factory_crc32 is None else f"{self.factory_crc32:08x}"
+            ),
+            "factory_name": self.factory_name,
+            "at_factory": self.at_factory,
+            "anchors": (
+                None if self.anchors is None else [list(a) for a in self.anchors]
+            ),
+            "anchors_meta": self.anchors_meta,
+            "anchors_error": self.anchors_error,
+            "profile": self.profile,
+            "note": self.note,
+        }
+
+
+def read_calibration(
+    host: str = DEFAULT_HOST, *, with_profile: bool = True
+) -> CameraCalibration:
+    """Read the camera's current calibration state. Read-only.
+
+    Dumping the mesh is a read of the live VPE state -- it writes only a file on
+    the SD card and never touches the VPE or flash. Nothing here calls
+    `set_stitch` or `lut2d_ioctl set`.
+    """
+    dump_mesh(host, name="baseline.bin")
+    live = read_mesh(host, "baseline.bin")
+    state = CameraCalibration(live_crc32=crc32(live))
+    if with_profile:
+        state.profile = seam_profile(live)
+
+    for name in FACTORY_COPIES:
+        blob = _fetch_optional(host, f"stitchcal/{name}")
+        if blob is None:
+            continue
+        try:
+            state.factory_crc32 = crc32(Lut2D.from_bytes(blob))
+        except Lut2DError as exc:
+            state.anchors_error = f"{name} is unreadable: {exc}"
+            continue
+        state.factory_name = name
+        state.at_factory = state.factory_crc32 == state.live_crc32
+        break
+
+    raw = _fetch_optional(host, "stitchcal/anchors.txt")
+    if raw is not None:
+        try:
+            anchors, meta = parse_anchors(raw.decode("utf-8", "replace"))
+            state.anchors, state.anchors_meta = anchors, meta
+        except Lut2DError as exc:
+            state.anchors_error = f"anchors.txt is unparseable: {exc}"
+
+    if state.anchors is None and state.at_factory:
+        state.note = (
+            "This unit is at factory: no anchors.txt is installed and the live "
+            "mesh is byte-identical to the factory copy. Nothing has been applied."
+        )
+    elif state.anchors is None and state.at_factory is False:
+        state.note = (
+            "No anchors.txt is installed, but the live mesh differs from the "
+            "factory copy. Something changed the mesh outside this tool."
+        )
+    elif state.anchors is not None:
+        # The boot hook composes anchors onto the mesh the firmware just
+        # generated, so anchors are always relative to *factory*. The
+        # interactive apply path composes onto the *live* mesh instead, so
+        # re-applying while a calibration is installed stacks on top of it
+        # until the next reboot re-composes from factory. Say so rather than
+        # letting an operator discover it.
+        state.note = (
+            f"{len(state.anchors)} anchors are installed"
+            f"{' (' + state.anchors_meta['calibration_id'] + ')' if state.anchors_meta and state.anchors_meta.get('calibration_id') else ''}"
+            ". Anchors are relative to the factory mesh, which is what the boot "
+            "hook composes against. Applying again from here replaces this "
+            "curve at the next boot, but the immediate on-camera result is "
+            "composed onto the live mesh -- reboot to make the two agree."
+        )
+    return state
 
 
 # -- the ordered sequence -----------------------------------------------------

--- a/reolink-firmware-patching/vpe/stitch_apply.py
+++ b/reolink-firmware-patching/vpe/stitch_apply.py
@@ -14,10 +14,11 @@ entry point that writes a mesh on its own:
 
     1. set scalars (if any)      -- HTTP, persists to /mnt/para/stitch.cfg
     2. wait for the pipeline to settle and the mesh to stop changing
-    3. dump the NEW factory mesh -- this is the baseline
+    3. decide the TRUE baseline: the live mesh, unless the live mesh is our
+       own previous correction, in which case it is the saved factory copy
     4. compose the correction onto THAT
-    5. write, with read-back verification
-    6. re-dump and confirm the baseline did not move under us
+    5. write, with read-back verification, and record what we wrote
+    6. re-dump and confirm nothing else moved the mesh under us
 
 Step 6 is the guard that makes step 1 unskippable in practice: if anything
 re-ran the optimiser between the baseline dump and the write -- another
@@ -25,9 +26,20 @@ operator, the app, a second copy of this tool -- the composed mesh no longer
 matches its baseline and the write is refused rather than silently applied on
 top of a different calibration.
 
-The boot hook (`S98_StitchCal`) satisfies the same constraint structurally
-instead: it composes onto whatever mesh the firmware generated at boot, which by
-construction already reflects the persisted scalars.
+Step 3 is not a formality. The live mesh is only the baseline on an
+uncalibrated unit; once a calibration is installed it is `factory (+) old`, and
+composing onto it gives `factory (+) old (+) new` -- which the next boot then
+rewrites as `factory (+) new`, because the boot hook composes from the saved
+factory copy. Same stored anchors, two different meshes, distinguished only by
+whether the unit has been power-cycled. `S98_StitchCal` avoids this by keeping
+`applied.sig`, and this file uses the same file, the same byte range and the
+same rule, so the two paths cannot drift apart. That matters most for the
+sequence the editor now encourages: load the installed calibration, nudge it,
+apply.
+
+The boot hook satisfies the scalars constraint structurally instead: it composes
+onto whatever mesh the firmware generated at boot, which by construction already
+reflects the persisted scalars.
 
 Transport: HTTP for the scalars and the snapshot, the port-2323 probe shell for
 everything else, `wget` for pushing files (there is no base64 on the device).
@@ -35,6 +47,7 @@ everything else, `wget` for pushing files (there is no base64 on the device).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 import time
@@ -233,6 +246,21 @@ def wait_for_stable_mesh(host: str, tries: int = 12, interval: float = 5.0) -> L
 #: `S98_StitchCal` writes and documents, so it is tried first.
 FACTORY_COPIES = ("factory_boot.bin", "factory_vpe0.bin")
 
+#: Bytes skipped when identifying a mesh by its table alone.
+#:
+#: Must stay in lockstep with `S98_StitchCal`'s `mesh_sig()`, which is
+#: `dd bs=8 skip=1 | md5sum`: the interactive path writes `applied.sig` and the
+#: boot path reads it, so a disagreement here reintroduces exactly the doubling
+#: this exists to prevent. The header is skipped because a driver dump carries
+#: {id, n} plus whatever the driver left in the third word, while a composed
+#: file carries a canonical header -- only the table is comparable.
+MESH_SIG_SKIP = 8
+
+
+def mesh_signature(blob: bytes) -> str:
+    """Identify a mesh by its table alone, exactly as `S98_StitchCal` does."""
+    return hashlib.md5(blob[MESH_SIG_SKIP:]).hexdigest()  # noqa: S324
+
 
 def seam_profile(
     lut: Lut2D,
@@ -293,6 +321,12 @@ def _fetch_optional(host: str, sd_relative: str) -> bytes | None:
         raise
     except urllib.error.URLError:
         return None
+
+
+def _fetch_text(host: str, sd_relative: str) -> str:
+    """A small text file off the SD card, or "" if it is not there."""
+    blob = _fetch_optional(host, sd_relative)
+    return "" if blob is None else blob.decode("utf-8", "replace").strip()
 
 
 @dataclass
@@ -460,10 +494,40 @@ def apply_calibration(
             stage["state"] = "applied"
     report["stages"].append(stage)
 
-    # 2+3) settle, then dump THIS baseline
-    baseline = wait_for_stable_mesh(host)
+    # 2+3) settle, then work out what the TRUE baseline is.
+    #
+    # The live mesh is not automatically the baseline. On a unit that already
+    # carries a calibration it is `factory (+) old`, and composing onto it
+    # yields `factory (+) old (+) new` -- which then silently becomes
+    # `factory (+) new` at the next boot, because `S98_StitchCal` composes from
+    # the saved factory copy. Two different meshes for the same stored anchors,
+    # differing only by whether the unit has been power-cycled.
+    #
+    # `S98_StitchCal` already solves this and this mirrors it exactly rather
+    # than inventing a second scheme: remember the signature of what we last
+    # wrote, and if the live mesh IS that, the true baseline is the saved copy.
+    # Otherwise the live mesh is the baseline and the saved copy is stale --
+    # which is also what makes it self-heal through a legitimate `SetStitch`.
+    live = wait_for_stable_mesh(host)
+    live_sig = mesh_signature(live.to_bytes())
+    prev_sig = _fetch_text(host, "stitchcal/applied.sig")
+    factory_blob = _fetch_optional(host, f"stitchcal/{FACTORY_COPIES[0]}")
+    ours_is_live = bool(prev_sig) and prev_sig == live_sig and factory_blob is not None
+
+    if ours_is_live:
+        baseline = Lut2D.from_bytes(factory_blob)  # type: ignore[arg-type]
+        baseline_src = FACTORY_COPIES[0]
+    else:
+        baseline = live
+        baseline_src = ""  # the live dump is already at baseline.bin
     baseline_crc = crc32(baseline)
     report["baseline_crc32"] = f"{baseline_crc:08x}"
+    report["baseline"] = {
+        "source": "saved factory copy" if ours_is_live else "live mesh",
+        "live_sig": live_sig,
+        "applied_sig": prev_sig or None,
+        "our_correction_was_live": ours_is_live,
+    }
 
     # 4) compose against it
     text = format_anchors(
@@ -480,11 +544,19 @@ def apply_calibration(
         "result_crc32": f"{stats.result_crc32:08x}",
     }
 
-    # 6) re-check the baseline before writing. This is the ordering guard: if
-    #    anything re-ran the optimiser since step 3, the mesh we hold was
-    #    composed against a calibration that no longer exists.
+    # 6) re-check before writing. This is the ordering guard: if anything
+    #    re-ran the optimiser since step 3, the mesh we hold was composed
+    #    against a calibration that no longer exists.
+    #
+    #    Compare against the LIVE signature seen at decision time, not against
+    #    the baseline crc. Those are the same thing only on an uncalibrated
+    #    unit; once our own correction is live they differ by exactly that
+    #    correction, and a baseline comparison would refuse every re-calibration
+    #    while still failing to catch the doubling it was supposed to prevent.
+    #    What must be detected is *someone else* moving the mesh, which is a
+    #    change away from the signature we just observed.
     dump_mesh(host, name="recheck.bin")
-    if crc32(read_mesh(host, "recheck.bin")) != baseline_crc:
+    if mesh_signature(read_mesh(host, "recheck.bin").to_bytes()) != live_sig:
         raise OrderingViolation(
             "the live mesh changed between the baseline dump and the write. "
             "Something re-ran SetStitch (or another copy of this tool is "
@@ -504,11 +576,27 @@ def apply_calibration(
     #    the interactive path, where a baseline that moved means the operator
     #    changed something mid-flight.
     push_text(host, f"{CAM_DIR}/anchors.txt", text)
+    helper = _helper(host)
+    # Put the true baseline where the camera-side composer reads it, and keep
+    # the saved factory copy current, in the same order `S98_StitchCal` does:
+    # either restore the factory copy as the compose input (our correction was
+    # live), or save the live mesh as the factory copy (it is the baseline).
+    stage_baseline = (
+        f"cp {baseline_src} baseline.bin"
+        if baseline_src
+        else f"cp baseline.bin {FACTORY_COPIES[0]}"
+    )
+    # `applied.sig` is written from the composed file, by the camera, with the
+    # same byte range `S98_StitchCal` reads -- if the interactive path and the
+    # boot path can disagree about what is installed, eventually they will.
+    # `tail -c +9` rather than `dd bs=8 skip=1`: camsh refuses `dd` outright.
     out = sh(
-        f"cd {CAM_DIR} && "
-        f"{_helper(host)} compose baseline.bin anchors.txt mesh_apply.bin "
+        f"cd {CAM_DIR} && {stage_baseline} && "
+        f"{helper} compose baseline.bin anchors.txt mesh_apply.bin "
         f"--require-baseline 2>&1 && "
-        f"{_helper(host)} set 0 mesh_apply.bin --i-have-a-recovery-path 2>&1",
+        f"{helper} set 0 mesh_apply.bin --i-have-a-recovery-path 2>&1 && "
+        f"tail -c +{MESH_SIG_SKIP + 1} mesh_apply.bin | md5sum | "
+        f"cut -d' ' -f1 > applied.sig",
         host=host,
         timeout=120,
     )

--- a/tests/test_seam_echo.py
+++ b/tests/test_seam_echo.py
@@ -1,0 +1,177 @@
+"""Tests for the automatic seam measurement (`vpe/seam_echo.py`).
+
+The point of these is the *refusals*. Five passes at this measurement have
+produced confident wrong numbers -- grass texture, a parked car, a shirt, a pair
+of shorts, and in this pass a walking figure whose limbs sit at different
+heights and voted 18..33 px. So the behaviour worth pinning down is that the
+estimator declines to publish when its evidence does not support a number, and
+that its null cannot be skipped.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+VPE = Path(__file__).resolve().parents[1] / "reolink-firmware-patching" / "vpe"
+if str(VPE) not in sys.path:
+    sys.path.insert(0, str(VPE))
+
+seam_echo = pytest.importorskip("seam_echo")
+
+
+SEAM = 400
+BLEND = 128
+
+
+def _pitch(h=520, w=800, rng=None):
+    """Green, heavily luminance-textured, chromatically uniform -- i.e. grass.
+
+    Built in Lab with texture on L only. That is the property that matters: real
+    grass measures 13-17 in colour distance while carrying enough |dI/dx| to
+    saturate any gradient gate, and a fixture that put the noise on B, G and R
+    equally would leak into a/b and stop being grass.
+    """
+    import cv2
+
+    rng = rng or np.random.default_rng(7)
+    lab = np.zeros((h, w, 3), np.float32)
+    lab[..., 0] = 120.0 + rng.normal(0.0, 26.0, (h, w))  # mown blades
+    lab[..., 1] = 105.0  # green
+    lab[..., 2] = 145.0
+    lab = np.clip(lab, 0, 255).astype(np.uint8)
+    return cv2.cvtColor(lab, cv2.COLOR_Lab2BGR)
+
+
+def _paint(img, x, y0, y1, width=16, colour=(40, 40, 210)):
+    img[y0:y1, x - width // 2 : x + width // 2] = np.array(colour, np.uint8)
+
+
+def _ghosted(img, seam=SEAM, blend=BLEND, d=18):
+    """Apply the blend the camera applies: s = a*b(x) + (1-a)*b(x-d)."""
+    out = img.astype(np.float32).copy()
+    shifted = np.roll(img.astype(np.float32), d, axis=1)
+    lo, hi = seam - blend, seam + blend
+    xs = np.arange(lo, hi)
+    a = np.clip(0.5 - (xs - seam) / (2.0 * blend), 0.0, 1.0)[None, :, None]
+    out[:, lo:hi] = a * out[:, lo:hi] + (1.0 - a) * shifted[:, lo:hi]
+    return np.clip(out, 0, 255).astype(np.uint8)
+
+
+def test_blend_weight_is_half_at_the_seam_and_saturates_at_the_edges():
+    assert seam_echo.blend_weight(SEAM, seam_x=SEAM, blend_w=BLEND) == pytest.approx(
+        0.5
+    )
+    assert seam_echo.blend_weight(SEAM - BLEND, seam_x=SEAM, blend_w=BLEND) == 1.0
+    assert seam_echo.blend_weight(SEAM + BLEND, seam_x=SEAM, blend_w=BLEND) == 0.0
+
+
+def test_colour_distance_separates_a_target_from_grass():
+    """The gate the whole approach rests on. Grass has luminance texture and no
+    colour distinctiveness; a target has both."""
+    img = _pitch()
+    _paint(img, SEAM, 200, 300)
+    dist = seam_echo.colour_distance(img)
+    target = np.percentile(dist[200:300, SEAM - 8 : SEAM + 8], 95)
+    grass = np.percentile(dist[200:300, SEAM + 200 : SEAM + 300], 95)
+    assert target > 3 * grass
+
+
+def test_fit_recovers_a_known_two_copy_separation():
+    profile = np.zeros(140, np.float32)
+    profile[60:80] = 40.0
+    profile[77:97] += 30.0  # second copy, 17 px along
+    best, single = seam_echo._fit_two_copy(profile)
+    assert best is not None and single is not None
+    assert best[1] == pytest.approx(17.0, abs=2.0)
+    assert single[0] > best[0]  # two copies beat one lobe
+
+
+def test_refuses_when_nothing_is_chromatically_distinct():
+    """Bare pitch. The honest answer is an instruction, not a number."""
+    result = seam_echo.measure([_pitch()], seam_x=SEAM, blend_w=BLEND)
+    assert result.verdict == "refused"
+    assert result.dx is None
+    assert "stand" in result.remedy.lower()
+
+
+def test_refuses_a_target_outside_the_mixing_corridor():
+    """A target 106 px out sits at a_pred ~0.09 -- an 8.6% ghost, which nothing
+    should be believed on. An earlier fit reported 16.1 px here; truth is 0."""
+    img = _pitch()
+    _paint(img, SEAM + 106, 200, 300)
+    result = seam_echo.measure([_ghosted(img)], seam_x=SEAM, blend_w=BLEND)
+    assert result.verdict != "measured"
+    assert result.dx is None
+
+
+def test_far_corridor_target_is_not_measured():
+    img = _pitch()
+    _paint(img, SEAM + 300, 200, 320)
+    result = seam_echo.measure([_ghosted(img)], seam_x=SEAM, blend_w=BLEND)
+    assert result.verdict != "measured"
+    assert result.dx is None
+
+
+def test_disagreeing_candidates_refuse_rather_than_publish_a_median():
+    """The failure that mattered: a walking figure voted 18..33 px and a looser
+    gate published 25.5 where the hand-verified answer was 17-19."""
+    result = seam_echo.EchoResult()
+    result.verdict = "refused"
+    cands = [
+        seam_echo.Candidate((0, 26), SEAM, 120.0, d, 0.5, 0.5, 2.0, accepted=True)
+        for d in (18.0, 21.0, 25.0, 26.0, 28.0, 33.0)
+    ]
+    ds = np.array([c.d for c in cands])
+    spread = float(np.percentile(ds, 75) - np.percentile(ds, 25))
+    assert spread > seam_echo.MAX_SPREAD
+
+
+def test_measurement_reports_colour_distance_on_every_candidate():
+    """The audit trail the previous four passes lacked: a reviewer must be able
+    to see the estimator ran on something distinct from the pitch."""
+    img = _pitch()
+    _paint(img, SEAM, 120, 400)
+    result = seam_echo.measure([_ghosted(img)], seam_x=SEAM, blend_w=BLEND)
+    assert result.candidates, "a painted target should produce candidates"
+    for cand in result.candidates:
+        assert cand.lab >= seam_echo.MIN_LAB_DISTANCE
+        assert "lab" in cand.to_api()
+
+
+def test_null_runs_on_every_call_and_is_reported():
+    img = _pitch()
+    _paint(img, SEAM, 120, 400)
+    result = seam_echo.measure([_ghosted(img)], seam_x=SEAM, blend_w=BLEND)
+    api = result.to_api()
+    assert "control_accepted" in api
+    assert "control_rate" in api
+    # controls are scanned whatever the seam verdict -- the null is not optional
+    assert result.controls or result.control_accepted == 0
+
+
+def test_anchors_refuse_to_be_built_from_a_refusal():
+    result = seam_echo.EchoResult(verdict="refused")
+    with pytest.raises(ValueError):
+        seam_echo.anchors_from_measurement(result, (0, 540, 1080))
+
+
+def test_anchors_are_flat_and_cover_every_requested_row():
+    result = seam_echo.EchoResult(verdict="measured", dx=17.5)
+    rows = (0, 540, 1080, 1620, 2159)
+    anchors = seam_echo.anchors_from_measurement(result, rows)
+    assert [y for y, _ in anchors] == list(rows)
+    assert {round(dx, 3) for _, dx in anchors} == {17.5}
+
+
+def test_colour_frames_are_required():
+    with pytest.raises(ValueError):
+        seam_echo.measure([np.zeros((200, 400), np.uint8)], seam_x=SEAM)
+
+
+def test_empty_frame_list_is_rejected():
+    with pytest.raises(ValueError):
+        seam_echo.measure([], seam_x=SEAM)

--- a/tests/test_seam_echo.py
+++ b/tests/test_seam_echo.py
@@ -95,7 +95,7 @@ def test_refuses_when_nothing_is_chromatically_distinct():
     result = seam_echo.measure([_pitch()], seam_x=SEAM, blend_w=BLEND)
     assert result.verdict == "refused"
     assert result.dx is None
-    assert "stand" in result.remedy.lower()
+    assert "chromatically distinct" in result.remedy.lower()
 
 
 def test_refuses_a_target_outside_the_mixing_corridor():
@@ -153,18 +153,40 @@ def test_null_runs_on_every_call_and_is_reported():
     assert result.controls or result.control_accepted == 0
 
 
-def test_anchors_refuse_to_be_built_from_a_refusal():
-    result = seam_echo.EchoResult(verdict="refused")
+def test_anchors_are_refused_unconditionally():
+    """The estimator is withdrawn: no result, however confident, may become a
+    curve. It measures step edges rather than ghosts, and at scale it accepts
+    control corridors -- true answer zero -- almost as often as the seam."""
+    for verdict in ("refused", "void", "withdrawn", "measured"):
+        result = seam_echo.EchoResult(verdict=verdict, provisional_dx=17.5, dx=17.5)
+        with pytest.raises(ValueError, match="withdrawn"):
+            seam_echo.anchors_from_measurement(result, (0, 540, 1080))
+
+
+def test_a_confident_agreeing_measurement_still_does_not_propose(monkeypatch):
+    """The failure mode that made this dangerous: on the one hand-verified frame
+    with a real 18 px ghost, three agreeing candidates on a walking player's
+    torso produced 33 px and the old code published it."""
+    agreeing = [
+        seam_echo.Candidate((0, 26), 3800, 120.0, d, 0.5, 0.5, 2.0, accepted=True)
+        for d in (33.0, 33.0, 34.0)
+    ]
+    # confident at the seam, quiet at the controls -- i.e. the single-frame
+    # case where the old null was inert and a number got published
+    monkeypatch.setattr(
+        seam_echo,
+        "_scan",
+        lambda dist, centre, **k: list(agreeing) if centre == SEAM else [],
+    )
+    img = _pitch()
+    _paint(img, SEAM, 120, 400)
+    result = seam_echo.measure([_ghosted(img)], seam_x=SEAM, blend_w=BLEND)
+    assert result.verdict == "withdrawn"
+    assert result.dx is None
+    assert result.to_api()["dx"] is None
+    assert result.provisional_dx is not None  # kept as evidence
     with pytest.raises(ValueError):
-        seam_echo.anchors_from_measurement(result, (0, 540, 1080))
-
-
-def test_anchors_are_flat_and_cover_every_requested_row():
-    result = seam_echo.EchoResult(verdict="measured", dx=17.5)
-    rows = (0, 540, 1080, 1620, 2159)
-    anchors = seam_echo.anchors_from_measurement(result, rows)
-    assert [y for y, _ in anchors] == list(rows)
-    assert {round(dx, 3) for _, dx in anchors} == {17.5}
+        seam_echo.anchors_from_measurement(result, (0, 1080))
 
 
 def test_colour_frames_are_required():

--- a/tests/test_stitch_apply_baseline.py
+++ b/tests/test_stitch_apply_baseline.py
@@ -1,0 +1,219 @@
+"""The double-compose guard in `apply_calibration`.
+
+The bug: the live mesh is only the baseline on an *uncalibrated* unit. Once a
+calibration is installed the live mesh is `factory (+) old`, so composing onto
+it gives `factory (+) old (+) new` -- which the next boot silently rewrites as
+`factory (+) new`, because `S98_StitchCal` composes from the saved factory copy.
+Same stored anchors, two different meshes, distinguished only by whether the
+unit has been power-cycled.
+
+These tests pin the four cases that matter: onto factory, onto our own
+correction (must not double), when something else moved the mesh (must still
+refuse), and idempotency.
+
+Transport is faked throughout; the live end-to-end run is recorded in
+STITCH_CALIBRATION.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+VPE = Path(__file__).resolve().parents[1] / "reolink-firmware-patching" / "vpe"
+if str(VPE) not in sys.path:
+    sys.path.insert(0, str(VPE))
+
+lut2d = pytest.importorskip("lut2d")
+stitch_apply = pytest.importorskip("stitch_apply")
+
+ANCHORS_A = [(0.0, 4.0), (2159.0, 4.0)]
+ANCHORS_B = [(0.0, 8.0), (2159.0, 8.0)]
+
+
+def _factory(n: int = 33):
+    return lut2d.Lut2D.identity(n, lut2d.DEFAULT_HALF_WIDTH, lut2d.DEFAULT_HALF_HEIGHT)
+
+
+def _composed(baseline, anchors):
+    text = lut2d.format_anchors(anchors, baseline_crc32=lut2d.crc32(baseline))
+    mesh, _stats = lut2d.compose_from_anchors_file(baseline, text)
+    return mesh
+
+
+class FakeCamera:
+    """A camera whose mesh actually changes when the helper composes and sets.
+
+    Faithful enough to catch doubling: `set` really does replace the live mesh
+    with the composed one, so an apply that composes from the wrong baseline
+    produces a visibly different crc.
+    """
+
+    def __init__(self, factory):
+        self.factory = factory
+        self.live = factory
+        self.files: dict[str, bytes] = {}
+        self.text: dict[str, str] = {}
+        self.set_calls = 0
+        self.foreign_change_before_write = None
+
+    # -- the surfaces stitch_apply uses ---------------------------------
+    def dump_mesh(self, host, vpe_id=0, name="baseline.bin"):
+        # A foreign change lands between the baseline dump and the write, which
+        # is exactly the window the re-check exists to cover.
+        if name == "recheck.bin" and self.foreign_change_before_write is not None:
+            self.live = self.foreign_change_before_write
+            self.foreign_change_before_write = None
+        self.files[name] = self.live.to_bytes()
+        return "wrote"
+
+    def read_mesh(self, host, name="baseline.bin"):
+        return lut2d.Lut2D.from_bytes(self.files[name])
+
+    def fetch_optional(self, host, sd_relative):
+        key = sd_relative.split("/")[-1]
+        if key in self.files:
+            return self.files[key]
+        if key in self.text:
+            return self.text[key].encode()
+        return None
+
+    def push_text(self, host, remote_path, text):
+        self.text[remote_path.split("/")[-1]] = text
+
+    def get_stitch(self, host, user, password):
+        s = stitch_apply.Scalars(1.0, 0, 0)
+        return s, s
+
+    def sh(self, cmd, host=None, timeout=None, **kw):
+        if "-x" in cmd and "lut2d_ioctl" in cmd and "compose" not in cmd:
+            return "BAKED"  # _helper() probe
+        if "compose" not in cmd:
+            return ""
+        if "cp factory_boot.bin baseline.bin" in cmd:
+            self.files["baseline.bin"] = self.files["factory_boot.bin"]
+        elif "cp baseline.bin factory_boot.bin" in cmd:
+            self.files["factory_boot.bin"] = self.files["baseline.bin"]
+
+        baseline = lut2d.Lut2D.from_bytes(self.files["baseline.bin"])
+        mesh, stats = lut2d.compose_from_anchors_file(
+            baseline, self.text["anchors.txt"], require_baseline=True
+        )
+        self.live = mesh
+        self.files["mesh_apply.bin"] = mesh.to_bytes()
+        self.set_calls += 1
+        if "applied.sig" in cmd:
+            self.text["applied.sig"] = stitch_apply.mesh_signature(mesh.to_bytes())
+        return f"read-back matches, crc {stats.result_crc32:08x}"
+
+
+@pytest.fixture
+def cam(monkeypatch):
+    c = FakeCamera(_factory())
+    monkeypatch.setattr(stitch_apply, "dump_mesh", c.dump_mesh)
+    monkeypatch.setattr(stitch_apply, "read_mesh", c.read_mesh)
+    monkeypatch.setattr(stitch_apply, "_fetch_optional", c.fetch_optional)
+    monkeypatch.setattr(stitch_apply, "push_text", c.push_text)
+    monkeypatch.setattr(stitch_apply, "get_stitch", c.get_stitch)
+    monkeypatch.setattr(stitch_apply, "sh", c.sh)
+    monkeypatch.setattr(
+        stitch_apply, "time", type("T", (), {"sleep": staticmethod(lambda s: None)})
+    )
+    return c
+
+
+def _apply(anchors, **kw):
+    return stitch_apply.apply_calibration(anchors, password="x", **kw)
+
+
+# -- the four cases ----------------------------------------------------------
+
+
+def test_apply_onto_factory_uses_the_live_mesh_as_baseline(cam):
+    report = _apply(ANCHORS_A)
+    assert report["baseline"]["source"] == "live mesh"
+    assert report["baseline"]["our_correction_was_live"] is False
+    assert lut2d.crc32(cam.live) == lut2d.crc32(_composed(cam.factory, ANCHORS_A))
+
+
+def test_apply_onto_our_own_correction_does_not_double(cam):
+    _apply(ANCHORS_A)
+    first = lut2d.crc32(cam.live)
+    report = _apply(ANCHORS_B)
+    assert report["baseline"]["source"] == "saved factory copy"
+    assert report["baseline"]["our_correction_was_live"] is True
+    want = lut2d.crc32(_composed(cam.factory, ANCHORS_B))
+    doubled = lut2d.crc32(_composed(_composed(cam.factory, ANCHORS_A), ANCHORS_B))
+    assert lut2d.crc32(cam.live) == want, "must be factory (+) B"
+    assert lut2d.crc32(cam.live) != doubled, "must NOT be factory (+) A (+) B"
+    assert first != want
+
+
+def test_applying_the_same_anchors_twice_is_idempotent(cam):
+    _apply(ANCHORS_A)
+    once = lut2d.crc32(cam.live)
+    _apply(ANCHORS_A)
+    assert lut2d.crc32(cam.live) == once
+
+
+def test_refuses_when_something_else_moved_the_mesh(cam):
+    other = _factory()
+    other.set(0, 0, 11.0, 11.0)
+    cam.foreign_change_before_write = other
+    # the guard fires on the re-check, before any write
+    with pytest.raises(stitch_apply.OrderingViolation):
+        _apply(ANCHORS_A)
+
+
+def test_a_foreign_mesh_becomes_the_new_baseline_next_time(cam):
+    """Self-healing: a legitimate SetStitch produces a mesh matching neither our
+    signature nor the saved copy, and must be adopted as the baseline."""
+    _apply(ANCHORS_A)
+    resected = _factory()
+    resected.set(1, 1, 9.0, 9.0)
+    cam.live = resected  # as if SetStitch re-ran the optimiser
+    report = _apply(ANCHORS_B)
+    assert report["baseline"]["source"] == "live mesh"
+    assert lut2d.crc32(cam.live) == lut2d.crc32(_composed(resected, ANCHORS_B))
+
+
+# -- the pieces the two paths share ------------------------------------------
+
+
+def test_signature_skips_the_header_so_dumps_and_composed_files_compare(cam):
+    """A driver dump and a composed file carry different 8-byte headers; only
+    the table is comparable, which is why S98's mesh_sig skips it."""
+    mesh = _composed(_factory(), ANCHORS_A)
+    blob = mesh.to_bytes()
+    other_header = b"\xff" * 8 + blob[8:]
+    assert stitch_apply.mesh_signature(blob) == stitch_apply.mesh_signature(
+        other_header
+    )
+
+
+def test_signature_byte_range_matches_the_boot_hook():
+    """`S98_StitchCal` uses `dd bs=8 skip=1`; drift here silently reintroduces
+    the doubling, because the two paths would stop recognising each other."""
+    hook = (VPE.parent / "runtime" / "stitchcal" / "S98_StitchCal").read_text()
+    assert 'dd if="$1" bs=8 skip=1' in hook
+    assert stitch_apply.MESH_SIG_SKIP == 8
+
+
+def test_applied_sig_is_written_so_the_boot_path_agrees(cam):
+    _apply(ANCHORS_A)
+    assert cam.text["applied.sig"] == stitch_apply.mesh_signature(cam.live.to_bytes())
+
+
+def test_anchors_are_stamped_with_the_true_baseline_not_the_live_mesh(cam):
+    _apply(ANCHORS_A)
+    _apply(ANCHORS_B)
+    _parsed, meta = lut2d.parse_anchors(cam.text["anchors.txt"])
+    assert meta["baseline_crc32"] == lut2d.crc32(cam.factory)
+
+
+def test_dry_run_writes_nothing(cam):
+    _apply(ANCHORS_A, dry_run=True)
+    assert cam.set_calls == 0
+    assert lut2d.crc32(cam.live) == lut2d.crc32(cam.factory)

--- a/tests/test_stitch_camera_state.py
+++ b/tests/test_stitch_camera_state.py
@@ -1,0 +1,205 @@
+"""Reading the camera's installed calibration (`vpe/stitch_apply.py`).
+
+The premise these pin down: the editor must start from what is *installed*, and
+`dx = 0` must mean "the factory mesh, untouched". The boot hook composes anchors
+onto the mesh the firmware generates at boot, so anchors are always relative to
+factory -- which is what makes an all-zero curve and "back to factory" the same
+thing, and why there is only one button for them.
+
+Transport is faked throughout; the live-camera check is separate and manual.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+VPE = Path(__file__).resolve().parents[1] / "reolink-firmware-patching" / "vpe"
+if str(VPE) not in sys.path:
+    sys.path.insert(0, str(VPE))
+
+lut2d = pytest.importorskip("lut2d")
+stitch_apply = pytest.importorskip("stitch_apply")
+
+
+def _identity(n: int = 33):
+    return lut2d.Lut2D.identity(n, lut2d.DEFAULT_HALF_WIDTH, lut2d.DEFAULT_HALF_HEIGHT)
+
+
+# -- seam profile ------------------------------------------------------------
+
+
+def test_identity_mesh_has_no_displacement_at_the_seam():
+    """A pass-through mesh maps destination x to the same source x, so the
+    vendor displacement it 'chose' is zero on every row."""
+    prof = stitch_apply.seam_profile(_identity())
+    assert len(prof) == 33
+    assert all(abs(r["offset_px"]) < 0.5 for r in prof)
+
+
+def test_identity_mesh_has_unit_scale():
+    """`s` is source-px per destination-px, which is 1.0 for a pass-through."""
+    prof = stitch_apply.seam_profile(_identity())
+    assert all(abs(r["s"] - 1.0) < 1e-3 for r in prof)
+
+
+def test_seam_profile_rows_span_the_destination_height():
+    prof = stitch_apply.seam_profile(_identity())
+    assert prof[0]["y"] == 0.0
+    assert prof[-1]["y"] == pytest.approx(lut2d.DEFAULT_HALF_HEIGHT - 1, abs=1.0)
+
+
+def test_seam_profile_reports_the_seam_column_not_the_middle():
+    """The seam is the left half's LAST column; profiling the middle would
+    describe a part of the image the correction is not about."""
+    lut = _identity()
+    n = lut.n
+    du = (lut2d.DEFAULT_HALF_WIDTH - 1.0) / (n - 1)
+    prof = stitch_apply.seam_profile(lut)
+    assert prof[0]["src_x"] == pytest.approx((n - 1) * du, abs=1.0)
+
+
+def test_seam_profile_refuses_a_mesh_too_small_to_difference():
+    tiny = lut2d.Lut2D.identity(2, 3840.0, 2160.0)
+    with pytest.raises(lut2d.Lut2DError):
+        stitch_apply.seam_profile(tiny)
+
+
+# -- anchors_at --------------------------------------------------------------
+
+
+def test_uncalibrated_camera_has_no_curve_to_load():
+    assert stitch_apply.CameraCalibration().anchors_at((0, 1080, 2159)) is None
+
+
+def test_installed_anchors_are_resampled_onto_the_editor_rows():
+    cal = stitch_apply.CameraCalibration(
+        anchors=[(0.0, 4.0), (2159.0, 8.0)],
+        anchors_meta={"src_width": 7680.0, "src_height": 2160.0},
+    )
+    got = cal.anchors_at((0, 540, 1080, 1620, 2159))
+    assert [y for y, _ in got] == [0, 540, 1080, 1620, 2159]
+    assert got[0][1] == pytest.approx(4.0)
+    # linear across the full 0..2159 span, not a half of it: 4 + 4*(1080/2159)
+    assert got[2][1] == pytest.approx(6.0, abs=0.05)
+    assert got[-1][1] == pytest.approx(8.0)
+
+
+def test_anchors_authored_on_a_downscaled_still_are_rescaled():
+    """The failure this prevents: a curve measured on a half-size frame applying
+    a proportionally wrong correction with nothing complaining."""
+    cal = stitch_apply.CameraCalibration(
+        anchors=[(0.0, 5.0), (1080.0, 5.0)],
+        anchors_meta={"src_width": 3840.0, "src_height": 1080.0},
+    )
+    got = cal.anchors_at((0, 2159))
+    assert got[0][1] == pytest.approx(10.0)  # dx doubles with the width ratio
+
+
+# -- state notes -------------------------------------------------------------
+
+
+def test_factory_state_says_plainly_that_nothing_is_applied():
+    cal = stitch_apply.CameraCalibration(
+        live_crc32=0x8514014A,
+        factory_crc32=0x8514014A,
+        factory_name="factory_boot.bin",
+        at_factory=True,
+    )
+    # the note is produced by read_calibration; assert the wording contract via
+    # the same branch it uses
+    assert cal.at_factory is True
+    assert cal.anchors is None
+
+
+def test_to_api_renders_crc32_as_hex_and_survives_no_factory_copy():
+    cal = stitch_apply.CameraCalibration(live_crc32=0x0A0B0C0D)
+    api = cal.to_api()
+    assert api["live_crc32"] == "0a0b0c0d"
+    assert api["factory_crc32"] is None
+    assert api["at_factory"] is None
+
+
+def test_factory_copy_names_are_tried_in_documented_order():
+    """`factory_boot.bin` is what S98_StitchCal writes; both names exist on the
+    unit and are byte-identical, so order only decides which is reported."""
+    assert stitch_apply.FACTORY_COPIES[0] == "factory_boot.bin"
+    assert "factory_vpe0.bin" in stitch_apply.FACTORY_COPIES
+
+
+# -- read_calibration, faked transport ---------------------------------------
+
+
+@pytest.fixture
+def faked(monkeypatch):
+    lut = _identity()
+    blob = lut.to_bytes()
+    calls: dict[str, object] = {"dumped": [], "fetched": []}
+
+    def fake_dump(host, vpe_id=0, name="baseline.bin"):
+        calls["dumped"].append(name)
+        return "wrote"
+
+    def fake_read(host, name="baseline.bin"):
+        return lut
+
+    def fake_fetch(host, sd_relative):
+        calls["fetched"].append(sd_relative)
+        return calls.get(sd_relative)  # type: ignore[return-value]
+
+    monkeypatch.setattr(stitch_apply, "dump_mesh", fake_dump)
+    monkeypatch.setattr(stitch_apply, "read_mesh", fake_read)
+    monkeypatch.setattr(stitch_apply, "_fetch_optional", fake_fetch)
+    calls["stitchcal/factory_boot.bin"] = blob
+    return calls
+
+
+def test_read_calibration_reports_factory_when_nothing_is_installed(faked):
+    state = stitch_apply.read_calibration("1.2.3.4")
+    assert state.at_factory is True
+    assert state.anchors is None
+    assert "at factory" in state.note
+    assert "Nothing has been applied" in state.note
+    assert state.profile and len(state.profile) == 33
+
+
+def test_read_calibration_loads_installed_anchors(faked):
+    faked["stitchcal/anchors.txt"] = (
+        b"# seam_calibration/2 deploy-1\n# src 7680 2160  seam 3840\n"
+        b"dx 0 3.0000\ndx 2159 6.0000\n"
+    )
+    state = stitch_apply.read_calibration("1.2.3.4")
+    assert state.anchors == [(0.0, 3.0), (2159.0, 6.0)]
+    assert "anchors are installed" in state.note
+    # the live-vs-boot divergence must be surfaced, not discovered
+    assert "reboot" in state.note
+
+
+def test_read_calibration_flags_a_mesh_changed_outside_this_tool(faked, monkeypatch):
+    other = lut2d.Lut2D.identity(33, 3840.0, 2160.0)
+    other.set(0, 0, 5.0, 5.0)
+    monkeypatch.setattr(stitch_apply, "read_mesh", lambda h, n="baseline.bin": other)
+    state = stitch_apply.read_calibration("1.2.3.4")
+    assert state.at_factory is False
+    assert "outside this tool" in state.note
+
+
+def test_read_calibration_survives_an_unparseable_anchors_file(faked):
+    faked["stitchcal/anchors.txt"] = b"this is not an anchors file\n"
+    state = stitch_apply.read_calibration("1.2.3.4")
+    assert state.anchors is None
+    assert "unparseable" in state.anchors_error
+
+
+def test_read_calibration_never_writes_to_the_camera(faked, monkeypatch):
+    """Read-only is a constraint, not an intention."""
+
+    def boom(*a, **k):
+        raise AssertionError("read_calibration must not write to the camera")
+
+    monkeypatch.setattr(stitch_apply, "set_stitch", boom)
+    monkeypatch.setattr(stitch_apply, "push_text", boom)
+    stitch_apply.read_calibration("1.2.3.4")
+    assert faked["dumped"] == ["baseline.bin"]

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -1967,3 +1967,62 @@ which was left untouched here because it is live-verified and this change is rea
 `anchors.txt`, camera hook log `nothing is calibrated on this unit`; `factory_boot.bin` and
 `factory_vpe0.bin` byte-identical (md5 `7ac18ef2…`); seam `s` at mid-row 0.70018 against the
 independently documented 0.700.
+
+
+---
+
+## Decision: the interactive apply path picks its baseline the way the boot hook does (2026-08-19)
+
+**Context:** `apply_calibration` composed onto the **live** mesh unconditionally, while
+`S98_StitchCal` keeps `applied.sig` and composes onto the saved factory copy when the live mesh is
+its own last write. On a unit already carrying a calibration that produced `factory + old + new`
+interactively and `factory + new` after a reboot — the same stored anchors giving two different
+meshes. `--require-baseline` could not catch it, because the interactive path stamps the live crc it
+has just measured. It became urgent rather than theoretical the moment the editor started loading
+the installed calibration as its starting curve: "load, nudge, apply" is precisely the doubling
+sequence.
+
+**Decision:** mirror the boot hook rather than invent a second scheme. `mesh_signature()` uses the
+same byte range as `S98`'s `mesh_sig` (md5 of the table, 8-byte header skipped); if the live mesh
+matches `applied.sig`, compose from the saved factory copy; write `applied.sig` after a successful
+set so the two paths cannot drift apart. `tail -c +9` rather than `dd`, which `camsh` refuses.
+
+**Rejected:** comparing the re-dump against the baseline crc in the ordering guard. That is only
+correct on an uncalibrated unit; once our own correction is live it differs from the baseline by
+exactly that correction, so it would refuse every legitimate re-calibration while still missing the
+doubling. The guard now compares against the live signature observed at decision time, which is what
+"did someone else move it" actually means.
+
+**Verified live, writes included**, with expected crcs computed before writing: factory `8514014a`;
+apply A → `9604929c`; apply A again → `9604929c` unchanged (old code would have written `3cdcb4aa`);
+apply B → `83e3bedc` = factory+B, not `f18b0999` = factory+A+B. Unit restored to factory, md5
+`7ac18ef2...`, uncalibrated. Details in STITCH_CALIBRATION.md 16.5.
+
+
+---
+
+## Decision: seam auto-measure withdrawn; /stitch/auto is diagnostics only (2026-08-19)
+
+**Supersedes** "ship the seam auto-measure as a refusing instrument" (same date). That entry judged
+the estimator honest because it refused on the hand-verified frames. Run at scale it does not: on
+frame 1104, which carries a real 18 px ghost, the shipped module **published 33.0 px**, and across
+7,688 frames it accepts control corridors (6.3%) almost as often as the seam (7.4%) - 1.18x against
+its own `NULL_MARGIN` of 3.0 - with overlapping d distributions.
+
+**Why it fails:** it measures a **step edge**, not a ghost. Two lobes fit a shirt-against-grass step
+better than one, so `gain` is anti-correlated with truth on this material. Cross-frame agreement,
+which was expected to be the discriminator, is *better at the controls* than at the seam, so it
+cannot serve as the acceptance criterion either.
+
+**The null shipped here was also defective:** `if ctl_ok and seam_rate < NULL_MARGIN * ctl_rate` is
+skipped when the controls accept nothing, which is the common single-frame case - inert at exactly
+the sample size the button uses.
+
+**Decision:** keep the endpoint and the plumbing as **diagnostics**; remove the proposal.
+`measure()` always returns `verdict="withdrawn"` with its numbers as evidence, and
+`anchors_from_measurement` raises unconditionally so no result can become a curve. The UI has no
+adopt control. The seam is calibrated by hand from the camera's installed state.
+
+**Not attempted in this pass:** a fix. Colour gating was necessary and insufficient; discriminating a
+ghost from a step is new work with its own acceptance bar, not a parameter tweak. Shards for
+re-analysis: `F:/archive/duo3_stitch/harvest/report_shards_dense/`.

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -1879,3 +1879,57 @@ in decision 8 (that guard required a `truncated_start` flag that does not exist 
 and cannot be derived in-detector). **Fast-follow:** replace the NTFY 5-min walk fallback with a
 single detector-seeded "is this the kickoff?" confirmation (the S3 verify, moved ahead of the trim).
 **Files:** `video_grouper/task_processors/phase_game_start.py`, `tests/test_phase_game_start.py`
+
+---
+
+## Decision: ship the seam auto-measure as a refusing instrument, not a number generator (2026-08-19)
+
+**Context:** five passes have tried to measure the Duo 3 stitch misregistration
+automatically. Four built a detector for an object class (ball, person) and each
+measured something else — grass texture, a parked car, a shirt, a pair of
+shorts. This pass abandoned object detection for class-agnostic echo estimation:
+inside the blend `s(x) = a·b(x) + (1−a)·b(x−d)` for *whatever* `b` is, so only
+horizontal gradient and position in the corridor matter, never identity.
+
+**What was established** (evidence in `reolink-firmware-patching/docs/STITCH_CALIBRATION.md`
+§15). Grey-level echo estimation fails its null: it recovers a synthetic `a`=0.5,
+`d`=18 ghost injected into the same real grass at 0.23–0.57, but the real
+corridor reads 0.03–0.06, and across 40 archived frames **seam median ÷ control
+p90 = 0.68**. Chroma changes that — excluding L (mown grass *is* a luminance
+texture), a target separates from grass by **9.7–13.3×** and from worst-case
+foreground grass by **6.6–8.7×**. In the chroma channel frame 1104's profile
+shows two lobes 17 px apart at amplitude ratio ~0.45, and a two-copy fit returns
+**d = 18.0** (gain 1.99) against 1.06–1.19 for the three negative cases and four
+control corridors — matching the hand-verified 17–19 px and `a` = 0.451.
+
+**What is not established:** automatic candidate selection ranks by chroma and
+on frame 1104 prefers a walking person, whose bands vote 21–35 px. A loose
+agreement gate published their median, **25.5 px, against a hand-verified
+17–19**. The disagreement is physical: the factory mesh nulls the ground plane,
+so residual disparity scales with height above it, and a walking figure's boots,
+shorts and head legitimately differ.
+
+**Decision:** ship `vpe/seam_echo.py` + `POST /stitch/auto` as an instrument that
+**proposes or refuses, and never applies**. The null is inside `measure()` and
+cannot be skipped (identical fit at control corridors, pretending the seam is
+there, so `a_pred` cannot refuse them for free); the agreement gate is tight
+enough that every hand-verified case refuses rather than publishing a wrong
+number; chroma distance is reported on every candidate as the audit trail the
+previous four passes lacked. Applying still goes through `apply_calibration()`
+via the existing `/stitch/apply`.
+
+**Rejected alternative:** publishing the median anyway. A button that emits a
+number which failed its own controls is worse than no button — that is exactly
+how the previous four passes produced confident wrong answers.
+
+**Consequences:** (a) scale does not rescue the grey-level version — averaging
+more rows/frames averages more *unghosted* pixels; (b) a per-row `dx(y)` shear
+cannot represent a height-dependent residual, since at one row the ground and a
+person's head need different `dx`; (c) the calibration target should be flat and
+single-height (a board, a sign, a cone), not a person — a person remains right
+for the human-in-the-loop workflow and wrong for this measurement.
+
+**Reversible:** widen/refine the `d` search (fits pinning at `D_MAX`=36 are not
+measurements), estimate per row band, or — the clean lead — pull the two sensor
+contributions separately (§14 question 1), which turns this from inferring an
+unobservable mixture into direct registration.

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -1933,3 +1933,37 @@ for the human-in-the-loop workflow and wrong for this measurement.
 measurements), estimate per row band, or — the clean lead — pull the two sensor
 contributions separately (§14 question 1), which turns this from inferring an
 unobservable mixture into direct registration.
+
+
+---
+
+## Decision: the seam editor starts from the camera's installed calibration (2026-08-19)
+
+**Context:** Mark asked for the phone app to "pull the current mesh from the camera and apply that
+to the snapshot ... show what the camera automatically generated". The premise needed correcting:
+`cmd=Snap` already returns the **fused** panorama — the VPE warp and the stitcher have both run
+before the JPEG exists, which is why the blend corridor is visible in it at all — so applying the
+mesh to that image would apply it twice.
+
+**Decision:** do not re-warp the snapshot. Instead (a) read the camera's real state on session start
+— live mesh crc32, whether it still matches the on-camera factory copy, and `anchors.txt` if present
+— and initialise the curve from it, labelled as the camera's state rather than as the operator's
+edit; (b) show the *vendor's* solution as the per-row source-x displacement its mesh applies down
+the seam column, which is the honest reading of "what the camera automatically generated".
+
+**Consequences.** `dx = 0` **is** factory, because §7.1 stores the correction as anchors and
+composes at every boot against the mesh the firmware just generated. So "reset to zero" and "back to
+factory" were one button wearing two names; there is now **Back to factory** and **Back to camera
+current**, two buttons with two meanings, and the third was removed rather than left ambiguous.
+
+**Hazard found and surfaced, not fixed:** `apply_calibration` composes onto the *live* mesh while
+the boot hook composes onto the *factory* mesh, so re-calibrating an already-calibrated unit yields
+`factory ⊕ old ⊕ new` until the next reboot, when it becomes `factory ⊕ new`. `--require-baseline`
+cannot catch it (the interactive path stamps the live crc it just measured). Recorded in
+STITCH_CALIBRATION.md §16.5 and surfaced in the UI note; the fix belongs in `apply_calibration`,
+which was left untouched here because it is live-verified and this change is read-only.
+
+**Verified live** (read-only, 2026-08-19): live mesh crc32 `8514014a` == `factory_boot.bin`, no
+`anchors.txt`, camera hook log `nothing is calibrated on this unit`; `factory_boot.bin` and
+`factory_vpe0.bin` byte-identical (md5 `7ac18ef2…`); seam `s` at mid-row 0.70018 against the
+independently documented 0.700.

--- a/training/docs/EXPERIMENTS.md
+++ b/training/docs/EXPERIMENTS.md
@@ -3960,3 +3960,47 @@ truncation-framed question) -> `phase_game_start.resolve_truncated_start`: trim 
 signals (~min); a follow-up can cache the phase_detect-step signals for an instant re-fuse.
 **Still to do:** a "still playing" END-task tap for `truncated_end`, and a truncated toggle in the T2
 app for the confident-but-truncated games that never get the walk (05.09 / 06.06-Fairport).
+
+---
+
+## EXP-STITCH-01: class-agnostic seam echo — grey fails, chroma works, automation does not yet (2026-08-19)
+
+**Goal (Mark):** an operator "Auto" button measuring the stitch misregistration
+from *whatever* is at the seam — person, car, chair, field marking — with no
+detector for any object class.
+
+**Instrument validated first.** Synthetic `a`=0.5, `d`=18 injected into real
+grass from the GT frames is recovered at the correct lag in 6/6 bands, 0.23–0.57
+vs clean-control 0.03–0.09.
+
+**Grey-level echo — negative, fails its null:**
+- GT frame 1104 (ball at x=3846 visibly doubled, required 17–19 px): full-height
+  band×lag map at the seam statistically identical to ±400 controls (0.03–0.06,
+  scattered lags). A tight window **on the doubled ball** reads 0.029–0.058 vs
+  controls 0.049–0.076.
+- Motion-isolated (temporal-median) variants: seam z = +0.04 vs controls.
+  Blob-restricted ACF gives a systematic lag 9–11 everywhere — it measures blob
+  **width**.
+- 40 archived frames, many placements: seam median +0.050/p90 +0.095 vs control
+  median +0.039/p90 +0.074 → **seam ÷ control p90 = 0.68**. The one 10× outlier
+  is **two players standing 16 px apart**, confirmed by eye.
+
+**Chroma — positive.** Excluding L (mown grass is a luminance texture), target
+vs grass separates **9.7–13.3×**, and vs worst foreground grass **6.6–8.7×**
+(with L: 3.9× and 1.35×). Frame 1104's chroma profile shows two lobes, ~45 at
+−14 px and ~33 at +3 px with a dip between → separation ~17 px, ratio ~0.45.
+Two-copy fit on those rows: **d = 18.0, gain 1.99**, against gain 1.14/1.19 for
+frames 1088/1120 and 1.06–1.12 for four control corridors. `a` is predicted from
+geometry (`a_pred` = 0.086 for the 1088 ball), making those refusals geometric.
+
+**Automation — not yet reliable.** Chroma ranking prefers a walking person over
+the ball on frame 1104; its bands vote 21–35 px, several pinned at the `D_MAX`
+grid edge, and a loose gate published the median **25.5 px against 17–19**. The
+disagreement is physical — the mesh nulls the ground plane, so disparity scales
+with height, and a walking figure disagrees with itself.
+
+**Shipped:** `vpe/seam_echo.py` + `POST /stitch/auto`, proposing or refusing,
+never applying; null baked into `measure()` (0/325 control candidates accepted
+vs 12–18 at the seam on the same archive frames); chroma reported per candidate.
+Every hand-verified case refuses and says what would fix it: a flat single-height
+target. Full write-up: `reolink-firmware-patching/docs/STITCH_CALIBRATION.md` §15.

--- a/training/docs/EXPERIMENTS.md
+++ b/training/docs/EXPERIMENTS.md
@@ -4004,3 +4004,46 @@ never applying; null baked into `measure()` (0/325 control candidates accepted
 vs 12–18 at the seam on the same archive frames); chroma reported per candidate.
 Every hand-verified case refuses and says what would fix it: a flat single-height
 target. Full write-up: `reolink-firmware-patching/docs/STITCH_CALIBRATION.md` §15.
+
+
+---
+
+## EXP-STITCH-02: seam echo withdrawn at scale - it measures a step edge (2026-08-19)
+
+**What was tested:** the shipped `vpe/seam_echo.py` (chromatic candidate selection + two-copy fit on
+the Lab-chroma profile, `a` predicted from geometry), run unmodified over the archive.
+
+**Acceptance tests - failed:**
+
+| frame | required | reported |
+|---|---|---|
+| 1104 (+6 px, real 18 px ghost) | 17-19 px | **33.0 px, published** |
+| 1088 (+106 px) | ~0 / refuse | void |
+| 1120 (-51 px) | ~0 / refuse | void |
+
+**Null at scale** - 7,688 frames, 46,088 seam candidates, 90,609 controls, 28 games: seam acceptance
+7.4% vs control 6.3% (**1.18x**, against the module's own `NULL_MARGIN` of 3.0). `ctl-1200` accepts
+more often than the seam. d-histogram overlap 0.85; seam/control median d 31/30 px, unchanged after
+matching on colour decile and row band. 96 gate settings swept, none both quiet off-seam and correct
+on it.
+
+**Mechanism:** a step edge (shirt against grass) is fitted better by two lobes than by one, so `gain`
+rises on precisely the objects the chromatic gate finds best - `gain` is anti-correlated with truth
+here. On f1104 all three accepted candidates were a walking player's torso/shorts/leg 37-47 px from
+the seam; the ball's band ranked 15th chromatically and `max_fits=10` never fitted it. Forced onto
+the ball, the fit returns d=1.
+
+**Agreement inverts and cannot be the criterion:** within-track IQR median 1.0 px / 74% <=1 px at
+*controls* vs 2.0 px / 38% at the seam. The steadiest landmark in the corpus is a control reading
+d=35.0 px with IQR 0.0 over 25 looks, where truth is 0.
+
+**Own-code flaw worth keeping:** the null guard `if ctl_ok and seam_rate < NULL_MARGIN * ctl_rate`
+is skipped entirely when the controls accept nothing, which is common on a single frame - inert at
+exactly the sample size the button uses, and the reason single-frame and scale runs disagreed. A null
+a small sample can switch off is not a null.
+
+**Outcome:** `/stitch/auto` is diagnostics only. `measure()` always returns `verdict="withdrawn"`
+and `anchors_from_measurement` raises unconditionally; the UI has no adopt control. Colour gating was
+necessary but insufficient - a fix must discriminate a **ghost** from a **step**, which is new work
+with its own acceptance bar. Shards: `F:/archive/duo3_stitch/harvest/report_shards_dense/` (78
+`.npz`). Full write-up: `reolink-firmware-patching/docs/STITCH_CALIBRATION.md` section 15.5.

--- a/video_grouper/web/stitch_calibration.py
+++ b/video_grouper/web/stitch_calibration.py
@@ -239,6 +239,12 @@ class _Session:
     auto: dict | None = None
     auto_state: str = "idle"  # idle | running | ready | failed
     auto_error: str = ""
+    # What is actually installed on the camera. The editor starts from this
+    # instead of from a flat zero curve, so an operator's first adjustment is a
+    # delta from reality rather than from nothing.
+    camera_cal: dict | None = None
+    camera_cal_state: str = "idle"  # idle | running | ready | failed
+    camera_cal_error: str = ""
 
     lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -1121,6 +1127,72 @@ def build_router(config_path: Path, storage_path: Path | None = None) -> APIRout
         with _session.lock:
             return JSONResponse(_state_payload())
 
+    def _read_camera_cal_async(host: str) -> None:
+        """Read the camera's installed calibration off the request thread.
+
+        A mesh dump plus two 267 KB SD reads; seconds, not milliseconds, and it
+        must not sit inside `/stitch/state`, which the page polls.
+        """
+        camera_mod = load_toolkit()["camera"]
+        try:
+            state = camera_mod.read_calibration(host)
+            payload = state.to_api()
+            payload["anchors_at_rows"] = (
+                None
+                if state.anchors is None
+                else [list(a) for a in state.anchors_at(ANCHOR_ROWS)]
+            )
+            with _session.lock:
+                _session.camera_cal = payload
+                _session.camera_cal_state = "ready"
+                _session.camera_cal_error = ""
+            logger.info(
+                "STITCH: camera calibration live=%s factory=%s at_factory=%s anchors=%s",
+                payload["live_crc32"],
+                payload["factory_crc32"],
+                payload["at_factory"],
+                0 if state.anchors is None else len(state.anchors),
+            )
+        except Exception as exc:  # noqa: BLE001 -- an unreadable camera is a state
+            logger.warning("STITCH: could not read camera calibration: %s", exc)
+            with _session.lock:
+                _session.camera_cal_state = "failed"
+                _session.camera_cal_error = f"{type(exc).__name__}: {exc}"
+
+    @router.post("/stitch/camera")
+    def post_camera_cal() -> JSONResponse:
+        """Read what is installed on the camera: mesh, factory copy, anchors.
+
+        Read-only. Dumping the mesh reads the live VPE state into a file on the
+        SD card; nothing here calls `SetStitch` or writes a mesh.
+
+        Note what this deliberately does not do: it does not warp the snapshot.
+        `cmd=Snap` already returns the *fused* panorama -- the warp and the
+        stitcher have both run before the JPEG exists, which is why the blend
+        corridor is visible in it -- so applying the mesh to that image would
+        apply it twice. The mesh's honest contribution is its own per-row shape,
+        which is what `profile` carries.
+        """
+        camera_mod = load_toolkit()["camera"]
+        if camera_mod is None:
+            raise HTTPException(503, "stitch_apply is not importable")
+        cam = _reolink_camera(config_path)
+        host = _camera_host(cam)
+        with _session.lock:
+            if _session.camera_cal_state == "running":
+                return JSONResponse(_state_payload())
+            _session.camera_cal = None
+            _session.camera_cal_state = "running"
+            _session.camera_cal_error = ""
+        threading.Thread(
+            target=_read_camera_cal_async,
+            args=(host,),
+            daemon=True,
+            name="stitch-camera-cal",
+        ).start()
+        with _session.lock:
+            return JSONResponse(_state_payload())
+
     @router.post("/stitch/apply")
     def post_apply(body: dict = Body(default={})) -> JSONResponse:
         """Send the calibration to the camera, in the one order that is correct.
@@ -1243,6 +1315,9 @@ def _state_payload() -> dict:
         "auto": _session.auto,
         "auto_state": _session.auto_state,
         "auto_error": _session.auto_error,
+        "camera_cal": _session.camera_cal,
+        "camera_cal_state": _session.camera_cal_state,
+        "camera_cal_error": _session.camera_cal_error,
     }
 
 
@@ -1474,7 +1549,8 @@ var S = {
   imgs: {}, blink: 0, cursorRow: 1080, ready: false,
   metrics: null, baseline: null, quality: null, vertical: null,
   busy: false, pending: false, stale: false, scoredAt: null, netFails: 0,
-  spanX: 256, grab: 'curve', narrow: true, retry: null
+  spanX: 256, grab: 'curve', narrow: true, retry: null,
+  auto: null, cameraCal: null
 };
 // Geometry is taken from the frame the server actually fetched, never assumed.
 // These are only the pre-snapshot defaults.
@@ -2112,7 +2188,86 @@ function snap() {
       if (!res.ok) { $('dockstate').textContent = res.j.detail || 'snapshot failed'; return; }
       $('dockstate').textContent = 'live snapshot ' + new Date().toLocaleTimeString();
       loadFrame(res.j);
+      // Start the session from the camera's real calibration, not from zero.
+      if (!S.cameraCal) readCamera(true);
     }).catch(function (e) { $('snap').disabled = false; $('dockstate').textContent = String(e); });
+}
+
+// The camera's installed state. Read once per session so the curve starts from
+// what is really on the unit; `dx = 0` means the factory mesh untouched, because
+// the boot hook composes anchors onto the mesh the firmware just generated.
+function readCamera(thenInit) {
+  $('camread').disabled = true;
+  $('camstate').textContent = 'reading mesh and anchors…';
+  fetch('/stitch/camera', { method: 'POST', credentials: 'same-origin' })
+    .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      if (!res.ok) {
+        $('camread').disabled = false;
+        $('camstate').textContent = res.j.detail || 'could not read the camera';
+        return;
+      }
+      pollCamera(thenInit);
+    }).catch(function (e) { $('camread').disabled = false; $('camstate').textContent = String(e); });
+}
+
+function pollCamera(thenInit) {
+  fetch('/stitch/state', { credentials: 'same-origin' })
+    .then(function (r) { return r.json(); })
+    .then(function (st) {
+      if (st.camera_cal_state === 'running') { setTimeout(function () { pollCamera(thenInit); }, 2000); return; }
+      $('camread').disabled = false;
+      if (st.camera_cal_state === 'failed') {
+        $('camstate').textContent = st.camera_cal_error || 'could not read the camera';
+        return;
+      }
+      showCamera(st.camera_cal, thenInit);
+    }).catch(function (e) { $('camread').disabled = false; $('camstate').textContent = String(e); });
+}
+
+function showCamera(c, thenInit) {
+  if (!c) { $('camstate').textContent = 'no camera state'; return; }
+  S.cameraCal = c;
+  var installed = c.anchors_at_rows;
+  $('camstate').textContent = installed
+    ? (installed.length + ' anchors installed — live mesh ' + c.live_crc32)
+    : ('at factory — live mesh ' + c.live_crc32 +
+       (c.at_factory ? ' matches ' + c.factory_name : ''));
+  $('camnote').textContent = c.note || '';
+  $('camcurrent').disabled = !installed;
+  drawCamProfile(c.profile);
+  if (thenInit) {
+    // Start from the camera, labelled as the camera's state rather than as an
+    // edit the operator made.
+    setAnchors((installed || S.anchors.map(function (p) { return [p[0], 0]; })),
+      installed ? 'loaded from the calibration installed on the camera'
+                : 'camera is at factory — curve starts at zero (factory mesh untouched)');
+  }
+}
+
+function drawCamProfile(profile) {
+  var cv = $('camprofile');
+  if (!profile || !profile.length) { cv.style.display = 'none'; return; }
+  cv.style.display = ''; $('camprofilecap').style.display = '';
+  var g = cv.getContext('2d'), W = cv.width, H = cv.height, pad = 30;
+  g.clearRect(0, 0, W, H);
+  var offs = profile.map(function (r) { return r.offset_px; });
+  var lo = Math.min.apply(null, offs), hi = Math.max.apply(null, offs);
+  if (hi - lo < 1e-6) hi = lo + 1;
+  g.strokeStyle = '#999'; g.lineWidth = 1;
+  g.strokeRect(pad, 6, W - pad - 6, H - pad - 6);
+  g.beginPath();
+  profile.forEach(function (r, i) {
+    var x = pad + (r.offset_px - lo) / (hi - lo) * (W - pad - 6);
+    var y = 6 + i / (profile.length - 1) * (H - pad - 6);
+    if (i === 0) g.moveTo(x, y); else g.lineTo(x, y);
+  });
+  g.strokeStyle = '#e08a2e'; g.lineWidth = 2; g.stroke();
+  g.fillStyle = '#777'; g.font = '10px sans-serif';
+  g.fillText(lo.toFixed(0) + ' px', pad, H - 16);
+  g.fillText(hi.toFixed(0) + ' px', W - 52, H - 16);
+  g.fillText('row 0', 2, 12);
+  g.fillText('row ' + profile[profile.length - 1].y.toFixed(0), 2, H - pad + 2);
 }
 
 // Class-agnostic seam measurement. It proposes or refuses; it never applies,
@@ -2411,8 +2566,19 @@ function init() {
   $('save').addEventListener('click', save);
   $('apply').addEventListener('click', function () { applyToCamera(false); });
   $('dryrun').addEventListener('click', function () { applyToCamera(true); });
+  $('camread').addEventListener('click', function () { readCamera(true); });
   $('reset').addEventListener('click', function () {
-    setAnchors(S.anchors.map(function (p) { return [p[0], 0]; }), 'curve reset to zero');
+    // dx = 0 IS the factory mesh: the boot hook composes anchors onto the mesh
+    // the firmware generates at boot, so an all-zero curve leaves it untouched.
+    // "reset to zero" and "back to factory" were the same button, so there is
+    // only one of them.
+    setAnchors(S.anchors.map(function (p) { return [p[0], 0]; }),
+      'back to factory — zero correction on the vendor mesh');
+  });
+  $('camcurrent').addEventListener('click', function () {
+    var c = S.cameraCal;
+    if (!c || !c.anchors_at_rows) return;
+    setAnchors(c.anchors_at_rows, 'back to the calibration installed on the camera');
   });
   $('suggest').addEventListener('click', function () {
     // The swept minimum, not `implied_dx`. The sweep descends the objective
@@ -2532,6 +2698,24 @@ __BANNER__
 <div class="grid">
 <div class="col">
 
+  <div class="panel" id="campanel">
+    <h2 class="sec">What the camera <span class="accent">already has</span></h2>
+    <p class="hint">The snapshot is the mesh's <em>output</em> &mdash;
+      <span class="mono">Snap</span> returns the fused panorama, after the warp and the
+      stitcher &mdash; so it is not re-warped here. What is shown instead is the shape the
+      camera's own optimiser chose, and the calibration installed on top of it.</p>
+    <div id="camstate" class="st">not read yet</div>
+    <div id="camnote" class="hint"></div>
+    <canvas id="camprofile" width="320" height="150"
+            style="width:100%;max-width:340px;display:none"></canvas>
+    <p class="faint" id="camprofilecap" style="display:none">Source-x displacement the factory
+      mesh applies down the seam column, per row. This is the vendor's stitch solution; your
+      curve is composed on top of it.</p>
+    <div class="btn-row">
+      <button class="btn btn-ghost btn-sm" id="camread">Read camera</button>
+    </div>
+  </div>
+
   <div class="panel" id="autopanel" style="display:none">
     <h2 class="sec">Automatic <span class="accent">measurement</span></h2>
     <p class="hint">Candidates are picked by <em>colour</em> distance from the
@@ -2612,7 +2796,8 @@ __BANNER__
       at a different height is what earns a roll.</p>
     <p class="faint" id="curvewhy"></p>
     <div class="btn-row">
-      <button class="btn btn-ghost btn-sm" id="reset">Reset to zero</button>
+      <button class="btn btn-ghost btn-sm" id="reset">Back to factory</button>
+      <button class="btn btn-ghost btn-sm" id="camcurrent" disabled>Back to camera current</button>
       <button class="btn btn-ghost btn-sm" id="suggest" disabled>Use measured dx</button>
     </div>
   </div>

--- a/video_grouper/web/stitch_calibration.py
+++ b/video_grouper/web/stitch_calibration.py
@@ -163,6 +163,7 @@ def load_toolkit() -> dict[str, Any]:
         "metric": None,
         "camera": None,
         "vertical": None,
+        "echo": None,
         "errors": [],
     }
     vpe = _vpe_dir()
@@ -178,6 +179,7 @@ def load_toolkit() -> dict[str, Any]:
     for key, name in (
         ("metric", "seam_metric"),
         ("vertical", "seam_vertical"),
+        ("echo", "seam_echo"),
         ("camera", "stitch_apply"),
     ):
         try:
@@ -231,6 +233,12 @@ class _Session:
     scene_source: str = ""
     scene_vertical: dict | None = None
     vertical: dict | None = None
+    # The automatic seam measurement (`seam_echo`). Kept beside the manual
+    # numbers rather than replacing them: the operator reviews a proposal, and
+    # a measurement that refuses must still say so on the page.
+    auto: dict | None = None
+    auto_state: str = "idle"  # idle | running | ready | failed
+    auto_error: str = ""
 
     lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -1026,6 +1034,93 @@ def build_router(config_path: Path, storage_path: Path | None = None) -> APIRout
             {"path": str(target), "archived": str(archive), "profile": profile}
         )
 
+    def _auto_measure_async(version: int, frames: list[Any], seam_x: int) -> None:
+        """Run `seam_echo.measure` off the request thread.
+
+        Comparable in cost to the SCR detection this page already runs in the
+        background (37-50 s), for the same reason: the operator should be
+        looking at the picture long before the numbers arrive.
+        """
+        echo = load_toolkit()["echo"]
+        try:
+            result = echo.measure(frames, seam_x=seam_x, blend_w=BLEND_W)
+            payload = result.to_api()
+            with _session.lock:
+                if _session.version != version:
+                    return
+                _session.auto = payload
+                _session.auto_state = "ready"
+                _session.auto_error = ""
+            logger.info(
+                "STITCH: auto measure %s dx=%s (seam %d/%d, control %d/%d)",
+                payload["verdict"],
+                payload["dx"],
+                payload["n_accepted"],
+                payload["n_candidates"],
+                payload["control_accepted"],
+                len(result.controls),
+            )
+        except Exception as exc:  # noqa: BLE001 -- report, never publish a guess
+            logger.error("STITCH: auto measure failed: %s", exc)
+            with _session.lock:
+                if _session.version == version:
+                    _session.auto_state = "failed"
+                    _session.auto_error = f"{type(exc).__name__}: {exc}"
+
+    @router.post("/stitch/auto")
+    def post_auto(body: dict = Body(default={})) -> JSONResponse:
+        """Measure `dx` from whatever is standing in the seam, or refuse.
+
+        Class-agnostic by construction: candidates are selected by *colour*
+        distance from the pitch, never by object class, because grass has
+        enormous luminance texture and almost no colour distinctiveness and
+        that is what defeated every gradient-gated attempt. See `seam_echo`.
+
+        Several frames are used when the source is the live camera -- the
+        camera is on a tripod and `Snap` is read-only, so a couple of seconds
+        of them is free and turns one lucky reading into an agreement test.
+        """
+        echo = load_toolkit()["echo"]
+        if echo is None:
+            raise HTTPException(503, "seam_echo is not importable")
+        n = max(1, min(int(body.get("frames") or 3), 8))
+        with _session.lock:
+            base, seam_x = _session.frame, _session.width // 2
+            live = bool(_session.frame is not None and not _session.source_path)
+            version = _session.version
+        if base is None:
+            raise HTTPException(409, "take a snapshot first")
+        if base.ndim != 3:
+            raise HTTPException(
+                415,
+                "the seam measurement needs a colour frame: a target is "
+                "separable from grass by colour, not by luminance",
+            )
+
+        frames = [base]
+        if live:
+            for _ in range(n - 1):
+                try:
+                    extra, _cam, _host = _live_frame()
+                except HTTPException:
+                    break  # a short series still measures; a failed one does not
+                frames.append(extra)
+
+        with _session.lock:
+            if _session.version != version:
+                raise HTTPException(409, "the snapshot changed; press Auto again")
+            _session.auto = None
+            _session.auto_state = "running"
+            _session.auto_error = ""
+        threading.Thread(
+            target=_auto_measure_async,
+            args=(version, frames, seam_x),
+            daemon=True,
+            name="stitch-auto",
+        ).start()
+        with _session.lock:
+            return JSONResponse(_state_payload())
+
     @router.post("/stitch/apply")
     def post_apply(body: dict = Body(default={})) -> JSONResponse:
         """Send the calibration to the camera, in the one order that is correct.
@@ -1145,6 +1240,9 @@ def _state_payload() -> dict:
             "width": SCENE_W,
         },
         "last_apply": _session.last_apply,
+        "auto": _session.auto,
+        "auto_state": _session.auto_state,
+        "auto_error": _session.auto_error,
     }
 
 
@@ -2017,6 +2115,67 @@ function snap() {
     }).catch(function (e) { $('snap').disabled = false; $('dockstate').textContent = String(e); });
 }
 
+// Class-agnostic seam measurement. It proposes or refuses; it never applies,
+// and it never publishes a number that its own control corridors also produced.
+function autoMeasure() {
+  $('auto').disabled = true;
+  $('autopanel').style.display = '';
+  $('autoverdict').textContent = 'measuring…';
+  $('autodetail').textContent = '';
+  $('autoadopt').style.display = 'none';
+  fetch('/stitch/auto', {
+    method: 'POST', credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ frames: 3 })
+  }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      if (!res.ok) {
+        $('auto').disabled = false;
+        $('autoverdict').textContent = res.j.detail || 'measurement failed';
+        return;
+      }
+      pollAuto();
+    }).catch(function (e) { $('auto').disabled = false; $('autoverdict').textContent = String(e); });
+}
+
+function pollAuto() {
+  fetch('/stitch/state', { credentials: 'same-origin' })
+    .then(function (r) { return r.json(); })
+    .then(function (st) {
+      if (st.auto_state === 'running') { setTimeout(pollAuto, 1500); return; }
+      $('auto').disabled = false;
+      if (st.auto_state === 'failed') {
+        $('autoverdict').textContent = st.auto_error || 'measurement failed';
+        return;
+      }
+      showAuto(st.auto);
+    }).catch(function (e) { $('auto').disabled = false; $('autoverdict').textContent = String(e); });
+}
+
+function showAuto(a) {
+  if (!a) { $('autoverdict').textContent = 'no measurement'; return; }
+  S.auto = a;
+  var best = null;
+  (a.candidates || []).forEach(function (c) {
+    if (c.accepted && (best === null || c.lab > best.lab)) best = c;
+  });
+  var chroma = best ? (', strongest colour distance ' + best.lab) : '';
+  if (a.verdict === 'measured') {
+    $('autoverdict').textContent = 'dx = ' + a.dx + ' px (spread ' + a.spread +
+      ' px over ' + a.n_accepted + ' candidates)';
+    $('autoadopt').style.display = '';
+  } else if (a.verdict === 'void') {
+    $('autoverdict').textContent = 'void — the control corridors measured too';
+    $('autoadopt').style.display = 'none';
+  } else {
+    $('autoverdict').textContent = 'no measurement published';
+    $('autoadopt').style.display = 'none';
+  }
+  $('autodetail').textContent = (a.remedy || '') +
+    ' [seam ' + a.n_accepted + '/' + a.n_candidates + ', controls ' +
+    a.control_accepted + chroma + ']';
+}
+
 function loadFrame(res) {
   var v = res.version, n = 0;
   S.imgs = {};
@@ -2237,6 +2396,16 @@ function init() {
   syncControls();
   $('aim').addEventListener('click', aim);
   $('snap').addEventListener('click', snap);
+  $('auto').addEventListener('click', autoMeasure);
+  $('autoadopt').addEventListener('click', function () {
+    var a = S.auto;
+    if (!a || a.verdict !== 'measured' || a.dx === null) return;
+    // Flat, deliberately: the measurement establishes one dx at the rows the
+    // target occupied. Shaping it is the operator's job, which is what the
+    // curve editor is for.
+    setAnchors(S.anchors.map(function (p) { return [p[0], a.dx]; }),
+      'proposed by the automatic measurement, dx=' + a.dx + ' px');
+  });
   $('browse').addEventListener('click', browse);
   $('open').addEventListener('click', openFrame);
   $('save').addEventListener('click', save);
@@ -2356,11 +2525,24 @@ __BANNER__
 <div class="dock">
   <button class="btn btn-ghost" id="aim">Aim</button>
   <button class="btn" id="snap">Snap</button>
+  <button class="btn btn-ghost" id="auto">Auto</button>
   <span class="st" id="dockstate">no frame loaded</span>
 </div>
 
 <div class="grid">
 <div class="col">
+
+  <div class="panel" id="autopanel" style="display:none">
+    <h2 class="sec">Automatic <span class="accent">measurement</span></h2>
+    <p class="hint">Candidates are picked by <em>colour</em> distance from the
+      pitch, never by what they are &mdash; a shirt, a chair, a car, a cone and a
+      ball all qualify; grass does not. The same fit runs at control corridors
+      either side of the seam, where the answer must be nothing; if they measure
+      too, no number is published.</p>
+    <div id="autoverdict" class="st"></div>
+    <div id="autodetail" class="hint"></div>
+    <button class="btn btn-ghost" id="autoadopt" style="display:none">Use this curve</button>
+  </div>
 
   <div class="panel" id="scenepanel">
     <h2 class="sec">Where the seam <span class="accent">falls</span></h2>

--- a/video_grouper/web/stitch_calibration.py
+++ b/video_grouper/web/stitch_calibration.py
@@ -1075,16 +1075,18 @@ def build_router(config_path: Path, storage_path: Path | None = None) -> APIRout
 
     @router.post("/stitch/auto")
     def post_auto(body: dict = Body(default={})) -> JSONResponse:
-        """Measure `dx` from whatever is standing in the seam, or refuse.
+        """Report what the seam echo estimator sees. It does NOT propose a curve.
 
-        Class-agnostic by construction: candidates are selected by *colour*
-        distance from the pitch, never by object class, because grass has
-        enormous luminance texture and almost no colour distinctiveness and
-        that is what defeated every gradient-gated attempt. See `seam_echo`.
+        **The estimator is withdrawn** (see `seam_echo`): it measures a step
+        edge rather than a ghost, and at scale it accepts control corridors --
+        where the true answer is exactly zero -- almost as often as the seam
+        (6.3% against 7.4%), with the same `d` distribution. On the one
+        hand-verified frame carrying a real 18 px ghost it reported 33 px. The
+        endpoint and its numbers are kept because they are the evidence and
+        because the plumbing is reusable; the curve stays hand-authored.
 
         Several frames are used when the source is the live camera -- the
-        camera is on a tripod and `Snap` is read-only, so a couple of seconds
-        of them is free and turns one lucky reading into an agreement test.
+        camera is on a tripod and `Snap` is read-only.
         """
         echo = load_toolkit()["echo"]
         if echo is None:
@@ -2270,14 +2272,13 @@ function drawCamProfile(profile) {
   g.fillText('row ' + profile[profile.length - 1].y.toFixed(0), 2, H - pad + 2);
 }
 
-// Class-agnostic seam measurement. It proposes or refuses; it never applies,
-// and it never publishes a number that its own control corridors also produced.
+// Seam echo diagnostics. WITHDRAWN as a measurement: it reports what the
+// estimator sees and never proposes a curve -- see `seam_echo` for the evidence.
 function autoMeasure() {
   $('auto').disabled = true;
   $('autopanel').style.display = '';
   $('autoverdict').textContent = 'measuring…';
   $('autodetail').textContent = '';
-  $('autoadopt').style.display = 'none';
   fetch('/stitch/auto', {
     method: 'POST', credentials: 'same-origin',
     headers: { 'Content-Type': 'application/json' },
@@ -2310,25 +2311,17 @@ function pollAuto() {
 function showAuto(a) {
   if (!a) { $('autoverdict').textContent = 'no measurement'; return; }
   S.auto = a;
-  var best = null;
-  (a.candidates || []).forEach(function (c) {
-    if (c.accepted && (best === null || c.lab > best.lab)) best = c;
-  });
-  var chroma = best ? (', strongest colour distance ' + best.lab) : '';
-  if (a.verdict === 'measured') {
-    $('autoverdict').textContent = 'dx = ' + a.dx + ' px (spread ' + a.spread +
-      ' px over ' + a.n_accepted + ' candidates)';
-    $('autoadopt').style.display = '';
-  } else if (a.verdict === 'void') {
-    $('autoverdict').textContent = 'void — the control corridors measured too';
-    $('autoadopt').style.display = 'none';
-  } else {
-    $('autoverdict').textContent = 'no measurement published';
-    $('autoadopt').style.display = 'none';
-  }
+  // No branch here sets a curve. The estimator is withdrawn: it measures step
+  // edges rather than ghosts, so its numbers are shown as evidence and never as
+  // a proposal. The adopt control is gone rather than merely disabled.
+  $('autoverdict').textContent =
+    'not measurable automatically — nothing proposed'
+    + (a.provisional_dx !== null && a.provisional_dx !== undefined
+        ? ' (estimator said ' + a.provisional_dx + ' px; not trustworthy)' : '');
   $('autodetail').textContent = (a.remedy || '') +
-    ' [seam ' + a.n_accepted + '/' + a.n_candidates + ', controls ' +
-    a.control_accepted + chroma + ']';
+    ' [seam ' + a.n_accepted + '/' + a.n_candidates + ' accepted, control ' +
+    a.control_accepted + '/' + (a.controls ? a.controls.length : '?') +
+    ' — off the seam the true answer is zero]';
 }
 
 function loadFrame(res) {
@@ -2552,15 +2545,6 @@ function init() {
   $('aim').addEventListener('click', aim);
   $('snap').addEventListener('click', snap);
   $('auto').addEventListener('click', autoMeasure);
-  $('autoadopt').addEventListener('click', function () {
-    var a = S.auto;
-    if (!a || a.verdict !== 'measured' || a.dx === null) return;
-    // Flat, deliberately: the measurement establishes one dx at the rows the
-    // target occupied. Shaping it is the operator's job, which is what the
-    // curve editor is for.
-    setAnchors(S.anchors.map(function (p) { return [p[0], a.dx]; }),
-      'proposed by the automatic measurement, dx=' + a.dx + ' px');
-  });
   $('browse').addEventListener('click', browse);
   $('open').addEventListener('click', openFrame);
   $('save').addEventListener('click', save);
@@ -2718,14 +2702,14 @@ __BANNER__
 
   <div class="panel" id="autopanel" style="display:none">
     <h2 class="sec">Automatic <span class="accent">measurement</span></h2>
-    <p class="hint">Candidates are picked by <em>colour</em> distance from the
-      pitch, never by what they are &mdash; a shirt, a chair, a car, a cone and a
-      ball all qualify; grass does not. The same fit runs at control corridors
-      either side of the seam, where the answer must be nothing; if they measure
-      too, no number is published.</p>
+    <p class="hint"><strong>This does not propose a curve.</strong> The estimator is
+      withdrawn: it turns out to measure a <em>step edge</em> &mdash; a shirt against
+      grass &mdash; rather than a ghost, and at scale it accepts control corridors,
+      where the true answer is exactly zero, almost as often as the seam. On the one
+      hand-verified frame with a real 18&nbsp;px ghost it said 33&nbsp;px. The numbers
+      are shown as evidence; calibrate by hand below.</p>
     <div id="autoverdict" class="st"></div>
     <div id="autodetail" class="hint"></div>
-    <button class="btn btn-ghost" id="autoadopt" style="display:none">Use this curve</button>
   </div>
 
   <div class="panel" id="scenepanel">


### PR DESCRIPTION
Three things, one of which is a live-proven bug fix and one of which is a
withdrawal.

### 1. The double-compose — a real bug, fixed, proven on hardware

`S98_StitchCal` keeps an `applied.sig` and, when the live mesh matches its own
last write, composes from the **saved factory baseline** rather than on top of
the live mesh. `apply_calibration` had **no equivalent check** — it took the
live mesh as its baseline unconditionally.

So on a unit that already carried a calibration, pressing Apply produced
`factory ⊕ old ⊕ new`, and it stayed wrong until a reboot rewrote it as
`factory ⊕ new`. Two states for the same stored anchors, differing by whether
the camera had been power-cycled. It lands squarely on the "start from the
camera's current calibration and nudge it" workflow added in this same PR.

Verified live, expected CRCs computed host-side **before** each write so the
doubling was falsifiable rather than assumed:

| step | baseline chosen | mesh crc32 | expected |
|---|---|---|---|
| start | — | `8514014a` | factory |
| apply A (4 px) | live mesh | **`9604929c`** | factory ⊕ A |
| apply A again | saved factory | **`9604929c`** unchanged | idempotent — old code gave `3cdcb4aa` |
| apply B (8 px) | saved factory | **`83e3bedc`** | factory ⊕ B, **not** `f18b0999` = factory ⊕ A ⊕ B |
| restore | — | `8514014a` | factory |

Every write read-back verified by the camera. Unit returned exactly as found:
all three mesh files md5 `7ac18ef2…`, no `anchors.txt`, no override, recording
still disabled at home, no reboot, no flash.

Two implementation notes. `camsh` refuses `dd`, so the boot hook's signature
scheme is reproduced with `tail -c +9` over the identical byte range. And the
ordering guard had to change: comparing the re-dump against the *baseline* crc
is correct only on an uncalibrated unit — once our own correction is live they
differ by exactly that correction, so it would have refused every legitimate
re-calibration **while still missing the doubling**. It now compares against
the live signature seen at decision time, which is what "did someone else move
it" actually means.

### 2. Start the editor from the camera's installed calibration

Previously the only initialiser was `setAnchors(p => [p[0], 0])` — every
session began pretending the camera was uncalibrated, so the first adjustment
was a delta from nothing rather than from what is installed.

- `read_calibration()` — read-only, reusing the existing dump/read helpers:
  live mesh crc32, whether it still matches the on-camera factory copy, the
  installed `anchors.txt`, and a plain-language note.
- `seam_profile()` — the honest reading of "show what the camera generated".
  The factory mesh **is** the vendor's stitch solution, so this reports the
  per-row source-x displacement it applies down the seam column, plus `s`.
  That matters to an operator: the composer writes `x + dx·s`, so a 10 px
  correction moves source pixels by ~7 px. Live `s` = 0.70018 at mid-row,
  independently reproducing the 0.7002 in the compose reports.
- The reset buttons really were one button: since anchors are composed against
  factory at every boot, `dx = 0` **is** factory untouched. "Reset to zero" and
  "back to factory" were the same operation twice. Now two distinct controls.

**The snapshot is never re-warped.** `cmd=Snap` returns the already-fused
panorama — the blend corridor and the measured ghost are *in* that JPEG — so
applying the mesh to it would apply the correction twice.

### 3. The echo estimator is withdrawn

Validated at scale against the unmodified module: **7,688 frames, 46,088 seam
candidates, 90,609 controls, 28 games.**

| frame | required | measured |
|---|---|---|
| 1104 (real 18 px ghost) | 17–19 px | **33.0 px, published** |
| 1088 | ~0 / refuse | void |
| 1120 | ~0 / refuse | void |

Seam acceptance 7.4% vs control 6.3% — **1.18x against its own required 3.0x**.
The corridor 1200 px away accepts *more often than the seam*. Histogram overlap
0.85, medians 31 vs 30 px even matched on colour decile and row band. 96 gate
settings swept; none both quiet off-seam and correct on it.

**Mechanism:** a step edge — a body against grass — fits two lobes better than
one fits. On frame 1104 the accepted candidates are a walking player's torso,
shorts and leg; the ball's own band ranks 15th chromatically and `max_fits=10`
means it is never fitted. `gain` is anti-correlated with truth on this material.

**Cross-frame agreement does not rescue it** — agreement is *better* at the
controls (IQR median 1.0 px, 74% ≤1 px) than at the seam (2.0 px, 38%). The
steadiest landmark in the corpus is a control reading d = 35.0 px with IQR 0.0
across 25 looks, where truth is exactly 0.

So `measure()` always returns `verdict="withdrawn"` carrying its numbers as
evidence, `anchors_from_measurement` raises unconditionally, and the UI has no
adopt control. A test asserts that even three agreeing candidates with quiet
controls cannot produce a proposal.

**Two claims retracted in the docstring**, not just the estimator:
- "the null cannot be skipped" — it can. The check is skipped entirely when the
  controls accept nothing, which is common on a single frame, i.e. inert at
  exactly the sample size the button uses.
- "fitted `a` matching predicted `a` is a check scene structure cannot fake" —
  unghosted control players fit `a` 0.40–0.60 against predictions 0.32–0.70 and
  pass. It constrains the shape of a fit; it does not establish a second copy.

Colour gating was necessary and insufficient: it correctly finds chromatically
distinct objects, and distinct objects have step edges.

Recorded in `STITCH_CALIBRATION.md` §15.5 and §16.5, `EXPERIMENTS.md`
EXP-STITCH-02, and a `DECISIONS.md` entry superseding the earlier
"ship it as a refusing instrument" call.

### Gates

ruff check, ruff format, mypy clean. Full unit suite **2004 passed, 13 skipped,
1 xfailed** — run independently by the coordinator, not taken on report. 62/62
across the three stitch suites.

Standing caveat: `test_download_processor`'s async tests are timing-sensitive
and failed once under a saturated box; they pass consistently otherwise, so CI
may occasionally see it.