### PR TITLE
firmware: bound power-cut loss with periodic segment rollover

### DIFF
--- a/reolink-firmware-patching/builds/BUILD_LOG.md
+++ b/reolink-firmware-patching/builds/BUILD_LOG.md
@@ -52,13 +52,52 @@ computed — and `verify/check_recording_default.sh` must pass.
 
 | File | Notes |
 |---|---|
-| **`IPC_…4920…_stitchcal.pak`** | **CURRENT.** 4919 + **idempotent hook.** Re-running S98 within one boot composed the correction onto its *own output* and silently doubled the shear (3 px → 6 px) while the log read healthy. The hook now records a signature of what it wrote and, on recognising it, composes from the saved baseline instead. Verified on camera: three consecutive runs all produce mesh crc `0bf0934f`. |
+| **`IPC_…4921…_stitchcal.pak`** (`7514d015…`, CRC `0x317cfb07`) | **CURRENT.** 4920 + **`S99_NetState` v3: periodic segment rollover.** The camera finalises an MP4 only when recording *stops* — it pre-allocates the `moov` at the front of the file and fills it on close — so an abrupt power cut loses the **entire session**, not a truncated tail. Observed 2026-08-22: a ~435 MB main stream was **absent from the card**, `df` confirming the space was never consumed; only the sub-stream survived. v3 therefore toggles recording off→`sync`→on every `ROLLOVER_SECS` **while away**, bounding the loss to one interval. Default **60 s**, retunable with a file drop at `/mnt/sda/netstate/rollover_secs` (0 disables, 15 s floor). Also **releases API sessions** (`Logout`) — see below. Builder gates the three invariants (logout present, `do_rollover` away-guarded, `sync` inside it). |
+| `IPC_…4920…_stitchcal.pak` | superseded — 4919 + **idempotent hook.** Re-running S98 within one boot composed the correction onto its *own output* and silently doubled the shear (3 px → 6 px) while the log read healthy. The hook now records a signature of what it wrote and, on recognising it, composes from the saved baseline instead. Verified on camera: three consecutive runs all produce mesh crc `0bf0934f`. |
 | `IPC_…4919…_stitchcal.pak` | superseded — first build whose hook actually ran. 4918 + **wait for `/mnt/sda` before reading config** + `S36_RootShell` restored. **On-camera validated:** S98 applied a ±3 px calibration 38 s into boot, read-back ok, and the correction was visible in a snapshot. |
 | `IPC_…4918…_stitchcal.pak` | superseded, and instructive. Gates passed, flashed clean — and the hook **did nothing, silently**. `rcS` does `mount -a` then runs `S*`, but `/mnt/sda` is `/dev/hd/sda1`, mounted later by the app; S98 checked for `anchors.txt` first, found none, and could not even log it because `/` is read-only squashfs. It also dropped `S36_RootShell` (the comprehensive builder never installed one), taking tcp/2323 with it. |
 
 Known gap: `commit=` in the manifest reads `unknown` unless `SOCCERCAM_COMMIT` is
 set, because `git rev-parse` refuses a `/mnt/c` worktree from WSL (dubious
 ownership). Pass it explicitly.
+
+### Segment rollover (v3) — measured, not assumed
+
+Measured on the camera at build 4920 before the v3 build, driving `SetRecV20`
+over HTTP with the exact call shape the daemon uses (login → set → logout):
+
+| What | Measured |
+|---|---|
+| Natural rollover without intervention | **none** — one file grew for 3+ min hands-off |
+| Toggle cost, off→`sync`→on, no settle delay | **0.62 s** end to end |
+| Frames lost per rollover | **zero** |
+| Content *duplicated* per rollover | **≈0.50 s (~10 frames @ 20 fps)** |
+
+Over 10 consecutive rollovers, segment **start** times (independent camera-clock
+stamps) advanced 208 s while 212.98 s of content was written — a 4.98 s surplus,
+i.e. the camera's pre-record buffer **backfills** the toggle rather than dropping
+frames. All 11 segments probed clean: 7680×2160 HEVC, real `moov`, playable.
+
+Two consequences drove the design:
+
+- **60 s is cheap.** A rollover costs duplicated frames, not lost ones, so a
+  tight loss bound is nearly free (~0.8 % duplicated content at 60 s). For match
+  footage the cost is ~90 half-second hitches over 90 minutes; raise
+  `rollover_secs` to 300 if that reads badly, or teach the downstream concat to
+  trim the overlap (the duplicate frames are present, so it is recoverable).
+- **Sessions must be released.** The camera caps concurrent API sessions at
+  **5** (`"max session"`, rspCode −5) with a 3600 s lease. v2 logged in per call
+  and never logged out — harmless at one call per home/away transition, fatal at
+  one rollover a minute: the pool empties within minutes, `SetRecV20` starts
+  failing `"please login first"`, and **recording stops silently**. Verified: 5
+  leaked logins exhaust the pool; with `Logout`, 12/12 succeed. This was found by
+  measurement, not review, and it would have made the whole feature a no-op.
+
+Caveat not closed at home: the overlap was measured on a static indoor scene
+(~1.2 Mbps actual, against the 20480 kbps cap). If the pre-record buffer is
+size-bounded it may cover less at true field bitrate, in which case the rollover
+degrades from ~0.5 s of overlap toward a gap of at most the 0.62 s toggle time.
+Bounded and sub-second either way, but it is inference, not measurement.
 
 ## "Comprehensive" firmware — ready to flash
 | File | sha256 | Notes |

--- a/reolink-firmware-patching/builds/build_stitchcal.sh
+++ b/reolink-firmware-patching/builds/build_stitchcal.sh
@@ -5,6 +5,15 @@
 #   - /usr/bin/lut2d_ioctl            (static aarch64; get / set / compose)   (rootfs)
 #   - /etc/init.d/S98_StitchCal       (re-apply the seam correction at boot)  (rootfs)
 #   - /etc/init.d/S36_RootShell       (tcp/2323 recovery channel)              (rootfs)
+#   - /etc/init.d/S99_NetState  v3    (periodic segment rollover while away)   (rootfs)
+#
+# WHY v3. The camera finalises an MP4 only when recording STOPS, so a power cut
+# mid-session loses the entire session -- not a truncated tail, the whole file
+# (2026-08-22: a ~435 MB main stream was absent from the card, df confirming the
+# space was never consumed). v3 turns recording off and straight back on every
+# ROLLOVER_SECS while away, bounding the loss to one interval. Measured on
+# hardware, the toggle costs ~0.5 s of DUPLICATED content and drops no frames,
+# because the pre-record buffer backfills it.
 #
 # WHY THIS NEEDS A FLASH AT ALL. /etc/init.d is squashfs and read-only, so the
 # hook itself cannot be dropped onto the SD card. It is baked ONCE; every
@@ -44,10 +53,25 @@ case "$(basename "$OUT")" in
      echo "         the camera's Local Upgrade will reject it." >&2 ;;
 esac
 
+# Segment rollover interval, in seconds, baked in as the default. Overridable at
+# runtime by dropping /mnt/sda/netstate/rollover_secs. 0 disables rollover.
+# 60 s is the shipped default: measured on hardware, one rollover costs ~0.5 s of
+# DUPLICATED content (the pre-record buffer backfills the toggle) and loses
+# nothing, so a tight loss bound is close to free. See the v3 template header.
+ROLLOVER_SECS="${ROLLOVER_SECS:-60}"
+case "$ROLLOVER_SECS" in
+  ''|*[!0-9]*) echo "ERROR: ROLLOVER_SECS must be a non-negative integer, got '$ROLLOVER_SECS'"; exit 1 ;;
+esac
+if [[ "$ROLLOVER_SECS" != 0 && "$ROLLOVER_SECS" -lt 15 ]]; then
+  echo "ERROR: ROLLOVER_SECS=$ROLLOVER_SECS is below the 15 s floor the daemon enforces;"
+  echo "       it would be silently ignored at runtime. Pick >=15, or 0 to disable."
+  exit 1
+fi
+
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
 PAK_DIR="$ROOT/pak"
-NS_TPL="$ROOT/runtime/netstate/S99_NetState_v2.template"
+NS_TPL="$ROOT/runtime/netstate/S99_NetState_v3.template"
 REC_SH="$ROOT/runtime/recover/S35_RecRecover"
 REC_C="$ROOT/recover/recover_mp4.c"
 SC_SH="$ROOT/runtime/stitchcal/S98_StitchCal"
@@ -103,13 +127,37 @@ assert bytes(d[OFF:OFF+4])==CUR, "reserve site mismatch"
 d[OFF:OFF+4]=new; open(SO,"wb").write(bytes(d)); print(f"   reserve {$RES_GB}GiB ({new.hex()})")
 PY
 
-echo "==> 5) install S99_NetState v2"
+echo "==> 5) install S99_NetState v3 (rollover=${ROLLOVER_SECS}s)"
 python3 - <<PY
-t=open("$NS_TPL").read().replace("%%HOME_MACS%%","$HOME_MACS_LC").replace("%%CAMERA_USER%%","$USER").replace("%%CAMERA_PASS%%","$PASS")
+t=open("$NS_TPL").read().replace("%%HOME_MACS%%","$HOME_MACS_LC").replace("%%CAMERA_USER%%","$USER").replace("%%CAMERA_PASS%%","$PASS").replace("%%ROLLOVER_SECS%%","$ROLLOVER_SECS")
+assert "%%" not in t, "unsubstituted placeholder left in S99_NetState"
 import os; os.makedirs("rootfs_unpacked/etc/init.d",exist_ok=True)
 open("rootfs_unpacked/etc/init.d/S99_NetState","w",newline="\n").write(t); os.chmod("rootfs_unpacked/etc/init.d/S99_NetState",0o755)
 print(f"   S99_NetState ({len(t)}b)")
 PY
+# Gates on the daemon's actual code, comments stripped. Each of these encodes a
+# failure that is invisible once flashed: the camera keeps answering, the log
+# keeps looking healthy, and it simply is not recording.
+NS_CODE="$(sed 's/#.*//' rootfs_unpacked/etc/init.d/S99_NetState)"
+# The camera caps concurrent API sessions at 5 with a 3600 s lease. A rollover
+# every minute that never releases its token exhausts the pool within minutes,
+# after which SetRecV20 fails "please login first" and recording stops dead.
+grep -q 'cmd=Logout' <<<"$NS_CODE" \
+  || { echo "ERROR: S99_NetState never logs out -- the 5-session pool will be exhausted by rollovers"; exit 1; }
+grep -q 'api_logout' <<<"$NS_CODE" \
+  || { echo "ERROR: set_record_state does not release its session"; exit 1; }
+awk '/^set_record_state\(\)/,/^}/' <<<"$NS_CODE" | grep -q 'api_logout' \
+  || { echo "ERROR: set_record_state does not call api_logout -- sessions leak per call"; exit 1; }
+# A rollover ends with "recording on". Anywhere but the away state that means
+# recording at home, which is the standing thing this firmware must never do.
+awk '/^do_rollover\(\)/,/^}/' <<<"$NS_CODE" | grep -q 'LAST_STATE' \
+  || { echo "ERROR: do_rollover has no away-state guard -- it could enable recording at home"; exit 1; }
+# The whole point is that the close reaches the card, not the page cache.
+awk '/^do_rollover\(\)/,/^}/' <<<"$NS_CODE" | grep -qE '^[[:space:]]*sync([[:space:]]|$)' \
+  || { echo "ERROR: do_rollover does not sync -- the closed segment may never reach the card"; exit 1; }
+grep -q "ROLLOVER_SECS_DEFAULT=\"$ROLLOVER_SECS\"" <<<"$NS_CODE" \
+  || { echo "ERROR: rollover default did not bake in as $ROLLOVER_SECS"; exit 1; }
+echo "   S99_NetState v3 gates passed (logout, away-guard, sync, default=${ROLLOVER_SECS}s)"
 
 echo "==> 6) build + install recover_mp4 (static aarch64) + boot script"
 HELIX_SRC="$ROOT/recover/helix/ESP8266Audio/src/libhelix-aac"
@@ -203,7 +251,8 @@ pak=$(basename "$OUT")
 base=v3.0.0.4867_2505072124
 kbps=$KBPS
 reserve_gb=$RES_GB
-netstate=v2
+netstate=v3
+rollover_secs=$ROLLOVER_SECS
 recover=yes
 audio=$AUDIO
 stitchcal=S98+lut2d_ioctl
@@ -241,6 +290,11 @@ bash "$ROOT/verify/check_recording_default.sh" "$OUT"
 echo "==================================================================="
 echo " STITCHCAL: comprehensive + S98_StitchCal + /usr/bin/lut2d_ioctl"
 echo " Boot chain verified identical to stock; recording defaults to off at home."
+echo
+echo " S99_NetState v3: segments roll every ${ROLLOVER_SECS}s while AWAY, so an abrupt"
+echo " power cut costs one interval instead of the whole session. Retune with a"
+echo " file drop, no reflash:"
+echo "   /mnt/sda/netstate/rollover_secs   seconds per segment (0 disables, min 15)"
 echo
 echo " After flashing, a calibration is a FILE DROP, not a reflash:"
 echo "   /mnt/sda/stitchcal/anchors.txt   the correction"

--- a/reolink-firmware-patching/runtime/camsh.py
+++ b/reolink-firmware-patching/runtime/camsh.py
@@ -29,6 +29,7 @@ Usage as a CLI:
 
 from __future__ import annotations
 
+import hashlib
 import re
 import socket
 import sys
@@ -184,6 +185,62 @@ def sh_bytes(
     return _send_bytes(cmd, host, port, timeout)
 
 
+def put_file(
+    path: str,
+    data: str | bytes,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+) -> None:
+    """Write `data` to `path` on the camera, then verify it by md5.
+
+    Why this is not just `sh("cat > path <<EOF ...")`: `check()` scans the whole
+    command string, and a command that carries a file body contains that file's
+    words. Pushing a copy of S99_NetState this way trips the reboot refusal on
+    the word "reboot" in one of its comments. That refusal is not wrong -- it
+    cannot tell code from data -- so the answer is a separate operation whose
+    risk profile is actually different, not a reworded payload. Rewording the
+    firmware to slip past a guard is how guards stop meaning anything.
+
+    So the refusals here apply to the *destination*, which is the part that can
+    do damage: nothing may be written inside a PROTECTED path, and the netstate
+    override is reserved to hold_recording_override(). The body is never parsed
+    as a command -- it goes through a quoted heredoc, so the remote shell does
+    no expansion on it either.
+
+    Raises CameraCommandRefused for a forbidden destination, and RuntimeError if
+    the md5 read back does not match what was sent.
+    """
+    if isinstance(data, str):
+        data = data.encode()
+    for protected in PROTECTED:
+        if path.startswith(protected):
+            raise CameraCommandRefused(
+                f"refusing to write inside {protected}\n  path: {path}"
+            )
+    if path.rstrip("/") == OVERRIDE_FLAG:
+        raise CameraCommandRefused(
+            "refusing to write the netstate override; use hold_recording_override()"
+        )
+
+    digest = hashlib.md5(data).hexdigest()
+    delim = "EOF_CAMSH_PUT"
+    while delim.encode() in data:
+        delim += "_"
+    body = data.decode(errors="strict")
+    cmd = (
+        f"cat > {path} <<'{delim}'\n"
+        f"{body.rstrip(chr(10))}\n"
+        f"{delim}\n"
+        f"sync; md5sum {path}"
+    )
+    out = _send(cmd, host, port, timeout=90)
+    if digest not in out:
+        raise RuntimeError(
+            f"put_file({path}) verification failed: expected md5 {digest}\n"
+            f"  camera said: {out.strip()[:300]}"
+        )
+
+
 def hold_recording_override(
     on: bool, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT
 ) -> str:
@@ -256,6 +313,54 @@ def recording_override_held(
                 f"be recording at home. Remove {OVERRIDE_FLAG} by hand.\n"
                 f"  camera said: {out.strip()[:200]}"
             )
+
+
+class SysrqUnavailable(RuntimeError):
+    """The kernel will not accept a sysrq reset, so the cut cannot be simulated."""
+
+
+def simulate_power_cut(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> str:
+    """Reset the camera immediately via sysrq, with no sync and no unmount.
+
+    This exists to TEST power-cut resilience, which is the one thing that cannot
+    be argued into evidence: the segment-rollover work in S99_NetState v3 is
+    only worth anything if an abrupt loss of power costs a bounded amount of
+    footage, and the only way to know is to take the power away.
+
+    `check()` refuses reboot/halt/poweroff/shutdown in a free-form command, and
+    must keep doing so -- the point of that refusal is that a reboot should
+    never be a side effect of a command batch, because the camera boots
+    recording-enabled and writes a stub before the daemon disables it. Testing a
+    power cut is the opposite of a side effect, so it lives here for the same
+    reason hold_recording_override() does: a named function, one fixed command,
+    no free-form input, obvious in a transcript. Wording your way around the
+    regex in an ad-hoc `sh()` call would get the same bytes onto the wire while
+    hiding the intent, and then the refusal protects nothing.
+
+    How close this is to the real thing: `sysrq-b` resets the SoC immediately
+    without syncing buffers or unmounting /mnt/sda, so unflushed FAT directory
+    entries and an unfinalised moov are lost exactly as they would be on a yank.
+    It is NOT identical -- the SD card keeps its own power and finishes any
+    in-flight block write, where a real cut can tear a sector. For the failure
+    being defended against (metadata that never reached the card) they are
+    equivalent; for media-level corruption they are not. Say which one you did.
+
+    Raises SysrqUnavailable if the kernel's sysrq is disabled, rather than
+    returning as though it had worked -- a reset that silently does not happen
+    would be read as "the camera survived".
+    """
+    enabled = _send("cat /proc/sys/kernel/sysrq 2>/dev/null", host, port).strip()
+    value = enabled.splitlines()[-1].strip() if enabled else ""
+    if value in ("", "0"):
+        raise SysrqUnavailable(
+            "kernel sysrq is disabled (/proc/sys/kernel/sysrq="
+            f"{value or 'unreadable'}); cannot simulate a power cut this way"
+        )
+    # No response is expected: the box is gone mid-sentence. That is the point.
+    try:
+        return _send("echo b > /proc/sysrq-trigger", host, port, timeout=5)
+    except OSError as exc:
+        return f"connection dropped as expected: {exc}"
 
 
 def _selftest() -> int:
@@ -337,6 +442,49 @@ def _selftest() -> int:
         else:
             print(f"  [FAIL] {name}: release_attempted={released} raised={stuck}")
             fails += 1
+
+    # put_file() gates on its DESTINATION, since its payload is data and will
+    # routinely contain words the command refusals look for.
+    for path, should_refuse in (
+        ("/mnt/sda/Mp4Record/2026-08-22/x.mp4", True),
+        ("/mnt/para/anything", True),
+        (OVERRIDE_FLAG, True),
+        ("/tmp/S99_v3", False),
+        ("/mnt/sda/netstate/rollover_secs", False),
+    ):
+        total += 1
+        real_send = _send
+        _send = lambda *a, **k: "d41d8cd98f00b204e9800998ecf8427e  x"  # noqa: E731
+        try:
+            put_file(path, b"")
+            refused = False
+        except CameraCommandRefused:
+            refused = True
+        except RuntimeError:
+            refused = False  # got past the destination check; md5 is not the gate here
+        finally:
+            _send = real_send  # type: ignore[assignment]
+        if refused is should_refuse:
+            print(f"  [ok]   put_file {'refused' if refused else 'allowed'}: {path}")
+        else:
+            print(f"  [FAIL] put_file {path}: refused={refused} want={should_refuse}")
+            fails += 1
+
+    # A payload containing a forbidden word must still go through, because it is
+    # data. This is the case that forced put_file() to exist.
+    total += 1
+    real_send = _send
+    _send = lambda *a, **k: "d41d8cd98f00b204e9800998ecf8427e  x"  # noqa: E731
+    try:
+        put_file("/tmp/script.sh", b"# retune with a file drop and no reboot\n")
+        print("  [ok]   put_file allows a payload containing 'reboot'")
+    except CameraCommandRefused:
+        print("  [FAIL] put_file refused a payload containing 'reboot'")
+        fails += 1
+    except RuntimeError:
+        print("  [ok]   put_file allows a payload containing 'reboot'")
+    finally:
+        _send = real_send  # type: ignore[assignment]
 
     print(f"\n{total - fails}/{total} gates passed")
     return 1 if fails else 0

--- a/reolink-firmware-patching/runtime/netstate/S99_NetState_v3.template
+++ b/reolink-firmware-patching/runtime/netstate/S99_NetState_v3.template
@@ -1,0 +1,393 @@
+#!/bin/sh
+# /etc/init.d/S99_NetState  (v3: + periodic segment rollover, + API session release)
+# Toggles scheduled recording based on the default-gateway MAC address.
+# Idle on home networks (the HOME_MACS_DEFAULT list below, set at build time);
+# record continuously everywhere else.
+#
+# v2 change: when we are HOME (recording disabled), automatically delete any
+# recording files created during THIS boot (the boot-window "stub" the camera
+# writes before the daemon flips enable=0). Files from previous boots (real
+# field game footage already on the card) are never touched, because we only
+# delete files whose mtime is at/after this boot's start time.
+#
+# v3 change: SEGMENT ROLLOVER. The camera writes one MP4 per recording session
+# and only finalises it -- fills the pre-allocated moov at the front of the
+# file, renames to the full start_end_hash form -- when recording STOPS. Cut
+# power mid-session and the whole session is lost, not truncated: on 2026-08-22
+# a ~435 MB main stream was absent from the card entirely, with df confirming
+# the space was never consumed. Toggling recording off is what makes a file
+# durable, so while we are AWAY we do that on a timer: off -> sync -> on, every
+# ROLLOVER_SECS. A power cut then costs at most one interval instead of
+# everything.
+#
+# Measured on hardware (build 4920, 2026-08-22, 10 consecutive rollovers): the
+# toggle takes ~0.6 s end to end, and the camera's pre-record buffer backfills
+# it, so consecutive segments OVERLAP by ~0.5 s (~10 frames at 20 fps) rather
+# than dropping frames. Segment start times advanced 208 s while 212.98 s of
+# content was recorded. Nothing is lost per rollover; ~0.5 s is duplicated. If
+# the pre-record buffer ever fails to cover the toggle (it is a fixed-size ring,
+# so a much higher bitrate could shorten it), the worst case degrades to a gap
+# equal to the toggle time, ~0.6 s -- still bounded and sub-second.
+#
+# v3 also makes set_record_state() LOG OUT. The camera allows a maximum of 5
+# concurrent API sessions ("max session", rspCode -5) and a token's lease is
+# 3600 s, so every login that is never released holds a slot for an hour. v2
+# logged in per call and never logged out, which was harmless when calls were
+# rare (one per home/away transition) and is fatal at one rollover a minute:
+# the pool is exhausted within minutes, SetRecV20 starts failing "please login
+# first", and the camera silently stops recording at a game. Verified on
+# hardware: 5 leaked logins exhaust the pool; with Logout, 12/12 succeed.
+#
+# Runtime overrides (on the writable SD card):
+#   /mnt/sda/netstate/home_macs.txt  - one MAC per line, replaces baked-in list
+#   /mnt/sda/netstate/override       - presence => daemon yields, you control rec
+#   /mnt/sda/netstate/no_stub_clean  - presence => disable home-stub cleanup
+#   /mnt/sda/netstate/rollover_secs  - segment length in seconds; 0 disables
+#   /mnt/sda/netstate/log            - decision log (auto-rotates at 256 KB)
+
+HOME_MACS_DEFAULT="%%HOME_MACS%%"
+USER="%%CAMERA_USER%%"
+PASS="%%CAMERA_PASS%%"
+ROLLOVER_SECS_DEFAULT="%%ROLLOVER_SECS%%"
+
+CONFIG_DIR=/mnt/sda/netstate
+HOME_MACS_FILE=$CONFIG_DIR/home_macs.txt
+OVERRIDE_FILE=$CONFIG_DIR/override
+NOCLEAN_FILE=$CONFIG_DIR/no_stub_clean
+ROLLOVER_FILE=$CONFIG_DIR/rollover_secs
+LOG=$CONFIG_DIR/log
+REC_DIR=/mnt/sda/Mp4Record
+
+POLL_INTERVAL=30
+# Head-start before the first home/away check. Kept short: wait_for_api (below)
+# already polls until the camera API is reachable, so a long pre-sleep only
+# delays the home-disable and lets the camera record a longer boot "stub" at
+# home. Fail-enabled is preserved regardless -- the camera boots recording and
+# we only ever DISABLE on a confirmed home MAC.
+INIT_GRACE=5
+LOG_MAX_BYTES=262144
+# Refuse a rollover interval shorter than this. Each rollover is two API round
+# trips plus a sync; below ~15 s the daemon would spend a visible fraction of
+# its life toggling, and the duplicated pre-record overlap stops being a
+# rounding error. A bad value falls back to the built-in default rather than
+# being silently clamped, so the operator finds out from the log.
+ROLLOVER_MIN=15
+
+# This boot's start time (epoch). Anything in Mp4Record with mtime >= this was
+# written during the current power-on; if we're home, it's a stub to remove.
+BOOT_EPOCH=$(( $(date +%s) - $(awk '{print int($1)}' /proc/uptime 2>/dev/null || echo 0) ))
+
+ALL_ON='111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111'
+
+mkdir -p "$CONFIG_DIR" 2>/dev/null
+
+# Surface the firmware build manifest to the SD card so it is readable over the
+# HTTP unlock at /downloadfile/soccercam/build.txt -- identifies which build is
+# running (every pak reports the same stock version string otherwise).
+if [ -f /etc/soccercam_build ]; then
+    mkdir -p /mnt/sda/soccercam 2>/dev/null
+    cp -f /etc/soccercam_build /mnt/sda/soccercam/build.txt 2>/dev/null
+fi
+
+log() {
+    local MSG="[$(date '+%F %T')] $*"
+    echo "$MSG"
+    if [ -w "$CONFIG_DIR" ] || mkdir -p "$CONFIG_DIR" 2>/dev/null; then
+        if [ -f "$LOG" ] && [ "$(wc -c <"$LOG" 2>/dev/null)" -gt $LOG_MAX_BYTES ]; then
+            mv "$LOG" "$LOG.old" 2>/dev/null
+        fi
+        echo "$MSG" >>"$LOG"
+    fi
+}
+
+# Delete recordings created during THIS boot (mtime >= BOOT_EPOCH). Only called
+# while home.
+#
+# We deliberately do NOT compute "today's" directory from `date`: the shell's
+# clock is UTC, but the camera names its Mp4Record/<YYYY-MM-DD> subdirs in LOCAL
+# time, so after dark the two land on different calendar days and a date-derived
+# path misses the stub entirely (this is exactly why the home boot-stub was not
+# being cleaned). Instead we scan EVERY date subdir and let the epoch-based
+# mtime test -- which is timezone-independent -- decide what belongs to this
+# boot. Verbose logging records the boot epoch, what was scanned, and whether
+# each rm actually removed the file (re-stat after deleting).
+clean_home_stubs() {
+    [ -f "$NOCLEAN_FILE" ] && return
+    local D F MT N=0 CAND=0 SCANNED=0 FIRST=0
+    [ -z "$CLEAN_RAN" ] && { FIRST=1; CLEAN_RAN=1; }
+    [ -d "$REC_DIR" ] || { [ "$FIRST" = 1 ] && log "  clean: $REC_DIR missing -- nothing to clean"; return; }
+    # First pass: count candidates (mtime >= this boot) WITHOUT deleting, so the
+    # verbose per-file log only fires when there is actually a stub to remove.
+    for D in "$REC_DIR"/*; do
+        [ -d "$D" ] || continue
+        for F in "$D"/*.mp4; do
+            [ -f "$F" ] || continue
+            SCANNED=$((SCANNED+1))
+            MT=$(stat -c %Y "$F" 2>/dev/null) || continue
+            [ "$MT" -ge "$BOOT_EPOCH" ] && CAND=$((CAND+1))
+        done
+    done
+    if [ "$CAND" = 0 ]; then
+        [ "$FIRST" = 1 ] && log "  clean: boot_epoch=$BOOT_EPOCH date_utc='$(date '+%F %T')' scanned=$SCANNED candidates=0 (nothing newer than this boot)"
+        return
+    fi
+    log "  clean: boot_epoch=$BOOT_EPOCH now=$(date +%s) date_utc='$(date '+%F %T')' scanned=$SCANNED candidates=$CAND -- deleting stub(s)"
+    for D in "$REC_DIR"/*; do
+        [ -d "$D" ] || continue
+        for F in "$D"/*.mp4; do
+            [ -f "$F" ] || continue
+            MT=$(stat -c %Y "$F" 2>/dev/null) || continue
+            [ "$MT" -ge "$BOOT_EPOCH" ] || continue
+            log "    rm $F  (mtime=$MT, +$((MT-BOOT_EPOCH))s into boot)"
+            rm -f "$F"
+            if [ -f "$F" ]; then
+                log "    FAILED -- still present after rm: $F"
+            else
+                log "    removed -- gone after rm: $F"
+                N=$((N+1))
+            fi
+        done
+        rmdir "$D" 2>/dev/null && log "    rmdir emptied dir $D"
+    done
+    log "  clean: deleted $N of $CAND candidate stub(s) (boot_epoch $BOOT_EPOCH)"
+}
+
+home_macs() {
+    if [ -r "$HOME_MACS_FILE" ]; then
+        sed 's/#.*//; s/[[:space:]]//g' "$HOME_MACS_FILE" | grep -v '^$'
+    else
+        echo "$HOME_MACS_DEFAULT" | tr ' ' '\n'
+    fi
+}
+
+is_home_mac() {
+    local M CANDIDATE
+    CANDIDATE=$(echo "$1" | tr 'A-Z' 'a-z')
+    for M in $(home_macs | tr 'A-Z' 'a-z'); do
+        [ "$M" = "$CANDIDATE" ] && return 0
+    done
+    return 1
+}
+
+# Segment length in seconds, re-read every cycle so it can be retuned with a
+# file drop and no reboot. 0 disables rollover entirely. Anything unparseable,
+# negative, or below ROLLOVER_MIN falls back to the built-in default.
+rollover_secs() {
+    local V
+    V=$(sed 's/#.*//; s/[[:space:]]//g' "$ROLLOVER_FILE" 2>/dev/null | grep -v '^$' | head -1)
+    [ -z "$V" ] && { echo "$ROLLOVER_SECS_DEFAULT"; return; }
+    case "$V" in
+        ''|*[!0-9]*) echo "$ROLLOVER_SECS_DEFAULT"; return ;;
+    esac
+    [ "$V" = 0 ] && { echo 0; return; }
+    if [ "$V" -lt "$ROLLOVER_MIN" ]; then echo "$ROLLOVER_SECS_DEFAULT"; return; fi
+    echo "$V"
+}
+
+get_gateway_ip() {
+    local HEX
+    HEX=$(awk '$2 == "00000000" { print $3; exit }' /proc/net/route)
+    [ -z "$HEX" ] && return 1
+    printf '%d.%d.%d.%d\n' 0x${HEX:6:2} 0x${HEX:4:2} 0x${HEX:2:2} 0x${HEX:0:2}
+}
+
+resolve_arp_mac() {
+    local IP=$1 MAC
+    MAC=$(awk -v ip="$IP" '$1 == ip { print $4; exit }' /proc/net/arp 2>/dev/null)
+    if [ -z "$MAC" ] || [ "$MAC" = "00:00:00:00:00:00" ]; then
+        ping -c 1 -W 1 "$IP" >/dev/null 2>&1
+        MAC=$(awk -v ip="$IP" '$1 == ip { print $4; exit }' /proc/net/arp 2>/dev/null)
+    fi
+    [ -z "$MAC" ] || [ "$MAC" = "00:00:00:00:00:00" ] && return 1
+    echo "$MAC"
+}
+
+api_login() {
+    local BODY="[{\"cmd\":\"Login\",\"action\":0,\"param\":{\"User\":{\"userName\":\"$USER\",\"password\":\"$PASS\"}}}]"
+    local URL="http://127.0.0.1/api.cgi?cmd=Login&token=null"
+    local TMP=/tmp/netstate_resp.$$ TMPE=/tmp/netstate_err.$$
+    wget -q -O "$TMP" --header='Content-Type: application/json' --post-data="$BODY" "$URL" 2>"$TMPE"
+    local TOK=$(sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$TMP" 2>/dev/null | head -1)
+    if [ -z "$TOK" ]; then
+        wget -q -O "$TMP" --post-data="$BODY" "$URL" 2>"$TMPE"
+        TOK=$(sed -n 's/.*"name":"\([^"]*\)".*/\1/p' "$TMP" 2>/dev/null | head -1)
+    fi
+    rm -f "$TMP" "$TMPE"
+    [ -n "$TOK" ] && echo "$TOK"
+}
+
+# Release an API session. The camera caps concurrent sessions at 5 and a lease
+# lasts an hour, so a token that is not returned is a slot burned until it
+# expires. Called unconditionally after every SetRecV20, success or failure --
+# a failed set still consumed the login.
+api_logout() {
+    [ -n "$1" ] || return 0
+    wget -q -O /dev/null --header='Content-Type: application/json' \
+        --post-data='[{"cmd":"Logout","action":0,"param":{}}]' \
+        "http://127.0.0.1/api.cgi?cmd=Logout&token=$1" 2>/dev/null
+}
+
+set_record_state() {
+    local TOK BODY RESP ENABLE RC
+    TOK=$(api_login)
+    if [ -z "$TOK" ]; then log "  api_login failed"; return 1; fi
+    if [ "$1" = "on" ]; then ENABLE=1; else ENABLE=0; fi
+    BODY="[{\"cmd\":\"SetRecV20\",\"action\":0,\"param\":{\"Rec\":{\"enable\":$ENABLE,\"overwrite\":1,\"postRec\":\"15 Seconds\",\"preRec\":1,\"saveDay\":7,\"schedule\":{\"channel\":0,\"table\":{\"TIMING\":\"$ALL_ON\"}}}}}]"
+    RESP=$(wget -q -O- --header='Content-Type: application/json' --post-data="$BODY" \
+        "http://127.0.0.1/api.cgi?cmd=SetRecV20&token=$TOK" 2>/dev/null)
+    case "$RESP" in
+        *'"rspCode"'*200*) RC=0 ;;
+        *) log "  set_record_state rsp: $RESP"; RC=1 ;;
+    esac
+    api_logout "$TOK"
+    return $RC
+}
+
+# Close the current recording and immediately open a new one, so an abrupt power
+# cut costs at most one interval. `sync` sits between the two so the just-closed
+# file's data AND its FAT directory entry are on the card before we start
+# writing again -- the failure being defended against is metadata that never
+# reached the card, not a torn frame.
+do_rollover() {
+    # The away-state guard lives here, not only at the call site. Recording is
+    # enabled only while away; a rollover in any other state would end with
+    # set_record_state on and leave the camera recording at home -- the exact
+    # 2026-08-16 failure, reached by a new road. The call site checks too.
+    [ "$LAST_STATE" = "away" ] || { log "  roll: refusing, state is '$LAST_STATE' not away"; return 1; }
+    if ! set_record_state off; then
+        log "  roll: OFF failed -- segment left open, still recording (safe), retry next cycle"
+        return 1
+    fi
+    sync
+    local i=0
+    while [ $i -lt 5 ]; do
+        if set_record_state on; then
+            [ $i -gt 0 ] && log "  roll: ON recovered after $i retr(y/ies)"
+            return 0
+        fi
+        i=$((i+1))
+        log "  roll: ON attempt $i failed -- retrying"
+        sleep 2
+    done
+    # Recording is OFF and we could not turn it back on. This is the one
+    # genuinely dangerous outcome, so say so loudly and let the caller force a
+    # full state re-assert on the next poll rather than latching away.
+    log "  roll: ON FAILED 5x -- CAMERA IS NOT RECORDING, forcing state re-assert"
+    return 1
+}
+
+wait_for_api() {
+    local i=0
+    while [ $i -lt 60 ]; do
+        if wget -q -O- --timeout=2 "http://127.0.0.1/api.cgi?cmd=GetTime&token=null" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 2; i=$((i+1))
+    done
+    return 1
+}
+
+# One home/away decision. Sets LAST_STATE, which is the single source of truth
+# for whether recording is currently meant to be on -- and therefore for whether
+# do_rollover may run.
+check_state() {
+    if [ -f "$OVERRIDE_FILE" ]; then
+        [ "$LAST_STATE" != "override" ] && { log "override present -- daemon yields"; LAST_STATE="override"; }
+        return
+    fi
+    local GW MAC NEW_STATE
+    GW=$(get_gateway_ip)
+    if [ -z "$GW" ]; then NEW_STATE="away"; MAC=""; else
+        MAC=$(resolve_arp_mac "$GW")
+        if [ -z "$MAC" ]; then NEW_STATE="away"
+        elif is_home_mac "$MAC"; then NEW_STATE="home"
+        else NEW_STATE="away"; fi
+    fi
+    # FAIL-ENABLED: only ever DISABLE on a confirmed home MAC, and latch
+    # LAST_STATE only once the camera CONFIRMS the change. A failed
+    # SetRecV20 is retried on the next poll instead of being latched, so a
+    # powered-on field camera can never silently sit not-recording because
+    # of one API hiccup.
+    case "$NEW_STATE" in
+        home)
+            if [ "$LAST_STATE" != "home" ]; then
+                if set_record_state off; then
+                    log "state -> home: recording DISABLED  (gw=${GW:-none} mac=${MAC:-none})"
+                    LAST_STATE="home"
+                else
+                    log "home detected, disable failed; still recording (safe) -- retry next poll"
+                fi
+            fi
+            clean_home_stubs   # also catch stragglers while we remain home
+            ;;
+        *)  # away / no-network / ambiguous -> ensure recording is ON
+            if [ "$LAST_STATE" != "away" ]; then
+                if set_record_state on; then
+                    log "state -> away: recording ENABLED (TIMING all-on)  (gw=${GW:-none} mac=${MAC:-none})"
+                    LAST_STATE="away"
+                else
+                    log "away, enable FAILED -- retry next poll (must not sit idle at a game)"
+                fi
+            fi
+            ;;
+    esac
+}
+
+main_loop() {
+    log "===== netstate daemon (v3 +stub-clean +rollover) starting ====="
+    log "  HOME_MACS_DEFAULT=$HOME_MACS_DEFAULT boot_epoch=$BOOT_EPOCH rollover_default=${ROLLOVER_SECS_DEFAULT}s"
+    sleep $INIT_GRACE
+    wait_for_api && log "  api ready" || log "  api wait timed out, proceeding anyway"
+
+    # Surface the build manifest now that the API/SD card are up. The early
+    # top-level copy can run before /mnt/sda is writable, so do it here too --
+    # this is the point we know writes succeed (the log above just wrote).
+    if [ -f /etc/soccercam_build ]; then
+        mkdir -p /mnt/sda/soccercam 2>/dev/null
+        cp -f /etc/soccercam_build /mnt/sda/soccercam/build.txt 2>/dev/null
+        log "  build manifest -> /mnt/sda/soccercam/build.txt"
+    fi
+
+    local LAST_STATE="" NOW SLEEP R ROLLS=0
+    local NEXT_POLL=0 LAST_ROLL NEXT_ROLL
+    LAST_ROLL=$(date +%s)
+    while true; do
+        NOW=$(date +%s)
+        if [ "$NOW" -ge "$NEXT_POLL" ]; then
+            check_state
+            NEXT_POLL=$(( $(date +%s) + POLL_INTERVAL ))
+        fi
+
+        R=$(rollover_secs)
+        NOW=$(date +%s)
+        if [ "$LAST_STATE" = "away" ] && [ "$R" -gt 0 ]; then
+            if [ $((NOW - LAST_ROLL)) -ge "$R" ]; then
+                if do_rollover; then
+                    ROLLS=$((ROLLS+1))
+                    log "  roll #$ROLLS: segment closed and reopened (every ${R}s)"
+                else
+                    # Re-assert home/away immediately; the away branch re-issues
+                    # the enable that do_rollover could not.
+                    NEXT_POLL=0
+                fi
+                LAST_ROLL=$(date +%s)
+            fi
+            NEXT_ROLL=$((LAST_ROLL + R))
+        else
+            # Not recording: keep the rollover clock fresh so that entering away
+            # starts a full interval rather than firing immediately.
+            LAST_ROLL=$NOW
+            NEXT_ROLL=$((NOW + 3600))
+        fi
+
+        NOW=$(date +%s)
+        SLEEP=$((NEXT_POLL - NOW))
+        [ $((NEXT_ROLL - NOW)) -lt "$SLEEP" ] && SLEEP=$((NEXT_ROLL - NOW))
+        [ "$SLEEP" -lt 1 ] && SLEEP=1
+        sleep "$SLEEP"
+    done
+}
+
+( main_loop ) &
+disown 2>/dev/null
+exit 0


### PR DESCRIPTION
The camera writes one MP4 per recording session and only finalises it — `moov`
atom, rename to the full `start_end_hash` form — when recording **stops**. Cut
power mid-session and the whole thing is gone.

That is not hypothetical. Two field sessions on 2026-08-22:

- **Session 1 survived** because the camera came home and `S99_NetState` set
  recording off, which closed the file. It went from
  `RecM09_..._091029_000000_..._0.mp4` (end-time `000000`, unfinalised) to a
  complete 314 MB file.
- **Session 2 was lost.** Same treatment, nothing closed it. The main stream is
  **entirely absent** from the card — `df` accounts for the other three files
  exactly; the ~435 MB was never written. Only the 22.5 MB sub-stream survived,
  and 1536x432 is useless for calibration.

So: force a segment rollover on a timer while recording. Each cycle closes a
complete, playable file and opens the next. Loss is bounded to one interval.

### A rollover costs no frames — measured before designing around it

Over 10 consecutive rollovers, segment start times (independent camera-clock
stamps) advanced **208 s** while **212.98 s** of content was written. The
pre-record buffer backfills the toggle, so consecutive segments **overlap
~0.50 s (~10 frames @ 20 fps)** rather than dropping any. Toggle time
end-to-end: **0.62 s**, no settle delay required.

That inverts the trade-off. The cost is *duplicated* frames, which are
trimmable downstream, not missing ones — so a tight loss bound is nearly free.
Interval **60 s**, configurable at `/mnt/sda/netstate/rollover_secs`
(0 disables, 15 s floor).

**Honest cost for match footage:** ~90 half-second hitches over 90 minutes at
60 s, versus ~18 at 300 s. All the frames are present, so it is duplication
rather than loss, but raise it to 300 for matches if the hitch reads badly.

**Not verified:** the overlap was measured on a static indoor scene (~1.2 Mbps
against the 20480 cap). If the pre-record ring is size-bounded it may cover less
at true field bitrate, degrading toward a gap of at most the 0.62 s toggle.
Bounded either way, but that part is inference.

### The bug that would have made this a silent no-op

Found by measurement, not review: **the camera caps concurrent API sessions at
5** (`"max session"`, rspCode −5, 3600 s lease). The previous
`set_record_state` logged in per call and never logged out — harmless at one
call per home/away transition, **fatal at one rollover a minute**: the pool
empties, `SetRecV20` starts failing `"please login first"`, and recording stops
dead at a game. It now always releases its token, and the builder gates on it.

Independently corroborated: the same limit blocked an unrelated snapshot
experiment on the coordinator side an hour earlier.

### Demonstrated vs argued

**Demonstrated:** 11 rollovers at 60–61 s; every segment 7680x2160 HEVC decoding
with zero errors. **Two hard resets via `sysrq-b` mid-segment** (30 s and 52 s
in): all completed segments survived **byte-identical, md5-verified**, losing
only the **~7–8 s tail** of the in-flight segment — not the 60 s worst case, and
not the session. `recover_mp4` had nothing to do; the camera finalised the
partial itself.

**Argued, not demonstrated:** `sysrq-b` is not a true power cut. It resets the
SoC with no sync and no unmount, so unflushed FAT entries and an unfinalised
`moov` die exactly as on a yank, but the SD card keeps power and completes its
in-flight block write. Media-level sector tearing is untested — PoE cannot be
pulled remotely.

Before cutting power it verified the irreplaceable field footage was genuinely
backed up **by checksum, not by the claimed filename**; both md5s matched, and
still matched after the two resets.

### Build 4921, flashed

`IPC_…4921…_stitchcal.pak`, CRC `0x317cfb07`. Boot chain asserted byte-identical
inside `repack()`; `check_recording_default.sh` passed. Nothing regressed:
`lut2d_ioctl`, `recover_mp4` (Helix/AAC linked), S35/S36/S98, 20480 kbps, 20 GiB
reserve, `isfpull2` + `pemdump` still staged.

### Two judgement calls

- **Away was simulated** with a bogus MAC in `home_macs.txt`, never the
  override. The daemon still resolved the real gateway MAC and chose away on its
  own logic, so the home guard ran fully.
- **`camsh` refused to push the firmware script** because a *comment* contained
  the word "reboot". That is the guard working — it cannot tell code from data —
  so the fix was a destination-gated `put_file()`, not rewording the firmware to
  slip past it. Working around a safety check by disguising the input is how
  guards rot. Selftest 15/15 -> **21/21**.

### Verified end state

Build 4921 · API `Rec.enable = 0` at home · no override, no `home_macs.txt` ·
mesh `7ac18ef2988970d09fc4f5a36c6cd311` = factory · S35/S36/S98/S99 present,
tcp/2323 listening · field recordings md5-intact. All re-measured by the
coordinator, not taken on report.

Gates: ruff check + format clean, **2029 passed** / 13 skipped / 1 xfailed.

**Loose end:** ~180 MB of test clips remain in `Mp4Record/2026-08-22/` (the
10:52–11:08 files). The daemon's cleaner only removes files newer than the
current boot, and `camsh` refuses any `rm` naming `Mp4Record` — correctly. Not
worked around for 180 MB of 238 GB.