### PR TITLE
feat(stitch): align the seam by hand on the two real sensor layers

### DIFF
--- a/reolink-firmware-patching/.gitignore
+++ b/reolink-firmware-patching/.gitignore
@@ -25,3 +25,7 @@ recover/helix/ESP8266Audio/
 recover/helix/build/
 *.a
 *.o
+
+# Build outputs for the seam layer helpers: C sources are tracked, binaries
+# are built (builds/build_seam_helpers.sh). Same rule as the rest of the tree.
+builds/out/

--- a/reolink-firmware-patching/builds/build_seam_helpers.sh
+++ b/reolink-firmware-patching/builds/build_seam_helpers.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Two small aarch64 helpers used to read the pre-blend seam layer pair off a
+# running camera. Read-only tools: they pull one frame descriptor and release it
+# microseconds later, and they read physical memory. Neither writes anything on
+# the device.
+#
+# WHY THESE ARE NOT BAKED INTO FIRMWARE, unlike lut2d_ioctl. lut2d_ioctl is on
+# the boot path -- S98_StitchCal needs it at every boot, so it has to survive a
+# reformatted SD card. These two are an operator-initiated diagnostic: they are
+# uploaded when the seam-calibration page asks for a layer pair and removed
+# again in the same call. Nothing on the camera depends on them being present,
+# so baking them would enlarge the flashed image for no gain.
+#
+# WHY THE BINARIES ARE NOT COMMITTED. Same rule the rest of this tree follows:
+# C sources are tracked, build outputs are not. `video_grouper/web`'s layer pull
+# looks for them in builds/out/ and refuses with an explicit "not built" message
+# naming the path, rather than half-working.
+#
+# Freestanding: both make raw syscalls and link no libc, which is why they are
+# ~4 KB and why -nostdlib is not optional.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="$ROOT/builds/out"
+CC="${CC:-aarch64-linux-gnu-gcc}"
+
+command -v "$CC" >/dev/null || {
+  echo "ERROR: need $CC (apt install gcc-aarch64-linux-gnu)" >&2
+  exit 1
+}
+
+mkdir -p "$OUT"
+
+# pmemdump.c builds to `pemdump` -- the name the camera-side call site uses.
+build() {
+  local src="$1" bin="$2"
+  "$CC" -O2 -static -nostdlib -ffreestanding -Wall -Wextra \
+    -o "$OUT/$bin" "$ROOT/vpe/$src"
+  echo "  $bin  $(stat -c%s "$OUT/$bin") bytes"
+}
+
+echo "==> building seam layer helpers into $OUT"
+build isfpull2.c isfpull2
+build pmemdump.c pemdump
+
+# A wrong-architecture binary uploads fine and then fails on the camera with
+# nothing but a silent non-zero, so check it here where the message is useful.
+for b in isfpull2 pemdump; do
+  arch="$(aarch64-linux-gnu-readelf -h "$OUT/$b" | awk -F: '/Machine/{print $2}' | xargs)"
+  [ "$arch" = "AArch64" ] || { echo "ERROR: $b built for '$arch', not AArch64" >&2; exit 1; }
+done
+
+echo "==> ok. The /stitch page will upload these on demand and remove them after."

--- a/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
+++ b/reolink-firmware-patching/docs/STITCH_CALIBRATION.md
@@ -1012,10 +1012,16 @@ That last one is what makes the two workflows genuinely one tool: the human is d
 objective the automated solver optimises, so their output is directly comparable and directly
 mergeable.
 
-**One honesty caveat, stated in the UI.** In a fused JPEG the blend window is already mixed, so modes
-1, 2 and 4 operate on *extrapolations from the shoulders*, not on separated layers. They show what
-registration implies, not ground truth inside the window. If the pre-stitch snapshot path of §9.1
-turns out to be reachable, these modes become exact and the caveat is deleted.
+**One honesty caveat, stated in the UI — now scoped, not deleted.** In a fused JPEG the blend window
+is already mixed, so modes 1, 2 and 4 operate on *extrapolations from the shoulders*, not on
+separated layers. They show what registration implies, not ground truth inside the window.
+
+This section originally said: *"If the pre-stitch snapshot path of §9.1 turns out to be reachable,
+these modes become exact and the caveat is deleted."* **It is reachable — see §17.** The caveat is
+therefore *scoped to the fused view* rather than removed outright, because the fused view still
+exists and is still an extrapolation. The UI says both halves: the fused panel keeps its caveat and
+points at the layer panel; the layer panel states that its overlay, difference, anaglyph and blink
+are true separated layers.
 
 **Transmit.** One "Apply", which does exactly what `correction_owner` says: `SetStitch` over HTTP for
 scalars; the §6.2 push plus §7 install for the mesh; nothing at all for downstream. Then it
@@ -1506,3 +1512,203 @@ Measured on the live frame: transition centred x ≈ 3840–3845; derivative ene
 over x ∈ [3812, 3868]; raw SSR 3.29, detrended 3.19; synthetic-disparity response tabulated in §9.2.
 The frame is an indoor IR scene at ~0.3 m against an 8 m stitch setting, so its absolute values are a
 mechanism check, **not** a field baseline.
+
+---
+
+## 17. The pre-blend layer pair — the caveat's cause, removed (2026-08-19)
+
+§11 promised that if the pre-stitch snapshot path became reachable, blink/anaglyph would stop being
+extrapolations. It is reachable. This section records what it is, what it is *not*, and how the two
+were kept from being confused.
+
+### 17.1 What was found
+
+**`VIDEOPROC 2 out[1]` (ISF path `0x00930001`) carries two separable 128×2160 views of the same
+overlap region** — the two sensors, un-blended, linear, already resampled into the panorama's output
+frame **[M]**. With `L = strip[:, 0:128]` and `R = strip[:, 128:256]`:
+
+```
+panorama[:, 3776+k] = (1 - w_k)*L[:,k] + w_k*R[:,k]        k = 0..127
+```
+
+`aL + aR = 1.000` at every one of the 128 columns, the ramp is monotone, the crossover is exactly at
+panorama x = 3840, and reconstruction error is **1.56 grey levels**. The blend band is panorama
+columns **3776–3903**.
+
+Two consequences:
+
+1. **The pair is pre-rectified.** An L-to-R displacement is residual disparity *in output pixels*.
+   It converts straight to `dx_anchors` — no lens model, no homography, no rescale. This is what
+   makes dragging the layers a calibration rather than a picture.
+2. **Blink, anaglyph and difference on this pair are exact**, not inference. §11's caveat is
+   accordingly scoped to the fused view rather than deleted, because the fused view still exists.
+
+### 17.2 What the full-resolution per-sensor frames are — and are not
+
+The vendor's own snap is reachable with no upload, no build and no login:
+
+```sh
+export LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib:/mnt/app
+/mnt/app/rpctool -s -t SNAP -c 13010 -m 02000000000000000000000000000000
+sleep 5; ls -la /mnt/tmp/*.jpg
+```
+
+Message **13010**, not 13003 (which hardcodes a task class that can only build `yuv_snap`). The
+parameter must be exactly 32 hex characters or the call returns `-803`. It writes
+`/mnt/tmp/01_<ts>.jpg` and `02_<ts>.jpg`; an identical timestamp means a matched pair. Success is
+silent, failure prints `to:SNAP error,ret :-822`. `/mnt/tmp` is a 55 MB tmpfs, so the files are
+removed by exact path afterwards.
+
+**These frames are 3840×2160 [M]** — read from the SOF0 headers of three fresh captures, and
+independently re-read here on four archived files. Ten fresh pairs across two agents are ten for ten
+at 3840×2160. 3840 is the native width of `VIDEOPROC 0/1 out[0]`, the full sensor view, so these
+frames are in **sensor coordinates, before the warp**.
+
+An earlier reading reported 3904×2160 and argued that the extra 64 columns per side were the overlap
+margin (64 + 64 = the 128 blended columns). **That does not reproduce.** It also turned out not to
+matter, for the reason below: the real margin is an order of magnitude larger, so 64 columns was
+noise. Do not build on 3904.
+
+**The overlap in these frames is ~450–530 columns per sensor, and the sensor→panorama warp is
+measured.** AKAZE is useless on this 0.3 m desk scene, so the mapping was recovered by matching
+panorama patches into each sensor frame *outside* the blend band — where every panorama column has
+exactly one source and there is no depth term — then fitting a 2-D cubic (`OVL_fit_map2.py`,
+`OVL_fit_s{0,1}_{A,B}.npz` in `F:\archive\duo3_stitch\prestitch`).
+
+Re-verified here independently, by resampling each sensor frame through the fitted map and
+differencing against the real panorama **[M]**:
+
+| sensor | mean abs err | p90 | panorama x = 3840 maps to sensor column |
+|---|---|---|---|
+| s0 | **2.29** grey levels | 6.0 | 3311 — i.e. 529 columns of margin past the seam |
+| s1 | **4.83** grey levels | 11.0 | 453 — i.e. 453 columns of margin before it |
+
+So the earlier statement that "this project does not have" the warp is **withdrawn**: it does, to a
+few grey levels, and it is re-derivable in ~10 minutes from one panorama plus one pair with no
+camera state change.
+
+**What shipped, and why.** The full frames are served as **context** in this build —
+`authoritative: false`, no gesture binding — and the 128-px strip pair is the working surface. That
+is a scope choice, not a claim of impossibility:
+
+- the strip pair is **pre-rectified by the hardware**, so it carries no fit error term at all, while
+  the full-frame route adds ~3 px rms of fitted warp on top of whatever the operator is judging;
+- the fitted maps are archived artifacts on a server share, not something a camera-manager install
+  has, so a customer path would need them derived or shipped;
+- the fit is tied to the **current mesh**, and installing a calibration changes the mesh — so the
+  map is downstream of the very thing being edited, and that coupling needs thinking through rather
+  than wiring in at speed.
+
+**Next step, designed but not built:** resample each sensor frame through its fitted map into
+panorama columns and hand the result back as an ordinary `LayerPair` with `left_x0 ≈ 3311`-derived
+and `right_x0` per the map — roughly a 950-column overlap instead of 128. The type already supports
+layers with different origins and a derived overlap (§17.4), so this is a new source function and
+**no UI change**, which is exactly what that abstraction was for.
+
+### 17.3 Keeping the two apart, structurally
+
+Both surfaces could be described as "two images of the same scene from the two sensors", and that
+shared description is the trap. They are therefore **two types**, not one type with a flag:
+
+| | `LayerPair` | `SensorViews` |
+|---|---|---|
+| space | panorama output columns | sensor, pre-warp |
+| converts to `dx_anchors` | yes, directly | not without the fitted map (§17.2) |
+| carries `overlap` / `seam_x` | yes | **no such field exists** |
+| UI may bind a gesture | yes | refused |
+
+Note the second row is a statement about *this type*, not about what is knowable. A sensor frame
+resampled through the fitted map stops being `SensorViews` and becomes a `LayerPair` — which is the
+right outcome, because by then it genuinely is in panorama coordinates. The type boundary tracks the
+coordinate space, so it stays correct when the full-frame surface is wired.
+
+`applyToCurve()` checks `authoritative` off the server's descriptor before writing anything, so the
+refusal is enforced rather than captioned. A test asserts `SensorViews.to_api()` exposes no
+panorama mapping at all, so making it look alignable requires deleting a test that asks what warp
+justified it.
+
+### 17.4 The endpoint's contract is deliberately thin
+
+`POST /stitch/layers` returns **"a left layer, a right layer, and the panorama columns they
+correspond to"** and nothing else. Each layer carries its *own* origin (`left_x0`, `right_x0`); the
+overlap is *derived* as their intersection; the cross-fade centre is derived as the middle of that
+overlap. No caller writes 128 or 3776.
+
+This is not speculative generality — it was load-bearing within hours. Deriving the seam from the
+overlap rather than from half the packed buffer is the difference between 3840 and 3904, and a test
+pins it. A hypothetical full-frame layer pair with origins 0 and 3776 derives the same seam, 3840,
+from completely different inputs; that test exists and passes without any hardware.
+
+Sources today: `camera` (live pull), `file` (an archived dump), `synthetic` (below). Adding one is a
+new entry in `SOURCES` and no UI change.
+
+### 17.5 Why the interaction was developed against a synthetic pair
+
+**The archived real pair cannot be aligned, and no disparity should be quoted from it.** It is a desk
+scene at ~0.3 m: sensor 1 is defocused and blown out, sensor 0 sees near-black desk, and there is no
+shared texture — AKAZE gets **0 keypoints** on this exact pair, while the same matcher recovers an
+injected (17, 9) shift *exactly* on either layer against itself. The instrument is sound; the scene
+is not matchable. Measured on a fresh live pull here: `mad = 135.4`, `ncc = -0.57` — anti-correlated,
+which is what "one layer dark, the other blown out" looks like numerically.
+
+So `seam_layers.synthetic()` builds a textured pair with a known offset and roll, and the gestures
+are validated against it. Driven through the real handlers in a real browser at 390×844:
+
+| state | dx | roll | mean abs(L−R) | NCC |
+|---|---|---|---|---|
+| unaligned | 0 | 0 | 41.76 | 0.357 |
+| after a 42 px one-finger drag | **5.95** | 0 | 26.30 | 0.668 |
+| after a two-finger twist | 5.95 | **12.00** | **1.85** | **0.9985** |
+
+The drag was predicted to give 5.95 px (42 CSS px ÷ 7.06 px per panorama column) and gave 5.947. The
+twist was asked for +12 px of roll and gave 12.000. The built-in answer was `dx=6, roll=12`.
+
+### 17.6 Gestures write the curve, never a parallel model
+
+Translation adds a constant to every anchor; rotation adds a ramp linear in the row, which is
+exactly `dx = -θ·y`, the shape a relative lens roll makes (§2). Both go through the same
+`setAnchors()` the sliders and the typed anchor boxes use, and the layer view repaints from the same
+`draw()` entry point — so dragging a layer moves the numeric anchors, and typing an anchor moves the
+layers. **The anchor curve remains the only stored artifact.** Applying is unchanged: the existing
+`/stitch/apply` → `apply_calibration()` path, which is live-verified end to end.
+
+Two-finger pinch and twist come off the same two pointers, because on a touchscreen they are one
+motion. The rotation mapping is `Δroll = -Δφ·(H-1)·sgn`, isotropic scaling in the view being what
+makes an on-screen twist equal a source-space rotation.
+
+### 17.7 Transport notes that cost time
+
+- **The pull ioctl returns `-14` regardless; the real result is `arg[0]`.** `arg[4]` is a
+  **millisecond timeout**, not a flag word — 200 ms.
+- **out[1]'s Y address rotates over at least five buffers**, and an address from an earlier pull gets
+  *repurposed for another producer*. Dumping a remembered address yields a foreign buffer that still
+  looks like a plausible image. The pull and the dump therefore go out as **one shell invocation**
+  and the address never returns to Python before being used.
+- `pemdump` mmaps `/dev/mem`, so the offset must be **4 KB aligned**; unaligned silently produces no
+  file. The transfer is verified by *size*, not by exit status.
+- **`camsh.check()` refuses any command containing both `rm` and a glob metacharacter, scanning the
+  whole string.** The pull command contains `phys_Y[168]` in its `sed` expression, so combining it
+  with a cleanup `rm` trips the guard on a `[` nowhere near the `rm`. The guard is right to be blunt
+  about deletion; the *command* was split instead of the rule being weakened.
+- Retrieval is plain `cat` over tcp/2323, which is binary-safe in both directions. There is **no
+  `base64`** on the device. `camsh.sh_bytes()` exists for this — same refusal checks as `sh()`,
+  without the decode that would corrupt every non-UTF-8 byte.
+- Upload of the two helpers is one `wget` per file against a short-lived HTTP server on the host.
+
+### 17.8 A performance defect worth recording
+
+At a useful inspection zoom the layer view shows **tens of rows out of 2160**, and handing the whole
+image to `drawImage` asks the compositor to rasterise roughly 900×15000 px per band. This does **not**
+show up in the `drawImage` call's own timing — it returned in 5 ms — and then wedges the compositor
+hard enough that screenshots time out. Clipping is not enough: the clip bounds the *output*, the
+source rectangle bounds the *work*. `drawLayerInto()` now intersects each band with the visible row
+range and skips bands entirely off screen.
+
+### 17.9 Camera end-state (measured, after this work)
+
+- **Mesh md5 = `7ac18ef2988970d09fc4f5a36c6cd311`** (267,288 B) — the factory baseline, re-measured
+  after the live pulls.
+- `/mnt/tmp` restored to stock (208 KB); `isfpull2`, `pemdump`, the strip dump and both sensor JPEGs
+  removed by exact path.
+- No `/mnt/sda/anchors.txt`; `/mnt/sda/netstate` = `{log}` only, no override.
+- Read-only throughout: no `SetStitch`, no mesh write, no flash.

--- a/reolink-firmware-patching/runtime/camsh.py
+++ b/reolink-firmware-patching/runtime/camsh.py
@@ -123,14 +123,14 @@ def check(cmd: str) -> None:
                 )
 
 
-def _send(
+def _send_bytes(
     cmd: str, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, timeout: int = 40
-) -> str:
-    """Put `cmd` on the wire and return its output. NO refusal checks.
+) -> bytes:
+    """Put `cmd` on the wire and return its output as raw bytes. NO refusal checks.
 
-    Private. Every caller from outside this module goes through `sh()`, which
-    checks first; the only other user is the override pair below, which sends
-    two fixed strings and no free-form input.
+    Private. Every caller from outside this module goes through `sh()` or
+    `sh_bytes()`, which check first; the only other user is the override pair
+    below, which sends two fixed strings and no free-form input.
     """
     s = socket.create_connection((host, port), timeout=timeout)
     try:
@@ -147,7 +147,13 @@ def _send(
             pass
     finally:
         s.close()
-    return b"".join(chunks).decode(errors="replace")
+    return b"".join(chunks)
+
+
+def _send(
+    cmd: str, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, timeout: int = 40
+) -> str:
+    return _send_bytes(cmd, host, port, timeout).decode(errors="replace")
 
 
 def sh(
@@ -160,6 +166,22 @@ def sh(
     """
     check(cmd)
     return _send(cmd, host, port, timeout)
+
+
+def sh_bytes(
+    cmd: str, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT, timeout: int = 40
+) -> bytes:
+    """`sh()` without the decode, for retrieving a binary file with `cat`.
+
+    `cat` through this shell is binary-safe in both directions -- a 16.6 MB
+    transfer came back with an exact md5 -- and the device has no `base64`, so
+    raw `cat` is the retrieval path rather than an encoding. Decoding it as text
+    would corrupt every byte that is not valid UTF-8, which for an image plane
+    is most of them. Refusal checks are identical to `sh()`; only the return
+    type differs.
+    """
+    check(cmd)
+    return _send_bytes(cmd, host, port, timeout)
 
 
 def hold_recording_override(

--- a/reolink-firmware-patching/vpe/isfpull2.c
+++ b/reolink-firmware-patching/vpe/isfpull2.c
@@ -1,0 +1,98 @@
+/* isfpull2 -- pull one frame descriptor from an ISF out-port and release it
+ * immediately, decoding the key fields. Freestanding aarch64.
+ *
+ * DIFFERENCE FROM isfpull.c (this is the whole point):
+ *   arg[4] is the PULL TIMEOUT IN MILLISECONDS, not a "flags" word.
+ *
+ * Recovered from `device` (statically-linked Novatek HDAL),
+ * hd_videoproc_pull_out_buf @0x5b65b0:
+ *
+ *   w23 = (HD_PATH_ID >> 16) - 0x236f      ; ISF unit  (0x2400-0x236f = 0x91)
+ *   w0  = (HD_PATH_ID & 0xff) - 1          ; ISF port  (1-based -> 0-based)
+ *   arg[1] = (w23 << 16) | w0              ; ISF path_id
+ *   arg[2..3] = &desc(296)   memset(0)     ; PURE OUTPUT
+ *   arg[4] = timeout_ms                    ; <-- caller's 3rd arg
+ *   ioctl(fd, 0xc020490c, arg)
+ *
+ * The vendor stitch loop (bc_stitch_main @0x481800) pulls the two per-sensor
+ * ports with timeout 200 ms. Its VSP-out thread pulls with timeout 0 and treats
+ * BOTH -56 and -15 as "no frame yet, sleep 20 ms and retry" (0x481e8c:
+ * cmn w0,#0x38 / ccmn w0,#0xf) -- i.e. -56 is the normal non-blocking
+ * would-block code, not a structural refusal.
+ *
+ * usage: isfpull2 <timeout_ms_dec> <path_hex> [<path_hex> ...]
+ */
+#define SYS_openat 56
+#define SYS_close  57
+#define SYS_ioctl  29
+#define SYS_write  64
+#define SYS_exit   93
+#define AT_FDCWD  -100
+
+static long sys3(long n,long a,long b,long c){
+    register long x8 __asm__("x8")=n; register long x0 __asm__("x0")=a;
+    register long x1 __asm__("x1")=b; register long x2 __asm__("x2")=c;
+    __asm__ volatile("svc #0":"+r"(x0):"r"(x8),"r"(x1),"r"(x2):"memory"); return x0; }
+static long sys4(long n,long a,long b,long c,long d){
+    register long x8 __asm__("x8")=n; register long x0 __asm__("x0")=a;
+    register long x1 __asm__("x1")=b; register long x2 __asm__("x2")=c; register long x3 __asm__("x3")=d;
+    __asm__ volatile("svc #0":"+r"(x0):"r"(x8),"r"(x1),"r"(x2),"r"(x3):"memory"); return x0; }
+
+static unsigned slen(const char*s){unsigned n=0;while(s[n])n++;return n;}
+static void out(const char*s){sys3(SYS_write,1,(long)s,slen(s));}
+static void hex32(unsigned v,char*b){static const char d[]="0123456789abcdef";b[0]='0';b[1]='x';for(int i=0;i<8;i++)b[2+i]=d[(v>>((7-i)*4))&0xf];b[10]=0;}
+static void dec(long v,char*b){char t[24];int n=0,neg=0;if(v<0){neg=1;v=-v;}if(!v)t[n++]='0';while(v){t[n++]='0'+(v%10);v/=10;}int i=0;if(neg)b[i++]='-';while(n)b[i++]=t[--n];b[i]=0;}
+static unsigned parse(const char*s){unsigned v=0;if(s[0]=='0'&&(s[1]=='x'||s[1]=='X'))s+=2;while(*s){char c=*s++;unsigned d;if(c>='0'&&c<='9')d=c-'0';else if(c>='a'&&c<='f')d=c-'a'+10;else if(c>='A'&&c<='F')d=c-'A'+10;else break;v=v*16+d;}return v;}
+static unsigned pdec(const char*s){unsigned v=0;while(*s>='0'&&*s<='9')v=v*10+(*s++-'0');return v;}
+static void kv(const char*k,unsigned v){char b[24];out(k);hex32(v,b);out(b);out(" (");dec((int)v,b);out(b);out(")\n");}
+
+void _c_start(long*sp){
+    long argc=sp[0]; char**argv=(char**)(sp+1); char b[24];
+    unsigned desc[0x128/4];
+    unsigned arg[8];
+    if(argc<3){out("usage: isfpull2 <timeout_ms> <path_hex> [...]\n");sys3(SYS_exit,2,0,0);}
+    unsigned tmo=pdec(argv[1]);
+
+    int fd=(int)sys4(SYS_openat,AT_FDCWD,(long)"/dev/isf_flow0",2,0);
+    if(fd<0){out("open isf_flow0 rc=");dec(fd,b);out(b);out("\n");sys3(SYS_exit,1,0,0);}
+
+    for(long ai=2; ai<argc; ai++){
+        unsigned path=parse(argv[ai]);
+        for(int i=0;i<0x128/4;i++) desc[i]=0;
+        for(int i=0;i<8;i++) arg[i]=0;
+        unsigned long dp=(unsigned long)desc;
+        arg[1]=path; arg[2]=(unsigned)(dp&0xffffffff); arg[3]=(unsigned)(dp>>32);
+        arg[4]=tmo;                       /* <-- TIMEOUT MS (was wrongly 0/"flags") */
+
+        long rp=sys3(SYS_ioctl,fd,(long)0xc020490c,(long)arg);
+        unsigned rr_pull=arg[0];
+        /* release immediately -- hold the depth-1 buffer for microseconds only */
+        long rr=sys3(SYS_ioctl,fd,(long)0xc020490a,(long)arg);
+        unsigned rr_rel=arg[0];
+
+        out("=== path ");hex32(path,b);out(b);out(" timeout_ms=");dec(tmo,b);out(b);out("\n");
+        out("pull ioctl_rc=");dec(rp,b);out(b);
+        out(" arg0=");dec((int)rr_pull,b);out(b);
+        out(" | release ioctl_rc=");dec(rr,b);out(b);
+        out(" arg0=");dec((int)rr_rel,b);out(b);out("\n");
+        if(rr_pull==0){
+            kv("  magic[0]      = ",desc[0]);
+            kv("  pxlfmt[60]    = ",desc[60/4]);
+            kv("  width[64]     = ",desc[64/4]);
+            kv("  height[68]    = ",desc[68/4]);
+            kv("  lineoff0[88]  = ",desc[88/4]);
+            kv("  lineoff1[92]  = ",desc[92/4]);
+            kv("  phys_Y[168]   = ",desc[168/4]);
+            kv("  phys_UV[176]  = ",desc[176/4]);
+        }
+        out("desc(0x128):\n");
+        for(int i=0;i<0x128/4;i++){
+            out("[");dec(i*4,b);out(b);out("]=");hex32(desc[i],b);out(b);
+            if((i&3)==3) out("\n"); else out(" ");
+        }
+        out("\n");
+    }
+    sys3(SYS_close,fd,0,0);
+    sys3(SYS_exit,0,0,0);
+}
+__asm__(".global _start\n_start:\n  mov x0, sp\n  b _c_start\n");

--- a/reolink-firmware-patching/vpe/pmemdump.c
+++ b/reolink-firmware-patching/vpe/pmemdump.c
@@ -1,0 +1,103 @@
+/* pemdump -- read a physical DRAM range via /dev/mem and write it to a file.
+ * Freestanding aarch64, no libc (modelled on runtime/isfbind.c), so it stays
+ * ~3 KB and can be wget'd to /mnt/tmp.
+ *
+ * Route A of the Duo 3 pre-stitch capture: the VIDEOPROC 0/1 out buffers are
+ * not kernel-bound (bind_dest (null)); bc_stitch_main pulls them in userspace.
+ * Their physical addresses are published by /proc/hdal/comm/info. We mmap
+ * /dev/mem read-only over the block and copy it out -- no ISF pull, so no
+ * competition with `device` for the single (depth 1) buffer. Tearing is
+ * possible (we read while it is written) but irrelevant for a static scene.
+ *
+ * usage:  pemdump <phys_hex> <len_hex> <outpath>
+ * e.g.    pemdump 0x1c105000 0xbdd800 /mnt/sda/dump/frame.bin
+ */
+
+#define SYS_openat 56
+#define SYS_close  57
+#define SYS_write  64
+#define SYS_mmap   222
+#define SYS_munmap 215
+#define SYS_exit   93
+
+#define O_RDONLY 0
+#define O_WRONLY 1
+#define O_CREAT  0100
+#define O_TRUNC  01000
+#define PROT_READ  1
+#define MAP_SHARED 1
+#define AT_FDCWD  -100
+
+static long sys6(long n, long a, long b, long c, long d, long e, long f)
+{
+    register long x8 __asm__("x8") = n;
+    register long x0 __asm__("x0") = a;
+    register long x1 __asm__("x1") = b;
+    register long x2 __asm__("x2") = c;
+    register long x3 __asm__("x3") = d;
+    register long x4 __asm__("x4") = e;
+    register long x5 __asm__("x5") = f;
+    __asm__ volatile("svc #0"
+                     : "+r"(x0)
+                     : "r"(x8), "r"(x1), "r"(x2), "r"(x3), "r"(x4), "r"(x5)
+                     : "memory");
+    return x0;
+}
+#define sys3(n,a,b,c)   sys6(n,a,b,c,0,0,0)
+
+static unsigned slen(const char *s){unsigned n=0;while(s[n])n++;return n;}
+static void out(const char *s){sys3(SYS_write,2,(long)s,slen(s));}
+static void dec(long v,char *b){char t[24];int n=0,neg=0;if(v<0){neg=1;v=-v;}if(!v)t[n++]='0';while(v){t[n++]='0'+(v%10);v/=10;}int i=0;if(neg)b[i++]='-';while(n)b[i++]=t[--n];b[i]=0;}
+static void emit(const char*m,long v){char b[24];out(m);dec(v,b);out(b);out("\n");}
+
+static unsigned long parse(const char *s)
+{
+    unsigned long v = 0;
+    if (s[0]=='0' && (s[1]=='x'||s[1]=='X')) s += 2;
+    while (*s) {
+        char c = *s++; unsigned d;
+        if (c>='0'&&c<='9') d=c-'0';
+        else if (c>='a'&&c<='f') d=c-'a'+10;
+        else if (c>='A'&&c<='F') d=c-'A'+10;
+        else break;
+        v = v*16 + d;
+    }
+    return v;
+}
+
+void _c_start(long *sp)
+{
+    long argc = sp[0];
+    char **argv = (char **)(sp + 1);
+    if (argc < 4) { out("usage: pemdump <phys_hex> <len_hex> <outpath>\n"); sys3(SYS_exit,2,0,0); }
+
+    unsigned long pa  = parse(argv[1]);
+    unsigned long len = parse(argv[2]);
+    const char *outp  = argv[3];
+
+    int fdm = (int)sys6(SYS_openat, AT_FDCWD, (long)"/dev/mem", O_RDONLY, 0,0,0);
+    if (fdm < 0) { emit("open /dev/mem rc=", fdm); sys3(SYS_exit,1,0,0); }
+
+    long p = sys6(SYS_mmap, 0, (long)len, PROT_READ, MAP_SHARED, fdm, (long)pa);
+    if (p < 0 && p > -4096) { emit("mmap rc=", p); sys3(SYS_exit,1,0,0); }
+
+    int fdo = (int)sys6(SYS_openat, AT_FDCWD, (long)outp, O_WRONLY|O_CREAT|O_TRUNC, 0644, 0,0);
+    if (fdo < 0) { emit("open out rc=", fdo); sys3(SYS_exit,1,0,0); }
+
+    unsigned long done = 0;
+    const char *base = (const char *)p;
+    while (done < len) {
+        unsigned long chunk = len - done;
+        if (chunk > 1u<<20) chunk = 1u<<20;
+        long w = sys3(SYS_write, fdo, (long)(base + done), (long)chunk);
+        if (w <= 0) { emit("write rc=", w); sys3(SYS_exit,1,0,0); }
+        done += (unsigned long)w;
+    }
+    sys3(SYS_close, fdo, 0, 0);
+    sys6(SYS_munmap, p, (long)len, 0,0,0,0);
+    sys3(SYS_close, fdm, 0, 0);
+    emit("ok bytes=", (long)done);
+    sys3(SYS_exit, 0, 0, 0);
+}
+
+__asm__(".global _start\n_start:\n  mov x0, sp\n  b _c_start\n");

--- a/reolink-firmware-patching/vpe/seam_layers.py
+++ b/reolink-firmware-patching/vpe/seam_layers.py
@@ -1,0 +1,701 @@
+#!/usr/bin/env python3
+"""The two sensors' contributions to the seam, as two separable layers.
+
+WHAT THIS IS FOR. Every earlier view of the seam had to work from the *fused*
+panorama, where the blend window is already a mixture of both sensors. There is
+no second layer in a mixture, so blink/anaglyph/mirror could only ever draw
+*extrapolations from the shoulders* -- honest, but inference. This module
+returns the real pair, un-blended, so those views become exact.
+
+WHAT A LAYER PAIR IS, AND WHY IT IS DEFINED THIS ABSTRACTLY.
+
+    "a left layer, a right layer, and the panorama columns they correspond to"
+
+That is the whole contract, and it is deliberately the *only* contract. Today
+the pair arrives as two 128-px strips lifted out of one ISF buffer. Tomorrow it
+may arrive as two 3840-px per-sensor frames from the vendor's own two-channel
+snap. Those differ in every dimension that a naive implementation would have
+hard-coded -- width, panorama origin, whether the two layers even cover the same
+columns -- and differ in none that the consumer actually needs. So:
+
+  * each layer carries its OWN panorama origin (`left_x0`, `right_x0`). For the
+    strip source they are equal; for full frames they are 0 and 3776. Code that
+    assumed one shared origin would be rewritten by the second source.
+  * the overlap is *derived* (`LayerPair.overlap`), never assumed. It is the
+    intersection of the two column ranges, which for strips is the whole thing
+    and for full frames is a 128-px window inside two 3840-px images.
+  * no caller may write 128 or 3776. They come off the descriptor. The only
+    numbers in this file that are specific to the strip transport live in
+    `capture()`, which is the one function whose job *is* that transport.
+
+WHAT IS TRUE OF THE PAIR, AND WHY IT MATTERS FOR CALIBRATION. Both layers are
+already resampled into the panorama's output coordinate frame -- the warp has
+run, the stitcher has not. So the pair is pre-rectified, and an L-to-R
+displacement measured on it is residual disparity in *output pixels*: it
+converts to `dx_anchors` with no lens model, no homography and no rescale. That
+is what makes hand-alignment on these two images a calibration rather than a
+picture.
+
+CAMERA ACCESS IS READ-ONLY. `capture()` pulls a frame descriptor and releases it
+microseconds later, then reads physical memory. It never calls `SetStitch`,
+never writes a mesh, never touches flash.
+"""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import re
+import socketserver
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# --------------------------------------------------------------------------
+# Transport constants -- specific to the strip source, used only by capture().
+# --------------------------------------------------------------------------
+
+#: VIDEOPROC 2's out[1] port. out[0] is the fused panorama and is contended;
+#: out[1] carries the pre-blend pair and no other consumer pulls it.
+ISF_ROOT_PATH = 0x00930000
+ISF_PORT_PATH = 0x00930001
+
+#: `arg[4]` of the pull ioctl is a **millisecond timeout**, not a flag word.
+#: 200 ms is ~4 frame intervals at the port's 20 Hz, so it waits for a real
+#: frame rather than racing the producer, and still bounds a stuck request.
+PULL_TIMEOUT_MS = 200
+
+#: The strip's Y plane: 256 x 2160, stride == width, linear. Also the dump
+#: length, which /dev/mem requires to start 4 KB aligned.
+STRIP_PACKED_W = 256
+STRIP_H = 2160
+STRIP_Y_BYTES = STRIP_PACKED_W * STRIP_H  # 0x87000
+
+#: Where the strip sits in the panorama, measured: the blend band is columns
+#: 3776..3903 and the cross-fade crosses over at 3840.
+STRIP_PANO_X0 = 3776
+
+DEFAULT_PANO_W = 7680
+DEFAULT_PANO_H = 2160
+
+CAM_TMP = "/mnt/tmp"
+
+
+class LayerCaptureError(RuntimeError):
+    """The pair could not be obtained. Always says which stage failed."""
+
+
+# --------------------------------------------------------------------------
+# The pair
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class LayerPair:
+    """Two single-sensor views plus the panorama columns they occupy.
+
+    `left` and `right` are 2-D uint8 luma. They need not be the same width and
+    need not start at the same panorama column -- see the module docstring.
+    """
+
+    left: Any  # np.ndarray (h, wL) uint8
+    right: Any  # np.ndarray (h, wR) uint8
+    left_x0: int
+    right_x0: int
+    #: Panorama column where the cross-fade hands over from left to right.
+    #: `None` means "the centre of the overlap", which is what it measured as
+    #: (band 3776..3903, crossover 3840) and what it must be for a symmetric
+    #: ramp. Deriving it rather than storing 3840 is what makes the same code
+    #: correct for full per-sensor frames, whose overlap is the same 128
+    #: columns sitting inside two 3840-px images.
+    seam_x: int | None = None
+    pano_w: int = DEFAULT_PANO_W
+    pano_h: int = DEFAULT_PANO_H
+    source: str = "unknown"
+    detail: str = ""
+    #: True when these are genuinely separated sensor layers rather than
+    #: anything reconstructed. The UI promises exactness on the strength of
+    #: this flag, so nothing sets it True speculatively.
+    exact: bool = True
+    #: Only the synthetic source fills this: the offset and roll it built in,
+    #: so a test can assert the tool recovers what was hidden.
+    truth: dict | None = None
+
+    def __post_init__(self) -> None:
+        if self.left.ndim != 2 or self.right.ndim != 2:
+            raise LayerCaptureError("layers must be 2-D single-channel images")
+        if self.left.shape[0] != self.right.shape[0]:
+            raise LayerCaptureError(
+                f"layers disagree on height: {self.left.shape[0]} vs "
+                f"{self.right.shape[0]} -- they are not the same moment"
+            )
+        if self.seam_x is None:
+            lo, hi = self.overlap
+            if hi <= lo:
+                raise LayerCaptureError(
+                    f"the two layers do not overlap (left {self.left_x0}..{self.left_x1}, "
+                    f"right {self.right_x0}..{self.right_x1}) -- there is no seam "
+                    "between them to align"
+                )
+            self.seam_x = (lo + hi) // 2
+
+    @property
+    def height(self) -> int:
+        return int(self.left.shape[0])
+
+    @property
+    def left_x1(self) -> int:
+        return self.left_x0 + int(self.left.shape[1])
+
+    @property
+    def right_x1(self) -> int:
+        return self.right_x0 + int(self.right.shape[1])
+
+    @property
+    def overlap(self) -> tuple[int, int]:
+        """Panorama columns where BOTH layers have pixels. Derived, never fixed.
+
+        This is the only region where a registration measure means anything,
+        and it is the region the UI centres on. For the strip source it is the
+        full 128 columns; for full per-sensor frames it is a narrow window
+        inside two much larger images.
+        """
+        return (max(self.left_x0, self.right_x0), min(self.left_x1, self.right_x1))
+
+    def to_api(self) -> dict:
+        lo, hi = self.overlap
+        return {
+            "source": self.source,
+            "detail": self.detail,
+            "exact": bool(self.exact),
+            # A LayerPair is by construction in panorama output coordinates --
+            # that is the property that makes a drag on it a calibration rather
+            # than a picture, so the UI asserts it before binding a gesture
+            # instead of trusting a label. Sensor-space frames are SensorViews.
+            "space": "panorama",
+            "authoritative": True,
+            "height": self.height,
+            "seam_x": int(self.seam_x),
+            "pano_w": int(self.pano_w),
+            "pano_h": int(self.pano_h),
+            "left": {
+                "x0": int(self.left_x0),
+                "x1": int(self.left_x1),
+                "w": int(self.left.shape[1]),
+            },
+            "right": {
+                "x0": int(self.right_x0),
+                "x1": int(self.right_x1),
+                "w": int(self.right.shape[1]),
+            },
+            "overlap": {"x0": int(lo), "x1": int(hi), "w": int(max(0, hi - lo))},
+            "truth": self.truth,
+        }
+
+    def registration(self) -> dict:
+        """Mean |L-R| and normalised cross-correlation over the overlap, as-is.
+
+        The server-side twin of the number the UI recomputes on every drag.
+        Reported at zero correction so an operator has a starting value to
+        improve on, and so a test can check that the client and the server are
+        measuring the same thing.
+        """
+        import numpy as np
+
+        lo, hi = self.overlap
+        if hi <= lo:
+            return {"mad": None, "ncc": None, "n": 0}
+        left = self.left[:, lo - self.left_x0 : hi - self.left_x0].astype(np.float64)
+        right = self.right[:, lo - self.right_x0 : hi - self.right_x0].astype(
+            np.float64
+        )
+        mad = float(np.abs(left - right).mean())
+        la, ra = left - left.mean(), right - right.mean()
+        den = float(np.sqrt((la * la).sum() * (ra * ra).sum()))
+        ncc = None if den <= 0 else float((la * ra).sum() / den)
+        return {"mad": mad, "ncc": ncc, "n": int(left.size)}
+
+
+def split_packed(
+    buf: bytes,
+    *,
+    width: int = STRIP_PACKED_W,
+    height: int = STRIP_H,
+    pano_x0: int = STRIP_PANO_X0,
+    seam_x: int | None = None,
+    source: str = "file",
+    detail: str = "",
+) -> LayerPair:
+    """Split one packed buffer into its two halves.
+
+    The strip transport hands back a single (height, width) plane whose left
+    half is sensor 0's contribution and whose right half is sensor 1's, both
+    covering the *same* panorama columns. That co-location is the surprising
+    part and the reason this is a named function rather than a slice at the
+    call site: `left_x0 == right_x0`, and a reader who assumed the two halves
+    were adjacent in the panorama would be wrong by 128 px.
+    """
+    import numpy as np
+
+    need = width * height
+    if len(buf) < need:
+        raise LayerCaptureError(
+            f"expected at least {need} bytes of luma ({width}x{height}), got {len(buf)}"
+        )
+    plane = np.frombuffer(buf[:need], dtype=np.uint8).reshape(height, width)
+    half = width // 2
+    return LayerPair(
+        left=np.ascontiguousarray(plane[:, :half]),
+        right=np.ascontiguousarray(plane[:, half:]),
+        left_x0=pano_x0,
+        right_x0=pano_x0,
+        seam_x=seam_x,
+        source=source,
+        detail=detail or f"{width}x{height} packed pair at panorama x={pano_x0}",
+    )
+
+
+def load_file(path: str | Path, **kw: Any) -> LayerPair:
+    """Read an archived packed pair off disk.
+
+    The fallback source, and the one that needs no camera: point it at a raw
+    dump and the whole UI comes up. Geometry defaults to the strip's, and every
+    part of it is overridable, because the next dump may not be 256 wide.
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise LayerCaptureError(f"no such layer dump: {p}")
+    kw.setdefault("detail", f"archived dump {p.name}")
+    return split_packed(p.read_bytes(), source="file", **kw)
+
+
+# --------------------------------------------------------------------------
+# Synthetic source
+# --------------------------------------------------------------------------
+
+
+def synthetic(
+    *,
+    width: int = 128,
+    height: int = STRIP_H,
+    dx: float = 6.0,
+    roll: float = 12.0,
+    pano_x0: int = STRIP_PANO_X0,
+    seed: int = 7,
+) -> LayerPair:
+    """A textured pair with a known offset and roll built in.
+
+    This exists because the archived real pair *cannot* be aligned: it is a desk
+    scene at 0.3 m where one sensor is defocused and blown out and the other
+    sees near-black, with no shared texture -- a feature matcher gets zero
+    keypoints on it. It proves the plumbing and the rendering and nothing else.
+    Tuning an interaction against it, or quoting a disparity from it, would be
+    reading noise.
+
+    So the interaction is developed against this instead, where the answer is
+    known: the right layer's content is displaced by
+
+        d(y) = dx + roll * (y - mid) / (height - 1)
+
+    and an operator (or a test) has succeeded when the authored curve reaches
+    mean `dx` and top-to-bottom roll amplitude `roll`. Sign follows the shipped
+    convention -- `dx` is px the RIGHT layer must move right.
+    """
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    mid = (height - 1) / 2.0
+    pad = int(np.ceil(abs(dx) + abs(roll))) + 4
+    scene_w = width + 2 * pad
+
+    # Band-limited noise: fine enough to make a 1-px error visible, coarse
+    # enough to survive resampling. Plus hard vertical and diagonal edges,
+    # which is what a human actually locks onto.
+    coarse = rng.random((height // 8 + 2, scene_w // 8 + 2))
+    scene = np.repeat(np.repeat(coarse, 8, axis=0), 8, axis=1)[:height, :scene_w]
+    scene = 60.0 + 120.0 * scene
+    xs = np.arange(scene_w)[None, :]
+    ys = np.arange(height)[:, None]
+    scene += 70.0 * (((xs // 17) % 2) == 0)  # vertical bars
+    scene += 55.0 * ((((xs + ys // 3) // 23) % 2) == 0)  # slanted bars
+    scene += rng.normal(0, 2.0, size=scene.shape)  # sensor noise, uncorrelated
+
+    left = np.clip(scene[:, pad : pad + width], 0, 255).astype(np.uint8)
+
+    # R samples the same scene displaced by d(y): content appears shifted LEFT,
+    # so moving the right layer +d px right is the correction.
+    d = dx + roll * (np.arange(height) - mid) / (height - 1)
+    src_x = np.arange(width)[None, :] + pad + d[:, None]
+    x0 = np.floor(src_x).astype(np.int64)
+    frac = src_x - x0
+    x0 = np.clip(x0, 0, scene_w - 2)
+    row = np.arange(height)[:, None]
+    right = scene[row, x0] * (1 - frac) + scene[row, x0 + 1] * frac
+    right = np.clip(right + rng.normal(0, 2.0, size=right.shape), 0, 255).astype(
+        np.uint8
+    )
+
+    return LayerPair(
+        left=left,
+        right=right,
+        left_x0=pano_x0,
+        right_x0=pano_x0,
+        source="synthetic",
+        detail=(
+            f"test pair with a known answer: dx={dx:+.2f} px, "
+            f"roll={roll:+.2f} px top-to-bottom"
+        ),
+        truth={"dx": float(dx), "roll": float(roll)},
+    )
+
+
+# --------------------------------------------------------------------------
+# Live capture
+# --------------------------------------------------------------------------
+
+
+def _camsh() -> Any:
+    """The sanctioned shell client, imported late so file/synthetic work without it."""
+    import importlib
+    import sys
+
+    runtime = Path(__file__).resolve().parents[1] / "runtime"
+    if str(runtime) not in sys.path:
+        sys.path.insert(0, str(runtime))
+    return importlib.import_module("camsh")
+
+
+def _sh() -> Any:
+    return _camsh().sh
+
+
+@functools.lru_cache(maxsize=4)
+def _helper_dir() -> Path:
+    """Where the two camera-side helper binaries are expected to be built."""
+    return Path(__file__).resolve().parents[1] / "builds" / "out"
+
+
+def _serve_dir(directory: Path) -> tuple[socketserver.TCPServer, int]:
+    """A one-shot HTTP server so the camera can `wget` the helpers.
+
+    There is no `base64` on the device, so pushing a binary through the shell
+    means octal `printf` per byte -- minutes, and fragile. Serving the directory
+    and issuing one `wget` per file is a single round trip and the file arrives
+    byte-exact. The server binds all interfaces because the camera has to reach
+    it, and lives only for the length of the upload.
+    """
+    handler = functools.partial(
+        http.server.SimpleHTTPRequestHandler, directory=str(directory)
+    )
+    httpd = socketserver.TCPServer(("0.0.0.0", 0), handler)  # noqa: S104
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, int(httpd.server_address[1])
+
+
+def _local_ip_towards(host: str) -> str:
+    import socket
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect((host, 80))
+        return str(s.getsockname()[0])
+    finally:
+        s.close()
+
+
+def ensure_helpers(host: str, names: tuple[str, ...], helper_dir: Path | None) -> None:
+    """Upload the pull/dump helpers if they are not already resident.
+
+    They are *not* baked into the firmware and are not expected to be: this is
+    an investigation surface, so it is uploaded when wanted and removed after.
+    Skipped entirely when the camera already has a byte-identical copy.
+    """
+    import hashlib
+
+    sh = _sh()
+    src = helper_dir or _helper_dir()
+    missing = []
+    for name in names:
+        local = src / name
+        if not local.is_file():
+            raise LayerCaptureError(
+                f"camera helper {name!r} is not built. Expected it at {local}. "
+                f"Build it from {name}.c (see vpe/README) or use the file source."
+            )
+        want = hashlib.md5(local.read_bytes()).hexdigest()  # noqa: S324 -- integrity
+        got = sh(f"md5sum {CAM_TMP}/{name} 2>/dev/null | cut -d' ' -f1", host=host)
+        if want not in got:
+            missing.append((name, want))
+    if not missing:
+        return
+    httpd, port = _serve_dir(src)
+    try:
+        ip = _local_ip_towards(host)
+        cmds = " && ".join(
+            f"wget -q -O {CAM_TMP}/{n} http://{ip}:{port}/{n} && chmod 755 {CAM_TMP}/{n}"
+            for n, _ in missing
+        )
+        sh(f"{cmds} && echo UPLOADED", host=host, timeout=60)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+    for name, want in missing:
+        got = sh(f"md5sum {CAM_TMP}/{name} | cut -d' ' -f1", host=host)
+        if want not in got:
+            raise LayerCaptureError(
+                f"{name} did not arrive intact: wanted {want}, camera reports {got.strip()!r}"
+            )
+
+
+_PHYS_RE = re.compile(r"phys_Y\[168\]\s*=\s*(0x[0-9a-fA-F]+)")
+
+
+def capture(
+    host: str,
+    *,
+    helper_dir: Path | None = None,
+    keep_helpers: bool = False,
+) -> LayerPair:
+    """Pull one pre-blend pair off the camera. Read-only, start to finish.
+
+    THE ONE THING THAT MUST NOT BE SPLIT UP. The port's Y buffer address rotates
+    over at least five buffers, and an address seen on an earlier pull gets
+    *repurposed for another producer*. Dumping a remembered address therefore
+    yields a foreign buffer that still looks like a plausible image -- one such
+    read was a 2560-wide frame that only gave itself away under a stride scan.
+    So the pull and the dump go out as ONE shell invocation, and the address
+    never crosses back into Python before it has been used.
+
+    The pull ioctl returns -14 whatever happens; the real result is `arg[0]`,
+    which the helper reports. `pemdump` mmaps /dev/mem, so the physical offset
+    must be 4 KB aligned -- an unaligned start silently produces no file, which
+    is why the transfer is verified by size rather than by exit status.
+    """
+    camsh = _camsh()
+    sh = camsh.sh
+    ensure_helpers(host, ("isfpull2", "pemdump"), helper_dir)
+    dump = f"{CAM_TMP}/seamlayers.bin"
+    # Clearing the stale dump is its OWN invocation, and must stay that way.
+    # `camsh.check()` refuses any command that contains both `rm` and a glob
+    # metacharacter, scanning the whole string -- and the pull command below
+    # contains `phys_Y[168]` in its sed expression. Combining them trips the
+    # guard on a `[` that is nowhere near the `rm`. The guard is right to be
+    # blunt about deleting things, so the command moves rather than the rule.
+    sh(f"rm -f {dump}", host=host)
+    one_shot = (
+        f"A=$({CAM_TMP}/isfpull2 {PULL_TIMEOUT_MS} "
+        f"0x{ISF_ROOT_PATH:08x} 0x{ISF_PORT_PATH:08x} "
+        f"| sed -n 's/.*phys_Y\\[168\\][ ]*= \\(0x[0-9a-f]*\\).*/\\1/p' | sed -n 2p); "
+        f"echo ADDR=$A; "
+        f'[ -n "$A" ] && {CAM_TMP}/pemdump $A 0x{STRIP_Y_BYTES:x} {dump}; '
+        f"echo SIZE=$(wc -c < {dump} 2>/dev/null || echo 0)"
+    )
+    out = sh(one_shot, host=host, timeout=60)
+    addr = ""
+    size = 0
+    for line in out.splitlines():
+        if line.startswith("ADDR="):
+            addr = line[5:].strip()
+        elif line.startswith("SIZE="):
+            try:
+                size = int(line[5:].strip())
+            except ValueError:
+                size = 0
+    if not addr:
+        raise LayerCaptureError(
+            "the pull returned no buffer address for out[1]. The port may not be "
+            f"producing. Helper said:\n{out.strip()}"
+        )
+    if size != STRIP_Y_BYTES:
+        raise LayerCaptureError(
+            f"dump of {addr} is {size} B, expected {STRIP_Y_BYTES} B -- "
+            "an unaligned or refused /dev/mem read produces a short or absent file"
+        )
+    # `cat` over the probe shell is binary-safe and needs no base64 on either end.
+    blob = camsh.sh_bytes(f"cat {dump}", host=host, timeout=120)
+    if len(blob) < STRIP_Y_BYTES:
+        raise LayerCaptureError(
+            f"retrieved {len(blob)} B of {STRIP_Y_BYTES} B from {dump}"
+        )
+    if not keep_helpers:
+        # Exact paths only. Globs inside /mnt/tmp are how a cleanup step once
+        # deleted 236 GB of recordings; camsh refuses them and so does this.
+        sh(
+            f"rm -f {dump} {CAM_TMP}/isfpull2 {CAM_TMP}/pemdump; echo CLEANED",
+            host=host,
+        )
+    return split_packed(
+        blob,
+        source="camera",
+        detail=f"live pull from {host}, out[1] buffer {addr}",
+    )
+
+
+#: Sources that produce an ALIGNMENT-CAPABLE pair -- one in panorama output
+#: coordinates, where a measured displacement converts straight to dx_anchors.
+SOURCES = ("camera", "file", "synthetic")
+
+
+# --------------------------------------------------------------------------
+# Whole-lens context views -- deliberately NOT a LayerPair
+# --------------------------------------------------------------------------
+
+
+#: The vendor's own per-sensor snap. Message 13010, not 13003: 13003 hardcodes a
+#: task class that can only ever build `yuv_snap`. The parameter must be exactly
+#: 32 hex characters or the call returns -803. Success is silent; failure prints
+#: `to:SNAP error,ret :-822`.
+RPC_SNAP_MSG = 13010
+RPC_SNAP_PARAM = "02" + "0" * 30
+RPC_SNAP_SETTLE_S = 5
+
+
+@dataclass
+class SensorViews:
+    """Two whole-lens JPEGs. Context for the operator, never a measurement.
+
+    WHY THIS IS A DIFFERENT TYPE FROM `LayerPair`, AND MUST STAY ONE.
+
+    These frames are 3840x2160 -- the native width of each sensor's own output
+    port -- which means they are in **sensor coordinates, before the warp**. A
+    displacement measured on them is not a panorama displacement and does not
+    convert to `dx_anchors` without the sensor->panorama warp.
+
+    That warp has since been measured (a 2-D cubic fitted by matching panorama
+    patches into each sensor frame outside the blend band; it reproduces the
+    panorama to ~2-5 grey levels, and each sensor carries 450-530 columns of
+    genuine margin past the seam). So this is a scope boundary, not a claim of
+    impossibility. It is not wired in here for three reasons: the strip pair is
+    pre-rectified by the hardware and so carries no fit error at all; the fitted
+    maps are archived artifacts a camera-manager install does not have; and the
+    fit is tied to the current mesh, which is the very thing a calibration
+    changes. Resampling a sensor frame through that map would produce an
+    ordinary `LayerPair` -- see the class docstring there.
+
+    A `LayerPair` is the opposite: already resampled into the panorama's output
+    frame, so a displacement on it *is* the correction. Both could be described
+    as "two images of the same scene from the two sensors", and that shared
+    description is exactly the trap. Giving them one type would make it a
+    reviewer's job to remember which instance was authoritative; giving them
+    two makes it the type checker's. The endpoint that serves these cannot
+    return a LayerPair and the UI cannot bind a gesture to them.
+
+    (An earlier reading had these at 3904 wide and argued the extra 64 columns
+    per side were the overlap margin, making them alignment-capable. Three
+    fresh captures read 3840 in their SOF0 headers, so that does not reproduce
+    and the argument is withdrawn.)
+    """
+
+    left: bytes  # JPEG, sensor 0
+    right: bytes  # JPEG, sensor 1
+    width: int
+    height: int
+    stamp: str
+    source: str = "camera"
+    #: Named to be read at the call site. There is no code path that sets this
+    #: to "panorama" -- that is what `LayerPair` is for.
+    space: str = "sensor"
+
+    def to_api(self) -> dict:
+        return {
+            "source": self.source,
+            "space": self.space,
+            "authoritative": False,
+            "width": int(self.width),
+            "height": int(self.height),
+            "stamp": self.stamp,
+            "why": (
+                "whole-lens views in sensor coordinates, before the warp. Use "
+                "them to see what each lens is looking at; the alignment "
+                "surface is the pre-rectified overlap pair."
+            ),
+        }
+
+
+def _jpeg_size(blob: bytes) -> tuple[int, int]:
+    """Width and height from the SOF marker. Trust the file, not the caller."""
+    import struct
+
+    i = 2
+    while i < len(blob) - 9:
+        if blob[i] != 0xFF:
+            i += 1
+            continue
+        marker = blob[i + 1]
+        if marker in (0xC0, 0xC1, 0xC2):
+            h, w = struct.unpack(">HH", blob[i + 5 : i + 9])
+            return int(w), int(h)
+        if marker in (0xD8, 0xD9) or 0xD0 <= marker <= 0xD7:
+            i += 2
+            continue
+        i += 2 + struct.unpack(">H", blob[i + 2 : i + 4])[0]
+    raise LayerCaptureError("no JPEG SOF marker -- that is not a JPEG")
+
+
+def capture_sensor_views(host: str, *, keep: bool = False) -> SensorViews:
+    """Ask the camera for one matched per-sensor still. Read-only.
+
+    Needs no upload, no build and no login: `rpctool` is already on the device.
+    The two files share a timestamp when they are a matched pair, which is the
+    only thing that makes them comparable, so a mismatched pair is refused
+    rather than shown.
+
+    `/mnt/tmp` is a 55 MB tmpfs, so the files are removed by exact path after
+    retrieval -- never by glob.
+    """
+    camsh = _camsh()
+    sh = camsh.sh
+    cmd = (
+        "export LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib:/mnt/app; "
+        f"/mnt/app/rpctool -s -t SNAP -c {RPC_SNAP_MSG} -m {RPC_SNAP_PARAM} 2>&1; "
+        f"sleep {RPC_SNAP_SETTLE_S}; "
+        "ls -1 /mnt/tmp/01_*.jpg /mnt/tmp/02_*.jpg 2>/dev/null"
+    )
+    out = sh(cmd, host=host, timeout=90)
+    if "error" in out.lower():
+        raise LayerCaptureError(f"the per-sensor snap refused:\n{out.strip()}")
+    found: dict[str, dict[str, str]] = {}
+    for line in out.splitlines():
+        line = line.strip()
+        m = re.match(r"^(/mnt/tmp/(0[12])_(\d+)\.jpg)$", line)
+        if m:
+            found.setdefault(m.group(3), {})[m.group(2)] = m.group(1)
+    matched = sorted(k for k, v in found.items() if "01" in v and "02" in v)
+    if not matched:
+        raise LayerCaptureError(
+            "the snap produced no matched 01_/02_ pair in /mnt/tmp. "
+            f"Shell said:\n{out.strip()}"
+        )
+    stamp = matched[-1]
+    paths = found[stamp]
+    blobs = {}
+    for side, key in (("left", "01"), ("right", "02")):
+        blob = camsh.sh_bytes(f"cat {paths[key]}", host=host, timeout=120)
+        if len(blob) < 1024:
+            raise LayerCaptureError(f"{paths[key]} came back as {len(blob)} B")
+        blobs[side] = blob
+    w, h = _jpeg_size(blobs["left"])
+    w2, h2 = _jpeg_size(blobs["right"])
+    if (w, h) != (w2, h2):
+        raise LayerCaptureError(
+            f"the two sensor views disagree on size: {w}x{h} vs {w2}x{h2}"
+        )
+    if not keep:
+        sh(f"rm -f {paths['01']} {paths['02']}; echo CLEANED", host=host)
+    return SensorViews(
+        left=blobs["left"], right=blobs["right"], width=w, height=h, stamp=stamp
+    )
+
+
+def load_sensor_views(left: str | Path, right: str | Path) -> SensorViews:
+    """Archived per-sensor stills, for working without a camera on the link."""
+    lp, rp = Path(left), Path(right)
+    for p in (lp, rp):
+        if not p.is_file():
+            raise LayerCaptureError(f"no such sensor view: {p}")
+    lb, rb = lp.read_bytes(), rp.read_bytes()
+    w, h = _jpeg_size(lb)
+    return SensorViews(
+        left=lb, right=rb, width=w, height=h, stamp=lp.stem, source="file"
+    )

--- a/tests/test_seam_layers.py
+++ b/tests/test_seam_layers.py
@@ -1,0 +1,189 @@
+"""The pre-blend layer pair: its geometry, and the line between the two surfaces.
+
+The camera transport is not exercised here -- it needs the hardware, and the
+live pull is recorded in STITCH_CALIBRATION.md. What is pinned here is
+everything that decides whether a *different* source can be dropped in without
+touching the UI, plus the one claim the tool rests on: that lining the layers up
+by hand descends a real objective.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+VPE = Path(__file__).resolve().parents[1] / "reolink-firmware-patching" / "vpe"
+if str(VPE) not in sys.path:
+    sys.path.insert(0, str(VPE))
+
+seam_layers = pytest.importorskip("seam_layers")
+
+
+def _shift_rows(img: np.ndarray, d: np.ndarray) -> np.ndarray:
+    """Resample each row horizontally by d[row]. The curve, applied."""
+    h, w = img.shape
+    x = np.arange(w)
+    out = np.empty((h, w), dtype=np.float64)
+    for y in range(h):
+        out[y] = np.interp(x - d[y], x, img[y].astype(np.float64))
+    return out
+
+
+class TestGeometryIsDerived:
+    """No caller writes 128 or 3776, so a new source cannot break the UI."""
+
+    def test_seam_is_the_centre_of_the_overlap_not_half_the_buffer(self):
+        # The strip arrives as one 256-wide packed buffer whose halves are the
+        # two layers. Half of 256 is 128, but the cross-fade is at 3840 --
+        # pano_x0 + 64. Deriving the seam from the overlap gets this right;
+        # halving the packed width gets 3904, which is off by a full layer.
+        pair = seam_layers.split_packed(bytes(256 * 8), width=256, height=8)
+        assert pair.overlap == (3776, 3904)
+        assert pair.seam_x == 3840
+
+    def test_the_two_strip_halves_share_panorama_columns(self):
+        # The surprising invariant: these are not adjacent strips, they are two
+        # views of the SAME columns. A reader who assumed adjacency would place
+        # the right layer 128 px too far over.
+        pair = seam_layers.split_packed(bytes(256 * 8), width=256, height=8)
+        assert pair.left_x0 == pair.right_x0 == 3776
+        assert pair.left.shape == pair.right.shape == (8, 128)
+
+    def test_full_frame_shaped_layers_derive_a_narrow_overlap(self):
+        # The source that does not exist yet, in the shape it would arrive in:
+        # two wide layers with DIFFERENT origins overlapping in a narrow band.
+        # Nothing in LayerPair needs changing for this, which is the whole
+        # point of the descriptor being the contract.
+        left = np.zeros((16, 3904), dtype=np.uint8)
+        right = np.zeros((16, 3904), dtype=np.uint8)
+        pair = seam_layers.LayerPair(
+            left=left, right=right, left_x0=0, right_x0=3776, source="hypothetical"
+        )
+        assert pair.overlap == (3776, 3904)
+        assert pair.seam_x == 3840  # same seam, from wildly different inputs
+        api = pair.to_api()
+        assert api["left"]["x0"] == 0
+        assert api["right"]["x0"] == 3776
+        assert api["overlap"]["w"] == 128
+
+    def test_layers_that_do_not_overlap_are_refused(self):
+        with pytest.raises(seam_layers.LayerCaptureError, match="do not overlap"):
+            seam_layers.LayerPair(
+                left=np.zeros((4, 10), dtype=np.uint8),
+                right=np.zeros((4, 10), dtype=np.uint8),
+                left_x0=0,
+                right_x0=500,
+            )
+
+    def test_mismatched_heights_are_refused(self):
+        with pytest.raises(seam_layers.LayerCaptureError, match="not the same moment"):
+            seam_layers.LayerPair(
+                left=np.zeros((4, 10), dtype=np.uint8),
+                right=np.zeros((8, 10), dtype=np.uint8),
+                left_x0=0,
+                right_x0=0,
+            )
+
+    def test_a_short_buffer_is_refused_rather_than_reshaped(self):
+        with pytest.raises(seam_layers.LayerCaptureError, match="expected at least"):
+            seam_layers.split_packed(bytes(100), width=256, height=8)
+
+
+class TestTheObjectiveIsReal:
+    """Hand-alignment has to descend something, or it is just dragging."""
+
+    def test_the_hidden_answer_is_the_minimum(self):
+        # The archived real pair cannot be aligned -- a 0.3 m desk scene where
+        # one sensor is blown out and the other near-black, zero keypoints. So
+        # the claim is tested where the answer is known by construction.
+        pair = seam_layers.synthetic(dx=6.0, roll=12.0, height=256)
+        h = pair.height
+        mid = (h - 1) / 2.0
+        left = pair.left.astype(np.float64)
+
+        def mad(dx: float, roll: float) -> float:
+            d = dx + roll * (np.arange(h) - mid) / (h - 1)
+            return float(np.abs(left - _shift_rows(pair.right, d)).mean())
+
+        truth = mad(6.0, 12.0)
+        assert truth < mad(0.0, 0.0) / 4  # far better than doing nothing
+        assert truth < mad(6.0, 0.0)  # translation alone is not enough
+        assert truth < mad(0.0, 12.0)  # nor is rotation alone
+        # and it is a genuine minimum, not a plateau: half a pixel either way
+        # is measurably worse, which is what makes the number steerable.
+        assert truth < mad(6.5, 12.0)
+        assert truth < mad(5.5, 12.0)
+        assert truth < mad(6.0, 13.0)
+
+    def test_registration_reports_both_measures_over_the_overlap_only(self):
+        pair = seam_layers.synthetic(dx=0.0, roll=0.0, height=64)
+        reg = pair.registration()
+        # dx=0, roll=0 means the layers are identical but for sensor noise.
+        assert reg["mad"] < 6.0
+        assert reg["ncc"] > 0.99
+        assert reg["n"] == 64 * 128
+
+    def test_synthetic_carries_its_answer_for_the_operator_to_check_against(self):
+        pair = seam_layers.synthetic(dx=3.5, roll=-8.0, height=32)
+        assert pair.truth == {"dx": 3.5, "roll": -8.0}
+        assert pair.to_api()["truth"] == {"dx": 3.5, "roll": -8.0}
+
+
+class TestTheTwoSurfacesStayApart:
+    """A LayerPair is a measurement. SensorViews are not. Enforced by type."""
+
+    def test_a_layer_pair_is_authoritative_and_in_panorama_space(self):
+        api = seam_layers.synthetic(height=8).to_api()
+        assert api["space"] == "panorama"
+        assert api["authoritative"] is True
+
+    def test_sensor_views_are_never_authoritative(self):
+        views = seam_layers.SensorViews(
+            left=b"", right=b"", width=3840, height=2160, stamp="x"
+        )
+        api = views.to_api()
+        assert api["space"] == "sensor"
+        assert api["authoritative"] is False
+
+    def test_sensor_views_expose_no_panorama_mapping_at_all(self):
+        # The guard against someone "just adding" x0/overlap to SensorViews and
+        # quietly making it look alignable. If this ever needs updating, the
+        # question to answer first is what warp turned sensor columns into
+        # panorama columns -- see the class docstring.
+        api = seam_layers.SensorViews(
+            left=b"", right=b"", width=3840, height=2160, stamp="x"
+        ).to_api()
+        for forbidden in ("overlap", "seam_x", "left", "right", "pano_w"):
+            assert forbidden not in api
+
+    def test_jpeg_size_is_read_from_the_file_not_taken_on_trust(self):
+        import io
+
+        from PIL import Image
+
+        buf = io.BytesIO()
+        Image.new("RGB", (640, 480), "black").save(buf, format="JPEG")
+        assert seam_layers._jpeg_size(buf.getvalue()) == (640, 480)
+
+    def test_a_non_jpeg_is_refused(self):
+        with pytest.raises(seam_layers.LayerCaptureError, match="not a JPEG"):
+            seam_layers._jpeg_size(b"\xff\xd8" + b"\x00" * 64)
+
+
+class TestArchivedDumps:
+    def test_a_dump_round_trips_through_load_file(self, tmp_path):
+        pair = seam_layers.synthetic(dx=2.0, roll=0.0, height=16)
+        packed = np.concatenate([pair.left, pair.right], axis=1)
+        p = tmp_path / "pair.bin"
+        p.write_bytes(packed.tobytes())
+        back = seam_layers.load_file(p, width=256, height=16)
+        assert np.array_equal(back.left, pair.left)
+        assert np.array_equal(back.right, pair.right)
+        assert back.source == "file"
+
+    def test_a_missing_dump_says_so(self, tmp_path):
+        with pytest.raises(seam_layers.LayerCaptureError, match="no such layer dump"):
+            seam_layers.load_file(tmp_path / "nope.bin")

--- a/tests/web/test_stitch_calibration.py
+++ b/tests/web/test_stitch_calibration.py
@@ -31,6 +31,7 @@ from video_grouper.web import stitch_calibration as sc
 VPE_DIR = Path(__file__).resolve().parents[2] / "reolink-firmware-patching" / "vpe"
 sys.path.insert(0, str(VPE_DIR))
 
+import seam_layers  # noqa: E402
 import seam_metric  # noqa: E402
 import seam_vertical  # noqa: E402
 
@@ -187,6 +188,7 @@ def client(tmp_path, calls, monkeypatch):
             "metric": seam_metric,
             "vertical": seam_vertical,
             "camera": _fake_camera(calls),
+            "layers": seam_layers,
             "errors": [],
         }
     )
@@ -225,8 +227,15 @@ def test_page_renders_and_states_the_constraints_it_must_state(client):
     # The two things the design says must be visible in the interface, not
     # merely true of the code.
     assert "already a mixture" in body, "the fused-JPEG caveat must be UI text"
-    assert "the window is inference" in body.lower()
     assert "camera can only move the left" in body.lower()
+    # The caveat is now scoped rather than blanket: it applies to the fused
+    # view and is explicitly lifted for the layer pair, which really is two
+    # separated sensors. Both halves of that have to be UI text -- a caveat
+    # that outlived its cause would send an operator to the weaker surface.
+    low = body.lower()
+    assert "these views are inference" in low
+    assert "the layer panel above is not" in low
+    assert "does not have this limitation" in low
 
 
 def test_the_page_is_built_for_the_phone_that_will_actually_run_it(client):
@@ -848,6 +857,7 @@ def test_a_non_reolink_camera_is_refused_with_a_reason(tmp_path, calls):
             "metric": seam_metric,
             "vertical": seam_vertical,
             "camera": _fake_camera(calls),
+            "layers": seam_layers,
             "errors": [],
         }
     )
@@ -859,3 +869,115 @@ def test_a_non_reolink_camera_is_refused_with_a_reason(tmp_path, calls):
     assert r.status_code == 400
     assert "dual-lens" in r.json()["detail"]
     sc._toolkit_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# The two-layer alignment surface
+# ---------------------------------------------------------------------------
+
+
+def test_the_layer_pair_is_served_with_its_panorama_columns(client):
+    """The descriptor IS the contract with the browser, so pin its shape."""
+    r = client.post("/stitch/layers", json={"source": "synthetic"})
+    assert r.status_code == 200, r.text
+    d = r.json()["layers"]
+    # Where the layers live, not how they were obtained.
+    assert d["left"]["x0"] == d["right"]["x0"] == 3776
+    assert d["overlap"] == {"x0": 3776, "x1": 3904, "w": 128}
+    assert d["seam_x"] == 3840
+    assert d["height"] == 2160
+    # ...and that a drag on them means something.
+    assert d["authoritative"] is True
+    assert d["space"] == "panorama"
+    assert d["exact"] is True
+    # served window is reported separately, because for a wider source it
+    # will not equal the layer's full extent.
+    assert d["left"]["served"]["w"] == 128
+
+
+def test_layers_are_png_so_the_difference_view_is_honest(client):
+    """JPEG ringing at the edges being aligned would read as residual."""
+    client.post("/stitch/layers", json={"source": "synthetic"})
+    for side in ("left", "right"):
+        r = client.get(f"/stitch/layer.png?side={side}")
+        assert r.status_code == 200
+        assert r.headers["content-type"] == "image/png"
+        assert r.content[:8] == b"\x89PNG\r\n\x1a\n"
+        img = cv2.imdecode(np.frombuffer(r.content, np.uint8), cv2.IMREAD_UNCHANGED)
+        assert img.shape == (2160, 128)
+
+
+def test_the_layer_pair_round_trips_without_losing_a_grey_level(client):
+    """Lossless, checked against the source rather than asserted."""
+    r = client.post("/stitch/layers", json={"source": "synthetic"})
+    assert r.status_code == 200
+    served = cv2.imdecode(
+        np.frombuffer(client.get("/stitch/layer.png?side=left").content, np.uint8),
+        cv2.IMREAD_UNCHANGED,
+    )
+    truth = seam_layers.synthetic(
+        dx=6.0, roll=12.0
+    ).left  # same seed, same construction
+    assert np.array_equal(served, truth)
+
+
+def test_a_registration_number_comes_back_with_the_pair(client):
+    r = client.post("/stitch/layers", json={"source": "synthetic"})
+    reg = r.json()["layers"]["registration"]
+    assert reg["mad"] is not None and reg["n"] == 2160 * 128
+    assert -1.0 <= reg["ncc"] <= 1.0
+
+
+def test_an_unknown_layer_source_is_refused(client):
+    r = client.post("/stitch/layers", json={"source": "wishful"})
+    assert r.status_code == 400
+    assert "wishful" in r.json()["detail"]
+
+
+def test_the_file_source_needs_a_path_and_says_which_sources_were_tried(client):
+    r = client.post("/stitch/layers", json={"source": "file"})
+    assert r.status_code == 502
+    assert "path" in r.json()["detail"]
+
+
+def test_serving_a_layer_before_pulling_one_is_a_404(client):
+    assert client.get("/stitch/layer.png?side=left").status_code == 404
+
+
+def test_state_carries_the_layer_descriptor_for_a_reloading_page(client):
+    client.post("/stitch/layers", json={"source": "synthetic"})
+    st = client.get("/stitch/state").json()
+    assert st["layers"]["overlap"]["w"] == 128
+    assert st["layers_version"] == 1
+
+
+def test_sensor_views_are_served_as_context_and_never_as_authoritative(
+    client, monkeypatch
+):
+    """The whole-lens views must not be mistakable for the alignment surface."""
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (3840, 2160), "black").save(buf, format="JPEG")
+    blob = buf.getvalue()
+
+    monkeypatch.setattr(
+        seam_layers,
+        "capture_sensor_views",
+        lambda host, **kw: seam_layers.SensorViews(
+            left=blob, right=blob, width=3840, height=2160, stamp="20260819191557000"
+        ),
+    )
+    r = client.post("/stitch/sensors", json={})
+    assert r.status_code == 200, r.text
+    d = r.json()["sensors"]
+    assert d["authoritative"] is False
+    assert d["space"] == "sensor"
+    assert d["width"] == 3840
+    # and no panorama mapping is offered anywhere in the payload
+    assert "overlap" not in d and "seam_x" not in d
+    img = client.get("/stitch/sensor.jpg?side=left")
+    assert img.status_code == 200
+    assert img.headers["content-type"] == "image/jpeg"

--- a/video_grouper/web/stitch_calibration.py
+++ b/video_grouper/web/stitch_calibration.py
@@ -2856,9 +2856,16 @@ function paintLayers() {
     // unlike on the fused frame these really are the two layers alternating.
     drawLayerInto(ctx, S.blink ? 'right' : 'left', geo, {});
   } else {
-    // alpha: both at once, the baseline view.
-    drawLayerInto(ctx, 'left', geo, {});
-    drawLayerInto(ctx, 'right', geo, { alpha: S.layerAlpha });
+    // alpha: both at once, the baseline view. The layer ON TOP is the one the
+    // operator is moving -- fading the thing under your finger over a fixed
+    // reference is what makes a misregistration readable. So the top layer is
+    // `movingSide()`, which is the left half for the camera mesh and flips to
+    // the right for the downstream corrector, and the other half sits beneath
+    // it fully opaque. Only the top layer takes the opacity control; a second
+    // slider on the reference would only dim the thing you are aligning to.
+    var top = movingSide(), base = top === 'left' ? 'right' : 'left';
+    drawLayerInto(ctx, base, geo, {});
+    drawLayerInto(ctx, top, geo, { alpha: S.layerAlpha });
   }
 
   // Overlap bounds and the cross-fade centre, in panorama columns. Drawn from
@@ -3298,7 +3305,13 @@ function surfaceChanged() {
     + 'downstream corrector rolls the right half. The stored curve is unchanged &mdash; '
     + 'only which half you see move, and the direction it moves, have flipped.';
   $('applywrap').style.display = $('owner').value === 'downstream' ? 'none' : '';
+  // The opacity slider always names the half it acts on, because which half is
+  // on top flips with the surface and a slider labelled for the wrong layer is
+  // worse than an unlabelled one.
+  var al = $('alphaLbl');
+  if (al) al.textContent = '(' + moving + ')';
   draw();
+  drawLayers();
 }
 
 function onResize() {
@@ -3559,7 +3572,8 @@ __BANNER__
       <button data-lmode="anaglyph">Anaglyph</button>
       <button data-lmode="blink">Blink</button>
     </div>
-    <label class="row" id="alpharow"><span class="lbl">Top layer opacity
+    <label class="row" id="alpharow"><span class="lbl">Opacity of the moving layer
+      <span class="val" id="alphaLbl">(left)</span>
       <span class="val" id="alphaV">50%</span></span>
       <input type="range" id="alpha" min="0" max="100" step="1" value="50"></label>
 

--- a/video_grouper/web/stitch_calibration.py
+++ b/video_grouper/web/stitch_calibration.py
@@ -63,18 +63,34 @@ is a *step* in this interface, not a tip, the tool checks whether they actually
 are in it before believing any number, and the reported residual leads with the
 subset of structures that can see `dx` at all.
 
-**The picture is a fused JPEG, so parts of it are already a mixture.** The
-camera blends the two sensors over a 256-px window, so nothing inside it is
-evidence about registration and there is no second layer to reveal. Blink and
-anaglyph therefore draw the *fitted* structures -- the same extrapolation the
-metric performs -- rather than smearing replicated pixels across the window.
-That is stated in the interface, not just here: an honest caveat in a source
-comment is a caveat nobody reads.
+**Two surfaces, and only one of them is a measurement.**
 
-What crosses the wire is two 640x2160 JPEG strips (~76 KB each), not the
-730 KB panorama: the operator only ever looks at the seam, and the browser can
-shear a strip with an affine transform far more smoothly than a server can
-re-render one per drag frame.
+*The layer pair* (`/stitch/layers`) is the two sensors' own contributions to the
+overlap, pulled *before* the camera cross-fades them. Both are already resampled
+into the panorama's output frame, so an L-to-R displacement measured there is
+residual disparity in output pixels and converts straight to `dx_anchors` -- no
+lens model, no homography, no rescale. Overlay, difference, anaglyph and blink on
+this pair are **exact**. This is where the gestures bind.
+
+*The fused `Snap`* is the older surface and is still a mixture over the 256-px
+blend window, so blink and anaglyph there draw the *fitted* structures -- the
+same extrapolation the metric performs -- rather than smearing replicated pixels
+across a window that has no second layer in it. That distinction is stated in the
+interface, not just here: an honest caveat in a source comment is a caveat nobody
+reads.
+
+*The whole-lens views* (`/stitch/sensors`) are a third thing and are **context
+only**. They come back at each sensor's native width, which puts them in sensor
+coordinates, before the warp; a displacement there is not a seam correction. The
+UI refuses to author a curve from them, on the descriptor's `authoritative` flag
+rather than on a caption.
+
+What crosses the wire for the fused view is two 640x2160 JPEG strips (~76 KB
+each), not the 730 KB panorama: the operator only ever looks at the seam, and the
+browser can shear a strip with an affine transform far more smoothly than a
+server can re-render one per drag frame. The layer pair is PNG, because the
+difference view subtracts one layer from the other and JPEG ringing at the very
+edges being aligned would read as residual that no drag can null.
 """
 
 from __future__ import annotations
@@ -164,6 +180,7 @@ def load_toolkit() -> dict[str, Any]:
         "camera": None,
         "vertical": None,
         "echo": None,
+        "layers": None,
         "errors": [],
     }
     vpe = _vpe_dir()
@@ -181,6 +198,7 @@ def load_toolkit() -> dict[str, Any]:
         ("vertical", "seam_vertical"),
         ("echo", "seam_echo"),
         ("camera", "stitch_apply"),
+        ("layers", "seam_layers"),
     ):
         try:
             out[key] = importlib.import_module(name)
@@ -245,6 +263,22 @@ class _Session:
     camera_cal: dict | None = None
     camera_cal_state: str = "idle"  # idle | running | ready | failed
     camera_cal_error: str = ""
+    # The two separated sensor layers over the overlap, and the panorama
+    # columns they occupy. Versioned independently of the fused snapshot
+    # because they arrive by a different door and neither implies the other:
+    # an operator can align layers with no `Snap` at all, and a `Snap` says
+    # nothing about the pair.
+    layers: dict[str, bytes] = field(default_factory=dict)
+    layers_desc: dict | None = None
+    layers_version: int = 0
+    layers_at: float = 0.0
+    layers_error: str = ""
+    # Whole-lens context views, in SENSOR coordinates. Held separately from
+    # `layers` and never merged into them: these cannot produce a calibration,
+    # and one dict holding both kinds is how that distinction would get lost.
+    sensors: dict[str, bytes] = field(default_factory=dict)
+    sensors_desc: dict | None = None
+    sensors_version: int = 0
 
     lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -313,6 +347,58 @@ def _encode_scene(frame: Any) -> bytes:
     if not ok:
         raise HTTPException(500, "could not encode the scene overview")
     return bytes(buf.tobytes())
+
+
+#: How much context outside the overlap to ship with each layer.
+#:
+#: The overlap is the only region where both layers exist, and therefore the
+#: only region a registration measure can read -- but an operator dragging a
+#: layer needs somewhere for content to come *from*, or the image runs out at
+#: the edge of the gesture. With the strip source there is no context to be had
+#: (the layers are exactly the overlap) and this clips to nothing. With full
+#: per-sensor frames it bounds the payload: 512 px per layer instead of 3840,
+#: without the UI knowing which source it got.
+LAYER_CONTEXT = 192
+
+#: PNG, not JPEG, and this is not a preference. The difference view subtracts
+#: one layer from the other, so JPEG ringing at exactly the high-contrast edges
+#: the operator is aligning to would show up as residual that no drag can null.
+#: A 128x2160 greyscale PNG is ~60 KB; the honesty is free.
+LAYER_MAX_SERVE_W = 1024
+
+
+def _encode_layers(pair: Any) -> tuple[dict[str, bytes], dict]:
+    """PNG each layer over a bounded window, and say which columns were sent.
+
+    Returns (images, descriptor). The descriptor is the whole contract with the
+    browser: per side, the panorama columns actually served. Nothing downstream
+    may assume those match the layer's full extent, because for a full-frame
+    source they will not.
+    """
+    import cv2
+    import numpy as np
+
+    lo, hi = pair.overlap
+    want_lo, want_hi = lo - LAYER_CONTEXT, hi + LAYER_CONTEXT
+    desc = pair.to_api()
+    out: dict[str, bytes] = {}
+    for side in ("left", "right"):
+        img = pair.left if side == "left" else pair.right
+        x0 = pair.left_x0 if side == "left" else pair.right_x0
+        sx0 = max(x0, want_lo)
+        sx1 = min(x0 + img.shape[1], want_hi)
+        if sx1 - sx0 > LAYER_MAX_SERVE_W:  # centre the cap on the overlap
+            mid = (lo + hi) // 2
+            sx0 = max(sx0, mid - LAYER_MAX_SERVE_W // 2)
+            sx1 = min(sx1, sx0 + LAYER_MAX_SERVE_W)
+        crop = np.ascontiguousarray(img[:, sx0 - x0 : sx1 - x0])
+        ok, buf = cv2.imencode(".png", crop)
+        if not ok:
+            raise HTTPException(500, f"could not encode the {side} layer")
+        out[side] = bytes(buf.tobytes())
+        desc[side]["served"] = {"x0": int(sx0), "x1": int(sx1), "w": int(sx1 - sx0)}
+    desc["context"] = LAYER_CONTEXT
+    return out, desc
 
 
 def _vertical_profile(frame: Any, seam_x: int) -> dict | None:
@@ -935,6 +1021,169 @@ def build_router(config_path: Path, storage_path: Path | None = None) -> APIRout
             headers={"Cache-Control": "no-store", "X-Stitch-Version": str(version)},
         )
 
+    @router.post("/stitch/layers")
+    def post_layers(body: dict = Body(default={})) -> JSONResponse:
+        """Fetch the two sensors' un-blended contributions to the overlap.
+
+        THE POINT OF THIS ENDPOINT. Everything else on this page works from the
+        fused panorama, where the two sensors are already mixed over the blend
+        window and cannot be pulled apart. This returns them *before* the
+        cross-fade: two real images of the same output columns, one per sensor.
+        Aligning them by hand is therefore direct measurement rather than
+        inference from the shoulders either side.
+
+        THE SOURCE IS DELIBERATELY NOT PART OF THE CONTRACT. The reply is
+        "a left layer, a right layer, and the panorama columns they correspond
+        to" and nothing else. Today `camera` lifts a 128-px pair out of one ISF
+        buffer. When the vendor's two-channel full-resolution snap becomes
+        reachable it is a third entry in `seam_layers.SOURCES` and *no change
+        here or in the UI*: the layers get wider, their origins stop coinciding,
+        the overlap stops being the whole image, and every one of those is
+        already a field the descriptor carries.
+
+        `auto` tries the camera and falls back to the archived dump, so the tool
+        comes up on a desk with no camera on the link.
+        """
+        toolkit = load_toolkit()
+        mod = toolkit["layers"]
+        if mod is None:
+            raise HTTPException(
+                503, "; ".join(toolkit["errors"]) or "seam_layers missing"
+            )
+        want = str(body.get("source") or "auto").strip().lower()
+        path = str(body.get("path") or "").strip()
+        attempts: list[str] = []
+
+        def _from_camera() -> Any:
+            cam = _reolink_camera(config_path)
+            return mod.capture(cam.device_ip)
+
+        def _from_file() -> Any:
+            if not path:
+                raise mod.LayerCaptureError(
+                    "the file source needs `path`: a raw dump of the packed pair"
+                )
+            return mod.load_file(path)
+
+        order: list[tuple[str, Any]]
+        if want == "auto":
+            order = [("camera", _from_camera)]
+            if path:
+                order.append(("file", _from_file))
+        elif want == "camera":
+            order = [("camera", _from_camera)]
+        elif want == "file":
+            order = [("file", _from_file)]
+        elif want == "synthetic":
+            order = [
+                (
+                    "synthetic",
+                    lambda: mod.synthetic(
+                        dx=float(body.get("dx", 6.0)),
+                        roll=float(body.get("roll", 12.0)),
+                    ),
+                )
+            ]
+        else:
+            raise HTTPException(400, f"unknown layer source {want!r}")
+
+        pair = None
+        for name, fn in order:
+            try:
+                pair = fn()
+                break
+            except Exception as exc:  # noqa: BLE001 -- every source fails differently
+                attempts.append(f"{name}: {type(exc).__name__}: {exc}")
+                logger.warning("STITCH: layer source %s failed: %s", name, exc)
+        if pair is None:
+            raise HTTPException(
+                502,
+                "could not obtain a layer pair. " + " | ".join(attempts),
+            )
+
+        images, desc = _encode_layers(pair)
+        desc["registration"] = pair.registration()
+        desc["attempts"] = attempts
+        with _session.lock:
+            _session.layers = images
+            _session.layers_version += 1
+            _session.layers_at = time.time()
+            _session.layers_desc = desc
+            _session.layers_error = " | ".join(attempts)
+            desc["version"] = _session.layers_version
+            payload = _state_payload()
+        payload["layers"] = desc
+        return JSONResponse(payload)
+
+    @router.get("/stitch/layer.png")
+    def get_layer(side: str = "left", v: int = 0) -> Response:
+        with _session.lock:
+            data = _session.layers.get(side)
+            version = _session.layers_version
+        if data is None:
+            raise HTTPException(404, "no layer pair pulled yet")
+        del v  # cache-buster only
+        return Response(
+            data,
+            media_type="image/png",
+            headers={"Cache-Control": "no-store", "X-Stitch-Layers": str(version)},
+        )
+
+    @router.post("/stitch/sensors")
+    def post_sensors(body: dict = Body(default={})) -> JSONResponse:
+        """Two whole-lens stills, so the operator can see what each lens sees.
+
+        CONTEXT ONLY, AND THE ENDPOINT SAYS SO IN ITS PAYLOAD. These come back
+        3840x2160 -- each sensor's native output width -- which puts them in
+        sensor coordinates, before the warp. A displacement measured here does
+        not convert to `dx_anchors`, because the warp between sensor space and
+        panorama space is not a thing this tool has.
+
+        They are worth serving anyway: two whole lens views tell an operator at
+        a tripod what each camera is actually pointed at, which the 128-px
+        overlap strip cannot. Orientation first, then precision work on the
+        pair that is pre-rectified. `authoritative: false` travels with every
+        response so the UI cannot accidentally treat them as the other thing.
+        """
+        toolkit = load_toolkit()
+        mod = toolkit["layers"]
+        if mod is None:
+            raise HTTPException(
+                503, "; ".join(toolkit["errors"]) or "seam_layers missing"
+            )
+        left, right = str(body.get("left") or ""), str(body.get("right") or "")
+        try:
+            if left and right:
+                views = mod.load_sensor_views(left, right)
+            else:
+                cam = _reolink_camera(config_path)
+                views = mod.capture_sensor_views(cam.device_ip)
+        except Exception as exc:  # noqa: BLE001 -- report, never fabricate
+            logger.warning("STITCH: sensor views failed: %s", exc)
+            raise HTTPException(502, f"{type(exc).__name__}: {exc}") from exc
+        desc = views.to_api()
+        with _session.lock:
+            _session.sensors = {"left": views.left, "right": views.right}
+            _session.sensors_version += 1
+            desc["version"] = _session.sensors_version
+            _session.sensors_desc = desc
+            payload = _state_payload()
+        return JSONResponse(payload)
+
+    @router.get("/stitch/sensor.jpg")
+    def get_sensor(side: str = "left", v: int = 0) -> Response:
+        with _session.lock:
+            data = _session.sensors.get(side)
+            version = _session.sensors_version
+        if data is None:
+            raise HTTPException(404, "no sensor views pulled yet")
+        del v  # cache-buster only
+        return Response(
+            data,
+            media_type="image/jpeg",
+            headers={"Cache-Control": "no-store", "X-Stitch-Sensors": str(version)},
+        )
+
     @router.post("/stitch/measure")
     def post_measure(body: dict = Body(default={})) -> JSONResponse:
         """Score a candidate curve against the metric the solver minimises.
@@ -1320,6 +1569,11 @@ def _state_payload() -> dict:
         "camera_cal": _session.camera_cal,
         "camera_cal_state": _session.camera_cal_state,
         "camera_cal_error": _session.camera_cal_error,
+        "layers": _session.layers_desc,
+        "layers_version": _session.layers_version,
+        "layers_at": _session.layers_at,
+        "sensors": _session.sensors_desc,
+        "sensors_version": _session.sensors_version,
     }
 
 
@@ -1446,6 +1700,29 @@ canvas { display:block; background:#000; image-rendering:pixelated; width:100%;
   touch-action:none; -webkit-user-select:none; user-select:none; }
 #zoomwrap, #viewwrap { border:1px solid var(--rule); position:relative; }
 #zoomwrap { margin-bottom:8px; }
+
+/* Two-layer alignment. The canvas inherits touch-action:none above, which is
+   what stops the browser claiming the drag and the two-finger twist for its
+   own scroll and zoom -- without it the primary gesture of this tool reaches
+   the page about one time in three. */
+#layercvwrap { border:1px solid var(--rule); position:relative; margin-bottom:6px; }
+#layercvwrap.locked { outline:2px solid var(--signal-warn); outline-offset:-2px; }
+/* 44 px, not the 38 the secondary mode buttons use: these are pressed with a
+   thumb, mid-task, while the other hand holds the phone. */
+#layermodes button, #layerpanel .btn-sm { min-height:44px; }
+.layerread { display:flex; flex-wrap:wrap; gap:6px; margin:10px 0 2px; }
+.lnum { flex:1 1 44%; min-width:120px; background:var(--bg-elev);
+  border:1px solid var(--rule); padding:8px 10px; }
+.lnum b { display:block; font-family:var(--display); font-size:23px; line-height:1.1;
+  font-weight:700; }
+.lnum span { font-family:var(--mono); font-size:10.5px; color:var(--text-mute);
+  letter-spacing:.03em; }
+.lnum.good b { color:var(--signal-on); }
+.lnum.good { border-color:var(--signal-on); }
+img.lens { display:block; width:100%; border:1px solid var(--rule); margin-bottom:8px;
+  background:#000; }
+.lenscap { font-family:var(--mono); font-size:10.5px; color:var(--text-mute);
+  letter-spacing:.06em; text-transform:uppercase; margin:2px 0 3px; }
 .modes { display:flex; gap:5px; flex-wrap:wrap; margin:9px 0 6px; }
 .modes button, .seg button {
   font-family:var(--mono); font-size:11px; letter-spacing:.06em; text-transform:uppercase;
@@ -1476,7 +1753,9 @@ label.row .lbl {
   display:flex; justify-content:space-between; align-items:baseline; gap:8px;
 }
 label.row .val { color:var(--accent); font-weight:600; }
-input[type=range] { width:100%; margin:2px 0 0; accent-color:var(--accent); height:38px; }
+/* 44 px: the slider is dragged with a thumb on a phone held one-handed, and
+   38 put it under the minimum target size at a 390 px viewport. */
+input[type=range] { width:100%; margin:2px 0 0; accent-color:var(--accent); height:44px; }
 input[type=number], input[type=text], select {
   background:var(--bg-input); color:var(--text); border:1px solid var(--rule);
   padding:9px 8px; font-family:var(--mono); font-size:15px; width:100%; min-height:42px;
@@ -1552,7 +1831,13 @@ var S = {
   metrics: null, baseline: null, quality: null, vertical: null,
   busy: false, pending: false, stale: false, scoredAt: null, netFails: 0,
   spanX: 256, grab: 'curve', narrow: true, retry: null,
-  auto: null, cameraCal: null
+  auto: null, cameraCal: null,
+  // Two-layer alignment. `layers` is the descriptor the server sent -- the
+  // panorama columns each layer occupies -- and everything drawn is derived
+  // from it, so a source with different geometry needs no change here.
+  layers: null, layerImgs: {}, layerMode: 'alpha', layerAlpha: 0.5,
+  layerGain: 4, layerSpan: 128, layerCx: 3840, layerCy: 1080,
+  layerReg: null, layerBest: null, layerBusy: false, layerPath: ''
 };
 // Geometry is taken from the frame the server actually fetched, never assumed.
 // These are only the pre-snapshot defaults.
@@ -1788,6 +2073,16 @@ function draw() {
 
   $('zoomlabel').textContent = 'rows ' + Math.round(top) + '-' + Math.round(top + zoomRows())
     + ' \u00b7 ' + (zoomScale()).toFixed(1) + 'x \u00b7 ' + Math.round(S.spanX) + ' px wide';
+
+  // The layer view is repainted from the SAME entry point, so it tracks the
+  // curve however the curve changed -- a drag here, a nudge button, the roll
+  // slider, a typed anchor, or a reset. One artifact, several lenses onto it.
+  var lc = $('layercv');
+  if (lc) { fitCanvas(lc, layerCssH()); drawLayers(); renderLayerLabel(); }
+}
+
+function layerCssH() {
+  return S.narrow ? Math.round(clamp(window.innerHeight * 0.42, 240, 460)) : 460;
 }
 
 // ---------------------------------------------------------------------------
@@ -2237,6 +2532,7 @@ function showCamera(c, thenInit) {
        (c.at_factory ? ' matches ' + c.factory_name : ''));
   $('camnote').textContent = c.note || '';
   $('camcurrent').disabled = !installed;
+  if ($('lcamcurrent')) $('lcamcurrent').disabled = !installed;
   drawCamProfile(c.profile);
   if (thenInit) {
     // Start from the camera, labelled as the camera's state rather than as an
@@ -2416,6 +2712,371 @@ function applyToCamera(dry) {
 }
 
 // ---------------------------------------------------------------------------
+// Two-layer alignment.
+//
+// This is the only view on the page that shows the two sensors SEPARATELY. The
+// rest of the page works from the fused panorama, where the blend window is
+// already a mixture and blink/anaglyph can only draw extrapolations from the
+// shoulders. Here both layers are real images of the same panorama columns,
+// captured before the cross-fade, so overlaying them IS the measurement.
+//
+// It authors nothing of its own. Every gesture lands in `S.anchors` through the
+// same `setAnchors` / `nudge` / `setRoll` the sliders use, so the curve stays
+// the single artifact and this view stays a lens onto it. Drag a layer here and
+// the numeric anchors below change; type an anchor below and the layers move.
+// ---------------------------------------------------------------------------
+
+// Geometry of the inspection view, in PANORAMA columns and rows. Isotropic on
+// purpose: a rotation gesture only reads correctly if x and y are at the same
+// scale, and this view exists to judge rotation.
+function layerGeo(c) {
+  var W = c.width, Hc = c.height;
+  var scale = W / S.layerSpan;
+  return {
+    left: S.layerCx - S.layerSpan / 2,
+    top: S.layerCy - (Hc / scale) / 2,
+    scale: scale, scaleY: scale,
+    rows: Hc / scale
+  };
+}
+
+// One layer, sheared by its share of the curve, in panorama coordinates.
+//
+// Same piecewise-linear decomposition as the fused view: each straight segment
+// of the anchor curve is one affine draw rather than 2160 per-row blits, which
+// is what keeps a drag at 60 fps on a phone with no round trip.
+function drawLayerInto(ctx, side, geo, opt) {
+  opt = opt || {};
+  var img = S.layerImgs[side], desc = S.layers && S.layers[side];
+  if (!img || !desc || !desc.served) return;
+  var sgn = signFor(side), x0 = desc.served.x0, bs = bands();
+  // Only the rows on screen. At a useful inspection zoom this view shows tens
+  // of rows out of 2160, and handing the whole image to drawImage asks the
+  // compositor to rasterise something like 900x15000 px per band -- which does
+  // not show up in the drawImage call's own timing (it returned in 5 ms) and
+  // then wedges the compositor. Clipping alone is not enough: the clip bounds
+  // the output, the source rectangle is what bounds the work.
+  var vTop = Math.max(0, Math.floor(geo.top) - 1);
+  var vBot = Math.min(img.height, Math.ceil(geo.top + geo.rows) + 1);
+  if (vBot <= vTop) return;
+  ctx.save();
+  ctx.globalAlpha = opt.alpha === undefined ? 1 : opt.alpha;
+  if (opt.composite) ctx.globalCompositeOperation = opt.composite;
+  for (var i = 0; i < bs.length; i++) {
+    var y0 = Math.max(bs[i][0], vTop), y1 = Math.min(bs[i][1], vBot);
+    if (y1 <= y0) continue;                     // band entirely off screen
+    var a = bs[i][2], b = bs[i][3];
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.beginPath();
+    ctx.rect(0, (y0 - geo.top) * geo.scaleY, ctx.canvas.width, (y1 - y0) * geo.scaleY);
+    ctx.clip();
+    // image column u, row v  ->  panorama x = x0 + u + sgn*(a*v + b)
+    //                       ->  canvas  x = (panx - geo.left) * geo.scale
+    ctx.setTransform(
+      geo.scale, 0,
+      geo.scale * sgn * a, geo.scaleY,
+      geo.scale * (x0 + sgn * b - geo.left), -geo.scaleY * geo.top
+    );
+    // Source and destination are the same rectangle in image space; the
+    // transform above puts it on screen.
+    ctx.drawImage(img, 0, y0, img.width, y1 - y0, 0, y0, img.width, y1 - y0);
+    ctx.restore(); ctx.save();
+    ctx.globalAlpha = opt.alpha === undefined ? 1 : opt.alpha;
+    if (opt.composite) ctx.globalCompositeOperation = opt.composite;
+  }
+  ctx.restore();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+}
+
+// Tint one layer into a single colour channel, for the anaglyph. Done on an
+// offscreen canvas because 'multiply' against the main canvas would pick up
+// whatever is already drawn there.
+var _tintCv = {};
+function tinted(side, colour, w, h, geo) {
+  var cv = _tintCv[side] || (_tintCv[side] = document.createElement('canvas'));
+  cv.width = w; cv.height = h;
+  var cx = cv.getContext('2d');
+  cx.setTransform(1, 0, 0, 1, 0, 0);
+  cx.clearRect(0, 0, w, h);
+  drawLayerInto(cx, side, geo, {});
+  cx.setTransform(1, 0, 0, 1, 0, 0);
+  cx.globalCompositeOperation = 'multiply';
+  cx.fillStyle = colour;
+  cx.fillRect(0, 0, w, h);
+  // keep the layer's own alpha, so outside-the-image stays transparent
+  cx.globalCompositeOperation = 'destination-in';
+  drawLayerInto(cx, side, geo, {});
+  cx.globalCompositeOperation = 'source-over';
+  return cv;
+}
+
+function paintLayers() {
+  var c = $('layercv');
+  if (!c) return;
+  var ctx = c.getContext('2d');
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, c.width, c.height);
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, 0, c.width, c.height);
+  if (!S.layers || !S.layerImgs.left || !S.layerImgs.right) {
+    ctx.fillStyle = '#5e616b';
+    ctx.font = '13px ui-monospace, monospace';
+    ctx.fillText(S.layerBusy ? 'pulling the layer pair…'
+      : 'no layer pair yet — press Pull layers', 10, 22);
+    return;
+  }
+  var geo = layerGeo(c), m = S.layerMode;
+
+  if (m === 'diff') {
+    // |L - R|. Registered content goes black; every misregistered edge lights
+    // up. The gain is there because a 1 px residual on a soft edge is a few
+    // grey levels and would otherwise be invisible on a phone in daylight.
+    drawLayerInto(ctx, 'left', geo, {});
+    drawLayerInto(ctx, 'right', geo, { composite: 'difference' });
+    if (S.layerGain > 1 && ('filter' in ctx)) {
+      var snap = document.createElement('canvas');
+      snap.width = c.width; snap.height = c.height;
+      snap.getContext('2d').drawImage(c, 0, 0);
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.fillStyle = '#000'; ctx.fillRect(0, 0, c.width, c.height);
+      ctx.filter = 'brightness(' + S.layerGain + ')';
+      ctx.drawImage(snap, 0, 0);
+      ctx.filter = 'none';
+    }
+  } else if (m === 'anaglyph') {
+    // Left red, right cyan. Registered content reads neutral grey; anything
+    // out of register fringes red on one side and cyan on the other, and the
+    // direction of the fringe tells you which way to drag.
+    ctx.drawImage(tinted('left', '#ff0000', c.width, c.height, geo), 0, 0);
+    ctx.globalCompositeOperation = 'lighter';
+    ctx.drawImage(tinted('right', '#00ffff', c.width, c.height, geo), 0, 0);
+    ctx.globalCompositeOperation = 'source-over';
+  } else if (m === 'blink') {
+    // Motion is the most sensitive misalignment detector a human has, and
+    // unlike on the fused frame these really are the two layers alternating.
+    drawLayerInto(ctx, S.blink ? 'right' : 'left', geo, {});
+  } else {
+    // alpha: both at once, the baseline view.
+    drawLayerInto(ctx, 'left', geo, {});
+    drawLayerInto(ctx, 'right', geo, { alpha: S.layerAlpha });
+  }
+
+  // Overlap bounds and the cross-fade centre, in panorama columns. Drawn from
+  // the descriptor, never from a constant -- with full-resolution layers these
+  // move and the drawing has to follow.
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  var X = function (px) { return (px - geo.left) * geo.scale; };
+  var ov = S.layers.overlap;
+  if (ov && ov.w > 0) {
+    ctx.strokeStyle = 'rgba(148,163,184,.45)'; ctx.lineWidth = 1;
+    ctx.setLineDash([5, 5]);
+    [ov.x0, ov.x1].forEach(function (px) {
+      ctx.beginPath(); ctx.moveTo(X(px) + .5, 0); ctx.lineTo(X(px) + .5, c.height); ctx.stroke();
+    });
+    ctx.setLineDash([]);
+  }
+  ctx.strokeStyle = 'rgba(251,146,60,.85)'; ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(X(S.layers.seam_x) + .5, 0);
+  ctx.lineTo(X(S.layers.seam_x) + .5, c.height);
+  ctx.stroke();
+
+  // Where in the 2160 rows this window is sitting.
+  var track = 4, ty = (geo.top / H) * c.height, th = (geo.rows / H) * c.height;
+  ctx.fillStyle = 'rgba(255,255,255,.10)';
+  ctx.fillRect(c.width - track, 0, track, c.height);
+  ctx.fillStyle = 'rgba(34,197,94,.75)';
+  ctx.fillRect(c.width - track, ty, track, Math.max(3, th));
+}
+
+// The number that turns dragging into a task with an end.
+//
+// Computed in the browser, on the pixels actually on screen, so it responds to
+// the drag itself rather than to a round trip. Both layers are rendered into
+// offscreen buffers over the OVERLAP ONLY -- the one region where both have
+// content and a comparison means anything -- and compared where both are
+// opaque, so content sliding out of the window stops counting instead of
+// counting as black.
+var _regCv = {};
+function computeRegistration() {
+  if (!S.layers || !S.layerImgs.left || !S.layerImgs.right) return null;
+  var ov = S.layers.overlap;
+  if (!ov || ov.w <= 0) return null;
+  var W = Math.min(ov.w, 192), ROWS = 240;
+  var geo = { left: ov.x0, top: 0, scale: W / ov.w, scaleY: ROWS / H, rows: H };
+  var data = {};
+  ['left', 'right'].forEach(function (side) {
+    var cv = _regCv[side] || (_regCv[side] = document.createElement('canvas'));
+    cv.width = W; cv.height = ROWS;
+    var cx = cv.getContext('2d', { willReadFrequently: true });
+    cx.setTransform(1, 0, 0, 1, 0, 0);
+    cx.clearRect(0, 0, W, ROWS);
+    drawLayerInto(cx, side, geo, {});
+    data[side] = cx.getImageData(0, 0, W, ROWS).data;
+  });
+  var a = data.left, b = data.right;
+  var n = 0, sa = 0, sb = 0, sad = 0;
+  for (var i = 0; i < a.length; i += 4) {
+    if (a[i + 3] < 250 || b[i + 3] < 250) continue;   // one layer absent here
+    n++; sa += a[i]; sb += b[i]; sad += Math.abs(a[i] - b[i]);
+  }
+  if (n < 64) return { mad: null, ncc: null, n: n };
+  var ma = sa / n, mb = sb / n, num = 0, va = 0, vb = 0;
+  for (var j = 0; j < a.length; j += 4) {
+    if (a[j + 3] < 250 || b[j + 3] < 250) continue;
+    var da = a[j] - ma, db = b[j] - mb;
+    num += da * db; va += da * da; vb += db * db;
+  }
+  var den = Math.sqrt(va * vb);
+  return { mad: sad / n, ncc: den > 0 ? num / den : null, n: n };
+}
+
+function renderLayerReadout() {
+  if (!$('layerread')) return;
+  var t = meanDx(), r = rollAmp();
+  var reg = S.layerReg;
+  var best = S.layerBest;
+  var html = '<div class="lnum"><b>' + (t >= 0 ? '+' : '') + t.toFixed(2)
+    + '</b><span>px translate</span></div>'
+    + '<div class="lnum"><b>' + (r >= 0 ? '+' : '') + r.toFixed(2)
+    + '</b><span>px rotate, top&rarr;bottom</span></div>';
+  if (reg && reg.mad !== null && reg.mad !== undefined) {
+    var better = (best !== null && best !== undefined && reg.mad <= best + 1e-9);
+    html += '<div class="lnum' + (better ? ' good' : '') + '"><b>' + reg.mad.toFixed(2)
+      + '</b><span>mean |L&minus;R|' + (better ? ' &mdash; best yet' : '') + '</span></div>'
+      + '<div class="lnum"><b>' + (reg.ncc === null ? '--' : reg.ncc.toFixed(4))
+      + '</b><span>correlation, 1.0 is perfect</span></div>';
+  }
+  $('layerread').innerHTML = html;
+}
+
+function refreshRegistration() {
+  S.layerReg = computeRegistration();
+  if (S.layerReg && S.layerReg.mad !== null) {
+    if (S.layerBest === null || S.layerReg.mad < S.layerBest) S.layerBest = S.layerReg.mad;
+  }
+  renderLayerReadout();
+}
+
+function drawLayers() {
+  paintLayers();
+  refreshRegistration();
+}
+
+function setLayerSpan(v) {
+  S.layerSpan = clamp(v, 16, 4096);
+  drawLayers();
+  renderLayerLabel();
+}
+function renderLayerLabel() {
+  var c = $('layercv'); if (!c || !S.layers) return;
+  var geo = layerGeo(c);
+  $('layerlabel').textContent =
+    'panorama x ' + Math.round(geo.left) + '-' + Math.round(geo.left + S.layerSpan)
+    + ' · rows ' + Math.round(geo.top) + '-' + Math.round(geo.top + geo.rows)
+    + ' · ' + geo.scale.toFixed(1) + '×';
+}
+
+function pullLayers(source) {
+  var body = { source: source || 'auto' };
+  if (S.layerPath) body.path = S.layerPath;
+  S.layerBusy = true;
+  $('layerstate').textContent = 'pulling the pre-blend pair…';
+  drawLayers();
+  fetch('/stitch/layers', {
+    method: 'POST', credentials: 'same-origin',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      S.layerBusy = false;
+      if (!res.ok) {
+        $('layerstate').innerHTML = '<span class="worse">'
+          + (res.j.detail || 'the pull failed') + '</span>';
+        drawLayers(); return;
+      }
+      applyState(res.j);
+      var d = res.j.layers;
+      S.layers = d;
+      S.layerBest = null;
+      // The curve's row space must match the layers' height. With no fused
+      // snapshot to take it from, the pair is the authority -- and a source
+      // whose layers are not 2160 rows tall must not silently author a curve
+      // addressing rows that do not exist.
+      if (!res.j.has_snapshot && d.height && d.height !== H) {
+        H = d.height;
+        S.anchors = S.anchors.map(function (p, i, all) {
+          return [i === all.length - 1 ? H - 1 : Math.round(p[0] * (H - 1) / 2159), p[1]];
+        });
+        S.cursorRow = Math.min(S.cursorRow, H - 1);
+        syncControls();
+      }
+      // Frame the overlap, centred on the cross-fade, at a zoom where a
+      // single pixel of misregistration is a visible step.
+      S.layerSpan = Math.max(32, d.overlap.w);
+      S.layerCx = d.seam_x;
+      S.layerCy = Math.round(d.height / 2);
+      var pending = 2;
+      ['left', 'right'].forEach(function (side) {
+        var img = new Image();
+        img.onload = function () {
+          S.layerImgs[side] = img;
+          if (--pending === 0) { drawLayers(); renderLayerLabel(); }
+        };
+        img.onerror = function () { if (--pending === 0) drawLayers(); };
+        img.src = '/stitch/layer.png?side=' + side + '&v=' + d.version;
+      });
+      var truth = d.truth
+        ? ' · built-in answer dx=' + d.truth.dx.toFixed(2)
+          + ' roll=' + d.truth.roll.toFixed(2)
+        : '';
+      $('layerstate').innerHTML = '<b>' + d.source + '</b> · ' + d.detail
+        + ' · overlap = panorama x ' + d.overlap.x0 + '-' + d.overlap.x1
+        + ' (' + d.overlap.w + ' px), cross-fade at ' + d.seam_x + truth;
+      $('layerattempts').textContent = (d.attempts && d.attempts.length)
+        ? 'fell back after: ' + d.attempts.join(' | ') : '';
+    }).catch(function (e) {
+      S.layerBusy = false;
+      $('layerstate').innerHTML = '<span class="worse">' + e + '</span>';
+      drawLayers();
+    });
+}
+
+// Whole-lens context. Two <img> and a caption -- no canvas, no gestures, no
+// curve. It exists so an operator can see what each lens is pointed at before
+// working a 128-px strip, and it is drawn plainly on purpose: anything that
+// looked like the alignment surface would invite a drag that cannot mean
+// anything in sensor coordinates.
+function pullSensors() {
+  $('sensorstate').textContent = 'asking the camera for a per-sensor pair…';
+  fetch('/stitch/sensors', {
+    method: 'POST', credentials: 'same-origin',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(S.sensorPaths || {})
+  }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      if (!res.ok) {
+        $('sensorstate').innerHTML = '<span class="worse">'
+          + (res.j.detail || 'the per-sensor snap failed') + '</span>';
+        return;
+      }
+      applyState(res.j);
+      renderSensors(res.j.sensors);
+    }).catch(function (e) {
+      $('sensorstate').innerHTML = '<span class="worse">' + e + '</span>';
+    });
+}
+
+function renderSensors(d) {
+  if (!d) return;
+  $('sensorwrap').style.display = '';
+  $('sensorL').src = '/stitch/sensor.jpg?side=left&v=' + d.version;
+  $('sensorR').src = '/stitch/sensor.jpg?side=right&v=' + d.version;
+  $('sensorstate').innerHTML = '<b>' + d.width + '&times;' + d.height + '</b> per sensor · '
+    + 'matched at ' + d.stamp + ' · <b class="worse">context only</b> — ' + d.why;
+}
+
+// ---------------------------------------------------------------------------
 // Gestures. Pointer Events, so one implementation serves a thumb and a mouse.
 // One finger is axis-locked -- across is the calibration, down is navigation --
 // and two fingers zoom. Nothing here touches the network.
@@ -2436,6 +3097,113 @@ function setSpan(v) {
   S.spanX = clamp(v, 48, 2 * STRIP);
   draw();
 }
+// Translate and rotate, both written into the anchor curve.
+//
+// A constant offset added to every anchor is a translation. A ramp that is
+// linear in y is a rotation -- `dx = -theta*y` is exactly the shape a relative
+// lens roll produces, which is why this tool models roll and not an arbitrary
+// warp. So a two-finger twist and the roll slider are the same edit arriving by
+// different routes, and both leave the curve as the only stored thing.
+function applyToCurve(before, dTranslate, dRoll, why) {
+  // A gesture may only author against a pair that is in PANORAMA output
+  // coordinates, because only there is a measured displacement already the
+  // correction. The whole-lens context views are in sensor coordinates, before
+  // the warp, and a drag on them would convert to nothing. Enforced rather
+  // than captioned: `authoritative` comes off the server's descriptor.
+  if (!S.layers || !S.layers.authoritative) {
+    $('curvewhy').textContent =
+      'That surface is context only — it is in sensor coordinates, before the '
+      + 'warp, so a displacement there is not a seam correction.';
+    return;
+  }
+  var mid = (H - 1) / 2;
+  setAnchors(before.map(function (p) {
+    return [p[0], p[1] + dTranslate + dRoll * (p[0] - mid) / (H - 1)];
+  }), why);
+}
+
+function pang(pts) {
+  var a = [];
+  pts.forEach(function (v) { a.push(v); });
+  return Math.atan2(a[1].y - a[0].y, a[1].x - a[0].x);
+}
+function angdiff(b, a) {
+  var d = b - a;
+  while (d > Math.PI) d -= 2 * Math.PI;
+  while (d < -Math.PI) d += 2 * Math.PI;
+  return d;
+}
+
+function bindLayerGestures(c) {
+  var pts = new Map(), one = null, two = null;
+  c.addEventListener('pointerdown', function (ev) {
+    try { c.setPointerCapture(ev.pointerId); } catch (e) { void e; }
+    pts.set(ev.pointerId, { x: ev.clientX, y: ev.clientY });
+    if (pts.size === 2) {
+      two = {
+        d: pdist(pts), ang: pang(pts), span: S.layerSpan,
+        before: S.anchors.slice()
+      };
+      one = null;
+      return;
+    }
+    if (pts.size !== 1) return;
+    one = {
+      x: ev.clientX, y: ev.clientY, mode: null,
+      before: S.anchors.slice(), cy: S.layerCy
+    };
+  });
+  c.addEventListener('pointermove', function (ev) {
+    if (!pts.has(ev.pointerId)) return;
+    pts.set(ev.pointerId, { x: ev.clientX, y: ev.clientY });
+    if (two && pts.size >= 2) {
+      // Pinch and twist come off the same two fingers, because on a
+      // touchscreen they are one motion and forcing them into separate modes
+      // makes both feel broken.
+      var d = pdist(pts);
+      if (d > 6 && two.d > 6) S.layerSpan = clamp(two.span * two.d / d, 16, 4096);
+      var dphi = angdiff(pang(pts), two.ang);
+      // Screen y runs downward, so a clockwise twist is +dphi, and a rotation
+      // by phi displaces row y by -phi*(y-mid). The moving layer realises that
+      // through `sgn`, so the stored roll carries the sign back out.
+      var sgn = signFor(movingSide()) || 1;
+      applyToCurve(two.before, 0, -dphi * (H - 1) * sgn,
+        'rotated ' + (dphi * 180 / Math.PI).toFixed(2) + '°');
+      renderLayerLabel();
+      return;
+    }
+    if (!one) return;
+    var dx = ev.clientX - one.x, dy = ev.clientY - one.y;
+    if (!one.mode) {
+      if (Math.hypot(dx, dy) < 7) return;
+      one.mode = Math.abs(dx) >= Math.abs(dy) ? 'shift' : 'row';
+    }
+    var geo = layerGeo(c), rect = c.getBoundingClientRect();
+    var cssScale = geo.scale * (rect.width / c.width);   // CSS px per panorama px
+    if (one.mode === 'row') {
+      S.layerCy = clamp(one.cy - dy / cssScale, 0, H - 1);
+      drawLayers(); renderLayerLabel();
+    } else {
+      var sgn2 = signFor(movingSide()) || 1;
+      var moved = (dx / cssScale) * sgn2;
+      applyToCurve(one.before, moved, 0,
+        'layers dragged ' + (moved >= 0 ? '+' : '') + moved.toFixed(2) + ' px');
+    }
+  });
+  function release(ev) {
+    pts.delete(ev.pointerId);
+    if (pts.size < 2) two = null;
+    if (pts.size === 0) one = null;
+  }
+  c.addEventListener('pointerup', release);
+  c.addEventListener('pointercancel', release);
+  c.addEventListener('lostpointercapture', release);
+  c.addEventListener('wheel', function (ev) {
+    ev.preventDefault();
+    setLayerSpan(S.layerSpan * (ev.deltaY > 0 ? 1.12 : 0.89));
+  }, { passive: false });
+}
+
 function bindGestures(c, kind) {
   var pts = new Map(), start = null, pinch = null;
   function rowAt(ev) {
@@ -2551,19 +3319,55 @@ function init() {
   $('apply').addEventListener('click', function () { applyToCamera(false); });
   $('dryrun').addEventListener('click', function () { applyToCamera(true); });
   $('camread').addEventListener('click', function () { readCamera(true); });
-  $('reset').addEventListener('click', function () {
+  // The two resets are one behaviour each, reachable from both the curve panel
+  // and the layer panel -- an operator working the layers with a thumb should
+  // not have to scroll back up to undo.
+  function resetFactory() {
     // dx = 0 IS the factory mesh: the boot hook composes anchors onto the mesh
     // the firmware generates at boot, so an all-zero curve leaves it untouched.
     // "reset to zero" and "back to factory" were the same button, so there is
     // only one of them.
     setAnchors(S.anchors.map(function (p) { return [p[0], 0]; }),
       'back to factory — zero correction on the vendor mesh');
-  });
-  $('camcurrent').addEventListener('click', function () {
+    S.layerBest = null;
+  }
+  function resetCameraCurrent() {
     var c = S.cameraCal;
     if (!c || !c.anchors_at_rows) return;
     setAnchors(c.anchors_at_rows, 'back to the calibration installed on the camera');
+    S.layerBest = null;
+  }
+  $('reset').addEventListener('click', resetFactory);
+  $('camcurrent').addEventListener('click', resetCameraCurrent);
+  $('lreset').addEventListener('click', resetFactory);
+  $('lcamcurrent').addEventListener('click', resetCameraCurrent);
+
+  $('pulllayers').addEventListener('click', function () { pullLayers('auto'); });
+  $('pullsynth').addEventListener('click', function () { pullLayers('synthetic'); });
+  $('pullsensors').addEventListener('click', pullSensors);
+  $('alpha').addEventListener('input', function (e) {
+    S.layerAlpha = parseFloat(e.target.value) / 100;
+    $('alphaV').textContent = Math.round(S.layerAlpha * 100) + '%';
+    drawLayers();
   });
+  var lmodes = document.querySelectorAll('#layermodes button');
+  for (var lm = 0; lm < lmodes.length; lm++) {
+    lmodes[lm].addEventListener('click', function (e) {
+      S.layerMode = e.currentTarget.getAttribute('data-lmode');
+      for (var k = 0; k < lmodes.length; k++) lmodes[k].classList.remove('on');
+      e.currentTarget.classList.add('on');
+      $('alpharow').style.display = S.layerMode === 'alpha' ? '' : 'none';
+      drawLayers();
+    });
+  }
+  var lnudges = document.querySelectorAll('#layernudge button');
+  for (var ln = 0; ln < lnudges.length; ln++) {
+    lnudges[ln].addEventListener('click', function (e) {
+      applyToCurve(S.anchors.slice(),
+        parseFloat(e.currentTarget.getAttribute('data-d')), 0, 'nudged from the layer view');
+    });
+  }
+  bindLayerGestures($('layercv'));
   $('suggest').addEventListener('click', function () {
     // The swept minimum, not `implied_dx`. The sweep descends the objective
     // itself; the regression behind `implied_dx` returned -17, +159 and -7 px
@@ -2610,7 +3414,15 @@ function init() {
     if (ev.key === 'ArrowUp') { S.cursorRow = clamp(S.cursorRow - 20, 0, H - 1); draw(); ev.preventDefault(); }
     if (ev.key === 'ArrowDown') { S.cursorRow = clamp(S.cursorRow + 20, 0, H - 1); draw(); ev.preventDefault(); }
   });
-  setInterval(function () { if (S.mode === 'blink' && S.imgs.left) { S.blink ^= 1; draw(); } }, 250);
+  // ~2 Hz. Drives the fused view's blink and the layer view's, so the two
+  // never disagree about which side is showing.
+  setInterval(function () {
+    var fused = (S.mode === 'blink' && S.imgs.left);
+    var layers = (S.layerMode === 'blink' && S.layerImgs.left);
+    if (!fused && !layers) return;
+    S.blink ^= 1;
+    if (fused) draw(); else drawLayers();
+  }, 250);
   window.addEventListener('resize', onResize);
   window.addEventListener('orientationchange', onResize);
   if (!S.narrow) {
@@ -2725,6 +3537,75 @@ __BANNER__
       measured session, so press it as often as you like while someone walks into position.</p>
   </div>
 
+  <div class="panel" id="layerpanel">
+    <h2 class="sec">Line up the <span class="accent">two layers</span></h2>
+    <p class="hint">These are the two sensors' <em>own</em> contributions to the
+      overlap, pulled before the camera cross-fades them &mdash; two real images of the
+      same panorama columns. Overlay them and drag until they coincide. Unlike every
+      other view on this page, nothing here is extrapolated.</p>
+    <div class="btn-row">
+      <button class="btn btn-sm" id="pulllayers">Pull layers</button>
+      <button class="btn btn-ghost btn-sm" id="pullsynth">Self-test pair</button>
+    </div>
+    <div id="layerstate" class="st">no layer pair yet</div>
+    <div id="layerattempts" class="faint mono"></div>
+
+    <div id="layercvwrap"><canvas id="layercv"></canvas></div>
+    <p class="faint mono" id="layerlabel"></p>
+
+    <div class="modes" id="layermodes">
+      <button data-lmode="alpha" class="on">Overlay</button>
+      <button data-lmode="diff">Difference</button>
+      <button data-lmode="anaglyph">Anaglyph</button>
+      <button data-lmode="blink">Blink</button>
+    </div>
+    <label class="row" id="alpharow"><span class="lbl">Top layer opacity
+      <span class="val" id="alphaV">50%</span></span>
+      <input type="range" id="alpha" min="0" max="100" step="1" value="50"></label>
+
+    <div class="layerread" id="layerread"></div>
+    <p class="faint">Mean |L&minus;R| falls as the layers coincide and correlation rises
+      toward 1.0 &mdash; both are computed in your browser on the pixels on screen, over
+      the overlap only, so they answer the drag itself. They are aids: the picture is
+      the instrument.</p>
+
+    <div class="nudge" id="layernudge">
+      <button data-d="-1">&minus;1</button>
+      <button data-d="-0.25">&minus;&frac14;</button>
+      <button data-d="0.25">+&frac14;</button>
+      <button data-d="1">+1</button>
+    </div>
+    <p class="faint"><b>One finger across</b> translates &middot; <b>one finger up/down</b>
+      travels the rows &middot; <b>two fingers</b> pinch to zoom and twist to rotate.
+      Rotation is a ramp linear in the row &mdash; <span class="mono">dx = &minus;&theta;&middot;y</span>,
+      the shape a relative lens roll actually makes.</p>
+    <div class="btn-row">
+      <button class="btn btn-ghost btn-sm" id="lreset">Back to factory</button>
+      <button class="btn btn-ghost btn-sm" id="lcamcurrent" disabled>Back to camera current</button>
+    </div>
+  </div>
+
+  <div class="panel" id="sensorpanel">
+    <h2 class="sec">What each lens <span class="accent">sees</span></h2>
+    <p class="hint">Two whole-lens stills, for orientation before precision work &mdash; what each
+      lens is actually pointed at, which a 128&nbsp;px strip cannot show you.
+      <b>Context, not the alignment surface.</b> They arrive at each sensor's native width,
+      which puts them in sensor coordinates, before the warp; the mapping into panorama
+      columns has been measured (to a few grey levels) but is not wired into this build, so
+      the tool will not let you author a correction from them. Use the layer panel above &mdash;
+      it is pre-rectified by the camera itself, so it carries no fitted-warp error at all.</p>
+    <div class="btn-row">
+      <button class="btn btn-ghost btn-sm" id="pullsensors">Show both lenses</button>
+    </div>
+    <div id="sensorstate" class="st">not pulled</div>
+    <div id="sensorwrap" style="display:none">
+      <div class="lenscap">sensor 0 &mdash; left</div>
+      <img id="sensorL" class="lens" alt="whole view from sensor 0">
+      <div class="lenscap">sensor 1 &mdash; right</div>
+      <img id="sensorR" class="lens" alt="whole view from sensor 1">
+    </div>
+  </div>
+
   <div class="panel">
     <h2 class="sec">The <span class="accent">seam</span></h2>
     <div id="zoomwrap"><canvas id="zoom"></canvas></div>
@@ -2744,17 +3625,20 @@ __BANNER__
       showing.</p>
     <div class="caption" id="caption"></div>
     <div id="vertical" style="display:none"></div>
-    <div class="caveat"><strong>What these views can and cannot show.</strong>
-      The camera fuses the two sensors before it hands out a JPEG, blending them over the
-      256&nbsp;px window shaded above. Every pixel in there is already a mixture of both, so
-      there is no second layer to reveal and no honest way to paint one. Blink and anaglyph
-      therefore draw the <em>fitted</em> structures instead: each one measured independently on
-      the left shoulder (red) and the right shoulder (cyan) and extrapolated to the seam, solid
-      where there is real image behind it and dashed where it is extrapolation. A gap between a
-      red line and its cyan partner at the seam is that structure's residual. Structures too
-      near horizontal to respond to a horizontal shift are drawn grey, because they cannot tell
-      you anything about what you are adjusting. The shoulders either side of the window are
-      real; the window is inference.</div>
+    <div class="caveat"><strong>These views are inference; the layer panel above is not.</strong>
+      A <span class="mono">Snap</span> is already fused &mdash; every pixel in the shaded window
+      is a mixture of both sensors &mdash; so blink and anaglyph <em>here</em> cannot reveal a
+      second layer and do not pretend to. They draw the <em>fitted</em> structures instead: each
+      measured independently on the left shoulder (red) and the right shoulder (cyan) and
+      extrapolated to the seam, solid where there is real image behind it and dashed where it is
+      extrapolation. A gap between a red line and its cyan partner is that structure's residual.
+      Structures too near horizontal to respond to a horizontal shift are drawn grey, because
+      they cannot tell you anything about what you are adjusting.
+      <br><br>The <b>Line up the two layers</b> panel above does not have this limitation: it
+      pulls the two sensors' contributions <em>before</em> the cross-fade, so its overlay,
+      difference, anaglyph and blink are the true separated layers rather than an
+      extrapolation. Prefer it. This view remains useful for the shoulders either side of the
+      window, which are real image in both.</div>
   </div>
 
   <div class="panel">


### PR DESCRIPTION
The two sensors' own views of the overlap, overlaid and moved by hand until they
coincide. Previously the tool worked on the fused panorama, where the blend has
already mixed the two views irreversibly — so blink, anaglyph and mirror
operated on *extrapolations from the shoulders* and said so on screen. These are
now the real layers.

### Getting the layers off the camera

`VIDEOPROC 2 out[1]` (ISF path `0x00930001`) carries **two separable 128x2160
views of the same overlap region**, linear, on a port nothing else reads
(`PULL 0`, `bind_dest (null)`). Verified against a same-moment panorama:

```
panorama[:, 3776+k] = (1 - w_k)*L[:,k] + w_k*R[:,k]

k:      0      32     56     64     72     96    127
aL:  0.995  0.986  0.805  0.485  0.176  0.007  0.005
aR:  0.005  0.012  0.203  0.523  0.828  0.991  0.995
```

Weights sum to 1.000 at every column, ramp monotonically, cross over exactly at
panorama x=3840. Reconstruction error **1.56 grey levels**. That also settles a
question three earlier passes disagreed about: the blend band is **3776–3903**,
crossover **3840**, an S-curve ~48 columns wide.

The strip pair is **pre-rectified into panorama output coordinates**, so a drag
converts straight to `dx_anchors` with no fit in the loop.

Reaching it needed one correction worth recording: **`arg[4]` of the pull ioctl
is a millisecond timeout, not a flags word.** Passing 0 makes it non-blocking,
and since these ports are `depth 1` with the stitcher holding the buffer most of
each 50 ms period, it returns `-56` — the ordinary would-block code. Two earlier
passes read that as "structurally not user-pullable". The ioctl also returns
`-14` by default regardless of outcome; **the real result is in `arg[0]`**.

### The UI

A new "Line up the two layers" panel: both layers at adjustable opacity, plus
difference, anaglyph (left red / right cyan) and ~2 Hz blink — **all four now
exact**. One finger across translates, one finger down travels rows, two fingers
pinch-zoom and twist-rotate off the same pointers. Live mean |L−R| and NCC
computed in-browser over the overlap only, marking best-so-far.

**Gestures write only the artifact.** Translation is a constant added to every
anchor; rotation is a ramp linear in row (`dx = −θ·y`), the physically expected
shape for a relative lens roll. Both go through the existing `setAnchors()`.
Drag a layer and the numbers move; type an anchor and the layers move. Apply is
untouched — still `/stitch/apply` → `apply_calibration()`.

Driven through the real handlers in a real 390x844 viewport against a synthetic
pair hiding `dx=6, roll=12`:

| state | dx | roll | mean abs diff | NCC |
|---|---|---|---|---|
| unaligned | 0 | 0 | 41.76 | 0.357 |
| 42 px one-finger drag | **5.947** | 0 | 26.30 | 0.668 |
| two-finger twist | 5.95 | **12.000** | **1.85** | **0.9985** |

Drag predicted 5.95 and gave 5.947; the twist asked +12 and gave 12.000. All
touch targets >=44 px, no horizontal overflow, `touch-action: none`.

### Full-resolution per-sensor frames — captured, shipped as context

Also new: **both lenses as full-resolution JPEGs**, one command, no network
login, no uploaded helper.

```
/mnt/app/rpctool -s -t SNAP -c 13010 -m 02000000000000000000000000000000
-> /mnt/tmp/01_<ts>.jpg (sensor 0), 02_<ts>.jpg (sensor 1), same timestamp
```

Message **13003 can never work** — it hardcodes a task class that only ever
builds `yuv_snap`, which is why a 16-combination sweep returned one identical
`-822`. And `-822` never meant "init_snapshot_yuv failed"; that vtable slot is a
stub that cannot fail.

The overlap in those frames is **~500 columns, not the 64** an earlier pass
inferred from a 3904-vs-3840 width argument that does not reproduce (ten fresh
captures, all 3840x2160). Demonstrated by matching panorama patches into each
sensor frame outside the blend band, where every panorama column has exactly one
source and there is no depth term: 128/458 NCC inliers, and resampling the
sensor frame through the fitted map reproduces the panorama at **2.3–4.8 grey
levels**.

They ship as **context, not as the working surface** — the strip pair carries no
fitted-warp error, the fit maps are server-share artifacts an install lacks, and
the fit is tied to a mesh that calibration changes. `LayerPair` and
`SensorViews` are separate types; `SensorViews` has no `overlap`/`seam_x` field
and the UI refuses gestures on `authoritative: false`. A test asserts the
mapping stays absent.

### Notes

- A rendering bug found by looking, not by reading: at inspection zoom the view
  shows ~65 of 2160 rows, and passing the whole image to `drawImage` asks the
  compositor to rasterise ~900x15000 px per band. It never appears in the
  `drawImage` timing — it wedges the compositor. Only a source rectangle bounds
  the work.
- The §11 extrapolation caveat is **scoped, not deleted**: the fused view still
  exists and is still extrapolation, so it keeps its caveat and points at the
  layer panel.
- `source: "camera"` needs two ~4 KB aarch64 helpers via the new
  `builds/build_seam_helpers.sh`. C sources committed, binaries not, per repo
  convention. Without them the endpoint refuses with an explicit "not built"
  message naming the path rather than half-working.

### Gates

ruff, ruff format, mypy clean. Full unit suite **2029 passed, 13 skipped, 1
xfailed** — run independently by the coordinator. 25 new tests.

Camera read-only throughout: no `SetStitch`, no mesh write, no flash. Mesh md5
`7ac18ef2988970d09fc4f5a36c6cd311` re-measured at the end, identical to factory.