### PR TITLE
Versioned config migrations, and one [TEAM.<key>] section per team

### DIFF
--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -1,0 +1,383 @@
+"""Tests for versioned config.ini migrations.
+
+The framework's job is to make a schema change apply exactly once and leave no
+permanent legacy-reading code behind. These tests pin the three properties that
+makes true: migrations run in order from whatever version a file is at, running
+them twice changes nothing, and a file from a newer build is refused rather
+than quietly mangled.
+"""
+
+import configparser
+
+import pytest
+
+from video_grouper.utils import config_migrations as cm
+from video_grouper.utils.config import load_config
+
+# The per-team sections exactly as the live server config spells them,
+# including configparser's lowercasing of the playlist-map keys and the short
+# substring spellings that only resolve because the lookup is fuzzy.
+LIVE_CONFIG = """\
+[STORAGE]
+path = D:\\soccer-cam-storage
+
+[TEAMSNAP]
+enabled = True
+client_id = tg_abc
+
+[TEAMSNAP.TEAM.0]
+enabled = True
+team_id = 10198718
+team_name = BU14 - Guzzetta
+
+[PLAYMETRICS]
+enabled = True
+username = mark@example.com
+
+[PLAYMETRICS.TEAM.0]
+team_id = 335774
+team_name = Western New York Flash - 13B ECNL-RL Rochester
+enabled = True
+
+[YOUTUBE.PLAYLIST_MAP]
+13b ecnl-rl rochester = WNY Flash 2013s
+guzzetta = Hilton Heat 2012s
+"""
+
+
+def _write(tmp_path, text, name="config.ini"):
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _sections(path):
+    parser = configparser.ConfigParser()
+    parser.read(path, encoding="utf-8")
+    return {s: dict(parser.items(s)) for s in parser.sections()}
+
+
+class TestFramework:
+    def test_unversioned_file_runs_every_migration(self, tmp_path):
+        path = _write(tmp_path, LIVE_CONFIG)
+        applied = cm.migrate_config_file(path)
+        assert [m.version for m in applied] == [m.version for m in cm.MIGRATIONS]
+
+    def test_version_is_stamped_and_second_run_is_a_no_op(self, tmp_path):
+        path = _write(tmp_path, LIVE_CONFIG)
+        cm.migrate_config_file(path)
+
+        after_first = path.read_text(encoding="utf-8")
+        assert _sections(path)[cm.VERSION_SECTION][cm.VERSION_OPTION] == str(
+            cm.current_schema_version()
+        )
+
+        assert cm.migrate_config_file(path) == []
+        assert path.read_text(encoding="utf-8") == after_first
+
+    def test_original_is_kept_as_a_backup(self, tmp_path):
+        path = _write(tmp_path, LIVE_CONFIG)
+        cm.migrate_config_file(path)
+        backup = path.with_suffix(path.suffix + ".bak")
+        assert backup.exists()
+        assert backup.read_text(encoding="utf-8") == LIVE_CONFIG
+
+    def test_a_partly_migrated_file_only_runs_what_it_still_needs(self, tmp_path):
+        """The 'between x and y' case: a file already past v1 skips it."""
+        path = _write(
+            tmp_path,
+            f"{LIVE_CONFIG}\n[{cm.VERSION_SECTION}]\n{cm.VERSION_OPTION} = 1\n",
+        )
+        applied = cm.migrate_config_file(path)
+        assert [m.version for m in applied] == [
+            m.version for m in cm.MIGRATIONS if m.version > 1
+        ]
+
+    def test_a_file_from_a_newer_build_is_refused(self, tmp_path):
+        """An older binary cannot know what a later migration did."""
+        future = cm.current_schema_version() + 5
+        path = _write(
+            tmp_path,
+            f"{LIVE_CONFIG}\n[{cm.VERSION_SECTION}]\n{cm.VERSION_OPTION} = {future}\n",
+        )
+        with pytest.raises(ValueError, match="newer soccer-cam"):
+            cm.migrate_config_file(path)
+
+    def test_unreadable_version_is_treated_as_unversioned(self, tmp_path):
+        """Better to re-run migrations (they are idempotent) than skip them."""
+        path = _write(
+            tmp_path,
+            f"{LIVE_CONFIG}\n[{cm.VERSION_SECTION}]\n{cm.VERSION_OPTION} = banana\n",
+        )
+        assert cm.migrate_config_file(path)
+
+    def test_missing_file_is_not_an_error(self, tmp_path):
+        assert cm.migrate_config_file(tmp_path / "nope.ini") == []
+
+    def test_migration_versions_are_ordered_and_contiguous(self):
+        """A gap or a repeat would silently skip or re-run a migration."""
+        versions = [m.version for m in cm.MIGRATIONS]
+        assert versions == list(range(1, len(versions) + 1))
+
+
+class TestPerTeamConsolidation:
+    """v2: five scattered per-team sections become one [TEAM.<key>] each."""
+
+    @pytest.fixture
+    def migrated(self, tmp_path):
+        path = _write(tmp_path, LIVE_CONFIG)
+        cm.migrate_config_file(path)
+        return load_config(path)
+
+    def test_both_real_teams_survive_with_their_ids(self, migrated):
+        heat = migrated.team_for("BU14 - Guzzetta")
+        flash = migrated.team_for("Western New York Flash - 13B ECNL-RL Rochester")
+
+        assert heat is not None and flash is not None
+        assert heat.teamsnap_team_id == "10198718"
+        assert flash.playmetrics_team_id == "335774"
+
+    def test_playlists_are_folded_in_across_the_spelling_mismatch(self, migrated):
+        """The playlist map is keyed 'guzzetta'; the team is 'BU14 - Guzzetta'.
+
+        Only substring matching ever connected those two, so the migration has
+        to reproduce it rather than compare the strings.
+        """
+        assert migrated.team_for("BU14 - Guzzetta").youtube_playlist == (
+            "Hilton Heat 2012s"
+        )
+        assert (
+            migrated.team_for(
+                "Western New York Flash - 13B ECNL-RL Rochester"
+            ).youtube_playlist
+            == "WNY Flash 2013s"
+        )
+
+    def test_the_short_playlist_key_is_kept_as_an_alias(self, migrated):
+        """It is what the operator wrote, and it still has to resolve."""
+        heat = migrated.team_for("BU14 - Guzzetta")
+        assert "guzzetta" in [a.casefold() for a in heat.aliases]
+        assert migrated.team_for("guzzetta") is heat
+
+    def test_legacy_sections_are_gone_from_disk(self, tmp_path):
+        """The point of migrating rather than shimming: the old shape is gone."""
+        path = _write(tmp_path, LIVE_CONFIG)
+        cm.migrate_config_file(path)
+        sections = _sections(path)
+
+        assert not [s for s in sections if s.startswith("TEAMSNAP.")]
+        assert not [s for s in sections if s.startswith("PLAYMETRICS.TEAM.")]
+        assert "YOUTUBE.PLAYLIST_MAP" not in sections
+        assert [s for s in sections if s.startswith("TEAM.")]
+
+    def test_credentials_are_left_alone(self, migrated):
+        """Only the per-team parts move; the integration sections stay."""
+        assert migrated.teamsnap.client_id == "tg_abc"
+        assert migrated.playmetrics.username == "mark@example.com"
+
+    def test_a_config_with_no_teams_migrates_cleanly(self, tmp_path):
+        path = _write(tmp_path, "[STORAGE]\npath = D:\\x\n")
+        cm.migrate_config_file(path)
+        config = load_config(path)
+        assert config.teams == {}
+        assert config.team_for("Anyone") is None
+
+
+class TestBallTrackingMigration:
+    """v1: the shim that used to run on every single load, now run once."""
+
+    def test_legacy_ball_tracking_becomes_a_pipeline(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "[STORAGE]\npath = D:\\x\n\n"
+            "[BALL_TRACKING]\nprovider = autocam_gui\nenabled = true\n\n"
+            "[BALL_TRACKING.AUTOCAM_GUI]\nexecutable = C:/once/AutocamGUI.exe\n",
+        )
+        cm.migrate_config_file(path)
+
+        config = load_config(path)
+        assert [s.type for s in config.pipeline.ordered_steps()] == ["autocam"]
+        assert "BALL_TRACKING" not in _sections(path)
+
+    def test_an_explicit_pipeline_is_not_overwritten(self, tmp_path):
+        """`[PIPELINE] enabled = false` is a deliberate choice, not an absence."""
+        path = _write(
+            tmp_path,
+            "[STORAGE]\npath = D:\\x\n\n"
+            "[BALL_TRACKING]\nprovider = autocam_gui\nenabled = true\n\n"
+            "[PIPELINE]\nenabled = false\nsteps =\n",
+        )
+        cm.migrate_config_file(path)
+
+        config = load_config(path)
+        assert config.pipeline.enabled is False
+        assert config.pipeline.ordered_steps() == []
+
+
+class TestPerTeamPipelineFinallyWorks:
+    """Per-team pipeline selection had two independent bugs and never fired.
+
+    `[PIPELINE.PER_TEAM]` round-tripped through config but `ordered_steps`
+    ignored its team argument, AND the team name it was given was always None
+    because pipeline discovery read `[MATCH] team_name` while match_info only
+    ever writes `my_team_name`. Both are fixed, so the setting means something
+    for the first time.
+    """
+
+    PIPELINE_INI = """\
+[STORAGE]
+path = /data
+
+[PIPELINE]
+enabled = true
+steps = stitch, ball_detect, render
+
+[PIPELINE.stitch]
+type = stitch_correct
+
+[PIPELINE.ball_detect]
+type = ball_detect
+
+[PIPELINE.render]
+type = render
+
+[TEAM.heat]
+name = BU14 - Guzzetta
+pipeline = stitch, render
+
+[TEAM.flash]
+name = WNY Flash
+"""
+
+    def test_a_team_can_override_which_steps_run(self, tmp_path):
+        config = load_config(_write(tmp_path, self.PIPELINE_INI))
+        team = config.team_for("BU14 - Guzzetta")
+
+        steps = config.pipeline.ordered_steps(
+            "BU14 - Guzzetta", override_steps=team.pipeline
+        )
+
+        assert [s.step_id for s in steps] == ["stitch", "render"]
+
+    def test_a_team_without_an_override_runs_the_shared_pipeline(self, tmp_path):
+        config = load_config(_write(tmp_path, self.PIPELINE_INI))
+        team = config.team_for("WNY Flash")
+
+        steps = config.pipeline.ordered_steps("WNY Flash", override_steps=team.pipeline)
+
+        assert [s.step_id for s in steps] == ["stitch", "ball_detect", "render"]
+
+    def test_discovery_reads_my_team_name_not_team_name(self, tmp_path):
+        """The option is `my_team_name`; reading `team_name` always gave None."""
+        from video_grouper.task_processors.pipeline_discovery_processor import (
+            PipelineDiscoveryProcessor,
+        )
+
+        group = tmp_path / "2026.07.12-10.00.00"
+        group.mkdir()
+        (group / "match_info.ini").write_text(
+            "[MATCH]\nmy_team_name = BU14 - Guzzetta\nopponent_team_name = X\n",
+            encoding="utf-8",
+        )
+
+        assert PipelineDiscoveryProcessor._read_team_name(group) == "BU14 - Guzzetta"
+
+
+class TestIntegrationsSurviveMigration:
+    """The migration deletes the sections TeamSnap/PlayMetrics read from.
+
+    Their `teams` lists are projected back out of [TEAM.*] at load time. Without
+    that, an upgraded install would silently find no teams and both
+    integrations would quietly stop fetching schedules.
+    """
+
+    def test_team_lists_are_identical_before_and_after(self, tmp_path):
+        path = _write(tmp_path, LIVE_CONFIG)
+        before = load_config(path)
+        cm.migrate_config_file(path)
+        after = load_config(path)
+
+        def summarise(config):
+            return (
+                sorted((t.team_name, t.team_id) for t in config.teamsnap.teams),
+                sorted((t.team_name, t.team_id) for t in config.playmetrics.teams),
+            )
+
+        assert summarise(after) == summarise(before)
+        assert summarise(after)[0] == [("BU14 - Guzzetta", "10198718")]
+
+    def test_a_disabled_team_is_not_projected(self, tmp_path):
+        config = load_config(
+            _write(
+                tmp_path,
+                "[STORAGE]\npath = /data\n\n[TEAMSNAP]\nenabled = true\n\n"
+                "[TEAM.heat]\nname = BU14 - Guzzetta\n"
+                "teamsnap_team_id = 10198718\nenabled = false\n",
+            )
+        )
+        assert config.teamsnap.teams == []
+
+
+class TestResolverAmbiguity:
+    """With several teams, the best match must win — not the first configured."""
+
+    AMBIGUOUS = """\
+[STORAGE]
+path = /data
+
+[TEAM.generic]
+name = Flash
+youtube_playlist = Generic Flash
+
+[TEAM.specific]
+name = WNY Flash Rochester
+youtube_playlist = WNY Flash 2013s
+"""
+
+    def test_longest_match_wins_regardless_of_config_order(self, tmp_path):
+        config = load_config(_write(tmp_path, self.AMBIGUOUS))
+
+        team = config.team_for("WNY Flash Rochester ECNL")
+
+        assert team is not None
+        assert team.youtube_playlist == "WNY Flash 2013s", (
+            "the more specific team must win; first-configured would misfile "
+            "the game into the other team's playlist"
+        )
+
+    def test_exact_match_beats_a_longer_substring_match(self, tmp_path):
+        config = load_config(_write(tmp_path, self.AMBIGUOUS))
+        assert config.team_for("Flash").youtube_playlist == "Generic Flash"
+
+    def test_a_disabled_team_never_matches(self, tmp_path):
+        config = load_config(
+            _write(
+                tmp_path,
+                "[STORAGE]\npath = /data\n\n"
+                "[TEAM.off]\nname = Flash\nenabled = false\n",
+            )
+        )
+        assert config.team_for("Flash") is None
+
+
+class TestUnreadableConfigIsLeftAlone:
+    """A file we cannot parse must not be replaced by a version stub.
+
+    configparser ignores unreadable paths silently rather than raising, so
+    without a guard an empty or missing file reads as "no sections", which
+    looks identical to "unversioned" — and the migration would back it up and
+    write a config containing nothing but [SCHEMA].
+    """
+
+    def test_empty_file_is_not_migrated(self, tmp_path):
+        path = _write(tmp_path, "")
+
+        assert cm.migrate_config_file(path) == []
+        assert path.read_text(encoding="utf-8") == ""
+        assert not path.with_suffix(path.suffix + ".bak").exists()
+
+    def test_a_file_with_only_comments_is_not_migrated(self, tmp_path):
+        path = _write(tmp_path, "# nothing but a comment\n")
+
+        assert cm.migrate_config_file(path) == []
+        assert "SCHEMA" not in path.read_text(encoding="utf-8")

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -65,6 +65,67 @@ class TestCreateDefaultConfig:
 # ---------------------------------------------------------------------------
 
 
+class TestEverySectionIsCovered:
+    """Adding a Config section must not silently skip the places that emit it.
+
+    Three generators used to hand-enumerate sections and all three drifted:
+    create_default_config omitted ARCHIVE/AUTOCAM/PIPELINE/NODE/MOMENT_TAGGING,
+    the wizard omitted a different set, and config.ini.dist a third. The two
+    code generators now build from the model, so only the hand-written
+    documentation can still fall behind — which is what this guards.
+    """
+
+    # Written by the app, never hand-edited, so deliberately undocumented.
+    MACHINE_OWNED = {"SETUP"}
+
+    def test_default_config_carries_every_section(self, tmp_path):
+        config = create_default_config(tmp_path / "config.ini", str(tmp_path))
+        missing = [
+            name for name in Config.model_fields if getattr(config, name, None) is None
+        ]
+        assert not missing, f"default config is missing sections: {missing}"
+
+    def test_wizard_and_default_config_agree(self, tmp_path):
+        """The wizard's config and the default one must cover the same sections."""
+        import types
+
+        from video_grouper.web.setup.router import _build_config
+
+        default = create_default_config(tmp_path / "config.ini", str(tmp_path))
+        wizard = _build_config(
+            types.SimpleNamespace(
+                storage_path=str(tmp_path),
+                camera_name="cam",
+                camera_type="reolink",
+                camera_ip="1.1.1.1",
+                camera_username="u",
+                camera_password="p",
+            )
+        )
+        covered = lambda c: {  # noqa: E731
+            n for n in Config.model_fields if getattr(c, n, None) is not None
+        }
+        assert covered(default) == covered(wizard)
+
+    def test_config_ini_dist_documents_every_section(self):
+        """config.ini.dist is user documentation; keep it from falling behind."""
+        import re
+        from pathlib import Path
+
+        dist = Path("video_grouper/config.ini.dist").read_text(encoding="utf-8")
+        documented = {
+            m.group(1) for m in re.finditer(r"^\[([A-Z_]+)(?:\.[^\]]+)?\]", dist, re.M)
+        }
+        expected = {
+            (f.alias or n).upper()
+            for n, f in Config.model_fields.items()
+            if n != "cameras"
+        } - self.MACHINE_OWNED
+        assert not (expected - documented), (
+            f"config.ini.dist is missing sections: {sorted(expected - documented)}"
+        )
+
+
 class TestConfigNeedsOnboarding:
     def test_returns_true_when_no_file(self, tmp_path):
         assert config_needs_onboarding(tmp_path / "missing.ini") is True

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -76,7 +76,12 @@ class TestEverySectionIsCovered:
     """
 
     # Written by the app, never hand-edited, so deliberately undocumented.
-    MACHINE_OWNED = {"SETUP"}
+    # SCHEMA is the config's own version stamp, managed by config_migrations.
+    MACHINE_OWNED = {"SETUP", "SCHEMA"}
+
+    # Keyed collections spelled [CAMERA.<name>] / [TEAM.<key>] rather than one
+    # flat section, so their field name is not the section name.
+    COLLECTIONS = {"cameras", "teams"}
 
     def test_default_config_carries_every_section(self, tmp_path):
         config = create_default_config(tmp_path / "config.ini", str(tmp_path))
@@ -119,7 +124,7 @@ class TestEverySectionIsCovered:
         expected = {
             (f.alias or n).upper()
             for n, f in Config.model_fields.items()
-            if n != "cameras"
+            if n not in self.COLLECTIONS
         } - self.MACHINE_OWNED
         assert not (expected - documented), (
             f"config.ini.dist is missing sections: {sorted(expected - documented)}"

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -9,6 +9,7 @@ from video_grouper.pipeline.config import (
     migrate_ball_tracking_to_pipeline,
 )
 from video_grouper.utils.config import load_config, save_config
+from video_grouper.utils.config_migrations import migrate_config_file
 
 _REQUIRED_SECTIONS = """\
 [STORAGE]
@@ -54,6 +55,18 @@ def _write(tmp_path, text, name="config.ini"):
     return p
 
 
+def _load_legacy(path):
+    """Load a pre-pipeline config the way the app now does.
+
+    [BALL_TRACKING] -> [PIPELINE] used to be folded in by load_config on every
+    single load. It is schema migration v1 now: applied once at startup and
+    written back to disk. These tests therefore migrate first, which also
+    proves the migration does exactly what the old shim did.
+    """
+    migrate_config_file(path)
+    return load_config(path)
+
+
 def test_load_pipeline_section(tmp_path):
     cfg = load_config(_write(tmp_path, _REQUIRED_SECTIONS + _PIPELINE_INI))
     pc = cfg.pipeline
@@ -97,13 +110,16 @@ def test_missing_pipeline_defaults_to_disabled(tmp_path):
     assert load_config(out_path).pipeline.enabled is False
 
 
-def test_per_team_round_trips(tmp_path):
+def test_per_team_section_no_longer_defines_anything(tmp_path):
     ini = _REQUIRED_SECTIONS + _PIPELINE_INI + "\n[PIPELINE.PER_TEAM]\nflash = stitch\n"
     cfg = load_config(_write(tmp_path, ini))
-    assert cfg.pipeline.per_team == {"flash": "stitch"}
+    # [PIPELINE.PER_TEAM] never worked: ordered_steps ignored its team
+    # argument and the team name was always None. Migration v2 moves it to
+    # [TEAM.<key>] pipeline, so the old section defines nothing.
+    assert not hasattr(cfg.pipeline, "per_team")
     out_path = tmp_path / "saved.ini"
     save_config(cfg, out_path)
-    assert load_config(out_path).pipeline.per_team == {"flash": "stitch"}
+    assert not hasattr(load_config(out_path).pipeline, "per_team")
 
 
 def test_migrate_autocam():
@@ -204,7 +220,7 @@ flash = autocam
 
 def test_per_team_is_reserved_not_a_step(tmp_path):
     cfg = load_config(_write(tmp_path, _REQUIRED_SECTIONS + _PER_TEAM_AS_STEP))
-    assert cfg.pipeline.per_team == {"flash": "autocam"}
+    assert not hasattr(cfg.pipeline, "per_team")
     assert cfg.pipeline.ordered_steps() == []  # PER_TEAM never becomes a step
 
 
@@ -256,7 +272,7 @@ def test_migrate_drops_legacy_per_team_and_carries_disabled():
     assert "PER_TEAM" not in out
     pc = PipelineConfig.model_validate(out)
     assert pc.enabled is False
-    assert pc.per_team == {}
+    assert not hasattr(pc, "per_team")
 
 
 _BALL_TRACKING_LEGACY = """\
@@ -307,7 +323,7 @@ render_output_width = 1920
 def test_load_migrates_ball_tracking_when_no_pipeline_section(tmp_path):
     # A pre-pipeline install (only [BALL_TRACKING], no [PIPELINE]) must
     # auto-adopt the config-driven pipeline at load time.
-    cfg = load_config(
+    cfg = _load_legacy(
         _write(tmp_path, _REQUIRED_SECTIONS + _BALL_TRACKING_HOMEGROWN_ONLY)
     )
     pc = cfg.pipeline
@@ -341,7 +357,7 @@ executable = C:/once/GUI.exe
 
 
 def test_load_migrates_autocam_gui_when_no_pipeline_section(tmp_path):
-    cfg = load_config(
+    cfg = _load_legacy(
         _write(tmp_path, _REQUIRED_SECTIONS + _BALL_TRACKING_AUTOCAM_ONLY)
     )
     assert cfg.pipeline.is_active() is True
@@ -385,7 +401,7 @@ def test_autocam_section_feeds_the_autocam_step(tmp_path):
     top-level sections — pipeline step specs are nested and never appear.
     The values have to reach the step that actually runs AutoCam.
     """
-    cfg = load_config(
+    cfg = _load_legacy(
         _write(
             tmp_path,
             _REQUIRED_SECTIONS + _AUTOCAM_SECTION + _BALL_TRACKING_AUTOCAM_ONLY,
@@ -420,7 +436,7 @@ def test_step_spec_value_wins_over_autocam_section(tmp_path):
 
 
 def test_no_autocam_section_changes_nothing(tmp_path):
-    cfg = load_config(
+    cfg = _load_legacy(
         _write(tmp_path, _REQUIRED_SECTIONS + _BALL_TRACKING_AUTOCAM_ONLY)
     )
     assert "license_key" not in cfg.pipeline.ordered_steps()[0].config

--- a/tests/test_upload_processor.py
+++ b/tests/test_upload_processor.py
@@ -96,6 +96,7 @@ class TestUploadProcessor:
                 youtube_config=mock_config.youtube,
                 ntfy_service=None,
                 storage_path=temp_storage,
+                teams=mock_config.teams,
             )
 
     @pytest.mark.asyncio
@@ -274,6 +275,7 @@ class TestUploadProcessorAuthCheck:
                 youtube_config=mock_config.youtube,
                 ntfy_service=mock_ntfy,
                 storage_path=temp_storage,
+                teams=mock_config.teams,
             )
 
     @pytest.mark.asyncio

--- a/tests/test_youtube_config.py
+++ b/tests/test_youtube_config.py
@@ -8,77 +8,14 @@ from pathlib import Path
 import pytest
 
 from video_grouper.utils.config import (
-    AppConfig,
-    AutocamConfig,
-    CameraConfig,
-    CloudSyncConfig,
-    Config,
-    LoggingConfig,
-    NtfyConfig,
-    PlayMetricsConfig,
-    ProcessingConfig,
-    RecordingConfig,
-    StorageConfig,
-    TeamSnapConfig,
     YouTubeConfig,
-    YouTubePlaylistMapConfig,
     load_config,
     save_config,
 )
 
 
-class TestYouTubePlaylistMapConfig:
-    """Test the YouTubePlaylistMapConfig class."""
-
-    def test_youtube_playlist_map_config_creation(self):
-        """Test creating YouTubePlaylistMapConfig with team mappings."""
-        mappings = {
-            "Team A": "Team A 2024 Season",
-            "Team B": "Team B Soccer Videos",
-            "U12 Eagles": "Eagles Youth Soccer",
-        }
-
-        playlist_map = YouTubePlaylistMapConfig(mappings)
-
-        assert playlist_map.root == mappings
-        assert playlist_map.get("Team A") == "Team A 2024 Season"
-        assert playlist_map.get("Team B") == "Team B Soccer Videos"
-        assert playlist_map.get("U12 Eagles") == "Eagles Youth Soccer"
-        assert playlist_map.get("Non-existent Team") is None
-
-    def test_youtube_playlist_map_config_empty(self):
-        """Test creating empty YouTubePlaylistMapConfig."""
-        playlist_map = YouTubePlaylistMapConfig({})
-
-        assert playlist_map.root == {}
-        assert playlist_map.get("Any Team") is None
-
-
 class TestYouTubeConfig:
     """Test the YouTubeConfig class."""
-
-    def test_youtube_config_with_playlist_map(self):
-        """Test YouTubeConfig with playlist mapping."""
-        mappings = {"Team A": "Team A Playlist"}
-        playlist_map = YouTubePlaylistMapConfig(mappings)
-
-        config = YouTubeConfig(
-            enabled=True, privacy_status="unlisted", playlist_map=playlist_map
-        )
-
-        assert config.enabled is True
-        assert config.privacy_status == "unlisted"
-        assert config.playlist_map is not None
-        assert config.playlist_map.get("Team A") == "Team A Playlist"
-        assert config.playlist_map_dict == mappings
-
-    def test_youtube_config_without_playlist_map(self):
-        """Test YouTubeConfig without playlist mapping."""
-        config = YouTubeConfig(enabled=False)
-
-        assert config.enabled is False
-        assert config.playlist_map is None
-        assert config.playlist_map_dict == {}
 
     def test_youtube_config_defaults(self):
         """Test YouTubeConfig default values."""
@@ -86,10 +23,8 @@ class TestYouTubeConfig:
 
         assert config.enabled is False
         assert config.privacy_status == "private"
-        assert config.playlist_map_dict == {}
         assert config.processed_playlist is None
         assert config.raw_playlist is None
-        assert config.playlist_map is None
 
 
 class TestConfigLoadingAndSaving:
@@ -156,185 +91,41 @@ enabled = false
         temp_config_file.write_text(config_content.strip())
         return temp_config_file
 
-    def test_load_config_with_playlist_map(self, sample_config):
-        """Test loading configuration with YouTube playlist mapping."""
+    def test_playlist_map_section_is_migrated_into_teams(self, sample_config):
+        """[YOUTUBE.PLAYLIST_MAP] is schema v2 territory now.
+
+        It had its own substring matching rule, which is exactly the
+        fragmentation [TEAM.<key>] removes. After migration the playlists live
+        on the teams and resolve through the shared resolver.
+        """
+        from video_grouper.utils.config_migrations import migrate_config_file
+
+        migrate_config_file(sample_config)
         config = load_config(sample_config)
 
-        assert isinstance(config, Config)
+        assert config.team_for("Team A").youtube_playlist == "Team A 2024 Season"
+        assert config.team_for("U12 Eagles").youtube_playlist == "Eagles Youth Soccer"
+
+    def test_the_section_stops_being_honoured_once_removed(self, sample_config):
+        """Loading WITHOUT migrating must not quietly half-work.
+
+        The field is gone from the model, so an unmigrated file simply has no
+        playlists — better than a config key that looks live and is ignored.
+        """
+        config = load_config(sample_config)
+        assert config.teams == {}
+        assert not hasattr(config.youtube, "playlist_map")
+
+    def test_youtube_scalars_still_round_trip(self, temp_config_file):
+        temp_config_file.write_text(
+            "[STORAGE]\npath = /tmp/test\n\n"
+            "[YOUTUBE]\nenabled = true\nprivacy_status = unlisted\n",
+            encoding="utf-8",
+        )
+        config = load_config(temp_config_file)
         assert config.youtube.enabled is True
         assert config.youtube.privacy_status == "unlisted"
-        assert config.youtube.playlist_map is not None
 
-        # Test playlist mappings
-        assert config.youtube.playlist_map.get("Team A") == "Team A 2024 Season"
-        assert config.youtube.playlist_map.get("Team B") == "Team B Soccer Videos"
-        assert config.youtube.playlist_map.get("U12 Eagles") == "Eagles Youth Soccer"
-        assert (
-            config.youtube.playlist_map.get("Special Characters")
-            == "Test & Special < > Characters"
-        )
-        assert config.youtube.playlist_map.get("Non-existent Team") is None
-
-        # Test playlist_map_dict property (keys will be lowercase due to configparser)
-        expected_dict = {
-            "team a": "Team A 2024 Season",
-            "team b": "Team B Soccer Videos",
-            "u12 eagles": "Eagles Youth Soccer",
-            "special characters": "Test & Special < > Characters",
-        }
-        assert config.youtube.playlist_map_dict == expected_dict
-
-    def test_load_config_without_playlist_map(self, temp_config_file):
-        """Test loading configuration without YouTube playlist mapping section."""
-        config_content = """
-[CAMERA]
-type = dahua
-device_ip = 192.168.1.100
-username = admin
-password = password
-
-[STORAGE]
-path = /tmp/test
-
-[RECORDING]
-min_duration = 60
-
-[PROCESSING]
-max_concurrent_downloads = 2
-
-[LOGGING]
-level = INFO
-
-[APP]
-check_interval_seconds = 60
-
-[TEAMSNAP]
-enabled = false
-
-[PLAYMETRICS]
-enabled = false
-
-[NTFY]
-enabled = false
-
-[YOUTUBE]
-enabled = true
-privacy_status = private
-
-[AUTOCAM]
-enabled = false
-
-[CLOUD_SYNC]
-enabled = false
-"""
-        temp_config_file.write_text(config_content.strip())
-
-        config = load_config(temp_config_file)
-
-        assert isinstance(config, Config)
-        assert config.youtube.enabled is True
-        assert config.youtube.privacy_status == "private"
-        assert config.youtube.playlist_map is None
-        assert config.youtube.playlist_map_dict == {}
-
-    def test_save_and_reload_config_with_playlist_map(self, temp_config_file):
-        """Test saving and reloading configuration with YouTube playlist mapping."""
-        # Create a config with playlist mapping
-        mappings = {"Team A": "Team A Videos", "Team B": "Team B Highlights"}
-        playlist_map = YouTubePlaylistMapConfig(mappings)
-
-        original_config = Config(
-            cameras=[
-                CameraConfig(
-                    name="default",
-                    type="dahua",
-                    device_ip="192.168.1.100",
-                    username="admin",
-                    password="password",
-                )
-            ],
-            storage=StorageConfig(path="/tmp/test"),
-            recording=RecordingConfig(),
-            processing=ProcessingConfig(),
-            logging=LoggingConfig(),
-            app=AppConfig(),
-            teamsnap=TeamSnapConfig(),
-            playmetrics=PlayMetricsConfig(),
-            ntfy=NtfyConfig(),
-            youtube=YouTubeConfig(
-                enabled=True, privacy_status="unlisted", playlist_map=playlist_map
-            ),
-            autocam=AutocamConfig(),
-            cloud_sync=CloudSyncConfig(),
-        )
-
-        # Save the config
-        save_config(original_config, temp_config_file)
-
-        # Reload the config
-        reloaded_config = load_config(temp_config_file)
-
-        # Verify the playlist mapping was preserved
-        assert reloaded_config.youtube.playlist_map is not None
-        assert reloaded_config.youtube.playlist_map.get("Team A") == "Team A Videos"
-        assert reloaded_config.youtube.playlist_map.get("Team B") == "Team B Highlights"
-        # Keys will be lowercase when reloaded from configparser
-        expected_mappings = {"team a": "Team A Videos", "team b": "Team B Highlights"}
-        assert reloaded_config.youtube.playlist_map_dict == expected_mappings
-
-    def test_config_with_empty_playlist_map_section(self, temp_config_file):
-        """Test configuration with empty YOUTUBE.PLAYLIST_MAP section."""
-        config_content = """
-[CAMERA]
-type = dahua
-device_ip = 192.168.1.100
-username = admin
-password = password
-
-[STORAGE]
-path = /tmp/test
-
-[RECORDING]
-min_duration = 60
-
-[PROCESSING]
-max_concurrent_downloads = 2
-
-[LOGGING]
-level = INFO
-
-[APP]
-check_interval_seconds = 60
-
-[TEAMSNAP]
-enabled = false
-
-[PLAYMETRICS]
-enabled = false
-
-[NTFY]
-enabled = false
-
-[YOUTUBE]
-enabled = true
-
-[YOUTUBE.PLAYLIST_MAP]
-# Empty section
-
-[AUTOCAM]
-enabled = false
-
-[CLOUD_SYNC]
-enabled = false
-"""
-        temp_config_file.write_text(config_content.strip())
-
-        config = load_config(temp_config_file)
-
-        assert isinstance(config, Config)
-        assert config.youtube.playlist_map is not None
-        assert config.youtube.playlist_map_dict == {}
-
-
-if __name__ == "__main__":
-    pytest.main([__file__])
+        save_config(config, temp_config_file)
+        reloaded = load_config(temp_config_file)
+        assert reloaded.youtube.privacy_status == "unlisted"

--- a/tests/test_youtube_playlist_functionality.py
+++ b/tests/test_youtube_playlist_functionality.py
@@ -73,17 +73,12 @@ async def test_youtube_upload_task_coordination_with_state_playlist(
         Config,
         NtfyConfig,
         YouTubeConfig,
-        YouTubePlaylistMapConfig,
     )
 
     mock_config = MagicMock(spec=Config)
     mock_config.youtube = MagicMock(spec=YouTubeConfig)
     mock_config.youtube.enabled = True
     mock_config.youtube.privacy_status = "private"
-    mock_config.youtube.playlist_mapping = {}
-    mock_config.youtube.playlist_map = MagicMock(spec=YouTubePlaylistMapConfig)
-    mock_config.youtube.playlist_map.get.return_value = None
-    mock_config.youtube.playlist_map.root = {}
     mock_config.ntfy = MagicMock(spec=NtfyConfig)
     mock_config.ntfy.enabled = True
 
@@ -150,7 +145,12 @@ async def test_youtube_upload_task_coordination_with_config_mapping(
     mock_ntfy_service,
     mock_dir_state,
 ):
-    """Test that the upload task properly uses config-based playlist mappings."""
+    """The team's configured playlist is used when state has none.
+
+    This used to read [YOUTUBE.PLAYLIST_MAP] with its own substring rule. That
+    map is now folded into [TEAM.<key>] by schema migration v2 and resolved by
+    the shared resolver, so the task is handed `teams` instead.
+    """
     group_dir = "/fake/group_dir"
 
     # Mock MatchInfo
@@ -164,22 +164,20 @@ async def test_youtube_upload_task_coordination_with_config_mapping(
     mock_dir_state_instance = mock_dir_state.return_value
     mock_dir_state_instance.get_youtube_playlist_name.return_value = None
 
-    # Create config with playlist mapping
+    # Configure the team whose playlist should be used.
     from video_grouper.utils.config import (
         Config,
         NtfyConfig,
+        TeamConfig,
         YouTubeConfig,
-        YouTubePlaylistMapConfig,
     )
+
+    teams = {"test": TeamConfig(name="Test Team", youtube_playlist="Config-Playlist")}
 
     mock_config = MagicMock(spec=Config)
     mock_config.youtube = MagicMock(spec=YouTubeConfig)
     mock_config.youtube.enabled = True
     mock_config.youtube.privacy_status = "private"
-    mock_config.youtube.playlist_mapping = {"Test Team": "Config-Playlist"}
-    mock_config.youtube.playlist_map = MagicMock(spec=YouTubePlaylistMapConfig)
-    mock_config.youtube.playlist_map.get.return_value = "Config-Playlist"
-    mock_config.youtube.playlist_map.root = {"Test Team": "Config-Playlist"}
     mock_config.ntfy = MagicMock(spec=NtfyConfig)
     mock_config.ntfy.enabled = True
 
@@ -205,7 +203,9 @@ async def test_youtube_upload_task_coordination_with_config_mapping(
     # Execute the task
     task = create_mock_youtube_upload_task(group_dir)
     result = await task.execute(
-        youtube_config=mock_config.youtube, ntfy_service=mock_ntfy_instance
+        youtube_config=mock_config.youtube,
+        ntfy_service=mock_ntfy_instance,
+        teams=teams,
     )
 
     # Verify success
@@ -216,7 +216,7 @@ async def test_youtube_upload_task_coordination_with_config_mapping(
     playlist_calls = mock_uploader_instance.get_or_create_playlist.call_args_list
     playlist_names = [call[0][0] for call in playlist_calls]
 
-    # Should use config mapping and create raw video playlist
+    # Should use the team's playlist and derive the raw one from it
     assert "Config-Playlist - Full Field" in playlist_names
 
 
@@ -257,17 +257,12 @@ async def test_youtube_upload_task_requests_playlist_when_not_found(
         Config,
         NtfyConfig,
         YouTubeConfig,
-        YouTubePlaylistMapConfig,
     )
 
     mock_config = MagicMock(spec=Config)
     mock_config.youtube = MagicMock(spec=YouTubeConfig)
     mock_config.youtube.enabled = True
     mock_config.youtube.privacy_status = "private"
-    mock_config.youtube.playlist_mapping = {}
-    mock_config.youtube.playlist_map = MagicMock(spec=YouTubePlaylistMapConfig)
-    mock_config.youtube.playlist_map.get.return_value = None
-    mock_config.youtube.playlist_map.root = {}
     mock_config.ntfy = MagicMock(spec=NtfyConfig)
     mock_config.ntfy.enabled = True
 
@@ -328,17 +323,12 @@ async def test_youtube_upload_task_skips_request_if_already_waiting(
         Config,
         NtfyConfig,
         YouTubeConfig,
-        YouTubePlaylistMapConfig,
     )
 
     mock_config = MagicMock(spec=Config)
     mock_config.youtube = MagicMock(spec=YouTubeConfig)
     mock_config.youtube.enabled = True
     mock_config.youtube.privacy_status = "private"
-    mock_config.youtube.playlist_mapping = {}
-    mock_config.youtube.playlist_map = MagicMock(spec=YouTubePlaylistMapConfig)
-    mock_config.youtube.playlist_map.get.return_value = None
-    mock_config.youtube.playlist_map.root = {}
     mock_config.ntfy = MagicMock(spec=NtfyConfig)
     mock_config.ntfy.enabled = True
 

--- a/tests/web/test_config_editor.py
+++ b/tests/web/test_config_editor.py
@@ -386,3 +386,99 @@ class TestSectionGating:
         if resp.status_code == 303:
             after = client.get("/config").text
             assert "https://example.invalid" in after
+
+
+_TEAM_INI = """\
+[STORAGE]
+path = /data
+
+[LOGGING]
+level = INFO
+
+[TEAMSNAP]
+enabled = true
+client_id = tg_abc
+
+[TEAM.heat2012]
+name = BU14 - Guzzetta
+aliases = Guzzetta, Hilton Heat
+teamsnap_team_id = 10198718
+youtube_playlist = Hilton Heat 2012s
+
+[TEAM.flash2013]
+name = Western New York Flash - 13B ECNL-RL Rochester
+playmetrics_team_id = 335774
+youtube_playlist = WNY Flash 2013s
+"""
+
+
+@pytest.fixture
+def team_config_path(tmp_path):
+    p = tmp_path / "config.ini"
+    p.write_text(_TEAM_INI, encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def team_client(tmp_path, team_config_path):
+    app = create_app(TTTConfig(), str(tmp_path), config_path=team_config_path)
+    with TestClient(app, base_url="http://localhost:8765", headers=_SAME_ORIGIN) as c:
+        yield c
+
+
+def test_post_config_preserves_team_sections(team_client, team_config_path):
+    """Editing an unrelated scalar must not drop [TEAM.*].
+
+    The editor renders scalar fields only, so teams are never in the form. It
+    rebuilds Config from the loaded model plus scalar overrides, which is the
+    only reason they survive — and save_config writes the file from
+    Config.model_fields onto an empty parser, so anything that fell out of the
+    model would be erased from the user's file permanently.
+    """
+    before = load_config(team_config_path)
+    assert set(before.teams) == {"heat2012", "flash2013"}
+
+    resp = team_client.post(
+        "/config",
+        data={"STORAGE.path": "/data/games", "LOGGING.level": "DEBUG"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    reloaded = load_config(team_config_path)
+    assert reloaded.storage.path == "/data/games"
+    assert reloaded.logging.level == "DEBUG"
+
+    assert set(reloaded.teams) == {"heat2012", "flash2013"}
+    heat = reloaded.teams["heat2012"]
+    assert heat.name == "BU14 - Guzzetta"
+    assert heat.teamsnap_team_id == "10198718"
+    assert heat.youtube_playlist == "Hilton Heat 2012s"
+    # The comma-separated alias list has to survive the INI round-trip too.
+    assert heat.aliases == ["Guzzetta", "Hilton Heat"]
+    # And the team still resolves after the save.
+    assert reloaded.team_for("BU14 - Guzzetta") is not None
+
+
+def test_schema_section_is_not_editable_but_survives(team_client, team_config_path):
+    """[SCHEMA] is machine-owned: never rendered, always preserved.
+
+    It records which config schema the file is written in. As a plain int it
+    would otherwise render as an editable number field — and setting it ahead
+    of what the build understands makes startup hard-fail by design, while
+    setting it back re-runs migrations. Neither belongs behind a text box.
+    """
+    page = team_client.get("/config").text
+    assert "SCHEMA.version" not in page
+    assert ">SCHEMA<" not in page
+
+    before = load_config(team_config_path).schema_meta.version
+
+    resp = team_client.post(
+        "/config",
+        data={"STORAGE.path": "/data/games"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    assert load_config(team_config_path).schema_meta.version == before

--- a/training/docs/DECISIONS.md
+++ b/training/docs/DECISIONS.md
@@ -2117,3 +2117,73 @@ argument for offering a re-scan from Settings later, not only during onboarding.
 
 **Not done:** no attempt at Reolink's or Dahua's proprietary UDP discovery broadcasts. The HTTP
 fingerprint is vendor-documented behaviour and needed no reverse engineering.
+
+## 2026-08-22: Versioned config migrations; one [TEAM.<key>] section per team
+
+**Context:** Per-team settings were spread across six sections and the same team was spelled
+differently in each. On the live install: `BU14 - Guzzetta` in `[TEAMSNAP.TEAM.0]`,
+`Western New York Flash - 13B ECNL-RL Rochester` in `[PLAYMETRICS.TEAM.0]`, and `guzzetta` /
+`13b ecnl-rl rochester` as `[YOUTUBE.PLAYLIST_MAP]` keys (configparser lowercases option keys). There
+was no canonical team identity: TeamSnap matched on a section name, PlayMetrics on an option value,
+and the playlist map on a *lowercased substring* — the last of which is the only reason the short
+keys resolved at all. Two of the six per-team maps were dead code: `[BALL_TRACKING.PER_TEAM]` was
+parsed then dropped, and `[PIPELINE.PER_TEAM]` round-tripped but `ordered_steps` ignored its team
+argument *and* the team name it received was always `None`, because pipeline discovery read
+`[MATCH] team_name` while match_info only ever writes `my_team_name`.
+
+**Decision (a): a versioned migration framework**, `video_grouper/utils/config_migrations.py`.
+`[SCHEMA] version` records the file's schema; every migration above that version is applied in order
+and the result written back once, with the original kept as `config.ini.bak`. Absent version = 0.
+A file from a *newer* build hard-fails rather than being silently mangled by an older one.
+
+Mark's requirement was "solve this for this migration and future migrations… apply all the
+migrations between version x and version y", and explicitly *not* permanent runtime shims. It runs at
+startup, not in the installer: `installer.nsi` mentions `config.ini` only in a comment, auto-upgrade
+returns early, the payload only lands in `$INSTDIR`, and NSIS is Windows-only while soccer-cam also
+ships Docker/Linux. Startup is the only path all installs share. Comments are not preserved
+(ConfigParser cannot); accepted, since `/config` already destroys them on every save.
+
+The existing `[BALL_TRACKING]` → `[PIPELINE]` shim — which ran on *every load, forever* — became
+migration v1, which both removes permanent code and proves the framework.
+
+**Decision (b): `[TEAM.<key>]`** carries `name`, `aliases`, `enabled`, `teamsnap_team_id`,
+`playmetrics_team_id`, `youtube_playlist` and `pipeline` (a per-team step-list override). One
+resolver, `resolve_team`, replaces five matching rules: exact match wins across all teams, then
+substring, longest identifier first. Migration v2 folds the old sections in and preserves the short
+playlist-map keys as `aliases`, so spellings that worked before still resolve.
+
+**Load-bearing detail:** migration v2 *deletes* the sections `TeamSnapService` and
+`PlayMetricsService` build their `teams` lists from. `load_config` therefore projects `[TEAM.*]` back
+into those lists. Without it an upgraded install would silently find no teams and both integrations
+would quietly stop fetching schedules — verified byte-identical across migration on a copy of the
+real server config.
+
+**Decision (c): one default-config generator.** `create_default_config`, the setup wizard's
+`_build_config` and `config.ini.dist` each hand-enumerated sections and all three disagreed (ARCHIVE,
+AUTOCAM, PIPELINE, NODE, MOMENT_TAGGING each missing from a different one). They existed only because
+nine `Config` sections were declared required with no `default_factory`, though eight construct with
+no arguments — only `storage.path` genuinely needs a value. With defaults, a complete config is
+`Config(storage=StorageConfig(path=...))` and a new section needs no generator edit, which is exactly
+what a migration framework wants. `config.ini.dist` stays hand-written (its comments are the point)
+and is guarded by a test that every `Config` section appears in it, minus a machine-owned allowlist
+(`[SETUP]`, `[SCHEMA]`). That test found five undocumented sections, including `[AUTOCAM]` and its
+licence key.
+
+**Also removed, as dead config:** `PipelineConfig.per_team` and
+`YouTubeConfig.playlist_map` (plus `YouTubePlaylistMapConfig`). Both are superseded by
+`[TEAM.<key>]` and neither had a production consumer left. Leaving them would have been the exact
+defect this change fixes — a config key that looks live and is silently ignored. `[PIPELINE.PER_TEAM]`
+stays *reserved* in the parser so an unmigrated file's section is never mistaken for a step spec.
+
+**Scope:** branched off `main`, independent of the unmerged watermark/archive work. Per-team
+*archive* settings are deliberately excluded — `ArchiveConfig` does not exist on `main`. Whichever
+merges second reconciles; the framework makes that a one-migration change.
+
+**Files:** `video_grouper/utils/config_migrations.py`, `video_grouper/utils/config.py`,
+`video_grouper/pipeline/config.py`, `video_grouper/task_processors/pipeline_processor.py`,
+`video_grouper/task_processors/pipeline_discovery_processor.py`,
+`video_grouper/task_processors/tasks/upload/youtube_upload_task.py`,
+`video_grouper/web/setup/router.py`, `video_grouper/__main__.py`,
+`video_grouper/service/main.py`, `video_grouper/config.ini.dist`,
+`tests/test_config_migrations.py`, `tests/test_onboarding.py`,
+`tests/web/test_config_editor.py`

--- a/video_grouper/__main__.py
+++ b/video_grouper/__main__.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from video_grouper.utils.config import create_default_config, load_config
+from video_grouper.utils.config_migrations import migrate_config_file
 from video_grouper.utils.locking import FileLock
 from video_grouper.utils.logger import get_logger, setup_logging
 from video_grouper.utils.paths import get_shared_data_path
@@ -56,6 +57,13 @@ def load_application_config(config_path: Path = None):
                 # then redirect the user to /setup/welcome.
                 logger.info("No config at %s; writing onboarding stub.", config_path)
                 return create_default_config(config_path, str(config_path.parent))
+            # Bring the file up to the current schema before reading it.
+            # Inside the lock, because it rewrites config.ini. Idempotent and a
+            # no-op once the file is current, so this costs one parse per boot.
+            # This is the only place migrations run: the NSIS installer never
+            # touches config.ini and is Windows-only anyway, while Docker,
+            # Linux and hand-copied configs all come through here.
+            migrate_config_file(config_path)
             return load_config(config_path)
     except TimeoutError:
         logger.error(f"Could not acquire lock to read config file at {config_path}.")

--- a/video_grouper/config.ini.dist
+++ b/video_grouper/config.ini.dist
@@ -210,3 +210,37 @@ auth_server_port = 8765
 # supabase_internal_url = http://supabase_kong_<project>:8000
 # Leave blank in production; one URL serves both legs.
 # supabase_internal_url =
+
+[AUTOCAM]
+# Installation-level AutoCam settings: where the vendor's app lives and the
+# licence key it runs under. Per-render options belong to the pipeline step,
+# not here.
+enabled = true
+# Leave blank to auto-detect the usual install location.
+executable =
+# Your AutoCam licence key.
+license_key =
+
+[CLOUD_SYNC]
+# Mirror finished games to a cloud provider. Off by default.
+enabled = false
+provider =
+
+[MOMENT_TAGGING]
+# Pull moment tags from a Team Tech Tools instance so clips can be cut from
+# them. Off by default; needs a reachable TTT API.
+enabled = false
+api_base_url = http://localhost:8000
+service_role_key =
+
+[NODE]
+# Multi-machine rendering. `standalone` (default) does everything locally.
+# `master` hands work out; `worker` polls a master for it — a worker must be
+# started with `python -m video_grouper.worker`, not the normal entry point.
+role = standalone
+# Workers only: where to poll.
+master_url =
+# Master only: comma-separated tokens workers authenticate with.
+worker_tokens =
+# Workers only: comma-separated capabilities this node advertises.
+capabilities =

--- a/video_grouper/config.ini.dist
+++ b/video_grouper/config.ini.dist
@@ -48,6 +48,8 @@ check_interval_seconds = 60
 timezone = America/New_York
 
 [TEAMSNAP]
+# Credentials only. WHICH teams to pull is configured per team, under
+# [TEAM.<key>] at the bottom of this file — set teamsnap_team_id there.
 # Set to true to enable TeamSnap integration
 enabled = false
 # OAuth credentials (get these from TeamSnap developer portal)
@@ -55,21 +57,14 @@ client_id = your_client_id
 client_secret = your_client_secret
 # Access token
 access_token = your_access_token
-# Your team ID from TeamSnap
-team_id = your_team_id
-# Your team name as it should appear in video titles
-my_team_name = Your Team Name
 
 [PLAYMETRICS]
+# Credentials only — see [TEAM.<key>] playmetrics_team_id for which teams.
 # Set to true to enable PlayMetrics integration
 enabled = false
 # Your PlayMetrics login credentials
 username = your_email@example.com
 password = your_password
-# Your team ID from PlayMetrics (optional, will try to find from dashboard if not provided)
-team_id = your_team_id
-# Your team name as it should appear in video titles (optional, will try to extract from PlayMetrics)
-team_name = Your Team Name
 
 [NTFY]
 # Set to true to enable NTFY integration for game start/end time detection
@@ -165,9 +160,8 @@ type = render
 # type = autocam
 # executable = C:\path\to\AutoCam.exe
 
-# [PIPELINE.PER_TEAM]
-# # Per-team pipeline override. Key = MatchInfo team_name.
-# # flash = ...
+# Per-team pipeline overrides are NOT configured here. Set `pipeline` on the
+# team itself — see [TEAM.<key>] at the bottom of this file.
 
 # Playlist configuration for processed videos
 [YOUTUBE.PLAYLIST.PROCESSED]
@@ -244,3 +238,29 @@ master_url =
 worker_tokens =
 # Workers only: comma-separated capabilities this node advertises.
 capabilities =
+
+# ---------------------------------------------------------------------------
+# Teams
+# ---------------------------------------------------------------------------
+# One section per team, spelled [TEAM.<key>]. The <key> is a short handle you
+# choose; it is never matched against anything, it just labels the section.
+#
+# Everything about a team lives here: which TeamSnap/PlayMetrics team it is,
+# which YouTube playlist its games go to, and which pipeline processes them.
+#
+# `name` is what gets matched, against [MATCH] my_team_name in each game's
+# match_info.ini. Matching is case-insensitive and falls back to substring, so
+# a short `aliases` entry resolves a longer real name.
+#
+# `pipeline` is an optional comma-separated list of step ids from the
+# [PIPELINE.<step_id>] sections above. Set it to run a different subset or
+# order for this team's games; leave it blank to use [PIPELINE] steps.
+#
+# [TEAM.heat2012]
+# name = BU14 - Guzzetta
+# aliases = Guzzetta, Hilton Heat
+# enabled = true
+# teamsnap_team_id = 10198718
+# playmetrics_team_id =
+# youtube_playlist = Hilton Heat 2012s
+# pipeline = stitch, render

--- a/video_grouper/pipeline/config.py
+++ b/video_grouper/pipeline/config.py
@@ -32,7 +32,8 @@ class PipelineConfig(BaseModel):
 
     ``steps`` is the ordered list of step ids; ``step_specs`` maps each id to its
     spec. ``enabled`` is the master switch. Resource-pool capacities tune the
-    scheduler. ``per_team`` allows per-team overrides (applied upstream).
+    scheduler. Per-team overrides live on [TEAM.<key>] pipeline, resolved by
+    the caller and passed to ordered_steps as ``override_steps``.
     """
 
     enabled: bool = False
@@ -41,7 +42,6 @@ class PipelineConfig(BaseModel):
     ram_heavy_concurrency: int = 1
     steps: list[str] = Field(default_factory=list)
     step_specs: dict[str, PipelineStepSpec] = Field(default_factory=dict)
-    per_team: dict[str, str] = Field(default_factory=dict, alias="PER_TEAM")
 
     model_config = {"populate_by_name": True}
 
@@ -64,14 +64,32 @@ class PipelineConfig(BaseModel):
         """
         return bool(self.enabled and self.ordered_steps(team_name))
 
-    def ordered_steps(self, team_name: str | None = None) -> list[StepSpec]:
+    def ordered_steps(
+        self, team_name: str | None = None, override_steps: str | None = None
+    ) -> list[StepSpec]:
         """Return the configured steps as runner-ready :class:`StepSpec`s, in order.
 
-        ``team_name`` is accepted for forward-compatibility with per-team
-        pipelines; today a single pipeline applies to all teams.
+        ``override_steps`` is a team's own comma-separated step list, from
+        ``[TEAM.<key>] pipeline``. It replaces ``[PIPELINE] steps`` for that
+        team's games and reuses the same ``[PIPELINE.<step_id>]`` specs, so a
+        team can run a subset or a different order without a second pipeline
+        definition. Empty or unset means the shared pipeline.
+
+        ``team_name`` is retained for logging and for callers that already pass
+        it; the override is resolved by the caller, which is the only place
+        that holds both the pipeline config and the team list.
         """
+        step_ids = self.steps
+        if override_steps and override_steps.strip():
+            step_ids = [s.strip() for s in override_steps.split(",") if s.strip()]
+            logger.info(
+                "pipeline: team %r overrides the step list with %s",
+                team_name,
+                step_ids,
+            )
+
         specs: list[StepSpec] = []
-        for step_id in self.steps:
+        for step_id in step_ids:
             spec = self.step_specs.get(step_id)
             if spec is None:
                 logger.warning(
@@ -131,9 +149,10 @@ def migrate_ball_tracking_to_pipeline(bt: dict | None) -> dict | None:
         "steps": [],
         "step_specs": {},
     }
-    # NOTE: legacy [BALL_TRACKING.PER_TEAM] mapped team -> provider name, which has
-    # no meaning under the pipeline's per-team model. Intentionally NOT carried
-    # over; per-team pipeline overrides get defined when that feature lands.
+    # NOTE: legacy [BALL_TRACKING.PER_TEAM] mapped team -> provider name, which
+    # has no meaning under the pipeline model. Still intentionally NOT carried
+    # over. Per-team pipeline selection now exists as [TEAM.<key>] pipeline (a
+    # step-list override), but a provider name does not translate into one.
 
     if provider == "autocam_gui":
         executable = (bt.get("AUTOCAM_GUI") or {}).get("executable")

--- a/video_grouper/service/main.py
+++ b/video_grouper/service/main.py
@@ -113,7 +113,14 @@ class VideoGrouperService(win32serviceutil.ServiceFramework):
 
         logger.info(f"Loading config from {config_path}")
         try:
+            from video_grouper.utils.config_migrations import migrate_config_file
+
             with FileLock(config_path):
+                # Same one-shot schema migration the console entry point runs.
+                # The service is how Windows installs actually boot, so it has
+                # to be here too or an upgraded service would read a config
+                # still in the old shape.
+                migrate_config_file(config_path)
                 config = load_config(config_path)
         except Exception as e:
             logger.error(f"Failed to load config: {e}")

--- a/video_grouper/task_processors/pipeline_discovery_processor.py
+++ b/video_grouper/task_processors/pipeline_discovery_processor.py
@@ -115,18 +115,25 @@ class PipelineDiscoveryProcessor(PollingProcessor):
 
     @staticmethod
     def _read_team_name(group_dir: Path) -> str | None:
-        """Read team_name from match_info.ini if present, else None."""
+        """Read the team name from match_info.ini if present, else None.
+
+        The option is ``my_team_name``. This used to read ``team_name``, which
+        match_info never writes — see ``MatchInfo.update_team_info`` and
+        ``match_info.ini.dist`` — so it always returned None and every
+        PipelineTask carried ``team_name=None``. Per-team pipeline selection
+        could therefore never fire, whatever the config said.
+        """
         match_info_path = group_dir / "match_info.ini"
         if not match_info_path.exists():
             return None
         try:
             parser = configparser.ConfigParser()
             parser.read(match_info_path, encoding="utf-8")
-            if parser.has_option("MATCH", "team_name"):
-                return parser.get("MATCH", "team_name") or None
+            if parser.has_option("MATCH", "my_team_name"):
+                return parser.get("MATCH", "my_team_name") or None
         except Exception as e:
             logger.debug(
-                "PIPELINE_DISCOVERY: could not read team_name from %s: %s",
+                "PIPELINE_DISCOVERY: could not read my_team_name from %s: %s",
                 match_info_path,
                 e,
             )

--- a/video_grouper/task_processors/pipeline_processor.py
+++ b/video_grouper/task_processors/pipeline_processor.py
@@ -151,7 +151,13 @@ class PipelineProcessor(QueueProcessor):
                 storage_path=Path(item.storage_path or self.storage_path),
                 ttt_config=ttt_dump,
             )
-            step_specs = self.config.pipeline.ordered_steps(team_name)
+            # A team may override which steps run on its games
+            # ([TEAM.<key>] pipeline). Resolved here because this is the only
+            # place holding both the pipeline config and the team list.
+            team = self.config.team_for(team_name)
+            step_specs = self.config.pipeline.ordered_steps(
+                team_name, override_steps=team.pipeline if team else None
+            )
 
             # Infer pipeline_preset from configured step types for TTT reporting.
             step_type_set = {s.type for s in step_specs}

--- a/video_grouper/task_processors/tasks/upload/youtube_upload_task.py
+++ b/video_grouper/task_processors/tasks/upload/youtube_upload_task.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from video_grouper.models import DirectoryState, MatchInfo
-from video_grouper.utils.config import YouTubeConfig
+from video_grouper.utils.config import YouTubeConfig, resolve_team
 from video_grouper.utils.paths import resolve_path
 
 from .base_upload_task import BaseUploadTask
@@ -48,7 +48,7 @@ class YoutubeUploadTask(BaseUploadTask):
         return {"task_type": self.task_type, "group_dir": self.group_dir}
 
     async def execute(
-        self, youtube_config=None, ntfy_service=None, storage_path=None
+        self, youtube_config=None, ntfy_service=None, storage_path=None, teams=None
     ) -> bool:
         """
         Execute the YouTube upload task.
@@ -109,7 +109,7 @@ class YoutubeUploadTask(BaseUploadTask):
 
             # Get playlist names using coordination logic
             processed_playlist_name, raw_playlist_name = await self._get_playlist_names(
-                match_info, youtube_config, ntfy_service, storage_path
+                match_info, youtube_config, ntfy_service, storage_path, teams
             )
 
             # If we don't have playlist names and a request was sent, skip for now
@@ -297,13 +297,14 @@ class YoutubeUploadTask(BaseUploadTask):
         config: YouTubeConfig,
         ntfy_service,
         storage_path: str,
+        teams: dict | None = None,
     ) -> tuple[str | None, str | None]:
         """
         Get playlist names for processed and raw videos.
 
         Lookup order:
         1. DirectoryState (playlist name stored in state.json)
-        2. config.playlist_map (team name → playlist name mapping)
+        2. the team's [TEAM.<key>] youtube_playlist
         3. config.processed_playlist / config.raw_playlist (format strings)
         4. Fall back to ntfy request if nothing found
 
@@ -326,22 +327,22 @@ class YoutubeUploadTask(BaseUploadTask):
         except Exception as e:
             logger.warning(f"Error reading playlist from directory state: {e}")
 
-        # 2. Check config.playlist_map for team-based mapping
-        #    Supports exact match or case-insensitive substring match
-        #    (e.g. key "13b ecnl-rl rochester" matches team "Western New York Flash - 13B ECNL-RL Rochester")
-        if not base_playlist_name:
-            if hasattr(config, "playlist_map") and config.playlist_map:
-                try:
-                    team_lower = match_info.my_team_name.lower()
-                    for key, playlist_name in config.playlist_map.root.items():
-                        if key.lower() == team_lower or key.lower() in team_lower:
-                            base_playlist_name = playlist_name
-                            logger.info(
-                                f"Using playlist from config map: {base_playlist_name} (matched key '{key}')"
-                            )
-                            break
-                except Exception as e:
-                    logger.warning(f"Error looking up playlist in config map: {e}")
+        # 2. The team's configured playlist. Resolution is shared with every
+        #    other per-team lookup (resolve_team), rather than this task
+        #    re-implementing "does the configured key appear in the team
+        #    name?" — that ad-hoc rule is why the same team ended up spelled
+        #    differently in every config section.
+        if not base_playlist_name and teams:
+            try:
+                team = resolve_team(teams, match_info.my_team_name)
+                if team and team.youtube_playlist:
+                    base_playlist_name = team.youtube_playlist
+                    logger.info(
+                        f"Using playlist from [TEAM.*]: {base_playlist_name} "
+                        f"(team '{team.name}')"
+                    )
+            except Exception as e:
+                logger.warning(f"Error resolving team for playlist: {e}")
 
         # 3. If we have a base playlist name, derive processed and raw names
         if base_playlist_name:

--- a/video_grouper/task_processors/upload_processor.py
+++ b/video_grouper/task_processors/upload_processor.py
@@ -115,6 +115,7 @@ class UploadProcessor(QueueProcessor):
                 youtube_config=self.config.youtube,
                 ntfy_service=self.ntfy_service,
                 storage_path=self.storage_path,
+                teams=getattr(self.config, "teams", None),
             )
 
             if success:

--- a/video_grouper/tray/main.py
+++ b/video_grouper/tray/main.py
@@ -263,6 +263,17 @@ class SystemTrayIcon(QSystemTrayIcon):
 
         self.config: Config | None = None
         if self.config_path.exists():
+            # The tray shares the service's config.ini and can start first, so
+            # it migrates too. Idempotent and lock-guarded, so whichever
+            # process gets there first does the work and the other no-ops.
+            from video_grouper.utils.config_migrations import migrate_config_file
+            from video_grouper.utils.locking import FileLock
+
+            try:
+                with FileLock(self.config_path):
+                    migrate_config_file(self.config_path)
+            except Exception as exc:  # noqa: BLE001 — never block the tray
+                logger.warning("TRAY: config migration skipped: %s", exc)
             self.config = load_config(self.config_path)
             # Switch logging from the bootstrap LOCALAPPDATA path to
             # the configured storage path (<storage>/logs/...) so the

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -5,9 +5,10 @@ import logging
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field, RootModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from video_grouper.pipeline.config import PipelineConfig
+from video_grouper.utils.config_migrations import current_schema_version
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,136 @@ class CameraConfig(BaseModel):
     # GOP boundary (observed 2026-05-30 Fairport), so locking to a
     # single protocol per game is the safer default for tournament use.
     download_protocol: Literal["auto", "http", "baichuan"] = "auto"
+
+
+class SchemaConfig(BaseModel):
+    """Which config schema this file is written in. Machine-owned.
+
+    Must be a real field on ``Config``: ``save_config`` rebuilds the file from
+    ``Config.model_fields`` onto an empty parser, so a section the model does
+    not know about is erased on the user's next ``/config`` save. A version
+    that vanished would make an already-migrated file look unversioned and get
+    migrated a second time.
+
+    Defaults to the current version, so anything soccer-cam writes itself — a
+    fresh install, the wizard — is stamped current and never migrated. Only a
+    file predating versioning reads as 0.
+
+    Because of that default, this field does NOT tell you what version a file
+    on disk is at: an unmigrated file has no ``[SCHEMA]`` section and still
+    reports current here. Version detection reads the raw parsed sections
+    instead — see :func:`config_migrations.read_version`. Nothing outside the
+    migration framework should need to ask.
+    """
+
+    version: int = Field(default_factory=current_schema_version)
+
+
+class TeamConfig(BaseModel):
+    """Everything about one team, in one place.
+
+    Per-team settings used to be spread across ``[TEAMSNAP.*]``,
+    ``[PLAYMETRICS.TEAM.*]``, ``[YOUTUBE.PLAYLIST_MAP]``,
+    ``[PIPELINE.PER_TEAM]`` and ``[BALL_TRACKING.PER_TEAM]``, and the same team
+    was spelled differently in each — on one real install, ``BU14 - Guzzetta``
+    in TeamSnap and ``guzzetta`` in the playlist map. There was no canonical
+    team identity anywhere, and each subsystem invented its own matching rule.
+
+    Spelled ``[TEAM.<key>]``, where ``<key>`` is a short handle you choose. The
+    key is never matched against anything; ``name`` and ``aliases`` are.
+    """
+
+    # As it appears in a game's match_info.ini [MATCH] my_team_name. That is
+    # what every lookup is given at runtime, so it is what we match on.
+    name: str = ""
+    # Extra spellings that also identify this team. A short alias works
+    # because matching falls back to substring — which is the only reason the
+    # existing playlist map resolves "guzzetta" against "BU14 - Guzzetta".
+    aliases: list[str] = Field(default_factory=list)
+    enabled: bool = True
+
+    teamsnap_team_id: str = ""
+    playmetrics_team_id: str = ""
+    youtube_playlist: str = ""
+    # Pipeline preset or step-list override for this team's games.
+    pipeline: str = ""
+
+    @field_validator("aliases", mode="before")
+    @classmethod
+    def _split_aliases(cls, value: object) -> object:
+        """Accept a comma-separated string — an INI cannot hold a list."""
+        if isinstance(value, str):
+            return [part.strip() for part in value.split(",") if part.strip()]
+        return value
+
+    def identifiers(self) -> list[str]:
+        """Every string that identifies this team, longest first.
+
+        Longest first so a specific alias wins over a shorter one that is also
+        a substring of the same team name.
+        """
+        names = [self.name, *self.aliases]
+        return sorted(
+            (n.strip() for n in names if n and n.strip()), key=len, reverse=True
+        )
+
+    def matches(self, my_team_name: str) -> bool:
+        """Whether *my_team_name* (from match_info.ini) is this team.
+
+        Exact match first, then substring, mirroring the behaviour the
+        playlist map already relied on. Case-insensitive throughout: section
+        names preserve case but option keys do not, and match_info is
+        hand-edited.
+        """
+        wanted = (my_team_name or "").strip().casefold()
+        if not wanted:
+            return False
+        candidates = [n.casefold() for n in self.identifiers()]
+        return any(c == wanted for c in candidates) or any(
+            c in wanted for c in candidates
+        )
+
+
+def resolve_team(
+    teams: dict[str, TeamConfig], my_team_name: str | None
+) -> TeamConfig | None:
+    """The configured team a game belongs to, or None.
+
+    The single place team identity is resolved. It replaces five different
+    matching rules — TeamSnap matched on a section name, PlayMetrics on an
+    option value, and the YouTube playlist map on a lowercased substring —
+    which is how the same team came to be spelled differently in every section.
+
+    Exact matches win over substring matches across ALL teams, so a team whose
+    name matches exactly always beats another team that merely contains the
+    string. Within substring matching, longer identifiers are tried first.
+
+    A free function rather than only a ``Config`` method because callers deep
+    in the pipeline (the upload task) are handed one section, not the whole
+    config.
+    """
+    if not my_team_name:
+        return None
+    candidates = [t for t in teams.values() if t.enabled]
+    wanted = my_team_name.strip().casefold()
+
+    for team in candidates:
+        if any(n.casefold() == wanted for n in team.identifiers()):
+            return team
+
+    # Substring fallback: pick the team with the LONGEST matching identifier,
+    # not merely the first one configured. With two teams whose names share a
+    # word ("Flash" and "WNY Flash Rochester"), first-match would hand the game
+    # to whichever happened to be listed first — a silent misfile that sends
+    # the video to the wrong playlist.
+    best: TeamConfig | None = None
+    best_len = 0
+    for team in candidates:
+        for identifier in team.identifiers():
+            folded = identifier.casefold()
+            if folded in wanted and len(folded) > best_len:
+                best, best_len = team, len(folded)
+    return best
 
 
 class StorageConfig(BaseModel):
@@ -352,21 +483,6 @@ class YouTubePlaylistConfig(BaseModel):
     privacy_status: str
 
 
-class YouTubePlaylistMapConfig(RootModel[dict[str, str]]):
-    def get(self, team_name: str) -> str | None:
-        # First try exact match
-        if team_name in self.root:
-            return self.root[team_name]
-
-        # Then try case-insensitive match
-        team_name_lower = team_name.lower()
-        for key, value in self.root.items():
-            if key.lower() == team_name_lower:
-                return value
-
-        return None
-
-
 class YouTubeConfig(BaseModel):
     enabled: bool = False
     privacy_status: str = "private"
@@ -382,13 +498,8 @@ class YouTubeConfig(BaseModel):
     quota_retry_minutes: int = 30
     processed_playlist: YouTubePlaylistConfig | None = None
     raw_playlist: YouTubePlaylistConfig | None = None
-    playlist_map: YouTubePlaylistMapConfig | None = None
 
     model_config = {"validate_by_name": True}
-
-    @property
-    def playlist_map_dict(self) -> dict[str, str]:
-        return self.playlist_map.root if self.playlist_map else {}
 
 
 class SetupConfig(BaseModel):
@@ -409,6 +520,10 @@ class Config(BaseModel):
     # omitting a different set (ARCHIVE, AUTOCAM, PIPELINE, NODE,
     # MOMENT_TAGGING), and every entry they did list was literally `{}`.
     # With defaults here, a new section needs no generator edit at all.
+    schema_meta: SchemaConfig = Field(alias="SCHEMA", default_factory=SchemaConfig)
+    # Keyed by the [TEAM.<key>] handle. Insertion-ordered, so a config's own
+    # ordering decides ties between two teams that both match.
+    teams: dict[str, TeamConfig] = Field(default_factory=dict)
     cameras: list[CameraConfig] = Field(default_factory=list)
     storage: StorageConfig = Field(alias="STORAGE")
     recording: RecordingConfig = Field(
@@ -449,6 +564,14 @@ class Config(BaseModel):
         """Convenience accessor for the first camera config."""
         return self.cameras[0]
 
+    def team_for(self, my_team_name: str | None) -> TeamConfig | None:
+        """The configured team a game belongs to, or None.
+
+        See :func:`resolve_team` — this is the same lookup, for callers that
+        hold the whole ``Config``.
+        """
+        return resolve_team(self.teams, my_team_name)
+
     def post_trim_processing_active(self) -> bool:
         """True when a post-trim processing stage owns ``trimmed`` groups.
 
@@ -477,11 +600,12 @@ def load_config(config_path: Path) -> Config:
             "YOUTUBE.PLAYLIST.RAW"
         )
 
-    # Add support for YOUTUBE.PLAYLIST_MAP
-    if "YOUTUBE.PLAYLIST_MAP" in config_dict:
-        config_dict.setdefault("YOUTUBE", {})["playlist_map"] = (
-            YouTubePlaylistMapConfig(config_dict.pop("YOUTUBE.PLAYLIST_MAP"))
-        )
+    # [YOUTUBE.PLAYLIST_MAP] was team -> playlist with its own substring
+    # matching rule. Schema migration v2 folds it into [TEAM.<key>]
+    # youtube_playlist, resolved by resolve_team like every other per-team
+    # setting. Drop the section if an unmigrated file still carries it, so it
+    # cannot look like it is still being honoured.
+    config_dict.pop("YOUTUBE.PLAYLIST_MAP", None)
 
     # Handle BALL_TRACKING sub-sections (provider configs + per-team overrides).
     # `[BALL_TRACKING.AUTOCAM_GUI]` -> nested under BALL_TRACKING.AUTOCAM_GUI
@@ -531,6 +655,17 @@ def load_config(config_path: Path) -> Config:
     if "PLAYMETRICS" in config_dict:
         config_dict["PLAYMETRICS"]["teams"] = playmetrics_teams
 
+    # Handle team sections: [TEAM.<key>] -> teams dict, keyed by the handle.
+    # Unlike [CAMERA.<name>] the section suffix is NOT the identity — `name`
+    # inside the section is what gets matched against match_info. The handle is
+    # just a stable label for the operator.
+    teams: dict[str, dict] = {}
+    for section in list(config_dict.keys()):
+        if section.startswith("TEAM."):
+            teams[section.split(".", 1)[1]] = config_dict.pop(section)
+    if teams:
+        config_dict["teams"] = teams
+
     # Handle camera sections: [CAMERA.name] -> cameras list
     cameras = []
     for section in list(config_dict.keys()):
@@ -555,26 +690,52 @@ def load_config(config_path: Path) -> Config:
     if "TEAMSNAP" in config_dict:
         config_dict["TEAMSNAP"]["teams"] = teamsnap_teams
 
-    # Legacy migration: a pre-pipeline install has a [BALL_TRACKING] section but
-    # NO [PIPELINE] section at all — auto-adopt the config-driven pipeline so it
-    # lights up the new path without hand-editing the INI. We key on the
-    # *absence of any [PIPELINE] section* (not merely absence of steps) so an
-    # explicit `[PIPELINE]\nenabled = false` — which save_config always emits —
-    # is respected as a deliberate "pipeline off" choice rather than silently
-    # re-migrated on every round-trip. The migrated dict is injected as
-    # config_dict["PIPELINE"] so model_validate builds it.
-    from video_grouper.pipeline.config import migrate_ball_tracking_to_pipeline
+    # Project [TEAM.*] into the integrations' own team lists.
+    #
+    # [TEAM.<key>] is the single operator-facing place a team is configured,
+    # but TeamSnapService/PlayMetricsService/TeamInfoTask each iterate their
+    # section's `teams` list. Migration v2 DELETES the [TEAMSNAP.*] and
+    # [PLAYMETRICS.TEAM.*] sections those lists were built from, so without
+    # this projection an upgraded install would silently find no teams at all
+    # and both integrations would quietly stop fetching schedules.
+    #
+    # Derived, not duplicated: entries appear here only because a [TEAM.*]
+    # section names them, and a legacy entry of the same name wins so an
+    # unmigrated file behaves exactly as before.
+    for team_key, team_body in (config_dict.get("teams") or {}).items():
+        team_name = (team_body.get("name") or team_key).strip()
+        if not team_name or str(team_body.get("enabled", "true")).lower() in (
+            "false",
+            "0",
+            "no",
+        ):
+            continue
+        for section, id_field, bucket in (
+            ("TEAMSNAP", "teamsnap_team_id", teamsnap_teams),
+            ("PLAYMETRICS", "playmetrics_team_id", playmetrics_teams),
+        ):
+            team_id = (team_body.get(id_field) or "").strip()
+            if not team_id or section not in config_dict:
+                continue
+            if any(
+                (t.get("team_name") or "").strip().casefold() == team_name.casefold()
+                for t in bucket
+            ):
+                continue
+            bucket.append({"team_name": team_name, "team_id": team_id, "enabled": True})
+    if "TEAMSNAP" in config_dict:
+        config_dict["TEAMSNAP"]["teams"] = teamsnap_teams
+    if "PLAYMETRICS" in config_dict:
+        config_dict["PLAYMETRICS"]["teams"] = playmetrics_teams
 
-    if "PIPELINE" not in config_dict and config_dict.get("BALL_TRACKING"):
-        migrated = migrate_ball_tracking_to_pipeline(config_dict["BALL_TRACKING"])
-        if migrated:
-            config_dict["PIPELINE"] = migrated
-
-    # The legacy [BALL_TRACKING] section (and its nested sub-sections) is no
-    # longer a Config field — drop it after migration so it isn't passed to
-    # model_validate. Migration above has already lifted anything worth keeping
-    # into [PIPELINE].
-    config_dict.pop("BALL_TRACKING", None)
+    # [BALL_TRACKING] -> [PIPELINE] used to be folded in right here, on every
+    # single load, forever. It is now schema migration v1
+    # (video_grouper/utils/config_migrations.py), applied once at startup and
+    # written back to disk. Drop the section if a caller loads a file that has
+    # not been migrated yet — it is not a Config field, so model_validate would
+    # ignore it anyway; being explicit keeps the intent readable.
+    for section in [s for s in config_dict if s.startswith("BALL_TRACKING")]:
+        config_dict.pop(section, None)
 
     # Installation-level AutoCam settings live in [AUTOCAM] so they're
     # editable from /config. Fold them into the AutoCam step spec, which is
@@ -625,6 +786,18 @@ def save_config(config: Config, config_path: Path):
 
         # cameras are handled above
         if field_name == "cameras":
+            continue
+
+        # teams -> one [TEAM.<key>] section each. `aliases` is a list, which an
+        # INI cannot hold, so join it back to the comma-separated form the
+        # field validator parses on the way in.
+        if field_name == "teams":
+            for key, team in value.items():
+                team_dict = team.model_dump()
+                team_dict["aliases"] = ", ".join(team_dict.get("aliases") or [])
+                parser[f"TEAM.{key}"] = {
+                    k: str(v) for k, v in team_dict.items() if v is not None
+                }
             continue
 
         if field_name == "playmetrics" and hasattr(value, "teams"):
@@ -679,10 +852,6 @@ def save_config(config: Config, config_path: Path):
                     if v is not None:
                         section_items[k] = str(v)
                 parser[f"PIPELINE.{step_id}"] = section_items
-            if value.per_team:
-                parser["PIPELINE.PER_TEAM"] = {
-                    k: str(v) for k, v in value.per_team.items()
-                }
             continue
 
         if isinstance(value, BaseModel):

--- a/video_grouper/utils/config.py
+++ b/video_grouper/utils/config.py
@@ -398,16 +398,33 @@ class SetupConfig(BaseModel):
 
 
 class Config(BaseModel):
+    # Every section defaults. Only `storage.path` is genuinely required — it
+    # needs a real directory and there is no sane default for it.
+    #
+    # These eight used to be declared required with no default_factory even
+    # though each constructs fine with no arguments. Nothing could build a
+    # Config without naming all of them, so every place that needed a default
+    # config hand-enumerated the sections: create_default_config, the setup
+    # wizard's _build_config, and config.ini.dist. All three drifted, each
+    # omitting a different set (ARCHIVE, AUTOCAM, PIPELINE, NODE,
+    # MOMENT_TAGGING), and every entry they did list was literally `{}`.
+    # With defaults here, a new section needs no generator edit at all.
     cameras: list[CameraConfig] = Field(default_factory=list)
     storage: StorageConfig = Field(alias="STORAGE")
-    recording: RecordingConfig = Field(alias="RECORDING")
-    processing: ProcessingConfig = Field(alias="PROCESSING")
-    logging: LoggingConfig = Field(alias="LOGGING")
-    app: AppConfig = Field(alias="APP")
-    teamsnap: TeamSnapConfig = Field(alias="TEAMSNAP")
-    playmetrics: PlayMetricsConfig = Field(alias="PLAYMETRICS")
-    ntfy: NtfyConfig = Field(alias="NTFY")
-    youtube: YouTubeConfig = Field(alias="YOUTUBE")
+    recording: RecordingConfig = Field(
+        alias="RECORDING", default_factory=RecordingConfig
+    )
+    processing: ProcessingConfig = Field(
+        alias="PROCESSING", default_factory=ProcessingConfig
+    )
+    logging: LoggingConfig = Field(alias="LOGGING", default_factory=LoggingConfig)
+    app: AppConfig = Field(alias="APP", default_factory=AppConfig)
+    teamsnap: TeamSnapConfig = Field(alias="TEAMSNAP", default_factory=TeamSnapConfig)
+    playmetrics: PlayMetricsConfig = Field(
+        alias="PLAYMETRICS", default_factory=PlayMetricsConfig
+    )
+    ntfy: NtfyConfig = Field(alias="NTFY", default_factory=NtfyConfig)
+    youtube: YouTubeConfig = Field(alias="YOUTUBE", default_factory=YouTubeConfig)
     cloud_sync: CloudSyncConfig = Field(
         alias="CLOUD_SYNC", default_factory=CloudSyncConfig
     )
@@ -704,25 +721,15 @@ def save_config(config: Config, config_path: Path):
 def create_default_config(config_path: Path, storage_path: str) -> Config:
     """Create a minimal config with sensible defaults and save to disk.
 
-    Used by the onboarding wizard to bootstrap a new config.ini.
+    Used on first boot when no config exists, and by the onboarding wizard.
+
+    Every section defaults, so only the storage path is named here. This used
+    to enumerate twelve sections as ``{}`` because they were declared required
+    on the model; it drifted from the wizard's copy of the same list (each
+    omitted a different set). Adding a section to ``Config`` now needs no edit
+    here.
     """
-    config = Config.model_validate(
-        {
-            "cameras": [],
-            "STORAGE": {"path": storage_path},
-            "RECORDING": {},
-            "PROCESSING": {},
-            "LOGGING": {},
-            "APP": {},
-            "TEAMSNAP": {},
-            "PLAYMETRICS": {},
-            "NTFY": {},
-            "YOUTUBE": {},
-            "CLOUD_SYNC": {},
-            "TTT": {},
-            "SETUP": {"onboarding_completed": False},
-        }
-    )
+    config = Config(storage=StorageConfig(path=storage_path))
     config_path.parent.mkdir(parents=True, exist_ok=True)
     save_config(config, config_path)
     return config

--- a/video_grouper/utils/config_migrations.py
+++ b/video_grouper/utils/config_migrations.py
@@ -1,0 +1,338 @@
+"""Versioned, one-shot migrations for ``config.ini``.
+
+A schema change used to mean one of two bad options: leave a permanent
+back-compat shim in ``load_config`` that reads the old shape on every load
+forever (what ``[BALL_TRACKING]`` -> ``[PIPELINE]`` did), or break existing
+installs silently — pydantic ignores unknown sections, so an upgraded config
+simply loses whatever moved, with no error anywhere.
+
+This is the third option. Each schema change is a numbered migration; the file
+records the version it is at; on startup every migration above that version is
+applied in order and the result written back once. Afterwards the file *is* the
+new shape and no legacy-reading code needs to survive.
+
+Not in the installer: NSIS is Windows-only and never touches ``config.ini``
+(auto-upgrade returns early and only writes to ``$INSTDIR``), while soccer-cam
+also ships Docker/Linux and supports hand-copied configs. Startup is the only
+place that covers all of them.
+
+Comments are not preserved — ``ConfigParser`` cannot round-trip them. The
+original is kept as ``config.ini.bak``. (The ``/config`` editor already
+destroys comments on every save, so this is not a new class of loss.)
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Section and option holding the schema version. Machine-owned; operators
+# should not edit it.
+VERSION_SECTION = "SCHEMA"
+VERSION_OPTION = "version"
+
+# A config written before versioning existed. Absence means 0, never "current"
+# — assuming current would skip every migration on exactly the files that need
+# them.
+UNVERSIONED = 0
+
+
+@dataclass(frozen=True)
+class Migration:
+    """One schema change.
+
+    ``apply`` takes the raw ``{section: {option: value}}`` mapping straight
+    from ConfigParser and returns the same shape. Pure dict-to-dict, like
+    :func:`video_grouper.pipeline.config.migrate_ball_tracking_to_pipeline`, so
+    it can be unit-tested without touching a file.
+    """
+
+    version: int  # the version this migration produces
+    description: str
+    apply: Callable[[dict[str, dict[str, str]]], dict[str, dict[str, str]]]
+
+
+def _v1_ball_tracking_to_pipeline(
+    raw: dict[str, dict[str, str]],
+) -> dict[str, dict[str, str]]:
+    """``[BALL_TRACKING]`` -> ``[PIPELINE]``.
+
+    This ran on every single load as a permanent shim in ``load_config``. It is
+    the same transform, moved here so it runs once and the shim can go.
+
+    Triggered by the *absence of a ``[PIPELINE]`` section*, not by it being
+    empty: ``save_config`` always emits ``[PIPELINE]``, so an explicit
+    ``enabled = false`` is a deliberate "pipeline off" and must not be
+    re-migrated over.
+    """
+    from video_grouper.pipeline.config import migrate_ball_tracking_to_pipeline
+
+    legacy: dict[str, object] = {}
+    for section in list(raw):
+        if section == "BALL_TRACKING":
+            legacy.update(raw.pop(section))
+        elif section.startswith("BALL_TRACKING."):
+            legacy[section.split(".", 1)[1]] = raw.pop(section)
+
+    has_pipeline = any(s == "PIPELINE" or s.startswith("PIPELINE.") for s in raw)
+    if has_pipeline or not legacy:
+        return raw  # nothing to do; BALL_TRACKING (if any) is now dropped
+
+    migrated = migrate_ball_tracking_to_pipeline(legacy)
+    if not migrated:
+        return raw
+
+    # Flatten back to INI sections: [PIPELINE] carries enabled + the step
+    # order, and each step gets its own [PIPELINE.<step_id>].
+    pipeline: dict[str, str] = {}
+    if "enabled" in migrated:
+        pipeline["enabled"] = str(migrated["enabled"])
+    steps = migrated.get("steps") or []
+    if steps:
+        pipeline["steps"] = ", ".join(steps)
+    raw["PIPELINE"] = pipeline
+    for step_id, spec in (migrated.get("step_specs") or {}).items():
+        step_section: dict[str, str] = {"type": str(spec.get("type", ""))}
+        step_section.update({k: str(v) for k, v in (spec.get("config") or {}).items()})
+        raw[f"PIPELINE.{step_id}"] = step_section
+    return raw
+
+
+def _v2_per_team_sections_to_team(
+    raw: dict[str, dict[str, str]],
+) -> dict[str, dict[str, str]]:
+    """Scattered per-team settings -> one ``[TEAM.<key>]`` each.
+
+    Sources, in the spellings real configs use:
+
+    * ``[TEAMSNAP.<anything>]``  — ``team_name`` in the body, or the section
+      suffix as a fallback (installs in the wild use ``[TEAMSNAP.TEAM.0]``)
+    * ``[PLAYMETRICS.TEAM.<n>]`` — ``team_name`` in the body only
+    * ``[YOUTUBE.PLAYLIST_MAP]`` — team -> playlist, keys LOWERCASED by
+      configparser and matched by substring, so ``guzzetta`` legitimately maps
+      ``BU14 - Guzzetta``. Carried across as an alias so that keeps working.
+    * ``[PIPELINE.PER_TEAM]``    — team -> preset
+
+    Teams are keyed by a slug of their name. A playlist-map entry that matches
+    an existing team by substring is folded into it rather than creating a
+    duplicate; one that matches nothing becomes its own team, since it names a
+    team the user clearly has.
+    """
+    teams: dict[str, dict[str, str]] = {}
+
+    def slug(name: str) -> str:
+        cleaned = "".join(c if c.isalnum() else "_" for c in name.strip().casefold())
+        return "_".join(p for p in cleaned.split("_") if p) or "team"
+
+    def upsert(name: str, **fields: str) -> dict[str, str]:
+        key = slug(name)
+        team = teams.setdefault(key, {"name": name.strip()})
+        for field, value in fields.items():
+            if value:
+                team[field] = value
+        return team
+
+    for section in list(raw):
+        if section.startswith("TEAMSNAP.") and (body := raw.pop(section)):
+            name = body.get("team_name") or section.split(".", 1)[1]
+            upsert(name, teamsnap_team_id=body.get("team_id", ""))
+        elif section.startswith("PLAYMETRICS.TEAM.") and (body := raw.pop(section)):
+            name = body.get("team_name", "")
+            if name:
+                upsert(name, playmetrics_team_id=body.get("team_id", ""))
+
+    for key, playlist in (raw.pop("YOUTUBE.PLAYLIST_MAP", None) or {}).items():
+        probe = key.strip().casefold()
+        for team in teams.values():
+            if probe == team["name"].casefold() or probe in team["name"].casefold():
+                team["youtube_playlist"] = playlist
+                # Keep the short spelling working — it is what the operator
+                # wrote, and substring matching is why it resolved at all.
+                if probe != team["name"].casefold():
+                    existing = [
+                        a for a in team.get("aliases", "").split(",") if a.strip()
+                    ]
+                    team["aliases"] = ", ".join([*existing, key.strip()])
+                break
+        else:
+            upsert(key, youtube_playlist=playlist)
+
+    for key, preset in (raw.pop("PIPELINE.PER_TEAM", None) or {}).items():
+        probe = key.strip().casefold()
+        for team in teams.values():
+            if probe == team["name"].casefold() or probe in team["name"].casefold():
+                team["pipeline"] = preset
+                break
+        else:
+            upsert(key, pipeline=preset)
+
+    # Legacy single-team scalars, folded into `teams` by the models today.
+    # Drop them so a migrated file does not carry two competing definitions.
+    for legacy_section, legacy_keys in (
+        ("TEAMSNAP", ("team_id", "team_name", "my_team_name")),
+        ("PLAYMETRICS", ("team_id", "team_name")),
+    ):
+        legacy_body = raw.get(legacy_section)
+        if not legacy_body:
+            continue
+        legacy_name = legacy_body.get("team_name") or legacy_body.get("my_team_name")
+        already_known = any(
+            t["name"].casefold() == (legacy_name or "").casefold()
+            for t in teams.values()
+        )
+        if legacy_name and not already_known:
+            field = (
+                "teamsnap_team_id"
+                if legacy_section == "TEAMSNAP"
+                else "playmetrics_team_id"
+            )
+            upsert(legacy_name, **{field: legacy_body.get("team_id", "")})
+        for legacy_key in legacy_keys:
+            legacy_body.pop(legacy_key, None)
+
+    for key, team in teams.items():
+        raw[f"TEAM.{key}"] = team
+    return raw
+
+
+# Ordered, contiguous from 1. Append only — never renumber or edit a shipped
+# migration, or configs part-way through the sequence will skip it.
+MIGRATIONS: list[Migration] = [
+    Migration(
+        version=1,
+        description="[BALL_TRACKING] -> [PIPELINE] (was a permanent load-time shim)",
+        apply=_v1_ball_tracking_to_pipeline,
+    ),
+    Migration(
+        version=2,
+        description="per-team settings -> one [TEAM.<key>] section each",
+        apply=_v2_per_team_sections_to_team,
+    ),
+]
+
+
+def current_schema_version() -> int:
+    """The version a freshly written config is at."""
+    return MIGRATIONS[-1].version if MIGRATIONS else UNVERSIONED
+
+
+def read_version(raw: dict[str, dict[str, str]]) -> int:
+    """Schema version recorded in *raw*, or ``UNVERSIONED``."""
+    section = raw.get(VERSION_SECTION) or {}
+    value = section.get(VERSION_OPTION)
+    if value is None:
+        return UNVERSIONED
+    try:
+        return int(str(value).strip())
+    except ValueError:
+        logger.warning(
+            "CONFIG_MIGRATION: unreadable %s.%s (%r); treating as unversioned.",
+            VERSION_SECTION,
+            VERSION_OPTION,
+            value,
+        )
+        return UNVERSIONED
+
+
+def pending(raw: dict[str, dict[str, str]]) -> list[Migration]:
+    """Migrations that still need to run against *raw*, in order.
+
+    Raises when the file is NEWER than this build understands. That is a
+    downgrade: an older binary cannot know what a later migration did, and
+    would happily write the file back out in a shape the newer build wrote,
+    minus whatever it does not model. Refusing is the only safe answer.
+    """
+    version = read_version(raw)
+    latest = current_schema_version()
+    if version > latest:
+        raise ValueError(
+            f"config.ini is at schema version {version}, but this build only "
+            f"understands {latest}. It was written by a newer soccer-cam; "
+            "upgrade rather than run this version against it."
+        )
+    return [m for m in MIGRATIONS if m.version > version]
+
+
+def migrate(
+    raw: dict[str, dict[str, str]],
+) -> tuple[dict[str, dict[str, str]], list[Migration]]:
+    """Apply every pending migration to *raw*, returning it and what ran."""
+    applied: list[Migration] = []
+    for migration in pending(raw):
+        raw = migration.apply(raw)
+        applied.append(migration)
+    if applied:
+        raw.setdefault(VERSION_SECTION, {})[VERSION_OPTION] = str(
+            current_schema_version()
+        )
+    return raw, applied
+
+
+def _read_raw(config_path: Path) -> dict[str, dict[str, str]]:
+    parser = configparser.ConfigParser()
+    parser.read(config_path, encoding="utf-8")
+    return {s: dict(parser.items(s)) for s in parser.sections()}
+
+
+def _write_raw(config_path: Path, raw: dict[str, dict[str, str]]) -> None:
+    parser = configparser.ConfigParser()
+    for section, options in raw.items():
+        parser[section] = {k: str(v) for k, v in options.items()}
+    with config_path.open("w", encoding="utf-8") as handle:
+        parser.write(handle)
+
+
+def migrate_config_file(config_path: Path) -> list[Migration]:
+    """Bring ``config.ini`` up to the current schema. Returns what ran.
+
+    Idempotent: a file already at the current version is not touched at all,
+    so this is safe to call on every startup. The caller is expected to hold
+    the config FileLock.
+    """
+    if not config_path.exists():
+        return []
+
+    raw = _read_raw(config_path)
+    if not raw:
+        # No sections at all: the file is empty, or configparser could not read
+        # it (it ignores unreadable paths silently rather than raising). Either
+        # way there is nothing to migrate, and stamping a version into a file
+        # we failed to understand would replace it with a bare stub. Leave it
+        # for load_config to report on.
+        return []
+
+    todo = pending(raw)
+    if not todo:
+        return []
+
+    backup = config_path.with_suffix(config_path.suffix + ".bak")
+    shutil.copy2(config_path, backup)
+    logger.info(
+        "CONFIG_MIGRATION: %s is at schema v%d; applying %d migration(s). "
+        "Original saved as %s",
+        config_path.name,
+        read_version(raw),
+        len(todo),
+        backup.name,
+    )
+
+    migrated, applied = migrate(raw)
+    for migration in applied:
+        logger.info(
+            "CONFIG_MIGRATION: v%d applied — %s",
+            migration.version,
+            migration.description,
+        )
+    _write_raw(config_path, migrated)
+    logger.info(
+        "CONFIG_MIGRATION: %s is now at schema v%d.",
+        config_path.name,
+        current_schema_version(),
+    )
+    return applied

--- a/video_grouper/web/config_editor.py
+++ b/video_grouper/web/config_editor.py
@@ -55,6 +55,16 @@ _SENSITIVE_FIELDS = frozenset(
     }
 )
 
+# Sections the app owns and the operator must not hand-edit. They are still
+# loaded, saved and preserved — just never rendered as a form.
+#
+# [SCHEMA] records which config schema the file is written in. It is a plain
+# int, so without this it would render as an editable number field: setting it
+# ahead of what this build understands makes startup hard-fail by design (see
+# config_migrations.pending), and setting it back re-runs migrations. Neither
+# is something to offer behind a text box.
+_MACHINE_OWNED_SECTIONS = frozenset({"SCHEMA"})
+
 
 def _is_scalar_field(annotation: Any) -> bool:
     """Return True for scalar types (incl. Optional[scalar])."""
@@ -361,6 +371,8 @@ def _render_section(section_alias: str, model: BaseModel) -> str:
     with no round trip; and ``display: none`` inputs still post, so turning a
     section off never silently discards what was configured in it.
     """
+    if section_alias in _MACHINE_OWNED_SECTIONS:
+        return ""
     gate = ""
     rows: list[str] = []
     for field_name, field_info in type(model).model_fields.items():

--- a/video_grouper/web/setup/router.py
+++ b/video_grouper/web/setup/router.py
@@ -15,21 +15,9 @@ from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 
 from video_grouper.pipeline.presets import apply_preset
 from video_grouper.utils.config import (
-    AppConfig,
-    AutocamConfig,
     CameraConfig,
-    CloudSyncConfig,
     Config,
-    LoggingConfig,
-    NtfyConfig,
-    PlayMetricsConfig,
-    ProcessingConfig,
-    RecordingConfig,
-    SetupConfig,
     StorageConfig,
-    TeamSnapConfig,
-    TTTConfig,
-    YouTubeConfig,
     load_config,
     save_config,
 )
@@ -1383,23 +1371,14 @@ def _build_config(state, existing: Config | None = None) -> Config:
     if existing is not None:
         data = existing.model_dump(by_alias=True)
     else:
-        data = {
-            "cameras": [],
-            "STORAGE": StorageConfig(path=state.storage_path).model_dump(),
-            "RECORDING": RecordingConfig().model_dump(),
-            "PROCESSING": ProcessingConfig().model_dump(),
-            "LOGGING": LoggingConfig().model_dump(),
-            "APP": AppConfig().model_dump(),
-            "TEAMSNAP": TeamSnapConfig().model_dump(),
-            "PLAYMETRICS": PlayMetricsConfig().model_dump(),
-            "NTFY": NtfyConfig().model_dump(),
-            "YOUTUBE": YouTubeConfig().model_dump(),
-            "AUTOCAM": AutocamConfig().model_dump(),
-            "CLOUD_SYNC": CloudSyncConfig().model_dump(),
-            "TTT": TTTConfig().model_dump(),
-            "SETUP": SetupConfig().model_dump(),
-            "PIPELINE": {},
-        }
+        # Every section defaults on the model, so only the storage path needs
+        # naming. This used to restate a dozen sections as `{}` because they
+        # were declared required — and drifted from create_default_config's
+        # copy of the same list, each omitting a different set. A section added
+        # to Config now appears here with no edit.
+        data = Config(storage=StorageConfig(path=state.storage_path)).model_dump(
+            by_alias=True
+        )
 
     # Seed a starting [PIPELINE] from the homegrown preset so a fresh install
     # has a real, hand-editable scaffold (stitch -> detect -> track -> render)

--- a/video_grouper/worker/__main__.py
+++ b/video_grouper/worker/__main__.py
@@ -196,6 +196,11 @@ async def main() -> int:
         )
         return 2
 
+    # A worker runs on its own machine with its own config.ini, so it needs
+    # the same one-shot schema migration the orchestrator entry points run.
+    from video_grouper.utils.config_migrations import migrate_config_file
+
+    migrate_config_file(config_path)
     config = load_config(config_path)
     setup_logging_from_config(config)
 


### PR DESCRIPTION
## Why

Per-team settings were spread across **six** sections, and the same team was spelled differently in each. From the live install:

```ini
[TEAMSNAP.TEAM.0]      team_name = BU14 - Guzzetta
[PLAYMETRICS.TEAM.0]   team_name = Western New York Flash - 13B ECNL-RL Rochester
[YOUTUBE.PLAYLIST_MAP] guzzetta = Hilton Heat 2012s
```

There was no canonical team identity: TeamSnap matched on a section name, PlayMetrics on an option value, and the playlist map on a lowercased **substring** — the only reason `guzzetta` ever resolved `BU14 - Guzzetta`. Two of the six maps were dead code.

## Versioned migrations

`[SCHEMA] version` records the file's schema; every migration above that version applies in order and the result is written back once, original kept as `config.ini.bak`. Absent version = 0. A file from a **newer** build hard-fails rather than being silently mangled by an older one.

Not in the installer, and this was checked rather than assumed: `installer.nsi` mentions `config.ini` only in a comment, auto-upgrade returns early, the payload only lands in `$INSTDIR`, and NSIS is Windows-only while soccer-cam ships Docker/Linux. Startup is the one path every install shares — wired into all four entry points.

**v1** is the `[BALL_TRACKING]` → `[PIPELINE]` shim, which until now ran on *every load, forever*. Moving it here removes permanent code and proves the framework. **v2** is the team consolidation.

## `[TEAM.<key>]`

`name` / `aliases` / `enabled` / `teamsnap_team_id` / `playmetrics_team_id` / `youtube_playlist` / `pipeline`. One resolver replaces five matching rules: exact wins across all teams, then substring, longest identifier first. v2 preserves the short playlist-map keys as aliases, so spellings that worked before still resolve.

**Load-bearing:** v2 *deletes* the sections `TeamSnapService` and `PlayMetricsService` build their `teams` lists from. `load_config` projects `[TEAM.*]` back into those lists — without it an upgraded install would silently find no teams and both integrations would quietly stop fetching schedules.

## One generator instead of three

`create_default_config`, the wizard's `_build_config` and `config.ini.dist` each hand-enumerated sections and all three disagreed (ARCHIVE, AUTOCAM, PIPELINE, NODE, MOMENT_TAGGING each missing from a different one). They existed only because nine `Config` sections were declared required with no `default_factory` — though eight construct with no arguments. A complete config is now `Config(storage=StorageConfig(path=...))`, and a new section needs no generator edit, which is what a migration framework wants.

`config.ini.dist` stays hand-written and is guarded by a test. That test found five undocumented sections, including `[AUTOCAM]` and its licence key.

## Bugs found on the way

1. `pipeline_discovery_processor` read `[MATCH] team_name`; match_info only ever writes `my_team_name`, so `PipelineTask.team_name` was **always `None`**. With `ordered_steps` also ignoring its team argument, per-team pipeline could never fire. Both fixed — it works for the first time.
2. `[SCHEMA] version` is a plain `int`, so the `/config` editor would have rendered it editable; setting it ahead of the build makes startup hard-fail by design. Machine-owned sections are no longer rendered (still loaded, saved, preserved).
3. `migrate_config_file` trusted `exists()` then copied. configparser ignores unreadable paths **silently**, so an empty or unparseable `config.ini` would have been replaced by a bare `[SCHEMA]` stub. A read yielding no sections is now left strictly alone.

Also removed as dead config: `PipelineConfig.per_team` and `YouTubeConfig.playlist_map`. Keeping them would be the exact defect this fixes — a key that looks live and is silently ignored.

## Verification

Migrated a copy of the live server `config.ini` (pulled read-only, deleted after — it held credentials): both teams extracted with the right ids, playlists folded across the spelling mismatch, integration team lists **byte-identical** before and after, credentials/camera/ntfy intact, idempotent on re-run.

Full unit suite: **2114 passed**, 15 skipped, 1 xfailed. ruff + mypy clean.

## Rebased onto the design-system merge

`78c960a fix(setup): merge the wizard's answers into config instead of replacing it` landed on main and collided with this branch's `_build_config` rewrite. **I took main's version wholesale** — it fixes a real bug this branch did not address: re-running the wizard on a configured install rebuilt every section from defaults and silently discarded NTFY, TeamSnap, PlayMetrics, TTT, playlists and the pipeline.

My change then applies to just its fresh-install branch, where the hand-enumerated `{}` list still lived. Both properties survive: the wizard merges rather than replaces, *and* a new `Config` section needs no edit there. Worth noting main hit the same "the generators drift" problem independently, from the other side.

Also resolved: `config_editor.py`, where main rewrote `_render_section` with section gating — kept main's signature and docstring and inserted the machine-owned `[SCHEMA]` guard into it.

## Note for review

Independent of #141. Per-team *archive* settings are deliberately out of scope here (`ArchiveConfig` does not exist on `main`). Whichever merges second reconciles — one migration entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zon5KgUuiwEe3dZV7z9r6

