### PR TITLE
One completion watermark decides what to download; archiving becomes a pipeline step

### DIFF
--- a/tests/test_archive_processor.py
+++ b/tests/test_archive_processor.py
@@ -478,3 +478,78 @@ class TestPerTeamArchiveRoots:
             await processor.process_item(ArchiveTask(group_dir=group_dir))
 
         assert os.path.exists(os.path.join(group_dir, "game.mp4"))
+
+
+class TestRootLookupMatchesRealTeamNames:
+    """The archive root is chosen from a game's my_team_name.
+
+    That value is the full registered name — on the live install
+    "BU14 - Guzzetta", not "Guzzetta" — while an operator writes the short
+    handle they think of the team by. An exact match misses, and archiving
+    refuses every game with "no archive root for team". Substring matching is
+    the same rule [YOUTUBE.PLAYLIST_MAP] has always used.
+    """
+
+    def test_the_real_my_team_name_resolves_from_a_short_key(self):
+        cfg = ArchiveConfig(after_upload="move", PER_TEAM={"guzzetta": HEAT_2012})
+
+        assert cfg.root_for_team("BU14 - Guzzetta") == HEAT_2012
+
+    def test_both_live_teams_resolve(self):
+        cfg = ArchiveConfig(
+            after_upload="move",
+            PER_TEAM={"guzzetta": HEAT_2012, "flash": FLASH_2013},
+        )
+
+        assert cfg.root_for_team("BU14 - Guzzetta") == HEAT_2012
+        assert (
+            cfg.root_for_team("Western New York Flash - 13B ECNL-RL Rochester")
+            == FLASH_2013
+        )
+
+    def test_longest_key_wins_so_age_groups_are_not_mixed(self):
+        """Filing a game under another team's root then deleting the original
+        is not something a later pass can undo."""
+        cfg = ArchiveConfig(
+            after_upload="move",
+            PER_TEAM={"flash": FLASH_2013, "wny flash rochester": HEAT_2013},
+        )
+
+        assert cfg.root_for_team("WNY Flash Rochester ECNL") == HEAT_2013
+
+    def test_an_unmapped_team_still_has_nowhere_to_go(self):
+        """The refusal must survive: a near-miss must not fall back silently."""
+        cfg = ArchiveConfig(after_upload="move", PER_TEAM={"guzzetta": HEAT_2012})
+
+        assert cfg.root_for_team("Some Other Club") == ""
+
+    def test_path_is_still_the_fallback_when_configured(self):
+        cfg = ArchiveConfig(
+            after_upload="move", path=FALLBACK, PER_TEAM={"guzzetta": HEAT_2012}
+        )
+
+        assert cfg.root_for_team("Some Other Club") == FALLBACK
+
+    @pytest.mark.asyncio
+    async def test_a_real_game_archives_instead_of_being_refused(
+        self, temp_storage, archive_root, archive_config
+    ):
+        """End to end: the group's match_info says "Heat", the operator
+        configured "heat", and the archive must actually run."""
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+        archive_config.archive.after_upload = "move"
+        archive_config.archive.path = ""
+        archive_config.archive.per_team = {"heat": archive_root}
+
+        processor = ArchiveProcessor(temp_storage, archive_config)
+        Path(get_camera_state_path(temp_storage)).write_text(
+            json.dumps({"cam": {"latest_video_time": "2026-07-12 10:35:15"}}),
+            encoding="utf-8",
+        )
+
+        await processor.process_item(ArchiveTask(group_dir=group_dir))
+
+        assert not os.path.exists(group_dir)
+        assert os.path.exists(
+            os.path.join(archive_root, "2026.07.12 - vs Kenmore (away)", "game.mp4")
+        )

--- a/tests/test_archive_processor.py
+++ b/tests/test_archive_processor.py
@@ -186,14 +186,16 @@ class TestArchiveOrdering:
         assert os.path.getsize(archived) == 4096
 
     @pytest.mark.asyncio
-    async def test_delete_after_verify_off_keeps_the_local_copy(
+    async def test_copy_disposition_keeps_the_local_copy(
         self, temp_storage, archive_root
     ):
+        """`copy`: a second copy exists, the working drive is untouched."""
         group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
 
         ok = await ArchiveTask(group_dir=group_dir).execute(
             archive_root=archive_root,
-            delete_after_verify=False,
+            make_second_copy=True,
+            reclaim_local_space=False,
             watermark=datetime(2026, 7, 12, 10, 35, 15),
         )
 
@@ -279,7 +281,7 @@ class TestWatermarkGuard:
 class TestArchiveIsOptIn:
     @pytest.mark.asyncio
     async def test_disabled_by_default_does_nothing(self, temp_storage, archive_config):
-        assert archive_config.archive.enabled is False
+        assert archive_config.archive.after_upload == "keep"
         processor = ArchiveProcessor(temp_storage, archive_config)
         task = Mock(spec=ArchiveTask)
         task.group_dir = os.path.join(temp_storage, "grp")
@@ -295,8 +297,101 @@ class TestArchiveIsOptIn:
         group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
 
         ok = await ArchiveTask(group_dir=group_dir).execute(
-            archive_root="", watermark=datetime(2026, 7, 12, 10, 35, 15)
+            archive_root="",
+            make_second_copy=True,
+            watermark=datetime(2026, 7, 12, 10, 35, 15),
         )
 
         assert ok is False
         assert os.path.exists(os.path.join(group_dir, "game.mp4"))
+
+
+class TestSingleDriveDiscard:
+    """`discard`: reclaim local space with no second location.
+
+    The case the earlier design ignored. An install with one drive has
+    nowhere to copy to, and is exactly the one that fills up — YouTube is
+    its archive.
+    """
+
+    @pytest.mark.asyncio
+    async def test_discard_reclaims_space_without_an_archive_path(self, temp_storage):
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+        dir_state = DirectoryState(group_dir)
+        dir_state.record_uploaded_video("processed", "8zQkiP3vHYk")
+
+        ok = await ArchiveTask(group_dir=group_dir).execute(
+            archive_root="",
+            make_second_copy=False,
+            reclaim_local_space=True,
+            watermark=datetime(2026, 7, 12, 10, 35, 15),
+        )
+
+        assert ok
+        assert not os.path.exists(group_dir)
+
+    @pytest.mark.asyncio
+    async def test_discard_refuses_without_a_recorded_youtube_id(self, temp_storage):
+        """These are the only files that exist. Reaching `complete` is not
+        proof YouTube has the game — a recorded video id is."""
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+
+        ok = await ArchiveTask(group_dir=group_dir).execute(
+            archive_root="",
+            make_second_copy=False,
+            reclaim_local_space=True,
+            watermark=datetime(2026, 7, 12, 10, 35, 15),
+        )
+
+        assert ok is False
+        assert os.path.exists(os.path.join(group_dir, "game.mp4"))
+
+    @pytest.mark.asyncio
+    async def test_discard_still_respects_the_watermark(self, temp_storage):
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+        dir_state = DirectoryState(group_dir)
+        dir_state.record_uploaded_video("processed", "8zQkiP3vHYk")
+
+        ok = await ArchiveTask(group_dir=group_dir).execute(
+            archive_root="",
+            make_second_copy=False,
+            reclaim_local_space=True,
+            watermark=datetime(2026, 7, 12, 9, 0, 0),
+        )
+
+        assert ok is False
+        assert os.path.exists(os.path.join(group_dir, "game.mp4"))
+
+
+class TestDispositionConfig:
+    def test_keep_is_the_default(self):
+        cfg = ArchiveConfig()
+        assert cfg.after_upload == "keep"
+        assert not cfg.makes_second_copy
+        assert not cfg.reclaims_local_space
+
+    @pytest.mark.parametrize(
+        "mode,second_copy,reclaims",
+        [
+            ("keep", False, False),
+            ("copy", True, False),
+            ("move", True, True),
+            ("discard", False, True),
+        ],
+    )
+    def test_disposition_matrix(self, mode, second_copy, reclaims):
+        cfg = ArchiveConfig(after_upload=mode, path="F:/archive")
+        assert cfg.makes_second_copy is second_copy
+        assert cfg.reclaims_local_space is reclaims
+
+    @pytest.mark.parametrize("mode", ["copy", "move"])
+    def test_second_copy_without_a_path_is_refused_at_config_load(self, mode):
+        """Hard-fail rather than degrade to a no-op: an operator who asked for
+        a second copy and silently got none finds out only once the working
+        drive is already gone."""
+        with pytest.raises(ValueError, match="needs a `path`"):
+            ArchiveConfig(after_upload=mode)
+
+    @pytest.mark.parametrize("mode", ["keep", "discard"])
+    def test_pathless_dispositions_are_valid(self, mode):
+        assert ArchiveConfig(after_upload=mode).path == ""

--- a/tests/test_archive_processor.py
+++ b/tests/test_archive_processor.py
@@ -1,0 +1,302 @@
+"""Tests for the archive step.
+
+The ordering guarantee is the thing under test: copy -> verify -> record ->
+delete. An earlier ad-hoc version deleted first and recorded nothing, and an
+interrupted run left a group that the pipeline read as mid-processing and
+began reprocessing — a game already published on YouTube.
+"""
+
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from video_grouper.models import DirectoryState, RecordingFile
+from video_grouper.task_processors.archive_processor import ArchiveProcessor
+from video_grouper.task_processors.tasks.archive import ArchiveTask
+from video_grouper.utils.config import (
+    AppConfig,
+    ArchiveConfig,
+    AutocamConfig,
+    CameraConfig,
+    CloudSyncConfig,
+    Config,
+    LoggingConfig,
+    NtfyConfig,
+    PlayMetricsConfig,
+    ProcessingConfig,
+    RecordingConfig,
+    StorageConfig,
+    TeamSnapConfig,
+    YouTubeConfig,
+)
+from video_grouper.utils.paths import get_camera_state_path
+
+
+@pytest.fixture(autouse=True)
+def real_filesystem(mock_file_system):
+    """Undo conftest's global filesystem mocks for this module.
+
+    These tests copy, hash and delete actual bytes — the point is that the
+    ordering holds against a real disk. The autouse ``mock_file_system``
+    fixture makes ``os.path.exists`` always True, ``getsize`` always 1 MB and
+    ``makedirs`` a no-op, which would make every assertion here meaningless.
+    """
+    mock_file_system["exists"].side_effect = os.path.lexists
+    mock_file_system["getsize"].side_effect = lambda p: os.stat(p).st_size
+    mock_file_system["makedirs"].side_effect = lambda p, *a, **kw: Path(p).mkdir(
+        parents=True, exist_ok=True
+    )
+    mock_file_system["access"].side_effect = lambda *a, **kw: True
+    return mock_file_system
+
+
+@pytest.fixture
+def archive_root(tmp_path):
+    root = tmp_path / "archive"
+    root.mkdir()
+    return str(root)
+
+
+@pytest.fixture
+def archive_config(temp_storage):
+    """A real Config — conftest's mock_config is a ConfigParser stand-in."""
+    return Config(
+        cameras=[
+            CameraConfig(
+                name="default",
+                type="dahua",
+                device_ip="127.0.0.1",
+                username="admin",
+                password="password",
+            )
+        ],
+        storage=StorageConfig(path=temp_storage),
+        archive=ArchiveConfig(),
+        recording=RecordingConfig(),
+        processing=ProcessingConfig(),
+        logging=LoggingConfig(),
+        app=AppConfig(storage_path=temp_storage, check_interval_seconds=1),
+        teamsnap=TeamSnapConfig(enabled=False, team_id="1", my_team_name="Team A"),
+        teamsnap_teams=[],
+        playmetrics=PlayMetricsConfig(
+            enabled=False, username="u", password="p", team_name="Team A"
+        ),
+        playmetrics_teams=[],
+        ntfy=NtfyConfig(enabled=False, server_url="http://ntfy.sh", topic="test"),
+        youtube=YouTubeConfig(enabled=False),
+        autocam=AutocamConfig(enabled=False),
+        cloud_sync=CloudSyncConfig(enabled=False),
+    )
+
+
+async def _make_group(
+    storage, name, *, status="complete", newest=None, payload=b"x" * 4096
+):
+    """A completed group with one real video file on disk."""
+    group_dir = os.path.join(storage, name)
+    # Path.mkdir, not os.makedirs — conftest patches the latter to a no-op.
+    Path(group_dir).mkdir(parents=True, exist_ok=True)
+    video = os.path.join(group_dir, "game.mp4")
+    Path(video).write_bytes(payload)
+
+    newest = newest or datetime(2026, 7, 12, 10, 35, 15)
+    dir_state = DirectoryState(group_dir)
+    await dir_state.add_file(
+        video,
+        RecordingFile(
+            start_time=newest - timedelta(minutes=30),
+            end_time=newest,
+            file_path=video,
+            status="complete",
+        ),
+    )
+    await dir_state.update_group_status(status)
+
+    match_info = os.path.join(group_dir, "match_info.ini")
+    Path(match_info).write_text(
+        "[MATCH]\nmy_team_name = Heat\nopponent_team_name = Kenmore\nlocation = Away\n",
+        encoding="utf-8",
+    )
+    return group_dir
+
+
+class TestArchiveOrdering:
+    @pytest.mark.asyncio
+    async def test_group_is_recorded_archived_before_anything_is_deleted(
+        self, temp_storage, archive_root
+    ):
+        """The interruption that nearly re-published a game.
+
+        If the process dies mid-delete, whatever survives must still read as
+        finished. That only holds if the terminal status is written first.
+        """
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+        task = ArchiveTask(group_dir=group_dir)
+
+        recorded_when_first_delete_happened = {}
+        real_remove = os.remove
+
+        def spy_remove(path, *a, **kw):
+            # Ignore FileLock's own .lock cleanup — that is bookkeeping, not
+            # a deletion of the game's content.
+            if not str(path).endswith(".lock") and (
+                "status" not in recorded_when_first_delete_happened
+            ):
+                state_file = os.path.join(group_dir, "state.json")
+                with open(state_file) as fh:
+                    recorded_when_first_delete_happened["status"] = json.load(fh).get(
+                        "status"
+                    )
+            return real_remove(path, *a, **kw)
+
+        os.remove = spy_remove
+        try:
+            ok = await task.execute(
+                archive_root=archive_root,
+                watermark=datetime(2026, 7, 12, 10, 35, 15),
+            )
+        finally:
+            os.remove = real_remove
+
+        assert ok
+        assert recorded_when_first_delete_happened["status"] == "archived", (
+            "status must already be 'archived' before the first file is removed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_verified_copy_lands_and_local_space_is_reclaimed(
+        self, temp_storage, archive_root
+    ):
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+
+        ok = await ArchiveTask(group_dir=group_dir).execute(
+            archive_root=archive_root, watermark=datetime(2026, 7, 12, 10, 35, 15)
+        )
+
+        assert ok
+        assert not os.path.exists(group_dir)
+        archived = os.path.join(
+            archive_root, "Heat", "2026.07.12 - vs Kenmore (away)", "game.mp4"
+        )
+        assert os.path.exists(archived)
+        assert os.path.getsize(archived) == 4096
+
+    @pytest.mark.asyncio
+    async def test_delete_after_verify_off_keeps_the_local_copy(
+        self, temp_storage, archive_root
+    ):
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+
+        ok = await ArchiveTask(group_dir=group_dir).execute(
+            archive_root=archive_root,
+            delete_after_verify=False,
+            watermark=datetime(2026, 7, 12, 10, 35, 15),
+        )
+
+        assert ok
+        assert os.path.exists(os.path.join(group_dir, "game.mp4"))
+        assert DirectoryState(group_dir).status == "archived"
+
+    @pytest.mark.asyncio
+    async def test_rerunning_an_archived_group_is_a_no_op(
+        self, temp_storage, archive_root
+    ):
+        group_dir = await _make_group(
+            temp_storage, "2026.07.12-10.00.00", status="archived"
+        )
+
+        ok = await ArchiveTask(group_dir=group_dir).execute(
+            archive_root=archive_root, watermark=datetime(2026, 7, 12, 10, 35, 15)
+        )
+
+        assert ok
+        assert os.path.exists(os.path.join(group_dir, "game.mp4")), (
+            "an already-archived group must not be touched again"
+        )
+
+
+class TestWatermarkGuard:
+    @pytest.mark.asyncio
+    async def test_refuses_to_archive_ahead_of_the_watermark(
+        self, temp_storage, archive_root
+    ):
+        """Archiving a game the poller has not finished with would let it be
+        rediscovered as new and downloaded again — the whole bug."""
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+
+        ok = await ArchiveTask(group_dir=group_dir).execute(
+            archive_root=archive_root,
+            # Watermark is BEHIND the group's newest recording.
+            watermark=datetime(2026, 7, 12, 9, 0, 0),
+        )
+
+        assert ok is False
+        assert os.path.exists(os.path.join(group_dir, "game.mp4"))
+        assert DirectoryState(group_dir).status == "complete", (
+            "a refused archive must not mark the group archived"
+        )
+
+    @pytest.mark.asyncio
+    async def test_refuses_when_there_is_no_watermark_at_all(
+        self, temp_storage, archive_root
+    ):
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+
+        ok = await ArchiveTask(group_dir=group_dir).execute(
+            archive_root=archive_root, watermark=None
+        )
+
+        assert ok is False
+        assert os.path.exists(os.path.join(group_dir, "game.mp4"))
+
+    @pytest.mark.asyncio
+    async def test_processor_takes_the_slowest_camera_watermark(
+        self, temp_storage, archive_config
+    ):
+        """With several cameras, only the slowest one's mark is safe: a fast
+        camera must not license deleting footage another is still behind on."""
+        state_path = get_camera_state_path(temp_storage)
+        Path(state_path).write_text(
+            json.dumps(
+                {
+                    "is_connected": False,  # legacy top-level key, must be skipped
+                    "fast_cam": {"latest_video_time": "2026-07-12 10:35:15"},
+                    "slow_cam": {"latest_video_time": "2026-07-01 08:00:00"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        processor = ArchiveProcessor(temp_storage, archive_config)
+
+        assert processor._read_watermark() == datetime(2026, 7, 1, 8, 0, 0)
+
+
+class TestArchiveIsOptIn:
+    @pytest.mark.asyncio
+    async def test_disabled_by_default_does_nothing(self, temp_storage, archive_config):
+        assert archive_config.archive.enabled is False
+        processor = ArchiveProcessor(temp_storage, archive_config)
+        task = Mock(spec=ArchiveTask)
+        task.group_dir = os.path.join(temp_storage, "grp")
+        task.execute = AsyncMock()
+
+        await processor.process_item(task)
+        task.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_archive_path_refuses_rather_than_guessing(
+        self, temp_storage
+    ):
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+
+        ok = await ArchiveTask(group_dir=group_dir).execute(
+            archive_root="", watermark=datetime(2026, 7, 12, 10, 35, 15)
+        )
+
+        assert ok is False
+        assert os.path.exists(os.path.join(group_dir, "game.mp4"))

--- a/tests/test_archive_processor.py
+++ b/tests/test_archive_processor.py
@@ -35,6 +35,14 @@ from video_grouper.utils.config import (
 )
 from video_grouper.utils.paths import get_camera_state_path
 
+# The live archive roots, as they exist on the server (verified 2026-08-07).
+# Raw strings: these are literal Windows paths, and "F:\Heat_2012s" would be
+# read as an escape sequence.
+HEAT_2012 = r"F:\Heat_2012s"
+HEAT_2013 = r"F:\Heat_2013s"
+FLASH_2013 = r"F:\Flash_2013s"
+FALLBACK = r"F:\archive"
+
 
 @pytest.fixture(autouse=True)
 def real_filesystem(mock_file_system):
@@ -180,7 +188,7 @@ class TestArchiveOrdering:
         assert ok
         assert not os.path.exists(group_dir)
         archived = os.path.join(
-            archive_root, "Heat", "2026.07.12 - vs Kenmore (away)", "game.mp4"
+            archive_root, "2026.07.12 - vs Kenmore (away)", "game.mp4"
         )
         assert os.path.exists(archived)
         assert os.path.getsize(archived) == 4096
@@ -380,7 +388,7 @@ class TestDispositionConfig:
         ],
     )
     def test_disposition_matrix(self, mode, second_copy, reclaims):
-        cfg = ArchiveConfig(after_upload=mode, path="F:/archive")
+        cfg = ArchiveConfig(after_upload=mode, path="F:/archive")  # noqa: E501
         assert cfg.makes_second_copy is second_copy
         assert cfg.reclaims_local_space is reclaims
 
@@ -389,9 +397,84 @@ class TestDispositionConfig:
         """Hard-fail rather than degrade to a no-op: an operator who asked for
         a second copy and silently got none finds out only once the working
         drive is already gone."""
-        with pytest.raises(ValueError, match="needs a `path`"):
+        with pytest.raises(ValueError, match="needs somewhere to put games"):
             ArchiveConfig(after_upload=mode)
+
+    @pytest.mark.parametrize("mode", ["copy", "move"])
+    def test_per_team_map_alone_satisfies_the_requirement(self, mode):
+        """A per-team map is somewhere to put games; no `path` needed."""
+        cfg = ArchiveConfig(after_upload=mode, PER_TEAM={"Guzzetta": HEAT_2012})
+        assert cfg.root_for_team("Guzzetta") == HEAT_2012
 
     @pytest.mark.parametrize("mode", ["keep", "discard"])
     def test_pathless_dispositions_are_valid(self, mode):
         assert ArchiveConfig(after_upload=mode).path == ""
+
+
+class TestPerTeamArchiveRoots:
+    """Archives are per-team, and the root is not derivable from the name.
+
+    Verified against the live layout on 2026-08-07: Heat_2012s, Heat_2013s
+    and Flash_2013s under F:, holding folders named
+    "2026.07.12 - vs Niagara Falls Soccer Club (away)". The team recorded in
+    match_info is "Guzzetta" while its root is Heat_2012s, and the two Heat
+    age groups must never be mixed — so the mapping is configured, not
+    inferred.
+    """
+
+    def test_team_maps_to_its_own_root(self):
+        cfg = ArchiveConfig(
+            after_upload="move",
+            PER_TEAM={
+                "Guzzetta": HEAT_2012,
+                "Heat 2013": HEAT_2013,
+                "Flash": FLASH_2013,
+            },
+        )
+        assert cfg.root_for_team("Guzzetta") == HEAT_2012
+        assert cfg.root_for_team("Heat 2013") == HEAT_2013
+        assert cfg.root_for_team("Flash") == FLASH_2013
+
+    def test_lookup_survives_configparser_lowercasing_and_stray_whitespace(self):
+        """configparser lowercases option keys, and match_info is hand-edited."""
+        cfg = ArchiveConfig(after_upload="move", PER_TEAM={"guzzetta": HEAT_2012})
+        assert cfg.root_for_team("  Guzzetta  ") == HEAT_2012
+
+    def test_unmapped_team_falls_back_to_path(self):
+        cfg = ArchiveConfig(
+            after_upload="move", path=FALLBACK, PER_TEAM={"Flash": FLASH_2013}
+        )
+        assert cfg.root_for_team("Someone Else") == FALLBACK
+
+    def test_unmapped_team_with_no_fallback_has_nowhere_to_go(self):
+        cfg = ArchiveConfig(after_upload="move", PER_TEAM={"Flash": FLASH_2013})
+        assert cfg.root_for_team("Guzzetta") == ""
+
+    @pytest.mark.asyncio
+    async def test_game_lands_directly_in_its_team_root(
+        self, temp_storage, archive_root
+    ):
+        """Matches the existing layout: <root>/<date> - vs <opponent> (away),
+        with NO team component appended — the root is already team-specific."""
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+
+        assert ArchiveTask(group_dir=group_dir).destination(
+            archive_root
+        ) == os.path.join(archive_root, "2026.07.12 - vs Kenmore (away)")
+
+    @pytest.mark.asyncio
+    async def test_processor_refuses_a_team_with_no_root(
+        self, temp_storage, archive_config
+    ):
+        """Filing a game under another team's root is not something a later
+        pass can untangle, so refuse instead of guessing."""
+        group_dir = await _make_group(temp_storage, "2026.07.12-10.00.00")
+        archive_config.archive.after_upload = "move"
+        archive_config.archive.path = ""
+        archive_config.archive.per_team = {"Flash": FLASH_2013}
+
+        processor = ArchiveProcessor(temp_storage, archive_config)
+        with pytest.raises(RuntimeError, match="no archive root for team 'Heat'"):
+            await processor.process_item(ArchiveTask(group_dir=group_dir))
+
+        assert os.path.exists(os.path.join(group_dir, "game.mp4"))

--- a/tests/test_camera_poller.py
+++ b/tests/test_camera_poller.py
@@ -1613,3 +1613,39 @@ class TestCompletionWatermark:
 
         await poller._advance_completion_watermark()
         assert await poller._get_latest_processed_time() == base + timedelta(hours=2)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_ignores_files_behind_the_watermark(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """Narrowing reconcile's query range is not a filter.
+
+        Cameras return recordings that merely *overlap* the requested window,
+        so a game ending just before the watermark still comes back. If the
+        pass does not re-check per file it falls through to
+        _file_needs_download, which asks whether the .mp4 is on disk — and an
+        archived game's deliberately is not. Found by replaying the live
+        server's state (watermark 2026-07-12, all July groups archived off
+        local disk): reconcile re-queued all five published games.
+        """
+        poller = CameraPoller(
+            temp_storage, mock_config, mock_camera, _idle_download_processor()
+        )
+        await poller._update_latest_processed_time(datetime(2026, 7, 12, 10, 35, 15))
+
+        # Camera still holds an archived game, and returns it despite the
+        # narrowed range — exactly what a real Reolink/Dahua search does.
+        mock_camera.get_file_list = AsyncMock(
+            return_value=[
+                {
+                    "path": "/archived.dav",
+                    "startTime": "2026-07-12 10:30:00",
+                    "endTime": "2026-07-12 10:35:15",
+                    "size": 5_000_000,
+                }
+            ]
+        )
+
+        await poller._reconcile_files_from_camera()
+
+        poller.download_processor.add_work.assert_not_called()

--- a/tests/test_camera_poller.py
+++ b/tests/test_camera_poller.py
@@ -347,10 +347,11 @@ class TestCameraPoller:
         self, temp_storage, mock_config, mock_camera, caplog
     ):
         """When the camera returns only runts (isolated short recordings),
-        no file advances the HWM. The poll-summary log must report
-        all-files-filtered AND a warning must fire so future stalls are
-        debuggable. Regression guard for the 2026-05-30 tournament
-        incident where the HWM stuck at a runt's end_time."""
+        nothing is queued, so nothing can settle and the watermark cannot
+        advance. The poll-summary log must report all-files-filtered AND a
+        warning must fire so future stalls are debuggable. Regression guard
+        for the 2026-05-30 tournament incident where the mark stuck at a
+        runt's end_time."""
         mock_camera.get_file_list.return_value = [
             {
                 "path": "/runt1.dav",
@@ -376,18 +377,25 @@ class TestCameraPoller:
             and "new=0" in r.message
             for r in caplog.records
         ), f"missing or wrong poll summary, got: {[r.message for r in caplog.records]}"
-        # Warning must fire to flag the HWM-stall risk.
+        # Warning must fire to flag the watermark-stall risk.
         assert any(
-            "HWM not advanced" in r.message and r.levelname == "WARNING"
+            "none actionable" in r.message and r.levelname == "WARNING"
             for r in caplog.records
-        ), "expected HWM-not-advanced warning for all-runts case"
+        ), "expected none-actionable warning for all-runts case"
 
     @pytest.mark.asyncio
     async def test_poll_summary_logs_normal_new_file(
         self, temp_storage, mock_config, mock_camera, caplog
     ):
-        """A normal poll with one new file must emit a summary showing
-        new=1 and an HWM-advanced INFO line citing the file."""
+        """A normal poll with one new file emits a summary showing new=1, and
+        must NOT advance the watermark.
+
+        This test previously asserted the opposite — that queueing a file
+        advanced the mark. That was the 2026-06-15 bug written down as an
+        expectation: the mark moved the instant a file was queued, before a
+        byte was downloaded, so a download that never completed was never
+        queried again. A merely-queued file is not settled.
+        """
         mock_camera.get_file_list.return_value = [
             {
                 "path": "/normal.dav",
@@ -410,10 +418,12 @@ class TestCameraPoller:
             "poll summary -- 1 files seen" in r.message and "new=1" in r.message
             for r in caplog.records
         )
-        assert any(
-            "HWM advanced to" in r.message and "normal.dav" in r.message
-            for r in caplog.records
-        ), "expected HWM-advanced INFO line citing the new file"
+        assert not any("Watermark advanced to" in r.message for r in caplog.records), (
+            "a queued-but-not-downloaded file must not advance the watermark"
+        )
+        assert await poller._get_latest_processed_time() is None, (
+            "watermark must stay unset until the download actually settles"
+        )
 
     def test_find_group_directory_new_group(self, temp_storage):
         """Test finding group directory when creating a new group."""
@@ -1432,3 +1442,174 @@ class TestAtomicStateWrites:
         assert state["reo"]["latest_video_time"] == "2026-06-15 10:00:00"
         assert state["reo"]["is_connected"] is True
         assert state["reo"]["connection_events"]
+
+
+class TestCompletionWatermark:
+    """The watermark is the single date that decides what to download.
+
+    It means "every recording at or before this is settled", so it may only
+    advance over a contiguous prefix of settled recordings, and it is
+    monotonic. Those two properties are what let the poller stop asking the
+    local disk whether it still holds the bytes — which is the question
+    archiving deliberately makes unanswerable.
+    """
+
+    async def _write_group(self, storage, name, files):
+        """Create a group dir with state.json holding (basename, end, status).
+
+        Uses Path.mkdir, not os.makedirs — conftest's autouse mock_file_system
+        patches os.makedirs to a no-op, so the directory would never appear and
+        DirectoryState's FileLock would fail to create its lock file.
+        """
+        group_dir = os.path.join(storage, name)
+        Path(group_dir).mkdir(parents=True, exist_ok=True)
+        dir_state = DirectoryState(group_dir)
+        for basename, end_time, status in files:
+            path = os.path.join(group_dir, basename)
+            await dir_state.add_file(
+                path,
+                RecordingFile(
+                    start_time=end_time - timedelta(minutes=30),
+                    end_time=end_time,
+                    file_path=path,
+                    status=status,
+                ),
+            )
+        return group_dir
+
+    @pytest.mark.asyncio
+    async def test_watermark_stops_at_first_unsettled_recording(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """Contiguous prefix only: a settled recording AFTER an unsettled one
+        must not drag the watermark past the gap, or the unfinished download
+        in between is never queried again."""
+        base = datetime(2026, 7, 1, 10, 0, 0)
+        await self._write_group(
+            temp_storage,
+            "2026.07.01-10.00.00",
+            [
+                ("a.dav", base, "complete"),
+                ("b.dav", base + timedelta(hours=1), "download_failed"),
+                ("c.dav", base + timedelta(hours=2), "complete"),
+            ],
+        )
+        poller = CameraPoller(
+            temp_storage, mock_config, mock_camera, _idle_download_processor()
+        )
+
+        await poller._advance_completion_watermark()
+
+        assert await poller._get_latest_processed_time() == base, (
+            "watermark must stop at the unsettled b.dav, not jump to c.dav"
+        )
+
+    @pytest.mark.asyncio
+    async def test_watermark_does_not_regress_when_games_are_archived(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """The bug that started this work.
+
+        Archiving deletes the whole group directory — videos AND the per-group
+        state.json that recorded "we handled this". If the watermark were
+        re-derived from what remains on local disk it would collapse to None,
+        read as a fresh install, and re-download every archived game. The
+        stored value is a floor.
+        """
+        poller = CameraPoller(
+            temp_storage, mock_config, mock_camera, _idle_download_processor()
+        )
+        archived_through = datetime(2026, 7, 12, 10, 35, 15)
+        await poller._update_latest_processed_time(archived_through)
+
+        # Archive ran: every group directory is gone from local storage.
+        assert not [
+            d
+            for d in os.listdir(temp_storage)
+            if os.path.isdir(os.path.join(temp_storage, d))
+        ]
+
+        await poller._advance_completion_watermark()
+
+        assert await poller._get_latest_processed_time() == archived_through
+
+    @pytest.mark.asyncio
+    async def test_archived_game_is_not_rediscovered(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """End-to-end: a published game still on the camera, archived off local
+        disk, behind the watermark — must not be re-downloaded."""
+        poller = CameraPoller(
+            temp_storage, mock_config, mock_camera, _idle_download_processor()
+        )
+        await poller._update_latest_processed_time(datetime(2026, 7, 12, 10, 35, 15))
+
+        mock_camera.get_file_list = AsyncMock(
+            return_value=[
+                {
+                    "path": "/archived_game.dav",
+                    "startTime": "2026-07-12 10:00:00",
+                    "endTime": "2026-07-12 10:35:15",
+                    "size": 5_000_000,
+                }
+            ]
+        )
+        await poller._sync_files_from_camera()
+
+        poller.download_processor.add_work.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_run_scans_a_year_and_later_runs_start_at_watermark(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """No watermark => scan the whole card. With one => start there, with
+        no lookback clamp skipping it forward."""
+        mock_camera.get_file_list = AsyncMock(return_value=[])
+        poller = CameraPoller(
+            temp_storage, mock_config, mock_camera, _idle_download_processor()
+        )
+
+        await poller._sync_files_from_camera()
+        first_start = mock_camera.get_file_list.call_args.kwargs["start_time"]
+        assert (datetime.now() - first_start).days >= 364
+
+        watermark = datetime.now() - timedelta(days=25)
+        await poller._update_latest_processed_time(watermark)
+        await poller._sync_files_from_camera()
+        resumed = mock_camera.get_file_list.call_args.kwargs["start_time"]
+
+        # Seconds-resolution round-trip through camera_state.json.
+        assert abs((resumed - watermark).total_seconds()) <= 1, (
+            "a 25-day-old watermark must be honoured, not clamped forward"
+        )
+
+    @pytest.mark.asyncio
+    async def test_abandoned_download_stops_blocking_the_watermark(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """A recording the camera no longer has would otherwise pin the
+        watermark — and every later game with it — forever."""
+        base = datetime(2026, 7, 1, 10, 0, 0)
+        group = await self._write_group(
+            temp_storage,
+            "2026.07.01-10.00.00",
+            [
+                ("gone.dav", base, "download_failed"),
+                ("later.dav", base + timedelta(hours=2), "complete"),
+            ],
+        )
+        poller = CameraPoller(
+            temp_storage, mock_config, mock_camera, _idle_download_processor()
+        )
+
+        await poller._advance_completion_watermark()
+        assert await poller._get_latest_processed_time() is None
+
+        # DownloadProcessor gives up and records the terminal outcome.
+        dir_state = DirectoryState(group)
+        await dir_state.update_file_state(
+            os.path.join(group, "gone.dav"), status="abandoned"
+        )
+
+        await poller._advance_completion_watermark()
+        assert await poller._get_latest_processed_time() == base + timedelta(hours=2)

--- a/tests/test_download_processor.py
+++ b/tests/test_download_processor.py
@@ -1,5 +1,6 @@
 """Tests for the DownloadProcessor."""
 
+import asyncio
 import os
 import tempfile
 from datetime import datetime
@@ -477,3 +478,68 @@ class TestDownloadProcessor:
 
         key = processor.get_item_key(recording_file)
         assert key == "recording:/test/path/test.dav"
+
+
+class TestAbandonExhaustedDownloads:
+    """A download that can never succeed must be recorded as terminal.
+
+    The base queue processor drops an item once its retries are exhausted, but
+    dropping it from the queue is not a record: the file stays at
+    ``download_failed``, which is not settled, so it pins the camera poller's
+    watermark — and therefore every later game — indefinitely.
+    """
+
+    @pytest.mark.asyncio
+    async def test_permanent_failure_marks_file_abandoned(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        from pathlib import Path
+
+        group_dir = os.path.join(temp_storage, "2026.07.01-10.00.00")
+        # Path.mkdir, not os.makedirs — conftest patches the latter to a no-op.
+        Path(group_dir).mkdir(parents=True, exist_ok=True)
+        file_path = os.path.join(group_dir, "gone.dav")
+
+        dir_state = DirectoryState(group_dir)
+        rec = RecordingFile(
+            start_time=datetime(2026, 7, 1, 10, 0, 0),
+            end_time=datetime(2026, 7, 1, 10, 30, 0),
+            file_path=file_path,
+            status="download_failed",
+        )
+        await dir_state.add_file(file_path, rec)
+
+        processor = DownloadProcessor(temp_storage, mock_config, mock_camera, Mock())
+        await processor.on_item_permanently_failed(rec)
+
+        assert DirectoryState(group_dir).files[file_path].status == "abandoned"
+
+    @pytest.mark.asyncio
+    async def test_base_processor_invokes_the_hook_on_retry_exhaustion(
+        self, temp_storage, mock_config, mock_camera
+    ):
+        """The hook is only useful if the base actually calls it."""
+        processor = DownloadProcessor(temp_storage, mock_config, mock_camera, Mock())
+        processor.on_item_permanently_failed = AsyncMock()
+        processor.process_item = AsyncMock(side_effect=RuntimeError("404 gone"))
+
+        rec = RecordingFile(
+            start_time=datetime(2026, 7, 1, 10, 0, 0),
+            end_time=datetime(2026, 7, 1, 10, 30, 0),
+            file_path=os.path.join(temp_storage, "grp", "gone.dav"),
+            status="pending",
+        )
+
+        await processor.add_work(rec)
+        await processor.start()
+        try:
+            # Retries are requeued at the back of the queue; give the loop
+            # enough turns to burn through _max_retries + the final drop.
+            for _ in range(200):
+                if processor.on_item_permanently_failed.await_count:
+                    break
+                await asyncio.sleep(0.01)
+        finally:
+            await processor.stop()
+
+        processor.on_item_permanently_failed.assert_awaited_once()

--- a/tests/test_queue_type.py
+++ b/tests/test_queue_type.py
@@ -54,11 +54,12 @@ class TestQueueType:
 
     def test_enum_iteration(self):
         all_types = list(QueueType)
-        assert len(all_types) == 12
+        assert len(all_types) == 13
         assert QueueType.BALL_TRACKING in all_types
         assert QueueType.PIPELINE in all_types
         assert QueueType.YOUTUBE in all_types
         assert QueueType.CLIPS in all_types
+        assert QueueType.ARCHIVE in all_types
         assert QueueType.TTT_HIGHLIGHT_REEL in all_types
         assert QueueType.TTT_JOB in all_types
         assert QueueType.TTT_REPROCESS_REQUEST in all_types

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -1920,6 +1920,12 @@ working drive. `discard` answers the single-drive case (YouTube is the archive) 
 the group carries a recorded YouTube video id, since those files are then the only copy. `copy`/`move`
 with nowhere to put games is a config-load hard failure rather than a silent no-op.
 
+Archive roots are matched against a game's `my_team_name` **by substring, not exactly** — the
+same rule `[YOUTUBE.PLAYLIST_MAP]` has always used. The live value is the full registered name
+(`BU14 - Guzzetta`), while an operator writes the short handle (`guzzetta`); an exact match misses
+and archiving refuses every game. Longest configured key wins, so two teams sharing a word do not
+get filed into each other's archive — which, followed by deleting the original, is unrecoverable.
+
 Archive roots are **per-team** and configured, never derived: `[ARCHIVE.PER_TEAM]` maps
 `my_team_name` to a root. Verified against the live layout 2026-08-07 — `F:\Heat_2012s`,
 `F:\Heat_2013s`, `F:\Flash_2013s`, holding `2026.07.12 - vs Niagara Falls Soccer Club (away)`.

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -1918,7 +1918,15 @@ two-location model, so a single-drive install — the one most likely to fill up
 feature at all. The two real questions are independent: keep a second copy (`path`), and reclaim the
 working drive. `discard` answers the single-drive case (YouTube is the archive) and refuses unless
 the group carries a recorded YouTube video id, since those files are then the only copy. `copy`/`move`
-without a `path` is a config-load hard failure rather than a silent no-op. The earlier name
+with nowhere to put games is a config-load hard failure rather than a silent no-op.
+
+Archive roots are **per-team** and configured, never derived: `[ARCHIVE.PER_TEAM]` maps
+`my_team_name` to a root. Verified against the live layout 2026-08-07 — `F:\Heat_2012s`,
+`F:\Heat_2013s`, `F:\Flash_2013s`, holding `2026.07.12 - vs Niagara Falls Soccer Club (away)`.
+The root is not derivable from the team name (match_info says "Guzzetta", the root is `Heat_2012s`),
+and one account carries two Heat age groups that must not be mixed, so a game whose team has no root
+(and no `path` fallback) is refused rather than filed under another team's archive. Lookup is
+case-insensitive because configparser lowercases option keys. The earlier name
 `delete_after_verify` was rejected for encoding an invariant as an option — we never delete without
 verifying, so the name implied a `delete_before_verify` mode that must not exist. The ordering is the point. The ad-hoc version deleted first and
 recorded nothing; interrupted by a dropped remote session it left a group whose `state.json` still

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -1907,9 +1907,20 @@ year, since neither camera backend can list "everything" and both return `[]` if
 Retries that exhaust now mark the file `abandoned` via a new `on_item_permanently_failed` hook, so
 one recording the camera has deleted cannot pin the watermark and every later game behind it.
 
-Archiving becomes a real pipeline step (`ArchiveProcessor`, post-`complete`, opt-in `[ARCHIVE]`)
-rather than an ad-hoc script: copy → verify SHA-256 → record `archived` → delete, in that order,
-with `state.json` deleted last. The ordering is the point. The ad-hoc version deleted first and
+Archiving becomes a real pipeline step (`ArchiveProcessor`, post-`complete`, `[ARCHIVE]`) rather
+than an ad-hoc script: copy → verify SHA-256 → record `archived` → delete, in that order, with
+`state.json` deleted last.
+
+The setting is a **disposition**, `after_upload = keep | copy | move | discard`, not a
+copy-to-a-second-location flag with a delete toggle. Mark's correction: "archiving to a separate
+location should be a configurable option, not a requirement for everyone." The first design forced a
+two-location model, so a single-drive install — the one most likely to fill up — could not use the
+feature at all. The two real questions are independent: keep a second copy (`path`), and reclaim the
+working drive. `discard` answers the single-drive case (YouTube is the archive) and refuses unless
+the group carries a recorded YouTube video id, since those files are then the only copy. `copy`/`move`
+without a `path` is a config-load hard failure rather than a silent no-op. The earlier name
+`delete_after_verify` was rejected for encoding an invariant as an option — we never delete without
+verifying, so the name implied a `delete_before_verify` mode that must not exist. The ordering is the point. The ad-hoc version deleted first and
 recorded nothing; interrupted by a dropped remote session it left a group whose `state.json` still
 said `combined`, which the pipeline read as mid-processing — it blanked `match_info.ini` to a stub
 and would have re-rendered and re-uploaded an already-published game. The step also **hard-refuses**

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -1880,6 +1880,66 @@ and cannot be derived in-detector). **Fast-follow:** replace the NTFY 5-min walk
 single detector-seeded "is this the kickoff?" confirmation (the S3 verify, moved ahead of the trim).
 **Files:** `video_grouper/task_processors/phase_game_start.py`, `tests/test_phase_game_start.py`
 
+## 2026-08-06: One completion watermark decides downloads; archiving becomes a pipeline step
+
+**Context:** Archiving five published July games from `D:` to `F:` made the camera poller
+re-download all of them. Every "do we already have this?" test soccer-cam had asks the local disk —
+the incremental pass reads the group's `state.json` via `is_file_in_state`, and the reconcile pass
+stats the `.mp4` — and archiving deletes both on purpose. A finished, published game therefore
+answers "never seen it". Mark's framing was that the record of what we've handled was stored next to
+the bulk data we intend to delete; that is exactly right for `state.json` (per-group), though the
+high-water mark itself was already central (`camera_state.json` at the storage root) and did survive.
+
+The mark could not settle it anyway, because it advanced at **discovery**: `camera_poller.py`
+recorded it immediately after files were queued, before a byte was downloaded, so a download that
+never completed was never queried again. That is the 2026-06-15 loss, and it is why
+`max_lookback_hours` and the reconcile pass existed at all — both were patches over a mark that did
+not mean what its name said.
+
+**Decision:** Make it mean it. The watermark is the newest recording end time `T` such that *every*
+recording at or before `T` is settled, and it only ever moves forward. "At or before the watermark"
+therefore means finished, so the poller stops asking the disk anything. Enforced directly in the
+discovery loop, not merely via the query range — cameras return recordings that overlap the window,
+so a game straddling the boundary comes back regardless. Reconcile is bounded below by it: on-disk
+completeness is the right question only for work we still owe. `max_lookback_hours` is removed (it
+only ever skipped a stale watermark forward, silently dropping what it skipped); first run scans a
+year, since neither camera backend can list "everything" and both return `[]` if handed `None`.
+Retries that exhaust now mark the file `abandoned` via a new `on_item_permanently_failed` hook, so
+one recording the camera has deleted cannot pin the watermark and every later game behind it.
+
+Archiving becomes a real pipeline step (`ArchiveProcessor`, post-`complete`, opt-in `[ARCHIVE]`)
+rather than an ad-hoc script: copy → verify SHA-256 → record `archived` → delete, in that order,
+with `state.json` deleted last. The ordering is the point. The ad-hoc version deleted first and
+recorded nothing; interrupted by a dropped remote session it left a group whose `state.json` still
+said `combined`, which the pipeline read as mid-processing — it blanked `match_info.ini` to a stub
+and would have re-rendered and re-uploaded an already-published game. The step also **hard-refuses**
+to archive a group the watermark has not passed, since doing so is precisely what lets the poller
+rediscover it.
+
+**Trade-off:** the watermark is a single scalar, not a per-file ledger, so it cannot express
+out-of-order completion — a stuck recording holds the line until it settles or is abandoned. That is
+deliberate: it is strictly less state, and the contiguous-prefix rule is what makes archiving
+structurally unobservable to the poller. A per-file central ledger was considered and rejected as a
+new store to migrate and maintain that also reintroduces the "known ≠ downloaded" ambiguity PR #89
+was written to kill.
+
+**Not done here:** TTT's `/api/internal/device-link/high-water-mark` returns
+`max(recording_start)` over *all registered* recordings, and registration happens at discovery — the
+same flaw. TTT does hold a full per-recording record (`pipeline_steps[]` with per-step status), but
+soccer-cam has no endpoint to read it back as a set, only that scalar. Making TTT's watermark
+completion-aware is a cross-repo change, deliberately deferred; the local watermark is the same value
+and the same semantics either way. Note this would reverse `ttt_reporter.get_high_water_mark`'s
+stated intent ("Supplementary — used for remote visibility, not for local decisions").
+
+**Files:** `video_grouper/task_processors/camera_poller.py`,
+`video_grouper/task_processors/archive_processor.py`,
+`video_grouper/task_processors/tasks/archive/archive_task.py`,
+`video_grouper/task_processors/base_queue_processor.py`,
+`video_grouper/task_processors/download_processor.py`,
+`video_grouper/task_processors/state_auditor.py`, `video_grouper/utils/config.py`,
+`tests/test_camera_poller.py`, `tests/test_archive_processor.py`,
+`tests/test_download_processor.py`
+
 ---
 
 ## Decision: ship the seam auto-measure as a refusing instrument, not a number generator (2026-08-19)

--- a/video_grouper/config.ini.dist
+++ b/video_grouper/config.ini.dist
@@ -67,10 +67,21 @@ timezone = America/New_York
 # Nothing is reclaimed before the camera poller has finished with the game's
 # recordings, or the poller would rediscover it as new and download it again.
 after_upload = keep
-# Destination root for `copy`/`move`; unused by `keep`/`discard`. Per-game
-# subdirectories are named from match_info:
-#   <path>/<my_team_name>/<date> - vs <opponent> (home|away)/
+# Fallback archive root for `copy`/`move`, used for teams with no
+# [ARCHIVE.PER_TEAM] entry. Enough on its own for a single-team install.
+# Unused by `keep`/`discard`.
 path =
+
+# Archives are per-team. A team's root cannot be derived from its name — a
+# team recorded in match_info as "Guzzetta" archives to Heat_2012s, and one
+# account can carry several age groups that must not be mixed — so map them
+# explicitly. Games land directly in their team's root:
+#   <root>/2026.07.12 - vs Niagara Falls Soccer Club (away)/
+# A game whose team has no root here (and no `path` fallback) is refused
+# rather than filed under some other team.
+[ARCHIVE.PER_TEAM]
+# Guzzetta = F:\Heat_2012s
+# Flash = F:\Flash_2013s
 
 [TEAMSNAP]
 # Set to true to enable TeamSnap integration

--- a/video_grouper/config.ini.dist
+++ b/video_grouper/config.ini.dist
@@ -47,6 +47,25 @@ backup_count = 30
 check_interval_seconds = 60
 timezone = America/New_York
 
+[ARCHIVE]
+# Move games off this drive once they are safely uploaded to YouTube.
+# Off by default: it deletes local footage, so it has to be chosen.
+#
+# A game is copied to `path`, verified file-by-file with SHA-256, recorded
+# as archived, and only then removed locally — in that order, so an
+# interrupted run leaves a group that plainly reads as finished rather than
+# one that looks half-processed and gets reprocessed.
+#
+# A game is never archived before the camera poller has finished with its
+# recordings, or the poller would rediscover it as new and download it again.
+enabled = false
+# Destination root. Per-game subdirectories are named from match_info:
+#   <path>/<my_team_name>/<date> - vs <opponent> (home|away)/
+path =
+# Set false to copy and verify but keep the local copy — useful for a first
+# run, to confirm the archive looks right before anything is deleted.
+delete_after_verify = true
+
 [TEAMSNAP]
 # Set to true to enable TeamSnap integration
 enabled = false

--- a/video_grouper/config.ini.dist
+++ b/video_grouper/config.ini.dist
@@ -48,23 +48,29 @@ check_interval_seconds = 60
 timezone = America/New_York
 
 [ARCHIVE]
-# Move games off this drive once they are safely uploaded to YouTube.
-# Off by default: it deletes local footage, so it has to be chosen.
+# What happens to a game's local files once it is safely on YouTube.
 #
-# A game is copied to `path`, verified file-by-file with SHA-256, recorded
-# as archived, and only then removed locally — in that order, so an
-# interrupted run leaves a group that plainly reads as finished rather than
-# one that looks half-processed and gets reprocessed.
+#   keep     leave them alone (default)
+#   copy     copy to `path`, keep the local files too
+#   move     copy to `path`, then reclaim the local files
+#   discard  reclaim the local files; YouTube holds the only copy
 #
-# A game is never archived before the camera poller has finished with its
+# A second location is one answer, not a requirement — a single-drive
+# install uses `discard` and still gets its space back.
+#
+# Verification is never optional. `copy`/`move` compare SHA-256 file by file
+# before anything is removed, and `discard` refuses unless the group has a
+# recorded YouTube video id. The group is marked archived BEFORE any delete,
+# so an interrupted run leaves a game that plainly reads as finished instead
+# of one that looks half-processed and gets reprocessed.
+#
+# Nothing is reclaimed before the camera poller has finished with the game's
 # recordings, or the poller would rediscover it as new and download it again.
-enabled = false
-# Destination root. Per-game subdirectories are named from match_info:
+after_upload = keep
+# Destination root for `copy`/`move`; unused by `keep`/`discard`. Per-game
+# subdirectories are named from match_info:
 #   <path>/<my_team_name>/<date> - vs <opponent> (home|away)/
 path =
-# Set false to copy and verify but keep the local copy — useful for a first
-# run, to confirm the archive looks right before anything is deleted.
-delete_after_verify = true
 
 [TEAMSNAP]
 # Set to true to enable TeamSnap integration

--- a/video_grouper/task_processors/__init__.py
+++ b/video_grouper/task_processors/__init__.py
@@ -1,5 +1,6 @@
 """Task processors package for video grouper application."""
 
+from .archive_processor import ArchiveProcessor
 from .base_polling_processor import PollingProcessor
 from .base_queue_processor import QueueProcessor
 from .camera_poller import CameraPoller
@@ -20,6 +21,7 @@ __all__ = [
     "DownloadProcessor",
     "NtfyProcessor",
     "StateAuditor",
+    "ArchiveProcessor",
     "UploadProcessor",
     "VideoProcessor",
     "ClipProcessor",

--- a/video_grouper/task_processors/archive_processor.py
+++ b/video_grouper/task_processors/archive_processor.py
@@ -78,13 +78,17 @@ class ArchiveProcessor(QueueProcessor):
             return
 
         archive_cfg = self.config.archive
-        if not archive_cfg.enabled:
-            logger.debug("ARCHIVE: disabled; skipping %s", item.group_dir)
+        if archive_cfg.after_upload == "keep":
+            logger.debug(
+                "ARCHIVE: [ARCHIVE] after_upload = keep; leaving %s alone.",
+                item.group_dir,
+            )
             return
 
         ok = await item.execute(
             archive_root=archive_cfg.path,
-            delete_after_verify=archive_cfg.delete_after_verify,
+            make_second_copy=archive_cfg.makes_second_copy,
+            reclaim_local_space=archive_cfg.reclaims_local_space,
             watermark=self._read_watermark(),
         )
         if not ok:

--- a/video_grouper/task_processors/archive_processor.py
+++ b/video_grouper/task_processors/archive_processor.py
@@ -85,8 +85,22 @@ class ArchiveProcessor(QueueProcessor):
             )
             return
 
+        # Archives are per-team; resolve this game's root from its
+        # my_team_name before anything is copied or deleted.
+        team = item.team_name()
+        team_root = archive_cfg.root_for_team(team)
+        if archive_cfg.makes_second_copy and not team_root:
+            # Refuse rather than dumping the game into some other team's
+            # archive: the roots are age-group specific and mixing them is
+            # not something a later pass can untangle.
+            raise RuntimeError(
+                f"[ARCHIVE] no archive root for team {team!r} "
+                f"({item.group_dir}). Add it under [ARCHIVE.PER_TEAM], or set "
+                "a fallback `path`."
+            )
+
         ok = await item.execute(
-            archive_root=archive_cfg.path,
+            archive_root=team_root,
             make_second_copy=archive_cfg.makes_second_copy,
             reclaim_local_space=archive_cfg.reclaims_local_space,
             watermark=self._read_watermark(),

--- a/video_grouper/task_processors/archive_processor.py
+++ b/video_grouper/task_processors/archive_processor.py
@@ -1,0 +1,94 @@
+"""Processor for archiving published games off the working drive.
+
+Sits after upload: a group reaches ``complete`` when its videos are on
+YouTube, and only then is it safe to reclaim the local footage. Runs on its
+own queue because verifying a game means hashing tens of gigabytes, which
+must not sit on the upload path.
+"""
+
+import logging
+import os
+from datetime import datetime
+
+from video_grouper.utils.config import Config
+from video_grouper.utils.locking import FileLock
+from video_grouper.utils.paths import get_camera_state_path
+
+from .base_queue_processor import QueueProcessor
+from .queue_type import QueueType
+from .tasks.archive import ArchiveTask
+from .tasks.base_task import BaseTask
+
+logger = logging.getLogger(__name__)
+
+_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+class ArchiveProcessor(QueueProcessor):
+    """Copies completed groups to the archive root and reclaims their space."""
+
+    def __init__(self, storage_path: str, config: Config):
+        super().__init__(storage_path, config)
+
+    @property
+    def queue_type(self) -> QueueType:
+        return QueueType.ARCHIVE
+
+    def get_item_key(self, item: BaseTask) -> str:
+        return f"archive:{item.get_item_path()}"
+
+    def _read_watermark(self) -> datetime | None:
+        """Newest watermark across all cameras in ``camera_state.json``.
+
+        The archive guard needs "has the poller finished with this time
+        range?", and with several cameras the answer is only yes when the
+        *slowest* one has passed it. Take the minimum across cameras that
+        have a watermark, so one lagging camera cannot let a game be archived
+        out from under it.
+        """
+        state_path = get_camera_state_path(self.storage_path)
+        if not os.path.exists(state_path):
+            return None
+        try:
+            with FileLock(state_path):
+                import json
+
+                with open(state_path) as fh:
+                    all_state = json.load(fh)
+        except Exception as e:  # noqa: BLE001
+            logger.error("ARCHIVE: cannot read camera state: %s", e)
+            return None
+
+        marks: list[datetime] = []
+        for value in all_state.values():
+            if not isinstance(value, dict):
+                continue  # legacy top-level connection_events / is_connected
+            raw = value.get("latest_video_time")
+            if not raw:
+                continue
+            try:
+                marks.append(datetime.strptime(str(raw).strip(), _DATE_FORMAT))
+            except ValueError:
+                continue
+        return min(marks) if marks else None
+
+    async def process_item(self, item: BaseTask) -> None:
+        if not isinstance(item, ArchiveTask):
+            logger.error("ARCHIVE: unexpected task %r; ignoring.", item)
+            return
+
+        archive_cfg = self.config.archive
+        if not archive_cfg.enabled:
+            logger.debug("ARCHIVE: disabled; skipping %s", item.group_dir)
+            return
+
+        ok = await item.execute(
+            archive_root=archive_cfg.path,
+            delete_after_verify=archive_cfg.delete_after_verify,
+            watermark=self._read_watermark(),
+        )
+        if not ok:
+            # Raise so the base class applies its retry/backoff. A refusal on
+            # the watermark guard is expected and temporary — the retry will
+            # succeed once the poller settles the recordings ahead of it.
+            raise RuntimeError(f"Archive incomplete for {item.group_dir}")

--- a/video_grouper/task_processors/base_queue_processor.py
+++ b/video_grouper/task_processors/base_queue_processor.py
@@ -333,6 +333,13 @@ class QueueProcessor(ABC):
                         logger.error(
                             f"{self.__class__.__name__}: Item exceeded max retries ({self._max_retries}), removing from queue: {item} (queue size: {queue_size})"
                         )
+                        try:
+                            await self.on_item_permanently_failed(item)
+                        except Exception as hook_exc:  # noqa: BLE001
+                            logger.error(
+                                f"{self.__class__.__name__}: on_item_permanently_failed "
+                                f"hook failed for {item}: {hook_exc}"
+                            )
                         await self.save_state()
 
             except Exception as e:
@@ -342,6 +349,16 @@ class QueueProcessor(ABC):
                 await asyncio.sleep(5)
 
         logger.info(f"{self.__class__.__name__}: Processing loop ended")
+
+    async def on_item_permanently_failed(self, item: BaseTask) -> None:
+        """Hook: the item exhausted its retries and is being abandoned.
+
+        Default no-op. Override to record the terminal outcome somewhere
+        durable. Dropping an item from the queue is not itself a record —
+        whatever persisted state the item represents still reads as
+        "unfinished" to everything else, forever.
+        """
+        return None
 
     def _serialize_item(self, item: BaseTask) -> dict:
         """Serialize a single task item to a dictionary."""

--- a/video_grouper/task_processors/camera_poller.py
+++ b/video_grouper/task_processors/camera_poller.py
@@ -756,6 +756,16 @@ class CameraPoller(PollingProcessor):
                 if file_end_time is None or file_end_time <= file_start_time:
                     file_end_time = file_start_time
 
+                # Re-check the watermark per file. Narrowing the query range
+                # above is NOT a filter: cameras return recordings that merely
+                # overlap the requested window, so a game ending just before
+                # the watermark still comes back. Without this the pass falls
+                # through to _file_needs_download, which asks whether the .mp4
+                # is on disk -- and for an archived game it deliberately is
+                # not, so all five published July games were re-queued.
+                if watermark is not None and file_end_time <= watermark:
+                    continue
+
                 filename = os.path.basename(file_info["path"])
                 group_dir = find_group_directory(
                     file_start_time, self.storage_path, existing_dirs

--- a/video_grouper/task_processors/camera_poller.py
+++ b/video_grouper/task_processors/camera_poller.py
@@ -35,6 +35,43 @@ MIN_SEGMENT_SECONDS = 5
 # skipped real game footage forever — the 2026-06-15 loss. Bound the open
 # session to this horizon past its start instead of letting it run to now.
 OPEN_CONNECTED_SESSION_HORIZON_HOURS = 12
+# How far back the very first poll of a fresh install looks. There is no
+# watermark yet, and neither camera backend can list "everything" — both
+# require an explicit (start, end) and silently return [] if handed None — so
+# scanning the whole card has to be spelled out as a deliberately wide window.
+# The cost is one Search per *active recording day* found (Reolink walks the
+# status bitmap), not per calendar day, so an empty year is nearly free.
+FIRST_RUN_SCAN_DAYS = 365
+# A recording is settled when we will never need to fetch it from the camera
+# again: either we have the bytes (or something derived from them), or we
+# deliberately gave up on it. The watermark may only advance over settled
+# recordings, which is what makes "at or before the watermark" mean "done"
+# rather than merely "seen".
+#
+# Kept as one name shared with _file_needs_download so the two can't drift:
+# a status that means "done" to one and "needs download" to the other would
+# make the poller re-queue everything behind the watermark.
+SETTLED_FILE_STATUSES = frozenset(
+    {
+        "downloaded",
+        "combined",
+        "trimmed",
+        "ball_tracking_complete",
+        "pipeline_complete",
+        "complete",
+        "skipped",
+        # Uploaded and moved off local disk. The bytes are deliberately gone;
+        # their absence must never be read as "never downloaded".
+        "archived",
+        # Retries exhausted — the camera no longer has it, or it is corrupt.
+        # Settled in the sense that matters here: we are never fetching it, so
+        # it must not hold the watermark (and every later game) hostage.
+        "abandoned",
+    }
+)
+# Group-level statuses that settle every file inside them regardless of the
+# individual file status — the group as a whole is finished with the camera.
+SETTLED_GROUP_STATUSES = frozenset({"not_a_game", "complete", "archived"})
 
 
 def create_directory(path):
@@ -215,15 +252,11 @@ class CameraPoller(PollingProcessor):
         self.ntfy_service = None
         self.ttt_reporter = None
         self._cleanup_state_path = get_home_cleanup_state_path(storage_path)
-        # Reconciliation pass: a full re-scan of a much larger window than the
-        # incremental sync, run when the download queue is idle. The
-        # incremental sync only moves forward (HWM .. now, clamped to
-        # max_lookback_hours), so any game that ages past that window before
-        # it was fully captured is never re-queried. The reconcile pass
-        # re-discovers anything still on the camera that is missing or
-        # incomplete on disk, regardless of the HWM. Tracked so we don't issue
-        # a wide camera search on every single poll while the queue happens to
-        # be idle.
+        # Reconciliation pass: re-scan the window between the watermark and
+        # now when the download queue is idle, and re-queue anything missing
+        # or short on disk. This heals downloads that died partway; the
+        # watermark itself handles "never discovered". Tracked so we don't
+        # issue a wide camera search on every poll while the queue is idle.
         self._last_reconcile_time: datetime | None = None
         self._reconcile_min_interval_seconds = 3600
 
@@ -254,11 +287,11 @@ class CameraPoller(PollingProcessor):
             await self._sync_files_from_camera()
 
             # Self-healing reconciliation. When the download queue is idle,
-            # re-scan a much larger window than the incremental sync and
-            # re-queue anything still on the camera that is missing or
-            # incomplete on disk — regardless of the high-water mark. This is
-            # the safety net for games that aged past max_lookback_hours
-            # before they were fully captured (the 2026-06-15 loss).
+            # re-scan from the watermark forward and re-queue anything still
+            # on the camera that is missing or incomplete on disk — the
+            # safety net for downloads that died partway (the 2026-06-15
+            # loss). Behind the watermark the same check would be actively
+            # wrong: an archived game is meant to be gone locally.
             if self._should_reconcile():
                 await self._reconcile_files_from_camera()
 
@@ -295,15 +328,32 @@ class CameraPoller(PollingProcessor):
 
     async def _sync_files_from_camera(self) -> None:
         """Sync files from camera and group them."""
-        start_time = await self._get_latest_processed_time()
-        if start_time:
-            start_time -= timedelta(minutes=1)
-
-        # Clamp start_time so we never look back further than max_lookback_hours
-        max_lookback = getattr(self.config.app, "max_lookback_hours", 48)
-        earliest_allowed = datetime.now() - timedelta(hours=max_lookback)
-        if start_time is None or start_time < earliest_allowed:
-            start_time = earliest_allowed
+        # Read once per poll. Only _advance_completion_watermark writes it,
+        # and that runs after this loop, so it cannot move underneath us.
+        watermark = await self._get_latest_processed_time()
+        start_time = watermark
+        if start_time is None:
+            # No watermark yet, so this install has never ingested anything:
+            # scan the whole card. Both backends require an explicit range
+            # (get_file_list(start, end) is mandatory on Dahua and Reolink,
+            # and passing None fails *silently* as "no files" through their
+            # blanket except), so "everything the camera holds" has to be
+            # spelled out as a deliberately wide window.
+            start_time = datetime.now() - timedelta(days=FIRST_RUN_SCAN_DAYS)
+            logger.info(
+                "CAMERA_POLLER: No watermark yet -- first-run scan over the "
+                "last %d days.",
+                FIRST_RUN_SCAN_DAYS,
+            )
+        else:
+            # The watermark means "every recording at or before this is
+            # settled", so it is the whole answer to what we still need.
+            # Deliberately NOT clamped to a lookback window: clamping skips
+            # a stale watermark forward, and anything it skipped over was
+            # never fetched and was never queried again. That is how the
+            # 2026-06-15 game was lost, and how archived games got
+            # re-downloaded once the window happened to reach them.
+            logger.debug("CAMERA_POLLER: Resuming from watermark %s", start_time)
 
         end_time = datetime.now()
 
@@ -334,7 +384,15 @@ class CameraPoller(PollingProcessor):
 
         self._last_poll_found_files = True
 
-        # Cap the number of files per poll to avoid overwhelming the pipeline
+        # Cap the number of files per poll to avoid overwhelming the pipeline.
+        # Sort by start time FIRST: the camera's own ordering is not
+        # guaranteed, so an unsorted slice keeps an arbitrary subset — which a
+        # wide first-run scan makes very visible. Sorting makes the cap mean
+        # "the oldest N", so ingest proceeds in recording order and the
+        # watermark can actually advance through the backlog poll by poll.
+        # startTime is zero-padded "%Y-%m-%d %H:%M:%S", so lexicographic
+        # ordering is chronological.
+        files.sort(key=lambda f: str(f.get("startTime") or ""))
         max_files = getattr(self.config.app, "max_files_per_poll", 50)
         if len(files) > max_files:
             logger.warning(
@@ -355,10 +413,8 @@ class CameraPoller(PollingProcessor):
         # other segments, so it is not flagged here.
         runt_paths = _identify_runt_recordings(files, existing_dirs)
 
-        latest_end_time = None
-        latest_end_time_file = None
-        # Per-poll diagnostics so HWM stalls can be root-caused after the
-        # fact: classify every file the camera returned and emit a single
+        # Per-poll diagnostics so watermark stalls can be root-caused after
+        # the fact: classify every file the camera returned and emit a single
         # summary line at end of poll. Without this, an HWM-stuck
         # incident (5/30 runt stuck at 19:44:06 for 14+ hours, 2026-05-30
         # tournament day) requires DEBUG logs to reconstruct.
@@ -368,6 +424,7 @@ class CameraPoller(PollingProcessor):
             "runt": 0,
             "home_connected": 0,
             "unparseable": 0,
+            "settled": 0,
         }
 
         # Get connected timeframes for filtering
@@ -457,10 +514,23 @@ class CameraPoller(PollingProcessor):
                     files_to_delete.append(file_info["path"])
                     continue
 
-                # Track high-water mark from non-skipped files only
-                if latest_end_time is None or file_end_time > latest_end_time:
-                    latest_end_time = file_end_time
-                    latest_end_time_file = filename
+                # The watermark decides this, and nothing else does. Every
+                # other "do we already have it?" test asks the local disk —
+                # is_file_in_state reads the group's state.json, and reconcile
+                # stats the .mp4 — and archiving deletes both on purpose, so
+                # both answer "never seen it" for a game that is finished and
+                # published. Enforced here rather than relying on the query
+                # range: cameras return recordings that merely *overlap* the
+                # window, so a game straddling the boundary comes back anyway.
+                if watermark is not None and file_end_time <= watermark:
+                    counts["settled"] += 1
+                    logger.debug(
+                        "CAMERA_POLLER: %s (end=%s) is at or before the "
+                        "watermark; already handled.",
+                        filename,
+                        file_end_time,
+                    )
+                    continue
 
                 group_dir = find_group_directory(
                     file_start_time, self.storage_path, existing_dirs
@@ -541,37 +611,44 @@ class CameraPoller(PollingProcessor):
         total_seen = sum(counts.values())
         logger.info(
             "CAMERA_POLLER: poll summary -- %d files seen "
-            "(new=%d already_known=%d runt=%d home_connected=%d unparseable=%d)",
+            "(new=%d already_known=%d settled=%d runt=%d home_connected=%d "
+            "unparseable=%d)",
             total_seen,
             counts["new_added"],
             counts["already_known"],
+            counts["settled"],
             counts["runt"],
             counts["home_connected"],
             counts["unparseable"],
         )
 
-        if latest_end_time:
-            await self._update_latest_processed_time(latest_end_time)
-            logger.info(
-                "CAMERA_POLLER: HWM advanced to %s (by file %s)",
-                latest_end_time,
-                latest_end_time_file,
-            )
-        elif total_seen > 0:
-            # Files were returned but none advanced the HWM -- all were
-            # runts, home-connected, or unparseable. The HWM stays where
-            # it is, so the next poll re-queries the same window. If
-            # this repeats for many consecutive polls, the camera has
-            # effectively stalled on a class of files the poller won't
-            # process; manual recovery (delete the offending dir + bump
-            # HWM) may be needed.
+        if (
+            total_seen > 0
+            and not counts["new_added"]
+            and not counts["already_known"]
+            and not counts["settled"]
+        ):
+            # Every file the camera returned was discarded as a runt, home
+            # footage, or unparseable. Nothing was queued, so nothing can ever
+            # settle, so the watermark cannot move and the next poll re-queries
+            # this exact window — forever. Worth a warning: this is the shape
+            # of the 2026-05-30 stall, where the mark stuck on a runt for 14+
+            # hours and only DEBUG logs could explain why.
             logger.warning(
-                "CAMERA_POLLER: %d files seen but HWM not advanced "
-                "(all filtered out by runt/home-connected/unparseable). "
-                "HWM remains at previous value; next poll will re-query "
-                "the same window.",
+                "CAMERA_POLLER: %d file(s) seen but none actionable "
+                "(all runt/home-connected/unparseable). Nothing queued, so "
+                "the watermark cannot advance; next poll re-queries the same "
+                "window.",
                 total_seen,
             )
+
+        # Advance the watermark over settled work only. Deliberately NOT to
+        # latest_end_time: that is merely "the camera told us this file
+        # exists", which is what the mark used to record. It moved forward
+        # the instant a file was queued -- before a single byte was
+        # downloaded -- so a recording that never finished downloading was
+        # never queried again (the 2026-06-15 loss).
+        await self._advance_completion_watermark()
 
     async def _file_needs_download(
         self, local_path: str, dir_state: DirectoryState, expected_size: int | None
@@ -605,30 +682,26 @@ class CameraPoller(PollingProcessor):
             if abs(actual_size - expected_size) / expected_size >= 0.01:
                 return True
 
-        done_statuses = {
-            "downloaded",
-            "combined",
-            "trimmed",
-            "ball_tracking_complete",
-            "pipeline_complete",
-            "complete",
-            "skipped",
-        }
         existing = dir_state.get_file_by_path(local_path)
-        if existing is not None and existing.status not in done_statuses:
+        if existing is not None and existing.status not in SETTLED_FILE_STATUSES:
             return True
 
         return False
 
     async def _reconcile_files_from_camera(self) -> None:
-        """Full reconcile pass: re-queue anything on the camera missing on disk.
+        """Heal partial downloads: re-queue anything incomplete on disk.
 
-        Unlike the incremental sync (which only queries a forward-moving
-        window and trusts the high-water mark + ``is_file_in_state``), this
-        walks a much larger window and decides purely on on-disk
-        completeness. It never advances the HWM. Self-healing: a game that
-        aged past ``max_lookback_hours`` before it was fully downloaded gets
-        rediscovered here.
+        Decides purely on on-disk completeness rather than on "known in
+        state", so a file recorded as ``pending``/``download_failed`` whose
+        bytes are missing or short gets re-fetched. It never advances the
+        watermark.
+
+        Bounded below by the watermark. On-disk completeness is the right
+        question only for recordings we still owe work on; behind the
+        watermark it is the wrong question entirely, because a game archived
+        off local disk is *supposed* to be missing. Scanning past the
+        watermark is what re-downloaded five published July games after they
+        were moved to the archive.
         """
         self._last_reconcile_time = datetime.now()
 
@@ -636,11 +709,22 @@ class CameraPoller(PollingProcessor):
         end_time = datetime.now()
         start_time = end_time - timedelta(days=reconcile_days)
 
+        watermark = await self._get_latest_processed_time()
+        if watermark is not None and watermark > start_time:
+            start_time = watermark
+
+        if start_time >= end_time:
+            logger.debug(
+                "CAMERA_POLLER: Nothing to reconcile — watermark %s is current.",
+                watermark,
+            )
+            return
+
         logger.info(
-            "CAMERA_POLLER: Reconcile pass scanning %s to %s (%d days)",
+            "CAMERA_POLLER: Reconcile pass scanning %s to %s (watermark=%s)",
             start_time,
             end_time,
-            reconcile_days,
+            watermark,
         )
 
         files = await self.camera.get_file_list(
@@ -737,14 +821,18 @@ class CameraPoller(PollingProcessor):
         )
 
     async def _get_latest_processed_time(self) -> datetime | None:
-        """Get the timestamp of the last processed video file for this camera.
+        """Read this camera's watermark: everything at or before it is settled.
 
-        Reads camera_state.json under the same FileLock the writers use, so it
-        can never observe a half-written/truncated file. Writers now write
-        atomically (temp + os.replace), so even a brief lock contention can't
-        surface a partial document. Returning None here resets the HWM to the
-        max_lookback window, which is exactly how the 2026-06-15 game got lost,
-        so we read defensively.
+        Lives in ``camera_state.json`` at the *storage root*, deliberately not
+        inside any group directory — it has to outlive the videos it describes,
+        since archiving deletes whole group directories (and the per-group
+        ``state.json`` with them).
+
+        Reads under the same FileLock the writers use, so it can never observe
+        a half-written file. Writers write atomically (temp + os.replace).
+        Returning None means "fresh install" and triggers a full first-run
+        scan, so read defensively — a spurious None here re-downloads
+        everything the camera still holds.
         """
         state_path = get_camera_state_path(self.storage_path)
         if not os.path.exists(state_path):
@@ -761,6 +849,109 @@ class CameraPoller(PollingProcessor):
         except Exception as e:
             logger.error(f"CAMERA_POLLER: Could not read latest video timestamp: {e}")
             return None
+
+    def _collect_known_recordings(self) -> list[tuple[datetime, bool, str, str]]:
+        """Every recording this install knows about, as (end, settled, name, status).
+
+        Read from the per-group ``state.json`` files. Note these live *inside*
+        each group directory, so they disappear when a game is archived off
+        local disk — which is precisely why they may only ever push the
+        watermark forward and can never be used to re-derive it. See
+        :meth:`_advance_completion_watermark`.
+        """
+        recordings: list[tuple[datetime, bool, str, str]] = []
+        try:
+            entries = os.listdir(self.storage_path)
+        except OSError as e:
+            logger.error("CAMERA_POLLER: Cannot list storage path: %s", e)
+            return recordings
+
+        for entry in entries:
+            group_dir = os.path.join(self.storage_path, entry)
+            if not os.path.isdir(group_dir):
+                continue
+            try:
+                dir_state = DirectoryState(group_dir)
+            except Exception as e:  # noqa: BLE001 — one bad group must not stall the watermark
+                logger.warning("CAMERA_POLLER: Cannot read state for %s: %s", entry, e)
+                continue
+
+            group_settled = dir_state.status in SETTLED_GROUP_STATUSES
+            for file_path, rec in dir_state.files.items():
+                end_time = getattr(rec, "end_time", None)
+                if not isinstance(end_time, datetime):
+                    continue
+                settled = (
+                    group_settled
+                    or bool(getattr(rec, "skip", False))
+                    or getattr(rec, "status", None) in SETTLED_FILE_STATUSES
+                )
+                recordings.append(
+                    (
+                        end_time,
+                        settled,
+                        os.path.basename(file_path),
+                        str(getattr(rec, "status", "?")),
+                    )
+                )
+        return recordings
+
+    async def _advance_completion_watermark(self) -> None:
+        """Move the watermark over the settled prefix of known recordings.
+
+        The watermark is the newest recording end time ``T`` such that *every*
+        recording at or before ``T`` is settled. That contiguous-prefix rule is
+        what lets "at or before the watermark" mean "finished", so the poller
+        can stop asking the disk whether it still holds the bytes.
+
+        Two properties carry the correctness:
+
+        * **Advance only over settled work.** The old mark moved the instant a
+          file was queued, before a byte was downloaded, so a download that
+          never finished was never queried again (the 2026-06-15 loss).
+        * **Monotonic.** The stored value is a floor and is never lowered. The
+          per-group ``state.json`` files this walks are deleted when a game is
+          archived, so a recompute-from-disk would see nothing and hand back
+          ``None`` — which reads as "fresh install" and re-downloads every
+          archived game. Archived work sits behind the floor, so its absence
+          is unobservable.
+        """
+        stored = await self._get_latest_processed_time()
+
+        recordings = self._collect_known_recordings()
+        if not recordings:
+            return
+
+        recordings.sort(key=lambda r: r[0])
+
+        candidate: datetime | None = None
+        blocker: tuple[str, str] | None = None
+        for end_time, settled, name, status in recordings:
+            if not settled:
+                blocker = (name, status)
+                break
+            candidate = end_time
+
+        if candidate is not None and (stored is None or candidate > stored):
+            await self._update_latest_processed_time(candidate)
+            logger.info(
+                "CAMERA_POLLER: Watermark advanced to %s%s",
+                candidate,
+                ""
+                if blocker is None
+                else f" (held there by {blocker[0]}, status={blocker[1]})",
+            )
+        elif blocker is not None:
+            # Not an error: work in flight is the normal reason the watermark
+            # sits still. It matters when it persists, so name what is holding
+            # it — that is the file to fix, and the one auto-retire will
+            # eventually settle if it can never complete.
+            logger.info(
+                "CAMERA_POLLER: Watermark held at %s by %s (status=%s)",
+                stored,
+                blocker[0],
+                blocker[1],
+            )
 
     async def _check_downloads_complete(self) -> None:
         """Check if all downloads are complete and send unplug notification."""

--- a/video_grouper/task_processors/download_processor.py
+++ b/video_grouper/task_processors/download_processor.py
@@ -323,5 +323,34 @@ class DownloadProcessor(QueueProcessor):
                 self.error_tracker.record("download", str(e), {"file": file_name})
             raise
 
+    async def on_item_permanently_failed(self, item: RecordingFile) -> None:
+        """Record a download we are never going to complete as terminal.
+
+        The base class drops the item from the queue after its retries are
+        exhausted, but the file stays at ``download_failed`` — a non-terminal
+        status. That is enough to pin the camera poller's watermark forever:
+        the watermark may only advance over settled recordings, so a single
+        recording the camera has since deleted (404-gone), or that is corrupt
+        on the card, would hold the line and every later game with it.
+
+        Marking it ``abandoned`` settles it, so the watermark moves past and
+        the reconcile pass stops re-queuing it. Logged at ERROR because
+        abandoning footage is a real loss, not routine cleanup — the file is
+        named so it can be recovered by hand if it still matters.
+        """
+        file_path = getattr(item, "file_path", None)
+        if not file_path:
+            return
+        logger.error(
+            "DOWNLOAD: Abandoning %s after %d failed attempts — marking it "
+            "terminal so it stops blocking the camera watermark. If this "
+            "recording matters, fetch it from the camera by hand.",
+            os.path.basename(file_path),
+            self._max_retries,
+        )
+        group_dir = os.path.dirname(file_path)
+        dir_state = DirectoryState(group_dir)
+        await dir_state.update_file_state(file_path, status="abandoned")
+
     def get_item_key(self, item: RecordingFile) -> str:
         return f"recording:{item.file_path}"

--- a/video_grouper/task_processors/queue_type.py
+++ b/video_grouper/task_processors/queue_type.py
@@ -17,6 +17,7 @@ class QueueType(Enum):
     PIPELINE = "pipeline"
     CLIP_REQUEST = "clip_request"
     CLIPS = "clips"
+    ARCHIVE = "archive"
     # TTT cloud features — each polled into a QueueProcessor by TTTPoller.
     TTT_HIGHLIGHT_REEL = "ttt_highlight_reel"
     TTT_JOB = "ttt_job"

--- a/video_grouper/task_processors/register_tasks.py
+++ b/video_grouper/task_processors/register_tasks.py
@@ -15,6 +15,7 @@ Entry points pick the right registration:
 
 from video_grouper.task_processors.task_registry import task_registry
 
+from .tasks.archive import ArchiveTask
 from .tasks.clip.clip_request_task import ClipRequestTask
 from .tasks.clips.clip_extraction_task import ClipExtractionTask
 from .tasks.clips.highlight_compilation_task import HighlightCompilationTask
@@ -33,6 +34,7 @@ from .tasks.video.trim_task import TrimTask
 def _register_common_tasks() -> None:
     """Register every task type. None pull heavy ML deps at import time."""
     task_registry.register_task(CombineTask)
+    task_registry.register_task(ArchiveTask)
     task_registry.register_task(TrimTask)
     task_registry.register_task(GameStartTask)
     task_registry.register_task(GameEndTask)

--- a/video_grouper/task_processors/state_auditor.py
+++ b/video_grouper/task_processors/state_auditor.py
@@ -93,6 +93,10 @@ class StateAuditor(PollingProcessor):
             self._download_processors = {}
         self.video_processor = video_processor
         self.ntfy_processor = ntfy_processor
+        # Attribute-injected by VideoGrouperApp after construction, mirroring
+        # how ttt_reporter is wired onto the pollers. None in the tray and in
+        # tests, where nothing archives.
+        self.archive_processor = None
 
         # Initialize API services using mock service factory functions
         self.teamsnap_service = create_teamsnap_service(config.teamsnap)
@@ -380,6 +384,20 @@ class StateAuditor(PollingProcessor):
             # this branch is a harmless no-op (the upload queue dedupes).
             elif dir_state.status in ("ball_tracking_complete", "pipeline_complete"):
                 await self._queue_upload(group_dir)
+
+            # Uploaded, but still occupying the working drive. The upload task
+            # hands finished groups straight to the archive queue, so this only
+            # fires when that was missed — a crash between upload and enqueue,
+            # or a group completed by a build that predates archiving. The
+            # archive step re-checks everything itself, and the queue dedupes,
+            # so a redundant enqueue costs nothing.
+            elif dir_state.status == "complete":
+                if self.archive_processor is not None:
+                    from .tasks.archive import ArchiveTask
+
+                    await self.archive_processor.add_work(
+                        ArchiveTask(group_dir=group_dir)
+                    )
 
             # Check for not_a_game status (user confirmed there was no match)
             elif dir_state.status == "not_a_game":

--- a/video_grouper/task_processors/state_auditor.py
+++ b/video_grouper/task_processors/state_auditor.py
@@ -41,6 +41,9 @@ _DOWNLOAD_DONE_STATUSES = frozenset(
         "pipeline_complete",
         "complete",
         "not_a_game",
+        # Uploaded and moved off local disk. Its files are *supposed* to be
+        # missing locally; re-fetching them would undo the archive.
+        "archived",
     }
 )
 

--- a/video_grouper/task_processors/tasks/archive/__init__.py
+++ b/video_grouper/task_processors/tasks/archive/__init__.py
@@ -1,0 +1,5 @@
+"""Archive tasks: move published games off the working drive."""
+
+from .archive_task import ArchiveTask
+
+__all__ = ["ArchiveTask"]

--- a/video_grouper/task_processors/tasks/archive/archive_task.py
+++ b/video_grouper/task_processors/tasks/archive/archive_task.py
@@ -1,0 +1,240 @@
+"""Archive a published game off the working drive.
+
+Copy -> verify -> record -> delete, strictly in that order. The ordering is
+the entire point of this module, so it is spelled out here rather than left
+implicit in the code below.
+
+An earlier ad-hoc version of this deleted files first and recorded nothing.
+When it was interrupted partway (a dropped remote session), it left a group
+directory holding a few surviving files and a ``state.json`` that still said
+``combined``. The pipeline read that as a game mid-processing and started
+reprocessing it: it re-derived match info, blanked ``match_info.ini`` to a
+bare stub, and would have re-rendered and re-uploaded a game that was already
+published on YouTube. Nothing in the group said "this is finished, its bytes
+are gone on purpose", because the only record of that lived in the same
+directory being deleted.
+
+So: the group is marked ``archived`` -- a terminal status -- *before* a single
+byte is removed, and ``state.json`` is the last thing deleted. Interrupt this
+at any point and what remains is a group that plainly reads as finished.
+"""
+
+import hashlib
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from video_grouper.models import DirectoryState, MatchInfo
+
+from ...queue_type import QueueType
+from ..base_task import BaseTask
+
+logger = logging.getLogger(__name__)
+
+# Read in chunks: a combined game video is tens of GB and will not fit in RAM.
+_HASH_CHUNK_BYTES = 4 * 1024 * 1024
+
+
+def _sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as fh:
+        while chunk := fh.read(_HASH_CHUNK_BYTES):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_component(value: str) -> str:
+    """Make a match-info field safe to use as a directory name component."""
+    cleaned = "".join(c for c in value if c not in '<>:"/\\|?*').strip()
+    return cleaned or "unknown"
+
+
+@dataclass(unsafe_hash=True)
+class ArchiveTask(BaseTask):
+    """Copy one completed group to the archive root, then reclaim its space."""
+
+    group_dir: str
+
+    @classmethod
+    def queue_type(cls) -> QueueType:
+        return QueueType.ARCHIVE
+
+    @property
+    def task_type(self) -> str:
+        return "archive"
+
+    def get_item_path(self) -> str:
+        return self.group_dir
+
+    def serialize(self) -> dict[str, Any]:
+        return {"task_type": self.task_type, "group_dir": self.group_dir}
+
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> "ArchiveTask":
+        return cls(group_dir=str(data["group_dir"]))
+
+    def destination(self, archive_root: str) -> str:
+        """Where this group's archive copy belongs.
+
+        Named from ``match_info.ini`` rather than from the group directory,
+        which is only a camera timestamp. Falls back to the directory name
+        when match info is missing, so a game is never archived to a path
+        built from empty strings.
+        """
+        group_name = os.path.basename(self.group_dir.rstrip("\\/"))
+        match_info = MatchInfo.from_file(os.path.join(self.group_dir, "match_info.ini"))
+        if match_info is None or not match_info.opponent_team_name:
+            logger.warning(
+                "ARCHIVE: %s has no usable match_info; archiving under its "
+                "raw group name.",
+                group_name,
+            )
+            return os.path.join(archive_root, group_name)
+
+        date_part = group_name[:10]
+        home_away = "home" if match_info.location.strip().lower() == "home" else "away"
+        name = (
+            f"{date_part} - vs "
+            f"{_safe_component(match_info.opponent_team_name)} ({home_away})"
+        )
+        team = _safe_component(match_info.my_team_name)
+        return os.path.join(archive_root, team, name)
+
+    async def execute(
+        self,
+        archive_root: str = "",
+        delete_after_verify: bool = True,
+        watermark: datetime | None = None,
+    ) -> bool:
+        """Run the archive. Returns True when the group is fully archived.
+
+        ``watermark`` is the camera poller's high-water mark. Archiving a
+        group the watermark has not yet passed is unsafe: the poller's query
+        window still covers those recordings, and every "do we have this?"
+        test it can run -- ``is_file_in_state`` against the group's
+        ``state.json``, or a stat of the ``.mp4`` -- reads the local disk we
+        are about to empty. It would see the game as new and download it
+        again. So this is a hard refusal, not a warning: the task fails, is
+        retried later, and succeeds once the watermark catches up.
+        """
+        if not archive_root:
+            logger.error("ARCHIVE: no archive path configured; refusing to run.")
+            return False
+
+        dir_state = DirectoryState(self.group_dir)
+        if dir_state.status == "archived":
+            logger.info(
+                "ARCHIVE: %s already archived; nothing to do.",
+                os.path.basename(self.group_dir),
+            )
+            return True
+
+        newest = max(
+            (
+                f.end_time
+                for f in dir_state.files.values()
+                if isinstance(getattr(f, "end_time", None), datetime)
+            ),
+            default=None,
+        )
+        if newest is not None and (watermark is None or watermark < newest):
+            logger.error(
+                "ARCHIVE: refusing to archive %s -- the camera watermark (%s) "
+                "has not passed its newest recording (%s). Archiving now would "
+                "let the poller rediscover this game as new and re-download it. "
+                "Will retry once the watermark advances.",
+                os.path.basename(self.group_dir),
+                watermark,
+                newest,
+            )
+            return False
+
+        dest = self.destination(archive_root)
+        os.makedirs(dest, exist_ok=True)
+
+        # ---- copy + verify ------------------------------------------------
+        verified: list[str] = []
+        for root, _dirs, files in os.walk(self.group_dir):
+            for name in files:
+                src = os.path.join(root, name)
+                rel = os.path.relpath(src, self.group_dir)
+                dst = os.path.join(dest, rel)
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+
+                if os.path.exists(dst):
+                    # A previous run was interrupted. Prefer the larger file:
+                    # a short destination is a truncated copy, never a source
+                    # of truth, so re-copy over it.
+                    if os.path.getsize(dst) < os.path.getsize(src):
+                        logger.warning(
+                            "ARCHIVE: %s is short at the destination "
+                            "(%d < %d); re-copying.",
+                            rel,
+                            os.path.getsize(dst),
+                            os.path.getsize(src),
+                        )
+                        shutil.copy2(src, dst)
+                else:
+                    shutil.copy2(src, dst)
+
+                if _sha256(src) != _sha256(dst):
+                    logger.error(
+                        "ARCHIVE: SHA-256 mismatch for %s; aborting %s. "
+                        "Nothing deleted.",
+                        rel,
+                        os.path.basename(self.group_dir),
+                    )
+                    return False
+                verified.append(src)
+
+        logger.info(
+            "ARCHIVE: verified %d file(s) of %s -> %s",
+            len(verified),
+            os.path.basename(self.group_dir),
+            dest,
+        )
+
+        # ---- record BEFORE deleting ---------------------------------------
+        # See the module docstring: this is what makes an interrupted delete
+        # recoverable instead of a game that reprocesses itself.
+        await dir_state.update_group_status("archived")
+
+        if not delete_after_verify:
+            logger.info(
+                "ARCHIVE: delete_after_verify is off; keeping the local copy of %s.",
+                os.path.basename(self.group_dir),
+            )
+            return True
+
+        # ---- delete, by explicit path, only what verified -----------------
+        state_file = dir_state.state_file_path
+        for path in verified:
+            if os.path.abspath(path) == os.path.abspath(state_file):
+                continue  # deleted last, below
+            try:
+                os.remove(path)
+            except OSError as e:
+                logger.error("ARCHIVE: could not remove %s: %s", path, e)
+                return False
+
+        try:
+            if os.path.exists(state_file):
+                os.remove(state_file)
+            shutil.rmtree(self.group_dir, ignore_errors=True)
+        except OSError as e:
+            logger.error(
+                "ARCHIVE: archived %s but could not fully remove it: %s",
+                os.path.basename(self.group_dir),
+                e,
+            )
+            return False
+
+        logger.info(
+            "ARCHIVE: %s archived to %s and reclaimed locally.",
+            os.path.basename(self.group_dir),
+            dest,
+        )
+        return True

--- a/video_grouper/task_processors/tasks/archive/archive_task.py
+++ b/video_grouper/task_processors/tasks/archive/archive_task.py
@@ -106,12 +106,18 @@ class ArchiveTask(BaseTask):
     async def execute(
         self,
         archive_root: str = "",
-        delete_after_verify: bool = True,
+        make_second_copy: bool = True,
+        reclaim_local_space: bool = True,
         watermark: datetime | None = None,
     ) -> bool:
-        """Run the archive. Returns True when the group is fully archived.
+        """Run the archive. Returns True when the group has been dealt with.
 
-        ``watermark`` is the camera poller's high-water mark. Archiving a
+        The two flags are independent, matching ``[ARCHIVE] after_upload``:
+        keep a second copy at ``archive_root``, and/or reclaim the local
+        files. An install with a single drive sets no ``archive_root`` at all
+        and still reclaims space -- YouTube is its archive.
+
+        ``watermark`` is the camera poller's high-water mark. Reclaiming a
         group the watermark has not yet passed is unsafe: the poller's query
         window still covers those recordings, and every "do we have this?"
         test it can run -- ``is_file_in_state`` against the group's
@@ -120,7 +126,7 @@ class ArchiveTask(BaseTask):
         again. So this is a hard refusal, not a warning: the task fails, is
         retried later, and succeeds once the watermark catches up.
         """
-        if not archive_root:
+        if make_second_copy and not archive_root:
             logger.error("ARCHIVE: no archive path configured; refusing to run.")
             return False
 
@@ -132,31 +138,60 @@ class ArchiveTask(BaseTask):
             )
             return True
 
-        newest = max(
-            (
-                f.end_time
-                for f in dir_state.files.values()
-                if isinstance(getattr(f, "end_time", None), datetime)
-            ),
-            default=None,
-        )
-        if newest is not None and (watermark is None or watermark < newest):
-            logger.error(
-                "ARCHIVE: refusing to archive %s -- the camera watermark (%s) "
-                "has not passed its newest recording (%s). Archiving now would "
-                "let the poller rediscover this game as new and re-download it. "
-                "Will retry once the watermark advances.",
-                os.path.basename(self.group_dir),
-                watermark,
-                newest,
+        if reclaim_local_space:
+            newest = max(
+                (
+                    f.end_time
+                    for f in dir_state.files.values()
+                    if isinstance(getattr(f, "end_time", None), datetime)
+                ),
+                default=None,
             )
-            return False
+            if newest is not None and (watermark is None or watermark < newest):
+                logger.error(
+                    "ARCHIVE: refusing to reclaim %s -- the camera watermark "
+                    "(%s) has not passed its newest recording (%s). Deleting "
+                    "now would let the poller rediscover this game as new and "
+                    "re-download it. Will retry once the watermark advances.",
+                    os.path.basename(self.group_dir),
+                    watermark,
+                    newest,
+                )
+                return False
 
-        dest = self.destination(archive_root)
-        os.makedirs(dest, exist_ok=True)
+            if not make_second_copy:
+                # `discard`: the local files are the only copy we hold, so
+                # YouTube has to actually have the game before we drop them.
+                # The group reaching `complete` is not proof on its own --
+                # recorded video ids are.
+                uploaded = dir_state.get_uploaded_videos()
+                if not uploaded:
+                    logger.error(
+                        "ARCHIVE: refusing to discard %s -- no uploaded video "
+                        "id recorded for it, so YouTube is not known to hold a "
+                        "copy and these are the only files that exist.",
+                        os.path.basename(self.group_dir),
+                    )
+                    return False
+                logger.info(
+                    "ARCHIVE: %s is on YouTube (%s); reclaiming local files "
+                    "without a second copy.",
+                    os.path.basename(self.group_dir),
+                    ", ".join(f"{k}={v}" for k, v in sorted(uploaded.items())),
+                )
+
+        dest = self.destination(archive_root) if make_second_copy else ""
 
         # ---- copy + verify ------------------------------------------------
+        # `verified` doubles as the delete list, so for `discard` (no second
+        # copy) it is simply every file in the group.
         verified: list[str] = []
+        if not make_second_copy:
+            for root, _dirs, files in os.walk(self.group_dir):
+                verified.extend(os.path.join(root, name) for name in files)
+            return await self._finalize(dir_state, verified, reclaim_local_space, dest)
+
+        os.makedirs(dest, exist_ok=True)
         for root, _dirs, files in os.walk(self.group_dir):
             for name in files:
                 src = os.path.join(root, name)
@@ -196,20 +231,32 @@ class ArchiveTask(BaseTask):
             os.path.basename(self.group_dir),
             dest,
         )
+        return await self._finalize(dir_state, verified, reclaim_local_space, dest)
 
-        # ---- record BEFORE deleting ---------------------------------------
-        # See the module docstring: this is what makes an interrupted delete
-        # recoverable instead of a game that reprocesses itself.
+    async def _finalize(
+        self,
+        dir_state: DirectoryState,
+        verified: list[str],
+        reclaim_local_space: bool,
+        dest: str,
+    ) -> bool:
+        """Record the group as archived, then optionally reclaim its files.
+
+        Shared by every disposition so the ordering can only be written once.
+        See the module docstring: recording BEFORE deleting is what makes an
+        interrupted run recoverable instead of a game that reprocesses itself.
+        """
         await dir_state.update_group_status("archived")
 
-        if not delete_after_verify:
+        if not reclaim_local_space:
             logger.info(
-                "ARCHIVE: delete_after_verify is off; keeping the local copy of %s.",
+                "ARCHIVE: %s copied to %s; local files kept.",
                 os.path.basename(self.group_dir),
+                dest,
             )
             return True
 
-        # ---- delete, by explicit path, only what verified -----------------
+        # Delete by explicit path, only files that were accounted for.
         state_file = dir_state.state_file_path
         for path in verified:
             if os.path.abspath(path) == os.path.abspath(state_file):
@@ -233,8 +280,8 @@ class ArchiveTask(BaseTask):
             return False
 
         logger.info(
-            "ARCHIVE: %s archived to %s and reclaimed locally.",
+            "ARCHIVE: %s reclaimed locally%s.",
             os.path.basename(self.group_dir),
-            dest,
+            f" (archived to {dest})" if dest else " (YouTube holds the copy)",
         )
         return True

--- a/video_grouper/task_processors/tasks/archive/archive_task.py
+++ b/video_grouper/task_processors/tasks/archive/archive_task.py
@@ -76,13 +76,27 @@ class ArchiveTask(BaseTask):
     def deserialize(cls, data: dict[str, Any]) -> "ArchiveTask":
         return cls(group_dir=str(data["group_dir"]))
 
-    def destination(self, archive_root: str) -> str:
-        """Where this group's archive copy belongs.
+    def team_name(self) -> str:
+        """This group's ``my_team_name``, used to pick its archive root."""
+        match_info = MatchInfo.from_file(os.path.join(self.group_dir, "match_info.ini"))
+        return match_info.my_team_name if match_info else ""
 
-        Named from ``match_info.ini`` rather than from the group directory,
-        which is only a camera timestamp. Falls back to the directory name
-        when match info is missing, so a game is never archived to a path
-        built from empty strings.
+    def destination(self, team_root: str) -> str:
+        """Where this group's archive copy belongs, inside its team's root.
+
+        ``team_root`` is already team-specific (see ``[ARCHIVE.PER_TEAM]``) —
+        no team component is appended here. The root name cannot be derived
+        from the team name anyway: a team recorded as "Guzzetta" archives to
+        ``Heat_2012s``, and one account can hold several age groups that must
+        not be mixed.
+
+        The game folder is named from ``match_info.ini`` rather than the group
+        directory, which is only a camera timestamp:
+
+            <team_root>/2026.07.12 - vs Niagara Falls Soccer Club (away)
+
+        Falls back to the raw group name when match info is unusable, so a
+        game is never archived to a path built from empty strings.
         """
         group_name = os.path.basename(self.group_dir.rstrip("\\/"))
         match_info = MatchInfo.from_file(os.path.join(self.group_dir, "match_info.ini"))
@@ -92,7 +106,7 @@ class ArchiveTask(BaseTask):
                 "raw group name.",
                 group_name,
             )
-            return os.path.join(archive_root, group_name)
+            return os.path.join(team_root, group_name)
 
         date_part = group_name[:10]
         home_away = "home" if match_info.location.strip().lower() == "home" else "away"
@@ -100,8 +114,7 @@ class ArchiveTask(BaseTask):
             f"{date_part} - vs "
             f"{_safe_component(match_info.opponent_team_name)} ({home_away})"
         )
-        team = _safe_component(match_info.my_team_name)
-        return os.path.join(archive_root, team, name)
+        return os.path.join(team_root, name)
 
     async def execute(
         self,

--- a/video_grouper/task_processors/upload_processor.py
+++ b/video_grouper/task_processors/upload_processor.py
@@ -25,6 +25,7 @@ class UploadProcessor(QueueProcessor):
         storage_path: str,
         config: Config,
         ntfy_service: Any | None = None,
+        archive_processor: Any | None = None,
     ):
         """Initialize the upload processor.
 
@@ -32,10 +33,14 @@ class UploadProcessor(QueueProcessor):
             storage_path: Base storage path
             config: Application configuration
             ntfy_service: Optional NtfyService for playlist requests and auth notifications
+            archive_processor: Optional ArchiveProcessor. A group is handed to
+                it the moment its upload completes — pushed downstream inline
+                rather than waiting for a sweep to notice.
         """
         super().__init__(storage_path, config)
         self.config = config
         self.ntfy_service = ntfy_service
+        self.archive_processor = archive_processor
         self.ttt_reporter = None
 
     @property
@@ -171,6 +176,26 @@ class UploadProcessor(QueueProcessor):
                                 )
                         except Exception:
                             pass  # Never block upload on TTT
+
+                # Hand the finished group straight to the archive queue.
+                # Pushed inline here rather than left for a periodic sweep to
+                # discover, so reclaiming disk follows publication directly.
+                # The archive step re-checks everything that matters
+                # (verification, the watermark guard), so a duplicate or
+                # premature enqueue is harmless.
+                if self.archive_processor is not None:
+                    try:
+                        from .tasks.archive import ArchiveTask
+
+                        await self.archive_processor.add_work(
+                            ArchiveTask(group_dir=item.get_item_path())
+                        )
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning(
+                            "UPLOAD: could not queue archive for %s: %s",
+                            item.get_item_path(),
+                            e,
+                        )
             else:
                 logger.error(f"UPLOAD: Task execution failed: {item}")
                 # Report upload failure to TTT (best-effort)

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -74,6 +74,26 @@ class StorageConfig(BaseModel):
     min_free_gb: float = 2.0
 
 
+class ArchiveConfig(BaseModel):
+    """Move published games off the working drive once they are safely uploaded.
+
+    Off by default: deleting local footage is destructive, so it must be an
+    explicit choice. When enabled, a group is copied to ``path``, verified
+    file-by-file with SHA-256, recorded as ``archived``, and only then
+    removed locally — in that order, so an interrupted run leaves a group
+    that is plainly finished rather than one that looks half-processed and
+    gets picked up for reprocessing.
+    """
+
+    enabled: bool = False
+    # Destination root. Per-game subdirectories are named from match_info.
+    path: str = ""
+    # Set false to copy and verify but keep the local copy — useful for a
+    # first run, when you want to confirm the archive looks right before
+    # anything is deleted.
+    delete_after_verify: bool = True
+
+
 class RecordingConfig(BaseModel):
     min_duration: int = 60
     max_duration: int = 3600
@@ -398,6 +418,7 @@ class SetupConfig(BaseModel):
 class Config(BaseModel):
     cameras: list[CameraConfig] = Field(default_factory=list)
     storage: StorageConfig = Field(alias="STORAGE")
+    archive: ArchiveConfig = Field(alias="ARCHIVE", default_factory=ArchiveConfig)
     recording: RecordingConfig = Field(alias="RECORDING")
     processing: ProcessingConfig = Field(alias="PROCESSING")
     logging: LoggingConfig = Field(alias="LOGGING")

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -143,14 +143,38 @@ class ArchiveConfig(BaseModel):
     def root_for_team(self, team_name: str) -> str:
         """Archive root for *team_name*, or "" when it has nowhere to go.
 
-        Matched case-insensitively and ignoring surrounding whitespace:
-        configparser lowercases option keys, and match_info is hand-edited.
+        *team_name* is a game's ``my_team_name`` from match_info.ini, and that
+        is the full registered name — on the live install, ``BU14 - Guzzetta``,
+        not ``Guzzetta``. An exact match therefore misses: an operator writes
+        the short handle they think of the team by, and archiving would refuse
+        every game with "no archive root for team".
+
+        So match exactly first, then by substring, which is the same rule
+        ``[YOUTUBE.PLAYLIST_MAP]`` has always used and the only reason a key
+        like ``guzzetta`` resolves ``BU14 - Guzzetta`` there. Longest key wins
+        among substring matches, so with two teams sharing a word ("Flash" and
+        "WNY Flash Rochester") the more specific root is chosen rather than
+        whichever happens to be first — filing a game under another team's
+        archive and then deleting the original is not recoverable.
+
+        Case-insensitive and whitespace-tolerant throughout: configparser
+        lowercases option keys, and match_info is hand-edited.
         """
         wanted = (team_name or "").strip().casefold()
+        if not wanted:
+            return self.path.strip()
+
         for name, root in self.per_team.items():
             if name.strip().casefold() == wanted:
                 return root.strip()
-        return self.path.strip()
+
+        best_root = ""
+        best_len = 0
+        for name, root in self.per_team.items():
+            folded = name.strip().casefold()
+            if folded and folded in wanted and len(folded) > best_len:
+                best_root, best_len = root.strip(), len(folded)
+        return best_root or self.path.strip()
 
     @property
     def makes_second_copy(self) -> bool:

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -99,25 +99,58 @@ class ArchiveConfig(BaseModel):
     copy's SHA-256 matches file-by-file (``copy``/``move``), or until the
     group carries a recorded YouTube video id (``discard``). ``keep`` is the
     default because deleting footage must be asked for, never assumed.
+
+    Archives are per-team, and a team's root is NOT derivable from its name.
+    A team recorded in match_info as "Guzzetta" archives to ``Heat_2012s``,
+    and one account can carry several age groups (``Heat_2012s`` and
+    ``Heat_2013s``) that must never be mixed. So the mapping is supplied,
+    not guessed::
+
+        [ARCHIVE.PER_TEAM]
+        Guzzetta = F:\\Heat_2012s
+        Flash = F:\\Flash_2013s
+
+    ``path`` is the fallback for teams with no entry, and is enough on its
+    own for a single-team install. Per-game subdirectories are named from
+    match_info: ``<root>/<date> - vs <opponent> (home|away)``.
     """
 
     after_upload: Literal["keep", "copy", "move", "discard"] = "keep"
-    # Destination root for `copy`/`move`. Per-game subdirectories are named
-    # from match_info. Unused by `keep` and `discard`.
+    # Fallback destination root for `copy`/`move`, used for teams with no
+    # PER_TEAM entry. Unused by `keep` and `discard`.
     path: str = ""
+    # my_team_name -> archive root. Wins over `path`.
+    per_team: dict[str, str] = Field(default_factory=dict, alias="PER_TEAM")
+
+    model_config = {"populate_by_name": True}
 
     @model_validator(mode="after")
-    def _path_required_for_second_copy(self) -> ArchiveConfig:
+    def _second_copy_needs_somewhere_to_go(self) -> ArchiveConfig:
         # Hard-fail rather than silently degrading to a no-op: an operator who
         # asked for a second copy and got none would find out only when the
         # working drive was already gone.
-        if self.after_upload in ("copy", "move") and not self.path.strip():
+        if self.after_upload in ("copy", "move") and not (
+            self.path.strip() or self.per_team
+        ):
             raise ValueError(
-                f"[ARCHIVE] after_upload = {self.after_upload} needs a `path` "
-                "to copy games to. Set one, or use `discard` to reclaim local "
-                "space without a second copy, or `keep` to do nothing."
+                f"[ARCHIVE] after_upload = {self.after_upload} needs somewhere "
+                "to put games: set `path`, or map teams to roots under "
+                "[ARCHIVE.PER_TEAM]. Use `discard` to reclaim local space "
+                "without a second copy, or `keep` to do nothing."
             )
         return self
+
+    def root_for_team(self, team_name: str) -> str:
+        """Archive root for *team_name*, or "" when it has nowhere to go.
+
+        Matched case-insensitively and ignoring surrounding whitespace:
+        configparser lowercases option keys, and match_info is hand-edited.
+        """
+        wanted = (team_name or "").strip().casefold()
+        for name, root in self.per_team.items():
+            if name.strip().casefold() == wanted:
+                return root.strip()
+        return self.path.strip()
 
     @property
     def makes_second_copy(self) -> bool:
@@ -517,6 +550,14 @@ def load_config(config_path: Path) -> Config:
     if "YOUTUBE.PLAYLIST_MAP" in config_dict:
         config_dict.setdefault("YOUTUBE", {})["playlist_map"] = (
             YouTubePlaylistMapConfig(config_dict.pop("YOUTUBE.PLAYLIST_MAP"))
+        )
+
+    # `[ARCHIVE.PER_TEAM]` -> dict of my_team_name -> archive root. Archives
+    # are per-team and the root is not derivable from the name (match_info
+    # "Guzzetta" -> Heat_2012s), so the mapping has to come from config.
+    if "ARCHIVE.PER_TEAM" in config_dict:
+        config_dict.setdefault("ARCHIVE", {})["PER_TEAM"] = config_dict.pop(
+            "ARCHIVE.PER_TEAM"
         )
 
     # Handle BALL_TRACKING sub-sections (provider configs + per-team overrides).

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -5,7 +5,13 @@ import logging
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field, RootModel, field_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    RootModel,
+    field_validator,
+    model_validator,
+)
 
 from video_grouper.pipeline.config import PipelineConfig
 
@@ -75,23 +81,51 @@ class StorageConfig(BaseModel):
 
 
 class ArchiveConfig(BaseModel):
-    """Move published games off the working drive once they are safely uploaded.
+    """What happens to a game's local files once it is safely on YouTube.
 
-    Off by default: deleting local footage is destructive, so it must be an
-    explicit choice. When enabled, a group is copied to ``path``, verified
-    file-by-file with SHA-256, recorded as ``archived``, and only then
-    removed locally — in that order, so an interrupted run leaves a group
-    that is plainly finished rather than one that looks half-processed and
-    gets picked up for reprocessing.
+    Two independent questions, not one: keep a second copy somewhere, and
+    reclaim the working drive. Copying to a second location is one answer,
+    not the shape of the feature — plenty of installs have a single drive
+    and no archive volume, and those are exactly the ones that fill up.
+
+        after_upload   second copy at `path`?   local files reclaimed?
+        ------------   ----------------------   ----------------------
+        keep           no                       no   (default)
+        copy           yes                      no
+        move           yes                      yes
+        discard        no                       yes
+
+    Verification is never a choice. Nothing is removed until the archive
+    copy's SHA-256 matches file-by-file (``copy``/``move``), or until the
+    group carries a recorded YouTube video id (``discard``). ``keep`` is the
+    default because deleting footage must be asked for, never assumed.
     """
 
-    enabled: bool = False
-    # Destination root. Per-game subdirectories are named from match_info.
+    after_upload: Literal["keep", "copy", "move", "discard"] = "keep"
+    # Destination root for `copy`/`move`. Per-game subdirectories are named
+    # from match_info. Unused by `keep` and `discard`.
     path: str = ""
-    # Set false to copy and verify but keep the local copy — useful for a
-    # first run, when you want to confirm the archive looks right before
-    # anything is deleted.
-    delete_after_verify: bool = True
+
+    @model_validator(mode="after")
+    def _path_required_for_second_copy(self) -> ArchiveConfig:
+        # Hard-fail rather than silently degrading to a no-op: an operator who
+        # asked for a second copy and got none would find out only when the
+        # working drive was already gone.
+        if self.after_upload in ("copy", "move") and not self.path.strip():
+            raise ValueError(
+                f"[ARCHIVE] after_upload = {self.after_upload} needs a `path` "
+                "to copy games to. Set one, or use `discard` to reclaim local "
+                "space without a second copy, or `keep` to do nothing."
+            )
+        return self
+
+    @property
+    def makes_second_copy(self) -> bool:
+        return self.after_upload in ("copy", "move")
+
+    @property
+    def reclaims_local_space(self) -> bool:
+        return self.after_upload in ("move", "discard")
 
 
 class RecordingConfig(BaseModel):

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -111,17 +111,15 @@ class AppConfig(BaseModel):
     timezone: str = "America/New_York"
     github_repo: str = "mblakley/soccer-cam"
     storage_path: str | None = None
-    max_lookback_hours: int = 48
     max_files_per_poll: int = 50
     recording_end_date: str | None = None
-    # Reconciliation pass lookback. The incremental sync only queries a
-    # forward-moving window (max_lookback_hours back from now), so a game
-    # that ages past that window before it was fully captured is never
-    # re-queried and is lost. When the download queue is idle, the poller
-    # runs a full reconcile over this much larger window and re-queues any
-    # camera file that is missing/short/incomplete on disk — regardless of
-    # the high-water mark. 14 days covers a typical multi-week gap between
-    # plugging the camera in.
+    # Reconciliation pass lookback. When the download queue is idle, the
+    # poller re-scans this window and re-queues any camera file that is
+    # missing/short/incomplete on disk, healing downloads that died partway.
+    # Bounded below by the watermark, so it only ever asks that question about
+    # recordings we still owe work on — behind the watermark a game is
+    # *supposed* to be missing locally once it has been archived.
+    # 14 days covers a typical multi-week gap between plugging the camera in.
     reconcile_lookback_days: int = 14
     # Auto-upgrade settings. auto_update=true (Chrome-style) silently installs
     # detected updates once the pipeline is quiescent; =false stops after

--- a/video_grouper/video_grouper_app.py
+++ b/video_grouper/video_grouper_app.py
@@ -7,6 +7,7 @@ from video_grouper.api_integrations.command_executor import CommandExecutor
 from video_grouper.api_integrations.ntfy_response import create_ntfy_response_service
 from video_grouper.api_integrations.ttt_reporter import TTTReporter
 from video_grouper.task_processors import (
+    ArchiveProcessor,
     CameraPoller,
     ClipDiscoveryProcessor,
     ClipProcessor,
@@ -103,9 +104,17 @@ class VideoGrouperApp:
         # Get poll interval from config
         self.poll_interval = config.app.check_interval_seconds
 
-        # Instantiate shared processors in dependency order
-        self.upload_processor = UploadProcessor(
+        # Instantiate shared processors in dependency order.
+        # Archive runs after upload: a group is only safe to reclaim locally
+        # once its videos are on YouTube. Its own queue keeps the hashing of
+        # tens of GB off the upload path.
+        self.archive_processor = ArchiveProcessor(
             storage_path=self.storage_path, config=self.config
+        )
+        self.upload_processor = UploadProcessor(
+            storage_path=self.storage_path,
+            config=self.config,
+            archive_processor=self.archive_processor,
         )
         self.video_processor = VideoProcessor(
             storage_path=self.storage_path,
@@ -664,6 +673,11 @@ class VideoGrouperApp:
             poll_interval=self.poll_interval,
             ntfy_processor=self.ntfy_processor,
         )
+        # Recovery net for archiving: the upload task pushes finished groups
+        # onto the archive queue directly, so this only catches groups that
+        # missed that path (a crash between upload and enqueue, or a group
+        # completed by a build that predates archiving).
+        self.state_auditor.archive_processor = self.archive_processor
 
         # Auto-upgrade poller. Lives in the service (always running)
         # so headless installs still update. The quiescence callable
@@ -686,6 +700,7 @@ class VideoGrouperApp:
             [
                 self.video_processor,
                 self.upload_processor,
+                self.archive_processor,
             ]
         )
         if self.ntfy_processor:


### PR DESCRIPTION
## Why

Archiving five published July games from `D:` to `F:` made the camera poller **re-download all of them**.

Every "do we already have this?" test soccer-cam had asks the local disk — the incremental pass reads the group's `state.json` (`is_file_in_state`), and the reconcile pass stats the `.mp4`. Archiving deletes both on purpose, so a finished, published game answers *"never seen it"*.

The high-water mark could not settle it either, because it advanced at **discovery**: it moved the instant a file was queued, before a byte was downloaded. That is the 2026-06-15 loss, and it is why `max_lookback_hours` and the reconcile pass existed at all — both were patches over a mark that did not mean what its name said.

## What changed

**One invariant.** The watermark is the newest recording end time `T` such that *every* recording at or before `T` is settled, and it only moves forward. "At or before the watermark" therefore means finished, so the poller stops asking the disk anything.

- advances over a contiguous settled prefix, never on discovery
- enforced **in the discovery loop**, not just via the query range — cameras return recordings that merely *overlap* a window, so a game straddling the boundary comes back regardless
- reconcile is bounded below by it; behind the watermark an archived game is *supposed* to be missing
- stored at the storage root, never re-derived from what remains on disk

`max_lookback_hours` is removed — it only ever skipped a stale watermark forward, silently dropping whatever it skipped. First run scans a year (neither backend can list "everything", and both return `[]` if handed `None`).

**Archiving becomes a real pipeline step** (opt-in `[ARCHIVE]`): copy → verify SHA-256 → record `archived` → delete, `state.json` last. The ad-hoc script it replaces deleted first and recorded nothing; interrupted by a dropped remote session it left a group reading as `combined`, which the pipeline began reprocessing — it would have re-rendered and re-uploaded an already-published game.

`after_upload = keep | copy | move | discard`. `discard` is the single-drive answer (YouTube is the archive) and refuses without a recorded video id. The step also hard-refuses to reclaim a group the watermark has not passed.

## Verification

The unit tests passed while the real bug survived, so this was replayed against the **live server's actual state** — watermark `2026-07-12 10:35:15`, all July groups archived off `D:`, camera still holding their recordings.

**It failed: 20 downloads queued.** Reconcile narrowed its query range but never re-checked what came back. That is now fixed and covered by a test.

- Full unit suite: **2131 passed**, 15 skipped, 1 xfailed. ruff + mypy clean.
- 14 new tests, each confirmed to fail against the unfixed code.
- `test_poll_summary_logs_normal_new_file` previously asserted that *queueing* a file advanced the mark — the 2026-06-15 bug written down as an expectation — and is inverted.

## One more fix since first posting

`root_for_team` matched the archive root **exactly**, but the value it is handed is a game's `my_team_name` — the full registered name, `BU14 - Guzzetta`, while an operator writes the short handle `guzzetta`. Those never compare equal, so the guard added here refused *every* game with "no archive root for team". The feature could not have worked on the config it was designed for.

It now matches exactly first, then by substring — the same rule `[YOUTUBE.PLAYLIST_MAP]` has always used. Longest key wins, so two teams sharing a word are not filed into each other's archive; combined with deleting the original that is unrecoverable. Six tests, three of which fail against the exact match.

## Note for review

`[ARCHIVE.PER_TEAM]` here is superseded by `[TEAM.<key>]` in #142. Whichever merges second reconciles; with the migration framework in that PR it is one migration entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zon5KgUuiwEe3dZV7z9r6
